### PR TITLE
fix(ci): install Node.js and skip az prereq in mock mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize line endings to LF on commit (prevents CRLF issues on Linux/CI)
+* text=auto eol=lf
+
+# Shell scripts must always use LF
+*.sh text eol=lf
+
+# Windows-specific files can keep CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y jq python3
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Node.js dependencies
+        run: npm install --prefix scripts
+
       - name: Validate JSON mock files
         run: |
           echo "Validating mock data JSON files..."

--- a/scripts/test-workspace.sh
+++ b/scripts/test-workspace.sh
@@ -153,7 +153,7 @@ test_prereqs() {
     fail "curl no encontrado" "Instalar curl"
   fi
 
-  # Azure CLI
+  # Azure CLI (solo obligatorio en modo --real; en mock se omite)
   log_section "Azure CLI"
   if command -v az &>/dev/null; then
     AZVER=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || echo "desconocida")
@@ -161,10 +161,18 @@ test_prereqs() {
     if az extension show --name azure-devops &>/dev/null 2>&1; then
       pass "Extensión azure-devops instalada"
     else
-      fail "Extensión azure-devops NO instalada" "Ejecutar: az extension add --name azure-devops"
+      if [[ "$MODE" == "mock" ]]; then
+        skip "Extensión azure-devops NO instalada" "No requerida en modo --mock"
+      else
+        fail "Extensión azure-devops NO instalada" "Ejecutar: az extension add --name azure-devops"
+      fi
     fi
   else
-    fail "az (Azure CLI) no encontrado" "Instalar: https://docs.microsoft.com/cli/azure/install-azure-cli"
+    if [[ "$MODE" == "mock" ]]; then
+      skip "az (Azure CLI) no encontrado" "No requerido en modo --mock"
+    else
+      fail "az (Azure CLI) no encontrado" "Instalar: https://docs.microsoft.com/cli/azure/install-azure-cli"
+    fi
   fi
 
   # Claude CLI


### PR DESCRIPTION
The 'Validate workspace' CI job was failing because:
1. The workflow only installed jq and python3, but test-workspace.sh also checks for Node.js and scripts/node_modules — causing FAIL counts that made the suite exit with code 1.
2. The az (Azure CLI) prereq check also failed in CI even in --mock mode, where az is not needed (connectivity tests are already skipped).

Fixes:
- ci.yml: add actions/setup-node@v4 (Node 20) and npm install --prefix scripts
- test-workspace.sh: downgrade az/az-extension checks to skip (not fail) when running in --mock mode
- .gitattributes: enforce LF line endings on commit to prevent future CRLF issues from Windows checkouts

## What does this PR add or fix?

<!-- 2-3 sentence summary -->

## Type of contribution

- [ ] New slash command
- [ ] New skill
- [x] Bug fix
- [ ] Documentation improvement
- [ ] Test suite addition
- [ ] Refactor (no behaviour change)
- [ ] Other: ___

## Files added / modified

<!-- List the key files and what each one does -->
- `.claude/commands/` —
- `.claude/skills/` —
- `scripts/` —
- `docs/` —

## How to test this

<!-- Step-by-step instructions for the reviewer to verify the change works -->

1.
2.
3.

## Test suite

- [ ] `./scripts/test-workspace.sh --mock` passes ≥ 93/96
- [ ] I added tests for new files (if applicable)

## Checklist

- [ ] Command/skill name follows existing conventions (`namespace:action`, kebab-case)
- [ ] I tested this in a real Claude Code conversation at least once
- [ ] No real PATs, org URLs, project names, or client data included
- [ ] Documentation in the file is sufficient for a PM to understand it without reading this PR
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (for features and fixes)

## Related issues

Closes #
