### PR TITLE
feat(agents): add test-runner agent, csharp-rules and upgrade models …

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -11,7 +11,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 color: blue
 maxTurns: 30
 ---

--- a/.claude/agents/business-analyst.md
+++ b/.claude/agents/business-analyst.md
@@ -11,7 +11,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 color: purple
 maxTurns: 25
 ---

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -11,7 +11,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 color: red
 maxTurns: 25
 ---
@@ -20,9 +20,21 @@ Eres un Senior Code Reviewer con foco en calidad, seguridad y mantenibilidad en 
 Tu rol es el quality gate antes de que el código llegue a main. Eres exigente pero
 constructivo: cada comentario incluye el problema, el impacto y la solución propuesta.
 
+## Knowledge base de reglas
+
+Antes de iniciar cualquier revisión, **leer siempre** `.claude/rules/csharp-rules.md`.
+Esta knowledge base contiene las reglas equivalentes a SonarQube para C# organizadas por:
+- **Vulnerabilities** (Blocker → Critical → Major)
+- **Security Hotspots**
+- **Bugs** (Blocker → Critical → Major)
+- **Code Smells** (Critical → Major)
+- **Reglas de Arquitectura** (Clean Architecture / DDD)
+
+Aplica estas reglas referenciando su ID (ej: S2259, ARCH-04) en cada hallazgo.
+
 ## Lo que siempre verificas
 
-### Seguridad (.NET)
+### Seguridad (.NET) — ver reglas S2068, S6418, S2077, S5131, S2755, S5122
 - SQL injection en queries WIQL o ADO.NET directo (EF Core protege, pero verificar)
 - XSS: validar que las respuestas de API sanitizan HTML donde aplica
 - Secrets hardcodeados: buscar `connectionString`, `password`, `apikey`, `token` en código
@@ -31,20 +43,20 @@ constructivo: cada comentario incluye el problema, el impacto y la solución pro
 - Autorización: `[Authorize]` donde hace falta, no solo `[ApiController]`
 - Validación de inputs: nada llega sin validar a las capas de dominio
 
-### Calidad de código C#
-- async/await: detectar `.Result`, `.Wait()`, deadlocks potenciales
-- Disposables: `IDisposable` / `IAsyncDisposable` gestionados con `using`
-- Null safety: nullable reference types activados, sin `!` injustificados
-- EF Core: detectar N+1 queries, `ToList()` prematuro, falta de `AsNoTracking()`
-- Excepciones: `catch (Exception)` vacío, swallowing de errores
+### Calidad de código C# — ver reglas S3168, S2259, S2930, S3655, S4586, S2971
+- async/await: detectar `.Result`, `.Wait()`, deadlocks potenciales (ARCH-11)
+- Disposables: `IDisposable` / `IAsyncDisposable` gestionados con `using` (S2930, S2931)
+- Null safety: nullable reference types activados, sin `!` injustificados (S2259)
+- EF Core: detectar N+1 queries, `ToList()` prematuro, falta de `AsNoTracking()` (ARCH-09, ARCH-10)
+- Excepciones: `catch (Exception)` vacío, swallowing de errores (S112)
 - Logging: mensajes con nivel correcto, sin datos sensibles en logs
 
-### Principios SOLID
+### Principios SOLID y Arquitectura — ver reglas ARCH-01 a ARCH-12
 - SRP: ¿cada clase tiene una sola razón para cambiar?
 - OCP: ¿se extiende sin modificar código existente?
 - LSP: ¿los subtipos cumplen el contrato del tipo base?
 - ISP: ¿las interfaces son pequeñas y cohesivas?
-- DIP: ¿las capas altas dependen de abstracciones, no de implementaciones?
+- DIP: ¿las capas altas dependen de abstracciones, no de implementaciones? (ARCH-02, ARCH-04)
 
 ### Cumplimiento de Spec SDD
 - ¿El código implementa exactamente lo que dice la spec? ¿Ni más ni menos?

--- a/.claude/agents/dotnet-developer.md
+++ b/.claude/agents/dotnet-developer.md
@@ -13,7 +13,7 @@ tools:
   - Bash
   - Glob
   - Grep
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-4-6
 color: green
 maxTurns: 40
 ---

--- a/.claude/agents/sdd-spec-writer.md
+++ b/.claude/agents/sdd-spec-writer.md
@@ -13,7 +13,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 color: cyan
 maxTurns: 35
 ---

--- a/.claude/agents/security-guardian.md
+++ b/.claude/agents/security-guardian.md
@@ -11,7 +11,7 @@ tools:
   - Read
   - Glob
   - Grep
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 color: red
 maxTurns: 20
 ---

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -13,7 +13,7 @@ tools:
   - Bash
   - Glob
   - Grep
-model: claude-sonnet-4-5-20250929
+model: claude-sonnet-4-6
 color: yellow
 maxTurns: 35
 ---

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,266 @@
+---
+name: test-runner
+description: >
+  Ejecución de tests y verificación de cobertura post-commit. Usar PROACTIVELY cuando:
+  se completa un commit y hay que verificar que los tests del proyecto afectado pasan,
+  se necesita validar la cobertura de código contra el umbral mínimo (TEST_COVERAGE_MIN_PERCENT),
+  o se quiere ejecutar la suite completa de tests de un proyecto tras cambios significativos.
+  Si los tests fallan, delega la corrección a dotnet-developer. Si la cobertura es insuficiente,
+  orquesta a architect, business-analyst y dotnet-developer para diseñar y programar los tests
+  necesarios.
+tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Task
+model: claude-sonnet-4-6
+color: magenta
+maxTurns: 40
+---
+
+Eres el agente de ejecución de tests del workspace. Tu responsabilidad es ejecutar la suite
+completa de tests de los proyectos afectados por un commit, verificar que todos pasan y
+comprobar que la cobertura de código cumple el umbral mínimo configurado en las reglas generales.
+
+## Constante de referencia
+
+```
+TEST_COVERAGE_MIN_PERCENT = 80    # Definido en .claude/rules/pm-config.md
+```
+
+Lee siempre `.claude/rules/pm-config.md` para obtener el valor actualizado de `TEST_COVERAGE_MIN_PERCENT`.
+
+## Protocolo de ejecución
+
+### PASO 1 — Identificar el proyecto afectado
+
+Determinar qué proyecto(s) dentro de `projects/` están afectados por los cambios:
+
+```bash
+# Obtener los ficheros del último commit
+git diff --name-only HEAD~1 HEAD | grep "^projects/"
+```
+
+Si no se recibe contexto explícito del proyecto, usar los ficheros del último commit para
+identificar el directorio del proyecto afectado bajo `projects/`.
+
+Para cada proyecto afectado, leer su `CLAUDE.md` específico para entender la estructura.
+
+### PASO 2 — Localizar la solución .NET
+
+```bash
+# Buscar el fichero .sln o .slnx del proyecto
+find projects/[proyecto]/ -name "*.sln" -o -name "*.slnx" | head -5
+```
+
+### PASO 3 — Ejecutar todos los tests
+
+```bash
+# Ejecutar TODOS los tests (unitarios + integración)
+dotnet test [path-al-sln] --configuration Release --verbosity normal 2>&1
+```
+
+Interpretar el resultado:
+- ✅ **Todos los tests pasan** → continuar con PASO 4 (cobertura)
+- 🔴 **Tests fallidos** → ir a PASO 3b (delegación de corrección)
+
+### PASO 3b — Tests fallidos: delegar corrección
+
+Delegar al agente `dotnet-developer` usando la herramienta `Task`:
+
+```
+Agente: dotnet-developer
+Descripción: Corrección de tests fallidos tras commit
+Prompt: Los siguientes tests han fallado tras el último commit en el proyecto [proyecto]:
+
+[Lista completa de tests fallidos con mensajes de error]
+
+Ficheros modificados en el commit:
+[Lista de ficheros del commit]
+
+Corrige el código de producción o los tests según corresponda para que todos pasen.
+Ejecuta `dotnet test` para verificar antes de terminar.
+```
+
+Tras la corrección del agente:
+1. **Re-ejecutar TODOS los tests** (PASO 3 completo, no solo los fallidos)
+2. Si pasan → continuar con PASO 4
+3. Si siguen fallando tras **2 intentos** → escalar al humano con informe completo
+
+### PASO 4 — Verificar cobertura de código
+
+```bash
+# Instalar reportgenerator si no está disponible
+dotnet tool install -g dotnet-reportgenerator-globaltool 2>/dev/null || true
+
+# Ejecutar tests con recopilación de cobertura
+dotnet test [path-al-sln] \
+  --configuration Release \
+  --collect "XPlat Code Coverage" \
+  --results-directory ./output/test-results 2>&1
+
+# Generar informe de cobertura
+reportgenerator \
+  -reports:"./output/test-results/**/coverage.cobertura.xml" \
+  -targetdir:"./output/coverage-report" \
+  -reporttypes:"TextSummary" 2>&1
+
+# Leer el resumen
+cat ./output/coverage-report/Summary.txt
+```
+
+Interpretar el resultado:
+- ✅ **Cobertura ≥ TEST_COVERAGE_MIN_PERCENT** → informe de éxito
+- 🔴 **Cobertura < TEST_COVERAGE_MIN_PERCENT** → ir a PASO 5 (orquestación de mejora)
+
+### PASO 5 — Cobertura insuficiente: orquestar mejora
+
+Cuando la cobertura está por debajo del umbral, orquestar una cadena de agentes para
+diseñar, proponer y programar los tests necesarios.
+
+#### 5a — Análisis de cobertura (architect)
+
+Delegar al agente `architect` usando la herramienta `Task`:
+
+```
+Agente: architect
+Descripción: Análisis de gaps de cobertura
+Prompt: La cobertura de código del proyecto [proyecto] es del [X]%, por debajo del
+umbral mínimo del [TEST_COVERAGE_MIN_PERCENT]%.
+
+Informe de cobertura:
+[Resumen de cobertura por ensamblado/namespace]
+
+Analiza qué áreas del código tienen menor cobertura y propón qué clases/métodos
+necesitan tests prioritariamente para alcanzar el umbral. Prioriza por:
+1. Código de negocio crítico (Domain, Application) sobre infraestructura
+2. Métodos públicos sin cobertura
+3. Ramas condicionales no cubiertas
+
+Devuelve una lista priorizada de ficheros/clases que necesitan tests con justificación.
+```
+
+#### 5b — Análisis de casos de test (business-analyst)
+
+Delegar al agente `business-analyst` usando la herramienta `Task`:
+
+```
+Agente: business-analyst
+Descripción: Definición de casos de test para mejorar cobertura
+Prompt: El architect ha identificado estas áreas sin cobertura en [proyecto]:
+
+[Output del architect]
+
+Para cada clase/método identificado, define los casos de test necesarios:
+- Happy path
+- Boundary conditions
+- Error cases
+- Reglas de negocio aplicables (consultar projects/[proyecto]/reglas-negocio.md)
+
+Devuelve los casos de test en formato Given/When/Then con datos concretos.
+```
+
+#### 5c — Implementación de tests (dotnet-developer)
+
+Delegar al agente `dotnet-developer` usando la herramienta `Task`:
+
+```
+Agente: dotnet-developer
+Descripción: Implementación de tests para alcanzar cobertura mínima
+Prompt: Se necesitan tests adicionales en el proyecto [proyecto] para alcanzar
+el [TEST_COVERAGE_MIN_PERCENT]% de cobertura (actualmente [X]%).
+
+Análisis del architect:
+[Output del architect]
+
+Casos de test definidos por business-analyst:
+[Output del business-analyst]
+
+Implementa los tests usando xUnit + FluentAssertions siguiendo las convenciones del
+proyecto. Usa [Trait("Category", "Unit")] para tests unitarios.
+
+Tras implementar, ejecuta:
+1. dotnet build --configuration Release
+2. dotnet test --filter "Category=Unit"
+3. dotnet test --collect "XPlat Code Coverage"
+
+Verifica que la cobertura ahora supera el [TEST_COVERAGE_MIN_PERCENT]%.
+```
+
+#### 5d — Verificación final
+
+Tras la implementación de los nuevos tests:
+1. **Re-ejecutar PASO 3** (todos los tests deben pasar)
+2. **Re-ejecutar PASO 4** (cobertura debe superar el umbral)
+3. Si la cobertura sigue por debajo tras la primera iteración → repetir PASO 5 (máx 2 ciclos)
+4. Si tras 2 ciclos no se alcanza el umbral → escalar al humano con informe detallado
+
+---
+
+## Tabla de delegación
+
+| Problema detectado | Agente a llamar | Qué comunicarle |
+|---|---|---|
+| Tests unitarios fallan | `dotnet-developer` | Tests fallidos con error completo, ficheros del commit |
+| Tests de integración fallan | `dotnet-developer` | Tests fallidos con error completo, contexto de infraestructura |
+| Cobertura insuficiente (análisis) | `architect` | Informe de cobertura, umbral requerido, áreas con gaps |
+| Cobertura insuficiente (casos) | `business-analyst` | Análisis del architect, reglas de negocio aplicables |
+| Cobertura insuficiente (código) | `dotnet-developer` | Análisis de architect + casos de business-analyst |
+| Tests fallan 2+ veces | ❌ Humano | Informe completo de ambos intentos |
+| Cobertura no alcanzada en 2 ciclos | ❌ Humano | Informe de cobertura, tests creados, gaps restantes |
+
+---
+
+## Flujo de delegación
+
+Cuando delegas a un subagente, usa la herramienta `Task` con:
+1. El tipo de agente correcto
+2. Una descripción clara del problema encontrado
+3. Los ficheros afectados y el contexto del proyecto
+4. El output de los agentes anteriores en la cadena (si aplica)
+
+Tras la corrección del subagente, **vuelves a ejecutar la verificación completa** para confirmarlo.
+Si el subagente corrige y la verificación pasa → continúas con el resto del protocolo.
+Si tras dos intentos la verificación sigue fallando → escalar al humano.
+
+---
+
+## Formato del informe de ejecución
+
+```
+═══════════════════════════════════════════════════════════════════
+  TEST RUNNER — [proyecto] — [rama]
+═══════════════════════════════════════════════════════════════════
+
+  Proyecto .......................... [nombre del proyecto]
+  Solución .......................... [path al .sln]
+  Commit ............................ [hash corto] — [mensaje]
+
+  ── Tests ──────────────────────────────────────────────────────
+  Tests unitarios ................... ✅ XX/XX passed
+  Tests integración ................. ✅ XX/XX passed / ⏭️ no aplica
+  Total ............................. ✅ XX tests passed, 0 failed
+
+  ── Cobertura ──────────────────────────────────────────────────
+  Cobertura global .................. XX.X%
+  Umbral mínimo ..................... TEST_COVERAGE_MIN_PERCENT%
+  Estado ............................ ✅ CUMPLE / 🔴 NO CUMPLE (faltan X.X%)
+
+  ── Acciones tomadas ───────────────────────────────────────────
+  [Lista de delegaciones realizadas y sus resultados]
+
+  RESULTADO: ✅ APROBADO / 🔴 ESCALADO AL HUMANO (motivo)
+═══════════════════════════════════════════════════════════════════
+```
+
+---
+
+## Restricciones absolutas
+
+- **NUNCA** ignorar tests fallidos — todos deben pasar antes de verificar cobertura
+- **NUNCA** falsificar cobertura — siempre ejecutar con `--collect "XPlat Code Coverage"`
+- **NUNCA** reducir el umbral de cobertura — es configurable solo por el humano en `pm-config.md`
+- **NUNCA** borrar tests existentes para mejorar métricas
+- **Máximo 2 ciclos** de corrección automática antes de escalar al humano
+- Si un proyecto no tiene infraestructura de tests, notificar al humano y proponer crearla

--- a/.claude/commands/agent-run.md
+++ b/.claude/commands/agent-run.md
@@ -11,7 +11,7 @@ Lanza un agente Claude (o equipo) directamente sobre una Spec, con soporte para 
 - `--all-pending`: Lanzar agentes para todas las specs pendientes `agent:single` del sprint
 - `--team`: Usar patrón `agent:team` (default: `impl-test`)
 - `--pattern {name}`: Patrón específico: `single` | `impl-test` | `impl-test-review` | `full-stack` | `parallel-handlers`
-- `--model {model}`: Sobreescribir modelo (default: `claude-opus-4-5-20251101`)
+- `--model {model}`: Sobreescribir modelo (default: `claude-opus-4-6`)
 
 ## Este comando orquesta
 
@@ -24,7 +24,7 @@ Lanza un agente Claude (o equipo) directamente sobre una Spec, con soporte para 
 SPEC_FILE="{spec_file}"
 BASE="projects/{proyecto}"
 TASK_ID=$(grep "^\*\*Task ID:\*\*" $SPEC_FILE | grep -oE '[0-9]+')
-MODEL="${model:-claude-opus-4-5-20251101}"
+MODEL="${model:-claude-opus-4-6}"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 LOG_FILE="output/agent-runs/${TIMESTAMP}-AB${TASK_ID}-single.log"
 
@@ -85,7 +85,7 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 echo "🤖🤖 AGENT:TEAM (impl-test) — AB#${TASK_ID}"
 echo "   Patrón:         impl-test (Implementador + Tester en paralelo)"
-echo "   Modelo impl:    claude-opus-4-5-20251101"
+echo "   Modelo impl:    claude-opus-4-6"
 echo "   Modelo tester:  claude-haiku-4-5-20251001"
 echo ""
 echo "¿Lanzar equipo de agentes? (s/n)"
@@ -97,7 +97,7 @@ Tras confirmación:
 # Resumen:
 
 # Agente Implementador (background)
-claude --model claude-opus-4-5-20251101 \
+claude --model claude-opus-4-6 \
   --system-prompt "$(cat $BASE/CLAUDE.md). Tu rol: SOLO código de producción en src/. No escribas tests." \
   "$(cat $SPEC_FILE)" \
   2>&1 | tee "output/agent-runs/${TIMESTAMP}-AB${TASK_ID}-implementador.log" &
@@ -123,7 +123,7 @@ echo "⚠️  Ejecuta 'dotnet build && dotnet test' para verificar compatibilida
 Si `--pattern impl-test-review`:
 ```bash
 # Después del wait anterior, lanzar el Reviewer
-claude --model claude-opus-4-5-20251101 \
+claude --model claude-opus-4-6 \
   --system-prompt "Eres un Tech Lead .NET. Tu rol: SOLO revisar y reportar — NO modificar código." \
   "Revisa estos logs contra la Spec y reporta discrepancias.
    $(cat $SPEC_FILE)
@@ -169,7 +169,7 @@ for SPEC_FILE in "${PENDING_SPECS[@]}"; do
   TASK_ID=$(grep "^\*\*Task ID:\*\*" $SPEC_FILE | grep -oE '[0-9]+')
   LOG_FILE="output/agent-runs/${TIMESTAMP}-AB${TASK_ID}-single.log"
 
-  claude --model claude-opus-4-5-20251101 \
+  claude --model claude-opus-4-6 \
     --system-prompt "$(cat $BASE/CLAUDE.md)" \
     --max-turns 40 \
     "Implementa la siguiente Spec: $(cat $SPEC_FILE)" \
@@ -199,11 +199,13 @@ done
 
 ```bash
 # Configuración en CLAUDE.md del proyecto o usar defaults:
-CLAUDE_MODEL_AGENT="claude-opus-4-5-20251101"   # Para código de producción y lógica compleja
+CLAUDE_MODEL_AGENT="claude-opus-4-6"            # Para código de producción y lógica compleja
+CLAUDE_MODEL_MID="claude-sonnet-4-6"            # Para tareas medianas/balanceadas
 CLAUDE_MODEL_FAST="claude-haiku-4-5-20251001"   # Para tests, DTOs, validadores simples
 
 # Criterios de selección:
 # - Usar AGENT para: handlers, servicios con lógica, repositorios complejos
+# - Usar MID para: tareas medianas, refactoring, lógica moderada
 # - Usar FAST para: unit tests, DTOs/Records, validators simples, mappers
 ```
 

--- a/.claude/commands/spec-implement.md
+++ b/.claude/commands/spec-implement.md
@@ -80,7 +80,7 @@ LOG_FILE="output/agent-runs/${TIMESTAMP}-AB${TASK_ID}-single.log"
 
 # Mostrar plan antes de ejecutar
 echo "🤖 LANZAR AGENTE — AB#${TASK_ID}"
-echo "   Modelo:  claude-opus-4-5-20251101"
+echo "   Modelo:  claude-opus-4-6"
 echo "   Spec:    $SPEC_FILE"
 echo "   Log:     $LOG_FILE"
 echo "   Max turns: 40"
@@ -90,7 +90,7 @@ echo "¿Procedo a lanzar el agente? (s/n)"
 
 Tras confirmación:
 ```bash
-claude --model claude-opus-4-5-20251101 \
+claude --model claude-opus-4-6 \
   --system-prompt "$(cat $BASE/CLAUDE.md)" \
   --max-turns 40 \
   "Implementa la siguiente Spec exactamente como se describe.

--- a/.claude/rules/csharp-rules.md
+++ b/.claude/rules/csharp-rules.md
@@ -1,0 +1,1318 @@
+# Reglas de Análisis Estático C#/.NET — Knowledge Base para Agente de Revisión
+
+> Fuente: [SonarSource sonar-dotnet](https://github.com/SonarSource/sonar-dotnet) · [Reglas C#](https://rules.sonarsource.com/csharp/)
+> Última actualización: 2026-02-25
+
+---
+
+## Instrucciones para el Agente
+
+Eres un agente de revisión de código C#/.NET. Tu rol es analizar código fuente aplicando las reglas documentadas a continuación, equivalentes a un análisis de SonarQube.
+
+**Protocolo de reporte:**
+
+Para cada hallazgo reporta:
+
+- **ID de regla** (ej: S2259)
+- **Severidad** (Blocker / Critical / Major / Minor)
+- **Línea(s) afectada(s)**
+- **Descripción del problema**
+- **Sugerencia de corrección con código**
+
+**Priorización obligatoria:**
+
+1. Primero: **Vulnerabilities** y **Security Hotspots** — riesgo de seguridad
+2. Después: **Bugs** — comportamiento incorrecto en runtime
+3. Finalmente: **Code Smells** — mantenibilidad y deuda técnica
+
+**Directivas de contexto:**
+
+- Aplica las reglas **en contexto** — no reportes falsos positivos obvios
+- Si un patrón es intencional y está documentado (comentario explícito), no lo reportes
+- Considera el framework (.NET 8/10, ASP.NET Core, EF Core) al evaluar las reglas
+- Responde siempre en **español**
+
+---
+
+## 1. VULNERABILITIES — Seguridad
+
+> 🔴 Prioridad máxima. Cada hallazgo aquí es un riesgo de seguridad real.
+
+### 1.1 Blocker
+
+#### S2068 — Credenciales hardcodeadas
+
+**Severidad**: Blocker · **Tags**: cwe
+**Problema**: Contraseñas y credenciales embebidas en código fuente exponen accesos no autorizados.
+
+```csharp
+// ❌ Noncompliant
+string password = "Admin123";
+string url = "scheme://user:Admin123@domain.com";
+
+// ✅ Compliant
+string password = GetEncryptedPassword();
+string url = $"scheme://{username}:{GetSecret()}@domain.com";
+```
+
+**Impacto**: Cualquier persona con acceso al código fuente obtiene las credenciales.
+
+#### S2115 — Conexión a BD sin contraseña segura
+
+**Severidad**: Blocker · **Tags**: cwe
+**Problema**: Connection strings con password vacío permiten acceso sin autenticación.
+
+```csharp
+// ❌ Noncompliant
+optionsBuilder.UseSqlServer("Server=myServer;Database=myDB;User Id=admin;Password=");
+
+// ✅ Compliant
+optionsBuilder.UseSqlServer("Server=myServer;Database=myDB;Integrated Security=True");
+```
+
+**Impacto**: Acceso no autenticado a la base de datos.
+
+#### S2755 — Vulnerabilidad XXE en parseo XML
+
+**Severidad**: Blocker · **Tags**: cwe
+**Problema**: XML parsers con resolución de entidades externas habilitada permiten XXE.
+
+```csharp
+// ❌ Noncompliant
+XmlDocument parser = new XmlDocument();
+parser.XmlResolver = new XmlUrlResolver();
+parser.LoadXml(input);
+
+// ✅ Compliant
+XmlDocument parser = new XmlDocument();
+parser.XmlResolver = null;
+parser.LoadXml(input);
+```
+
+**Impacto**: Lectura de ficheros del servidor, SSRF, DoS.
+
+#### S6418 — Secretos hardcodeados
+
+**Severidad**: Blocker · **Tags**: cwe
+**Problema**: Tokens y secretos como constantes en código son extraíbles fácilmente.
+
+```csharp
+// ❌ Noncompliant
+const string mySecret = "47828a8dd77ee1eb9dde2d5e93cb221ce8c32b37";
+
+// ✅ Compliant
+static readonly string mySecret = Environment.GetEnvironmentVariable("MY_APP_SECRET");
+```
+
+**Impacto**: Exposición directa de tokens de autenticación.
+
+#### S6781 — Claves JWT expuestas
+
+**Severidad**: Blocker · **Tags**: cwe, symbolic-execution
+**Problema**: Claves JWT en configuración o hardcodeadas permiten falsificar tokens.
+
+```csharp
+// ❌ Noncompliant
+var key = _config["Jwt:Key"];
+var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+
+// ✅ Compliant
+var key = Environment.GetEnvironmentVariable("JWT_KEY")
+    ?? throw new ApplicationException("JWT key not configured.");
+var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+```
+
+**Impacto**: Suplantación de identidad mediante tokens forjados.
+
+### 1.2 Critical
+
+#### S2053 — Salt predecible en hashing de passwords
+
+**Severidad**: Critical · **Tags**: cwe, symbolic-execution
+**Problema**: Sales débiles o predecibles facilitan ataques con tablas precomputadas.
+
+```csharp
+// ❌ Noncompliant
+var salt = Encoding.UTF8.GetBytes("salty");
+var hashed = new Rfc2898DeriveBytes(password, salt);
+
+// ✅ Compliant
+var hashed = new Rfc2898DeriveBytes(password, 16, 100_000, HashAlgorithmName.SHA512);
+```
+
+#### S3329 — IV predecible en cifrado CBC
+
+**Severidad**: Critical · **Tags**: cwe, symbolic-execution
+**Problema**: Reutilizar el mismo IV permite detectar patrones en el texto cifrado.
+
+```csharp
+// ❌ Noncompliant
+byte[] iv = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+var encryptor = aes.CreateEncryptor(key, iv);
+
+// ✅ Compliant
+var encryptor = aes.CreateEncryptor(key, aes.IV);
+```
+
+#### S4423 — Protocolos SSL/TLS débiles
+
+**Severidad**: Critical · **Tags**: cwe, privacy
+**Problema**: TLS 1.0/1.1 y SSL 3.0 tienen vulnerabilidades criptográficas conocidas.
+
+```csharp
+// ❌ Noncompliant
+ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+
+// ✅ Compliant
+ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls13;
+```
+
+#### S4426 — Claves criptográficas débiles
+
+**Severidad**: Critical · **Tags**: cwe, privacy
+**Problema**: RSA < 2048 bits o ECC < 224 bits son vulnerables a fuerza bruta.
+
+```csharp
+// ❌ Noncompliant
+var rsa = new RSACryptoServiceProvider(); // Default: 1024 bits
+ECDsa ecdsa = ECDsa.Create(ECCurve.NamedCurves.brainpoolP160t1);
+
+// ✅ Compliant
+var rsa = new RSACryptoServiceProvider(2048);
+ECDsa ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+```
+
+#### S4433 — Conexión LDAP sin autenticación
+
+**Severidad**: Critical · **Tags**: cwe
+**Problema**: Conexiones LDAP anónimas permiten acceso no autorizado al directorio.
+
+```csharp
+// ❌ Noncompliant
+var entry = new DirectoryEntry(adPath);
+entry.AuthenticationType = AuthenticationTypes.None;
+
+// ✅ Compliant
+var entry = new DirectoryEntry(adPath, "user", "pass", AuthenticationTypes.Secure);
+```
+
+#### S4830 — Validación de certificados TLS desactivada
+
+**Severidad**: Critical · **Tags**: cwe, privacy, ssl
+**Problema**: Desactivar la validación de certificados permite ataques MITM.
+
+```csharp
+// ❌ Noncompliant
+ServicePointManager.ServerCertificateValidationCallback +=
+    (sender, cert, chain, errors) => true;
+
+// ✅ Compliant — usar validación por defecto o añadir CAs al trust store
+```
+
+#### S5344 — Hashing de passwords débil
+
+**Severidad**: Critical · **Tags**: cwe
+**Problema**: Algoritmos rápidos (MD5, SHA1) o pocas iteraciones en PBKDF2.
+
+```csharp
+// ❌ Noncompliant
+KeyDerivation.Pbkdf2(password, salt, KeyDerivationPrf.HMACSHA256, iterationCount: 1, numBytesRequested: 32);
+
+// ✅ Compliant
+KeyDerivation.Pbkdf2(password, salt, KeyDerivationPrf.HMACSHA256, iterationCount: 100_000, numBytesRequested: 32);
+```
+
+#### S5445 — Creación insegura de ficheros temporales
+
+**Severidad**: Critical · **Tags**: cwe
+**Problema**: `Path.GetTempFileName()` tiene race conditions explotables.
+
+```csharp
+// ❌ Noncompliant
+var tempPath = Path.GetTempFileName();
+
+// ✅ Compliant
+var randomPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+using var fs = new FileStream(randomPath, FileMode.CreateNew, FileAccess.Write,
+    FileShare.None, 4096, FileOptions.DeleteOnClose);
+```
+
+#### S5542 — Modo de cifrado débil
+
+**Severidad**: Critical · **Tags**: cwe, privacy
+**Problema**: ECB no oculta patrones; PKCS1v1.5 para RSA es vulnerable.
+
+```csharp
+// ❌ Noncompliant
+new AesManaged { Mode = CipherMode.ECB };
+
+// ✅ Compliant
+var aes = new AesGcm(key);
+```
+
+#### S5547 — Algoritmo criptográfico obsoleto
+
+**Severidad**: Critical · **Tags**: cwe, privacy
+**Problema**: DES, Triple DES, RC2 son insuficientes para protección moderna.
+
+```csharp
+// ❌ Noncompliant
+var cipher = new DESCryptoServiceProvider();
+
+// ✅ Compliant
+using var aes = Aes.Create();
+```
+
+#### S5659 — JWT sin verificar firma
+
+**Severidad**: Critical · **Tags**: cwe, privacy
+**Problema**: Tokens JWT sin verificación de firma permiten tokens forjados.
+
+```csharp
+// ❌ Noncompliant
+decoder.Decode(token, secret, verify: false);
+
+// ✅ Compliant
+decoder.Decode(token, secret, verify: true);
+```
+
+### 1.3 Major
+
+#### S5773 — Deserialización sin restricciones
+
+**Severidad**: Major · **Tags**: cwe, symbolic-execution
+**Problema**: Deserialización no restringida de datos no confiables permite RCE.
+
+```csharp
+// ❌ Noncompliant
+var formatter = new BinaryFormatter();
+formatter.Deserialize(stream);
+
+// ✅ Compliant
+var formatter = new BinaryFormatter();
+formatter.Binder = new AllowListBinder(); // Restricción de tipos
+formatter.Deserialize(stream);
+```
+
+**Impacto**: Ejecución remota de código.
+
+#### S6377 — Validación insegura de firmas XML
+
+**Severidad**: Major
+**Problema**: Validar firmas XML sin verificar la referencia permite manipulación.
+
+---
+
+## 2. SECURITY HOTSPOTS — Revisión manual necesaria
+
+> 🟡 Código potencialmente sensible que requiere evaluación contextual.
+
+### 2.1 Critical
+
+#### S2245 — PRNG no criptográfico usado en contexto de seguridad
+
+**Tags**: cwe
+**Problema**: `System.Random` es predecible; no usar para tokens o claves.
+
+```csharp
+// ❌ Sensitive
+var random = new Random();
+byte[] token = new byte[16];
+random.NextBytes(token);
+
+// ✅ Compliant
+var rng = RandomNumberGenerator.Create();
+byte[] token = new byte[16];
+rng.GetBytes(token);
+```
+
+#### S4502 — CSRF protection desactivada
+
+**Tags**: cwe
+**Problema**: Desactivar tokens anti-CSRF permite ataques cross-site.
+
+```csharp
+// ❌ Sensitive
+[HttpPost, IgnoreAntiforgeryToken]
+public IActionResult ChangeEmail(Model model) => View();
+
+// ✅ Compliant
+[HttpPost, AutoValidateAntiforgeryToken]
+public IActionResult ChangeEmail(Model model) => View();
+```
+
+#### S4790 — Algoritmos hash débiles
+
+**Tags**: cwe
+**Problema**: MD5 y SHA-1 pueden producir colisiones.
+
+```csharp
+// ❌ Sensitive
+var hash = new MD5CryptoServiceProvider();
+var hash2 = new SHA1Managed();
+
+// ✅ Compliant
+var hash = new SHA512Managed();
+```
+
+#### S5042 — Zip Bomb
+
+**Tags**: cwe
+**Problema**: Extraer archivos sin validar tamaño permite DoS.
+
+```csharp
+// ❌ Sensitive
+entry.ExtractToFile("output.txt", true); // Sin validar tamaño
+
+// ✅ Compliant — validar ratio de compresión, tamaño total y número de entradas
+```
+
+#### S5332 — Protocolos en texto claro
+
+**Tags**: cwe
+**Problema**: HTTP, FTP, Telnet exponen datos a interceptación.
+
+```csharp
+// ❌ Sensitive
+var url = "http://example.com";
+using var smtp = new SmtpClient("host", 25); // Sin SSL
+
+// ✅ Compliant
+var url = "https://example.com";
+using var smtp = new SmtpClient("host", 25) { EnableSsl = true };
+```
+
+#### S5443 — Ficheros temporales en directorios públicos
+
+**Tags**: cwe
+**Problema**: Nombres predecibles en /tmp permiten race conditions.
+
+```csharp
+// ❌ Sensitive
+using var writer = new StreamWriter("/tmp/f");
+
+// ✅ Compliant
+var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+```
+
+### 2.2 Major
+
+#### S2077 — SQL con string formatting
+
+**Tags**: cwe, sql
+**Problema**: Concatenar strings en queries SQL facilita SQL injection.
+
+```csharp
+// ❌ Sensitive
+string query = string.Format("INSERT INTO Users (name) VALUES (\"{0}\")", param);
+command = new SqlCommand(query);
+
+// ✅ Compliant
+context.Database.ExecuteSqlCommand("SELECT * FROM mytable WHERE col=@p0", param);
+```
+
+#### S5693 — Sin límite de tamaño en requests HTTP
+
+**Tags**: cwe
+**Problema**: Permitir requests ilimitados facilita DoS.
+
+```csharp
+// ❌ Sensitive
+[HttpPost, DisableRequestSizeLimit]
+public IActionResult Upload(Model model) { }
+
+// ✅ Compliant
+[HttpPost, RequestSizeLimit(8_388_608)] // 8 MB
+public IActionResult Upload(Model model) { }
+```
+
+#### S6444 — Regex sin timeout
+
+**Tags**: cwe, regex
+**Problema**: Regex sin timeout pueden causar ReDoS (catastrophic backtracking).
+
+```csharp
+// ❌ Sensitive
+var regex = new Regex("(a+)+");
+Regex.IsMatch(input, "[0-9]+");
+
+// ✅ Compliant
+var regex = new Regex("(a+)+", RegexOptions.None, TimeSpan.FromMilliseconds(100));
+Regex.IsMatch(input, "[0-9]+", RegexOptions.NonBacktracking); // .NET 7+
+```
+
+### 2.3 Minor
+
+#### S2092 — Cookie sin flag Secure
+
+**Tags**: cwe, privacy
+**Problema**: Cookies sin `Secure` se transmiten por HTTP sin cifrar.
+
+```csharp
+// ❌ Sensitive
+myCookie.Secure = false;
+
+// ✅ Compliant
+myCookie.Secure = true;
+```
+
+#### S3330 — Cookie sin flag HttpOnly
+
+**Tags**: cwe, privacy
+**Problema**: Cookies sin `HttpOnly` son accesibles desde JavaScript (XSS).
+
+```csharp
+// ❌ Sensitive
+myCookie.HttpOnly = false;
+
+// ✅ Compliant
+myCookie.HttpOnly = true;
+```
+
+#### S4507 — Debug habilitado en producción
+
+**Tags**: cwe, debug
+**Problema**: `UseDeveloperExceptionPage()` expone información sensible del sistema.
+
+```csharp
+// ❌ Sensitive
+app.UseDeveloperExceptionPage(); // Sin verificar entorno
+
+// ✅ Compliant
+if (env.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+```
+
+#### S5122 — CORS permisivo
+
+**Tags**: cwe
+**Problema**: `Access-Control-Allow-Origin: *` permite a cualquier sitio acceder a la API.
+
+```csharp
+// ❌ Sensitive
+builder.WithOrigins("*");
+builder.AllowAnyOrigin();
+Response.Headers.Add("Access-Control-Allow-Origin", origin); // Sin validar
+
+// ✅ Compliant
+builder.WithOrigins("https://trustedwebsite.com");
+if (trustedOrigins.Contains(origin))
+{
+    Response.Headers.Add("Access-Control-Allow-Origin", origin);
+}
+```
+
+---
+
+## 3. BUGS — Errores de runtime
+
+> 🔴 Código que causa comportamiento incorrecto en ejecución.
+
+### 3.1 Blocker
+
+#### S1048 — Excepción en Finalizer
+
+**Tags**: (ninguno)
+**Problema**: Lanzar excepciones en `~Destructor()` puede crashear la aplicación.
+
+```csharp
+// ❌ Noncompliant
+~MyClass()
+{
+    throw new NotImplementedException();
+}
+
+// ✅ Compliant
+~MyClass()
+{
+    // Cleanup sin excepciones
+}
+```
+
+#### S2190 — Recursión o bucle infinito
+
+**Tags**: suspicious
+**Problema**: Bucles sin condición de salida o recursión sin caso base causan StackOverflow.
+
+```csharp
+// ❌ Noncompliant
+while (true) { result += i; i++; }
+int Prop { get => Prop; } // Recursión infinita en getter
+
+// ✅ Compliant
+while (result < 1000) { result += i; i++; }
+```
+
+#### S2275 — Format string inválido
+
+**Tags**: (ninguno)
+**Problema**: Placeholders incorrectos o argumentos insuficientes causan `FormatException`.
+
+```csharp
+// ❌ Noncompliant
+string.Format("[0}", arg0);          // Bracket incorrecto
+string.Format("{0} {1}", arg0);      // Falta arg1
+
+// ✅ Compliant
+string.Format("{0} {1}", arg0, arg1);
+```
+
+#### S2930 — IDisposable no dispuesto
+
+**Tags**: cwe, denial-of-service
+**Problema**: Recursos no dispuestos causan memory leaks y file handle leaks.
+
+```csharp
+// ❌ Noncompliant
+var fs = new FileStream(path, FileMode.Open);
+fs.Write(bytes, 0, bytes.Length);
+// fs nunca se dispone
+
+// ✅ Compliant
+using var fs = new FileStream(path, FileMode.Open);
+fs.Write(bytes, 0, bytes.Length);
+```
+
+#### S2931 — Clase con campo IDisposable sin implementar IDisposable
+
+**Tags**: cwe, denial-of-service
+**Problema**: Campos IDisposable nunca se disponen si la clase no implementa el patrón.
+
+```csharp
+// ❌ Noncompliant
+public class ResourceHolder // No implementa IDisposable
+{
+    private FileStream fs;
+}
+
+// ✅ Compliant
+public class ResourceHolder : IDisposable
+{
+    private FileStream fs;
+    public void Dispose() => fs?.Dispose();
+}
+```
+
+### 3.2 Critical
+
+#### S2222 — Lock no liberado en todos los paths
+
+**Tags**: cwe, multi-threading, symbolic-execution
+**Problema**: Locks no liberados causan deadlocks.
+
+```csharp
+// ❌ Noncompliant
+Monitor.Enter(obj);
+if (condition) { Monitor.Exit(obj); }
+// Si !condition, lock nunca se libera
+
+// ✅ Compliant
+lock (obj) { /* ... */ }
+```
+
+#### S2551 — Lock en objetos compartidos
+
+**Tags**: multi-threading
+**Problema**: `lock(this)`, `lock(typeof(T))` o `lock("string")` causan deadlocks accidentales.
+
+```csharp
+// ❌ Noncompliant
+lock (this) { /* ... */ }
+
+// ✅ Compliant
+private readonly object _lock = new();
+lock (_lock) { /* ... */ }
+```
+
+#### S4586 — Método async que retorna null
+
+**Tags**: async-await
+**Problema**: Retornar null desde un método que devuelve Task causa NullReferenceException al await.
+
+```csharp
+// ❌ Noncompliant
+public Task DoAsync() => null;
+
+// ✅ Compliant
+public Task DoAsync() => Task.CompletedTask;
+```
+
+#### S5856 — Regex con sintaxis inválida
+
+**Tags**: regex
+**Problema**: Expresiones regulares malformadas lanzan excepción en runtime.
+
+```csharp
+// ❌ Noncompliant
+var regex = new Regex("[A");
+
+// ✅ Compliant
+var regex = new Regex("[A-Z]");
+```
+
+#### S7131 — Read/Write lock liberado incorrectamente
+
+**Tags**: symbolic-execution
+**Problema**: Liberar un write lock cuando se adquirió un read lock (y viceversa).
+
+#### S7133 — Lock liberado fuera del método de adquisición
+
+**Tags**: symbolic-execution
+**Problema**: Locks adquiridos en un método deben liberarse en el mismo método.
+
+### 3.3 Major (selección más relevante para .NET moderno)
+
+#### S2259 — Null pointer dereference
+
+**Tags**: cwe, symbolic-execution
+**Problema**: Acceder a una referencia null causa `NullReferenceException`.
+
+```csharp
+// ❌ Noncompliant
+object obj = null;
+Console.WriteLine(obj.ToString());
+
+// ✅ Compliant
+var obj = new object();
+Console.WriteLine(obj.ToString());
+```
+
+#### S3168 — Método async void
+
+**Tags**: multi-threading, async-await
+**Problema**: `async void` impide capturar excepciones y testear correctamente.
+
+```csharp
+// ❌ Noncompliant
+private async void ThrowExceptionAsync()
+{
+    throw new InvalidOperationException();
+}
+
+// ✅ Compliant
+private async Task ThrowExceptionAsync()
+{
+    throw new InvalidOperationException();
+}
+```
+
+#### S3655 — Acceso a Nullable sin verificar HasValue
+
+**Tags**: cwe, symbolic-execution
+**Problema**: Acceder a `.Value` sin verificar lanza `InvalidOperationException`.
+
+```csharp
+// ❌ Noncompliant
+int? val = condition ? 42 : null;
+Console.WriteLine(val.Value);
+
+// ✅ Compliant
+if (val.HasValue) { Console.WriteLine(val.Value); }
+```
+
+#### S3949 — Overflow en cálculos
+
+**Tags**: overflow, symbolic-execution
+**Problema**: Operaciones aritméticas que exceden el rango del tipo se truncan silenciosamente.
+
+```csharp
+// ❌ Noncompliant
+int number = int.MaxValue;
+return number + value;
+
+// ✅ Compliant
+long number = int.MaxValue;
+return number + value;
+```
+
+#### S2583 — Condición siempre true/false
+
+**Tags**: cwe, symbolic-execution
+**Problema**: Condiciones constantes generan código inalcanzable.
+
+```csharp
+// ❌ Noncompliant
+bool a = false;
+if (a) { DoSomething(); } // Nunca se ejecuta
+
+// ✅ Compliant
+bool a = EvaluateCondition();
+if (a) { DoSomething(); }
+```
+
+#### S1244 — Comparación de flotantes con ==
+
+**Tags**: (ninguno)
+**Problema**: La imprecisión de punto flotante hace que `==` sea poco fiable.
+
+```csharp
+// ❌ Noncompliant
+if (myNumber == 3.146f) { }
+
+// ✅ Compliant
+if (Math.Abs(myNumber - 3.146f) < 0.0001f) { }
+```
+
+#### S2201 — Retorno ignorado de método sin side effects
+
+**Tags**: suspicious
+**Problema**: Llamar a un método puro sin usar su resultado es código muerto.
+
+#### S2114 — Colección pasada como argumento a su propio método
+
+**Tags**: (ninguno)
+**Problema**: `list.AddRange(list)` o `list.Equals(list)` es un error o sinsentido.
+
+#### S3966 — Doble dispose
+
+**Tags**: (ninguno)
+**Problema**: Disponer un objeto dos veces puede causar `ObjectDisposedException`.
+
+#### S4143 — Elementos de colección reemplazados incondicionalmente
+
+**Tags**: suspicious
+**Problema**: Asignar al mismo key sin verificar sobrescribe datos silenciosamente.
+
+---
+
+## 4. CODE SMELLS — Mantenibilidad
+
+> 🟡 No causan bugs directos pero aumentan la deuda técnica.
+
+### 4.1 Critical
+
+#### S3776 — Complejidad cognitiva alta
+
+**Tags**: brain-overload
+**Problema**: Métodos con demasiada complejidad son difíciles de entender y testear.
+
+```csharp
+// ❌ Noncompliant — Complejidad cognitiva > 15
+decimal CalculatePrice(User user, Cart cart)
+{
+    decimal total = CalculateTotal(cart);
+    if (user.HasMembership()               // +1
+        && user.OrdersCount > 10           // +1
+        && user.AccountActive
+        && !user.HasDiscount
+        || user.OrdersCount == 1)          // +1
+    {
+        total = ApplyDiscount(user, total);
+    }
+    return total;
+}
+
+// ✅ Compliant — Extraer condiciones
+decimal CalculatePrice(User user, Cart cart)
+{
+    decimal total = CalculateTotal(cart);
+    if (IsEligibleForDiscount(user)) { total = ApplyDiscount(user, total); }
+    return total;
+}
+```
+
+#### S3216 — ConfigureAwait(false) en librerías
+
+**Tags**: multi-threading, async-await, performance
+**Problema**: Código de librería debe usar `ConfigureAwait(false)` para evitar deadlocks.
+
+```csharp
+// ❌ Noncompliant (en código de librería)
+var response = await httpClient.GetAsync(url);
+
+// ✅ Compliant
+var response = await httpClient.GetAsync(url).ConfigureAwait(false);
+```
+
+#### S5034 — ValueTask consumido incorrectamente
+
+**Tags**: async-await
+**Problema**: `ValueTask` no debe ser awaited múltiples veces ni usado concurrentemente.
+
+```csharp
+// ❌ Noncompliant
+ValueTask<int> vt = ComputeAsync();
+int r1 = await vt;
+int r2 = await vt; // Segundo await
+
+// ✅ Compliant
+int r1 = await ComputeAsync();
+int r2 = await ComputeAsync();
+```
+
+#### S2696 — Escritura a campo static desde método de instancia
+
+**Tags**: multi-threading
+**Problema**: Actualizar campos estáticos desde métodos de instancia causa race conditions.
+
+```csharp
+// ❌ Noncompliant
+class MyClass { private static int count = 0; public void Inc() { count++; } }
+
+// ✅ Compliant — usar Interlocked o método estático
+```
+
+#### S4487 — Campo privado escrito pero nunca leído
+
+**Tags**: cwe, unused
+**Problema**: Dead store — campo que se asigna pero jamás se lee.
+
+#### S927 — Nombres de parámetros inconsistentes con base
+
+**Tags**: suspicious
+**Problema**: Override que cambia nombres de parámetros confunde a los consumidores.
+
+### 4.2 Major (selección .NET moderno)
+
+#### S1854 — Asignaciones no usadas (dead stores)
+
+**Tags**: cwe, unused
+**Problema**: Variables asignadas cuyo valor nunca se lee son código muerto.
+
+```csharp
+// ❌ Noncompliant
+int x = 100;  // Dead store
+x = 150;      // Dead store
+x = 200;
+return x;
+
+// ✅ Compliant
+int x = 200;
+return x;
+```
+
+#### S1481 — Variable local no usada
+
+**Tags**: unused
+**Problema**: Variables declaradas pero nunca referenciadas añaden ruido.
+
+```csharp
+// ❌ Noncompliant
+public int Minutes(int hours) { int seconds = 0; return hours * 60; }
+
+// ✅ Compliant
+public int Minutes(int hours) { return hours * 60; }
+```
+
+#### S112 — Lanzar excepciones genéricas o reservadas
+
+**Tags**: cwe, error-handling
+**Problema**: `throw new Exception()` o `throw new NullReferenceException()` no es específico.
+
+```csharp
+// ❌ Noncompliant
+throw new NullReferenceException("obj");
+
+// ✅ Compliant
+throw new ArgumentNullException(nameof(obj));
+```
+
+#### S1144 — Miembros privados no usados
+
+**Tags**: unused
+**Problema**: Código muerto — métodos o clases privadas sin referencias.
+
+#### S1066 — Ifs anidados que pueden fusionarse
+
+**Tags**: clumsy
+**Problema**: Ifs anidados sin else pueden combinarse con `&&`.
+
+```csharp
+// ❌ Noncompliant
+if (file != null) { if (file.IsFile()) { /* ... */ } }
+
+// ✅ Compliant
+if (file != null && file.IsFile()) { /* ... */ }
+```
+
+#### S2971 — LINQ simplificable
+
+**Tags**: clumsy
+**Problema**: Expresiones LINQ con pasos redundantes reducen rendimiento y legibilidad.
+
+```csharp
+// ❌ Noncompliant
+seq.Select(x => x as Car).Any(x => x != null);
+seq.Where(x => x.HasOwner).Any();
+list.Count();       // Usa Count() en vez de .Count
+
+// ✅ Compliant
+seq.OfType<Car>().Any();
+seq.Any(x => x.HasOwner);
+list.Count;         // Propiedad directa
+```
+
+#### S2589 — Expresiones booleanas gratuitas
+
+**Tags**: cwe, suspicious, symbolic-execution
+**Problema**: Condiciones que siempre son true/false no aportan lógica.
+
+```csharp
+// ❌ Noncompliant
+var a = true;
+if (a) { DoSomething(); }     // Siempre true
+string d = null;
+var v = d ?? "value";          // d siempre null
+```
+
+#### S2933 — Campos que deberían ser readonly
+
+**Tags**: confusing
+**Problema**: Campos asignados solo en constructor deben ser `readonly`.
+
+```csharp
+// ❌ Noncompliant
+private int _birthYear;
+Person(int year) { _birthYear = year; }
+
+// ✅ Compliant
+private readonly int _birthYear;
+Person(int year) { _birthYear = year; }
+```
+
+#### S4144 — Métodos con implementación idéntica
+
+**Tags**: suspicious
+**Problema**: Métodos duplicados indican copy-paste; refactorizar.
+
+#### S2699 — Tests sin assertions
+
+**Tags**: tests
+**Problema**: Tests sin aserciones dan falsa sensación de cobertura.
+
+```csharp
+// ❌ Noncompliant
+[Fact]
+public void Add_SingleNumber()
+{
+    var calc = new StringCalculator();
+    var result = calc.Add("0"); // Sin assert
+}
+
+// ✅ Compliant
+[Fact]
+public void Add_SingleNumber()
+{
+    var calc = new StringCalculator();
+    var result = calc.Add("0");
+    result.Should().Be(0);
+}
+```
+
+#### S1118 — Utility class instanciable
+
+**Tags**: design
+**Problema**: Clases con solo miembros estáticos no deben poder instanciarse.
+
+```csharp
+// ❌ Noncompliant
+public class StringUtils { public static string Concat(string a, string b) => a + b; }
+
+// ✅ Compliant
+public static class StringUtils { public static string Concat(string a, string b) => a + b; }
+```
+
+#### S1168 — Retornar null en vez de colección vacía
+
+**Tags**: (ninguno)
+**Problema**: Retornar null fuerza al caller a verificar nulidad.
+
+```csharp
+// ❌ Noncompliant
+public Result[] GetResults() => null;
+
+// ✅ Compliant
+public Result[] GetResults() => Array.Empty<Result>();
+public IEnumerable<Result> GetResults() => Enumerable.Empty<Result>();
+```
+
+#### S125 — Código comentado
+
+**Tags**: unused
+**Problema**: Código comentado es ruido; está en el control de versiones si se necesita.
+
+#### S2139 — Excepciones logueadas Y relanzadas
+
+**Tags**: logging, error-handling
+**Problema**: Loguear y relanzar duplica trazas en los logs.
+
+#### S2925 — Thread.Sleep en tests
+
+**Tags**: tests, bad-practice
+**Problema**: `Thread.Sleep` hace tests lentos e intermitentes.
+
+#### S3169 — Múltiples OrderBy
+
+**Tags**: performance
+**Problema**: Cada `OrderBy()` reemplaza el anterior; usar `ThenBy()`.
+
+---
+
+## 5. REGLAS DE ARQUITECTURA — Clean Architecture / DDD
+
+> Complementan las reglas de SonarQube con buenas prácticas de arquitectura hexagonal y DDD.
+
+### 5.1 Separación de capas
+
+#### ARCH-01 — Domain no debe depender de Infrastructure
+
+**Severidad**: Blocker
+**Problema**: El dominio importa namespaces de infraestructura (EF Core, HttpClient, etc).
+
+```csharp
+// ❌ Noncompliant
+namespace MyApp.Domain.Entities;
+using Microsoft.EntityFrameworkCore; // Domain depende de Infrastructure
+
+// ✅ Compliant
+namespace MyApp.Domain.Entities;
+// Solo tipos propios del dominio, sin dependencias externas
+```
+
+**Verificación**: `grep -rn "using Microsoft.EntityFrameworkCore" src/Domain/`
+
+#### ARCH-02 — Application solo depende de Domain
+
+**Severidad**: Critical
+**Problema**: La capa Application importa implementaciones concretas de Infrastructure.
+
+```csharp
+// ❌ Noncompliant
+namespace MyApp.Application.Services;
+using MyApp.Infrastructure.Persistence; // Dependencia directa
+
+// ✅ Compliant
+namespace MyApp.Application.Services;
+using MyApp.Domain.Interfaces; // Solo interfaces
+```
+
+#### ARCH-03 — API/Controllers no deben contener lógica de negocio
+
+**Severidad**: Major
+**Problema**: Controllers con más de validación + orquestación indican lógica mal ubicada.
+
+```csharp
+// ❌ Noncompliant
+[HttpPost]
+public async Task<IActionResult> CreateOrder(OrderRequest req)
+{
+    // Lógica de negocio directamente en el controller
+    if (req.Items.Sum(i => i.Price) > 1000) { /* descuento */ }
+    var order = new Order { /* mapeo manual */ };
+    _context.Orders.Add(order);
+    await _context.SaveChangesAsync();
+    return Ok(order);
+}
+
+// ✅ Compliant
+[HttpPost]
+public async Task<IActionResult> CreateOrder(CreateOrderCommand command)
+{
+    var result = await _mediator.Send(command);
+    return result.Match(Ok, BadRequest);
+}
+```
+
+### 5.2 Inyección de dependencias
+
+#### ARCH-04 — No usar `new` para crear servicios en producción
+
+**Severidad**: Critical
+**Problema**: Instanciar servicios con `new` viola DIP y dificulta el testing.
+
+```csharp
+// ❌ Noncompliant
+public class OrderService
+{
+    private readonly EmailService _email = new EmailService(); // Acoplamiento directo
+}
+
+// ✅ Compliant
+public class OrderService
+{
+    private readonly IEmailService _email;
+    public OrderService(IEmailService email) { _email = email; }
+}
+```
+
+#### ARCH-05 — Interfaces en Domain, implementaciones en Infrastructure
+
+**Severidad**: Major
+**Problema**: Las interfaces de repositorio deben estar en Domain, las implementaciones en Infrastructure.
+
+```csharp
+// ❌ Noncompliant
+// src/Infrastructure/IOrderRepository.cs ← interfaz en infra
+
+// ✅ Compliant
+// src/Domain/Interfaces/IOrderRepository.cs ← interfaz en domain
+// src/Infrastructure/Persistence/OrderRepository.cs ← impl en infra
+```
+
+### 5.3 Value Objects e inmutabilidad
+
+#### ARCH-06 — Value Objects deben ser inmutables
+
+**Severidad**: Major
+**Problema**: Value Objects con setters públicos pierden sus garantías de igualdad por valor.
+
+```csharp
+// ❌ Noncompliant
+public class Money
+{
+    public decimal Amount { get; set; }  // Mutable
+    public string Currency { get; set; } // Mutable
+}
+
+// ✅ Compliant
+public record Money(decimal Amount, string Currency);
+// O con clase:
+public sealed class Money : ValueObject
+{
+    public decimal Amount { get; }
+    public string Currency { get; }
+    public Money(decimal amount, string currency) { Amount = amount; Currency = currency; }
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return Amount;
+        yield return Currency;
+    }
+}
+```
+
+#### ARCH-07 — Entities deben proteger sus invariantes
+
+**Severidad**: Major
+**Problema**: Entidades con setters públicos permiten estados inválidos.
+
+```csharp
+// ❌ Noncompliant
+public class Order
+{
+    public OrderStatus Status { get; set; }  // Cualquiera puede cambiar el estado
+    public List<OrderLine> Lines { get; set; } = new();
+}
+
+// ✅ Compliant
+public class Order
+{
+    public OrderStatus Status { get; private set; }
+    private readonly List<OrderLine> _lines = new();
+    public IReadOnlyList<OrderLine> Lines => _lines.AsReadOnly();
+
+    public void Cancel()
+    {
+        if (Status == OrderStatus.Shipped)
+            throw new DomainException("No se puede cancelar un pedido enviado.");
+        Status = OrderStatus.Cancelled;
+    }
+}
+```
+
+### 5.4 EF Core y persistencia
+
+#### ARCH-08 — DbContext no debe exponerse fuera de Infrastructure
+
+**Severidad**: Critical
+**Problema**: Inyectar `DbContext` directamente en Application/API acopla capas.
+
+```csharp
+// ❌ Noncompliant
+public class OrderService
+{
+    private readonly AppDbContext _context; // Application depende de EF Core
+}
+
+// ✅ Compliant
+public class OrderService
+{
+    private readonly IOrderRepository _orders; // Abstracción
+}
+```
+
+#### ARCH-09 — Queries deben usar AsNoTracking para lecturas
+
+**Severidad**: Minor
+**Problema**: Queries de solo lectura sin `AsNoTracking()` desperdician memoria en change tracking.
+
+```csharp
+// ❌ Noncompliant
+var orders = await _context.Orders.Where(o => o.Status == "Active").ToListAsync();
+
+// ✅ Compliant
+var orders = await _context.Orders
+    .AsNoTracking()
+    .Where(o => o.Status == "Active")
+    .ToListAsync();
+```
+
+#### ARCH-10 — No materializar queries prematuramente
+
+**Severidad**: Major
+**Problema**: `.ToList()` antes de filtrar ejecuta la query completa en memoria.
+
+```csharp
+// ❌ Noncompliant
+var result = _context.Orders.ToList().Where(o => o.Total > 100);
+// Trae TODOS los pedidos a memoria y luego filtra
+
+// ✅ Compliant
+var result = await _context.Orders.Where(o => o.Total > 100).ToListAsync();
+// Filtra en base de datos
+```
+
+### 5.5 async/await
+
+#### ARCH-11 — Cadena async completa, sin .Result ni .Wait()
+
+**Severidad**: Critical
+**Problema**: `.Result` y `.Wait()` causan deadlocks en ASP.NET Core.
+
+```csharp
+// ❌ Noncompliant
+public string GetData()
+{
+    var result = _httpClient.GetStringAsync(url).Result; // Deadlock potencial
+    return result;
+}
+
+// ✅ Compliant
+public async Task<string> GetDataAsync()
+{
+    var result = await _httpClient.GetStringAsync(url);
+    return result;
+}
+```
+
+#### ARCH-12 — CancellationToken en toda la cadena async
+
+**Severidad**: Major
+**Problema**: Métodos async de I/O sin `CancellationToken` no pueden cancelarse.
+
+```csharp
+// ❌ Noncompliant
+public async Task<Order> GetOrderAsync(Guid id)
+{
+    return await _context.Orders.FindAsync(id);
+}
+
+// ✅ Compliant
+public async Task<Order> GetOrderAsync(Guid id, CancellationToken ct = default)
+{
+    return await _context.Orders.FindAsync(new object[] { id }, ct);
+}
+```
+
+---
+
+## Referencia rápida de severidades
+
+| Severidad | Acción | Bloquea merge |
+|---|---|---|
+| **Blocker** | Corregir inmediatamente | ✅ Sí |
+| **Critical** | Corregir antes de merge | ✅ Sí |
+| **Major** | Corregir en el sprint actual | 🟡 Depende |
+| **Minor** | Backlog técnico | ❌ No |
+| **Info** | Informativo | ❌ No |

--- a/.claude/rules/pm-config.md
+++ b/.claude/rules/pm-config.md
@@ -54,13 +54,17 @@ WIP_LIMIT_PER_PERSON        = 2
 WIP_LIMIT_PER_COLUMN        = 5
 
 # ── Spec-Driven Development (SDD) ─────────────────────────────────────────────
-CLAUDE_MODEL_AGENT          = "claude-opus-4-5-20251101"          # modelo para agentes de implementación
+CLAUDE_MODEL_AGENT          = "claude-opus-4-6"                   # modelo para agentes de implementación
+CLAUDE_MODEL_MID            = "claude-sonnet-4-6"                 # modelo para tareas medianas/balanceadas
 CLAUDE_MODEL_FAST           = "claude-haiku-4-5-20251001"         # modelo para agentes de tests/scaffolding
 AGENT_LOGS_DIR              = "./output/agent-runs"
 SPECS_BASE_DIR              = "./projects"
 SPEC_EXTENSION              = ".spec.md"
 SDD_MAX_PARALLEL_AGENTS     = 5
 SDD_DEFAULT_MAX_TURNS       = 40
+
+# ── Testing y Calidad ───────────────────────────────────────────────────────
+TEST_COVERAGE_MIN_PERCENT   = 80                                    # % mínimo de cobertura exigido por test-runner
 ```
 
 ## 🔐 Autenticación

--- a/.claude/rules/readme-update.md
+++ b/.claude/rules/readme-update.md
@@ -13,15 +13,24 @@ Actualizar `README.md` (y `README.en.md` si existe) **antes del commit** cuando:
 - Se incorporan **nuevas buenas prácticas** o herramientas al flujo de trabajo
 - Cambia cualquier **prerequisito de instalación** (MCPs, extensiones, dependencias)
 
+## Alineación obligatoria entre idiomas
+
+Los README traducidos (`README.en.md`, etc.) **siempre deben estar alineados** con `README.md`:
+- Si se añade una sección en `README.md`, se añade también en todas las traducciones
+- Si se actualiza información (tablas, diagramas, ejemplos), se actualiza en todos los idiomas
+- Si una traducción no tiene una sección que sí existe en `README.md`, se añade traducida
+- Al actualizar cualquier README, **verificar y actualizar todas las versiones en otros idiomas**
+
 ## Qué secciones revisar
 
 Revisar en orden:
 1. **Tabla de comandos** — refleja exactamente los ficheros en `.claude/commands/`
 2. **Tabla de skills** — refleja exactamente los directorios en `.claude/skills/`
-3. **Estructura de directorios** — árbol actualizado con los directorios reales
-4. **Requisitos previos** — versiones de herramientas, extensiones VSCode, MCPs
-5. **Proyectos de ejemplo** — si se han añadido nuevas estructuras de ejemplo
-6. **Changelog** — actualizar también `CHANGELOG.md` si el cambio es significativo
+3. **Tabla de agentes** — refleja exactamente los ficheros en `.claude/agents/` con modelo y color
+4. **Estructura de directorios** — árbol actualizado con los directorios reales
+5. **Requisitos previos** — versiones de herramientas, extensiones VSCode, MCPs
+6. **Proyectos de ejemplo** — si se han añadido nuevas estructuras de ejemplo
+7. **Changelog** — actualizar también `CHANGELOG.md` si el cambio es significativo
 
 ## Criterio de calidad
 

--- a/.claude/skills/spec-driven-development/SKILL.md
+++ b/.claude/skills/spec-driven-development/SKILL.md
@@ -35,7 +35,8 @@ SPECS_DIR="projects/{proyecto}/specs"          # directorio de specs del proyect
 SPECS_SPRINT_DIR="$SPECS_DIR/{sprint}"         # specs del sprint actual
 SPEC_EXTENSION=".spec.md"                      # extensión de los ficheros de spec
 AGENT_LOGS_DIR="output/agent-runs"             # logs de ejecuciones de agentes
-CLAUDE_MODEL_AGENT="claude-opus-4-5-20251101"  # modelo para agentes (configurable por proyecto)
+CLAUDE_MODEL_AGENT="claude-opus-4-6"           # modelo para agentes (configurable por proyecto)
+CLAUDE_MODEL_MID="claude-sonnet-4-6"           # modelo para tareas medianas/balanceadas
 CLAUDE_MODEL_FAST="claude-haiku-4-5-20251001"  # modelo para tareas simples (tests, DTOs)
 ```
 

--- a/.claude/skills/spec-driven-development/references/agent-team-patterns.md
+++ b/.claude/skills/spec-driven-development/references/agent-team-patterns.md
@@ -33,7 +33,7 @@ BASE="projects/{proyecto}"
 SPEC_FILE="$BASE/specs/{sprint}/{spec_filename}.spec.md"
 LOG_FILE="output/agent-runs/$(date +%Y%m%d-%H%M%S)-{task_id}-single.log"
 
-claude --model claude-opus-4-5-20251101 \
+claude --model claude-opus-4-6 \
   --system-prompt "$(cat $BASE/CLAUDE.md)" \
   --max-turns 40 \
   "Implementa la siguiente Spec exactamente como se describe.
@@ -79,7 +79,7 @@ SPEC_FILE="$BASE/specs/{sprint}/{spec_filename}.spec.md"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 # Agente 1: Implementador — solo código de producción, sin tests
-claude --model claude-opus-4-5-20251101 \
+claude --model claude-opus-4-6 \
   --system-prompt "Eres un desarrollador .NET 8 senior especializado en Clean Architecture y CQRS.
 Tu único rol es implementar el código de PRODUCCIÓN de la Spec:
 - Ficheros en src/ (NO tests/)
@@ -155,7 +155,7 @@ wait $PID_IMPL $PID_TEST
 IMPL_LOG="output/agent-runs/${TIMESTAMP}-{task_id}-implementador.log"
 TEST_LOG="output/agent-runs/${TIMESTAMP}-{task_id}-tester.log"
 
-claude --model claude-opus-4-5-20251101 \
+claude --model claude-opus-4-6 \
   --system-prompt "Eres un Tech Lead .NET revisando código generado por agentes IA.
 Tu rol es SOLO revisar y reportar — NO modificar código.
 Busca específicamente:
@@ -240,7 +240,7 @@ for ROLE in "api" "application" "infrastructure" "tests"; do
       ;;
   esac
 
-  claude --model claude-opus-4-5-20251101 \
+  claude --model claude-opus-4-6 \
     --system-prompt "$SYSTEM_PROMPT. $ROLE_PROMPT" \
     "$(cat $SPEC_FILE)" \
     2>&1 | tee "output/agent-runs/${TIMESTAMP}-{task_id}-${ROLE}.log" &
@@ -281,7 +281,7 @@ for SPEC_FILE in $SPRINT_DIR/*.spec.md; do
   fi
 
   echo "🚀 Lanzando agente para: $SPEC_BASENAME"
-  claude --model claude-opus-4-5-20251101 \
+  claude --model claude-opus-4-6 \
     --system-prompt "$(cat $BASE/CLAUDE.md)" \
     --max-turns 30 \
     "Implementa esta Spec exactamente. No tomes decisiones fuera de la Spec.
@@ -369,7 +369,7 @@ cat "output/agent-runs/${TIMESTAMP}-${TASK_ID}-summary.md"
 | `full-stack` | 4 | 25-40 c/u | ~180K total | ~90K total | ~$1.80 |
 | `parallel-handlers` (5 specs) | 5 | 20-30 c/u | ~200K total | ~120K total | ~$2.50 |
 
-*Estimaciones con claude-opus-4-5-20251101 a $15/MTok input, $75/MTok output.
+*Estimaciones con claude-opus-4-6 a $15/MTok input, $75/MTok output.
 El patrón `tester` usa claude-haiku que es ~20x más barato.*
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `csharp-rules.md` — knowledge base con 70+ reglas de análisis estático C# equivalentes a SonarQube (Vulnerabilities, Security Hotspots, Bugs, Code Smells) + 12 reglas de arquitectura Clean Architecture/DDD (ARCH-01 a ARCH-12)
+- `security-guardian` añadido a la tabla de agentes en CLAUDE.md
+- `CLAUDE_MODEL_MID` — nueva constante para el tier intermedio (Sonnet)
+
+### Changed
+- Modelos actualizados a generación 4.6: Opus `claude-opus-4-6`, Sonnet `claude-sonnet-4-6` (Haiku 4.5 se mantiene)
+- `commit-guardian` ampliado de 8 a 9 checks — nuevo CHECK 6 (Code Review) con ciclo automático de corrección vía `code-reviewer` → `dotnet-developer` → re-review (máx 2 intentos)
+- `code-reviewer` ahora referencia `csharp-rules.md` y cita IDs de regla en cada hallazgo
+- Actualizados los 10 ficheros de agentes, configs, skills, commands, y project CLAUDE.md con nuevos model IDs
+
 ### Planned for v0.2.0
 - `backlog:capture` — create PBIs from unstructured input (emails, meeting notes, support tickets)
 - `risk:log` — structured risk register updated automatically on each `/sprint:status`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,11 @@ AZURE_DEVOPS_API_VERSION = "7.1"
 # Proyectos activos → ver pm-config.local.md (git-ignorado)
 
 SPRINT_DURATION_WEEKS   = 2                      # TEAM_HOURS_PER_DAY = 8 · TEAM_FOCUS_FACTOR = 0.75
-CLAUDE_MODEL_AGENT      = "claude-opus-4-5-20251101"
+CLAUDE_MODEL_AGENT      = "claude-opus-4-6"
+CLAUDE_MODEL_MID        = "claude-sonnet-4-6"
 CLAUDE_MODEL_FAST       = "claude-haiku-4-5-20251001"
 SDD_MAX_PARALLEL_AGENTS = 5                      # SDD_DEFAULT_MAX_TURNS = 40
+TEST_COVERAGE_MIN_PERCENT = 80                   # Umbral mínimo de cobertura para test-runner
 ```
 
 ---
@@ -83,18 +85,21 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 
 | Agente | Modelo | Especialidad |
 |---|---|---|
-| `architect` | Opus | Diseño de capas, interfaces, patrones |
-| `business-analyst` | Opus | Reglas de negocio, criterios de aceptación |
-| `sdd-spec-writer` | Opus | Specs ejecutables para agentes de código |
-| `code-reviewer` | Opus | Calidad, seguridad, SOLID |
-| `dotnet-developer` | Sonnet | Implementación C#/.NET |
-| `test-engineer` | Sonnet | xUnit, TestContainers, cobertura |
-| `tech-writer` | Haiku | README, CHANGELOG, XML docs |
-| `azure-devops-operator` | Haiku | WIQL, work items, sprint, capacity |
-| `commit-guardian` | Sonnet | Pre-commit checks: rama, secrets, build, tests, README |
+| `architect` | Opus 4.6 | Diseño de capas, interfaces, patrones |
+| `business-analyst` | Opus 4.6 | Reglas de negocio, criterios de aceptación |
+| `sdd-spec-writer` | Opus 4.6 | Specs ejecutables para agentes de código |
+| `code-reviewer` | Opus 4.6 | Calidad, seguridad, SOLID |
+| `security-guardian` | Opus 4.6 | Auditoría de seguridad y confidencialidad pre-commit |
+| `dotnet-developer` | Sonnet 4.6 | Implementación C#/.NET |
+| `test-engineer` | Sonnet 4.6 | xUnit, TestContainers, cobertura |
+| `test-runner` | Sonnet 4.6 | Ejecución de tests, cobertura ≥ TEST_COVERAGE_MIN_PERCENT, orquestación de mejora |
+| `commit-guardian` | Sonnet 4.6 | Pre-commit checks: rama, secrets, build, tests, code review, README |
+| `tech-writer` | Haiku 4.5 | README, CHANGELOG, XML docs |
+| `azure-devops-operator` | Haiku 4.5 | WIQL, work items, sprint, capacity |
 
 Flujo SDD: `business-analyst` → `architect` → `sdd-spec-writer` → `dotnet-developer` ‖ `test-engineer` → `code-reviewer`
-Antes de cualquier commit → `commit-guardian`
+Antes de cualquier commit → `commit-guardian` (incluye code review automático via `code-reviewer`)
+Tras commit → `test-runner` (tests completos + cobertura ≥ `TEST_COVERAGE_MIN_PERCENT`; si falla → `dotnet-developer`; si cobertura baja → `architect` + `business-analyst` + `dotnet-developer`)
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -687,7 +687,7 @@ The full matrix is in `.claude/skills/spec-driven-development/references/layer-a
 >
 > **Claude responds:**
 > ```
-> Launching claude-opus-4-5 agent on AB302-B3...
+> Launching claude-opus-4-6 agent on AB302-B3...
 > Live log: output/agent-runs/20260519-094512-AB302-B3-single.log
 >
 > [09:45:14] Agent started — reading spec and project context
@@ -787,8 +787,8 @@ Available patterns are documented in `references/agent-team-patterns.md`:
 > **Claude responds:**
 > ```
 > Selected pattern: impl-test (production code + tests in parallel)
->   Agent 1 — Implementer: claude-opus-4-5  (handler + service)
->   Agent 2 — Tester:      claude-haiku-4-5 (unit tests + mocks)
+>   Agent 1 — Implementer: claude-opus-4-6  (handler + service)
+>   Agent 2 — Tester:      claude-haiku-4-5-20251001 (unit tests + mocks)
 >
 > Estimated cost: ~$1.40 USD
 > Confirm launch?
@@ -803,8 +803,8 @@ Available patterns are documented in `references/agent-team-patterns.md`:
 > ```
 > Launching 2 agents in parallel...
 >
-> [Agent 1] 09:51:03 → Implementing SendCitaConfirmationCommandHandler...
-> [Agent 2] 09:51:04 → Generating unit tests for SendCitaConfirmationCommand...
+> [Agent 1 — opus] 09:51:03 → Implementing SendCitaConfirmationCommandHandler...
+> [Agent 2 — haiku] 09:51:04 → Generating unit tests for SendCitaConfirmationCommand...
 >
 > [Agent 1] 09:52:41 → Handler + EmailTemplateService complete. Build OK.
 > [Agent 2] 09:52:58 → 9 unit tests generated. Waiting for implementation to run.
@@ -843,7 +843,8 @@ For fixed-price projects, you can adjust: higher weight on expertise and availab
 ```yaml
 # In projects/{project}/CLAUDE.md
 sdd_config:
-  model_agent: "claude-opus-4-5-20251101"
+  model_agent: "claude-opus-4-6"
+  model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   token_budget_usd: 30          # Monthly token budget
   max_parallel_agents: 5
@@ -880,6 +881,9 @@ sdd_config:
 >   growth:       0.00   # ← zero: no learning-time risk
 >
 > sdd_config:
+>   model_agent: "claude-opus-4-6"
+>   model_mid:   "claude-sonnet-4-6"
+>   model_fast:  "claude-haiku-4-5-20251001"
 >   agentization_target: 0.40    # ← conservative goal: only 40% agentized
 >   require_tech_lead_approval: true  # ← Carlos reviews EVERY spec before launching agent
 >   cost_alert_per_spec_usd: 1.50     # ← alert if a spec exceeds $1.50
@@ -1055,6 +1059,89 @@ The files in `projects/sala-reservas/test-data/` simulate real Azure DevOps API 
 /spec:review {spec_file}          Review Spec quality or implementation
 /spec:status [--project]          Sprint Spec dashboard
 /agent:run {spec_file} [--team]   Launch Claude agent on a Spec
+```
+
+---
+
+## Specialized Agent Team
+
+The workspace includes 11 subagents that Claude can invoke in parallel or in sequence,
+each optimized for its task with the most suitable LLM model:
+
+| Agent | Model | Color | When to use |
+|---|---|---|---|
+| `architect` | Opus 4.6 | 🔵 blue | .NET architecture design, layer assignment, technical decisions |
+| `business-analyst` | Opus 4.6 | 🟣 purple | PBI analysis, business rules, acceptance criteria |
+| `sdd-spec-writer` | Opus 4.6 | 🩵 cyan | Generation and validation of executable SDD Specs |
+| `code-reviewer` | Opus 4.6 | 🔴 red | Quality gate: security, SOLID, SonarQube rules (`csharp-rules.md`) |
+| `security-guardian` | Opus 4.6 | 🔴 red | Security and confidentiality audit before commit |
+| `dotnet-developer` | Sonnet 4.6 | 🟢 green | C#/.NET implementation following approved SDD specs |
+| `test-engineer` | Sonnet 4.6 | 🟡 yellow | xUnit/NUnit tests, TestContainers, coverage |
+| `test-runner` | Sonnet 4.6 | 🟣 magenta | Post-commit: test execution, coverage ≥ `TEST_COVERAGE_MIN_PERCENT`, improvement orchestration |
+| `commit-guardian` | Sonnet 4.6 | 🟠 orange | Pre-commit: branch, security, build, tests, code review, README |
+| `tech-writer` | Haiku 4.5 | ⚪ white | README, CHANGELOG, C# XML comments, project docs |
+| `azure-devops-operator` | Haiku 4.5 | ⬜ bright white | WIQL queries, create/update work items, sprint management |
+
+### SDD flow with parallel agents
+
+```
+User: /pbi:plan-sprint --project Alpha
+
+  ┌─ business-analyst (Opus) ─────────────────┐
+  │  Analyze candidate PBIs                   │   IN PARALLEL
+  │  Verify business rules                    │
+  └───────────────────────────────────────────┘
+  ┌─ azure-devops-operator (Haiku) ───────────┐
+  │  Get active sprint + capacities           │   IN PARALLEL
+  └───────────────────────────────────────────┘
+           ↓ (combined results)
+  ┌─ architect (Opus) ────────────────────────┐
+  │  Assign layers to each task               │
+  │  Detect technical dependencies            │
+  └───────────────────────────────────────────┘
+           ↓
+  ┌─ sdd-spec-writer (Opus) ──────────────────┐
+  │  Generate specs for agent tasks           │
+  └───────────────────────────────────────────┘
+           ↓
+  ┌─ dotnet-developer (Sonnet) ───┐  ┌─ test-engineer (Sonnet) ─┐
+  │  Implement tasks B, C, D      │  │  Write tests for E, F     │   IN PARALLEL
+  └───────────────────────────────┘  └──────────────────────────┘
+           ↓
+  ┌─ commit-guardian (Sonnet) ────────────────┐
+  │  9 checks: branch → security-guardian →   │
+  │  build → tests → format → code-reviewer   │
+  │  → README → CLAUDE.md → commit message    │
+  │                                           │
+  │  If code-reviewer REJECTS:                │
+  │    → dotnet-developer fixes               │
+  │    → re-build → re-review (max 2x)       │
+  │  If all ✅ → git commit                   │
+  └───────────────────────────────────────────┘
+           ↓
+  ┌─ test-runner (Sonnet) ──────────────────┐
+  │  Run ALL tests in the project            │
+  │  affected by the commit                  │
+  │                                          │
+  │  If tests fail:                          │
+  │    → dotnet-developer fixes (max 2x)     │
+  │  If tests pass → verify coverage         │
+  │    ≥ TEST_COVERAGE_MIN_PERCENT → ✅     │
+  │    < TEST_COVERAGE_MIN_PERCENT →         │
+  │      architect (gap analysis) →          │
+  │      business-analyst (test cases) →     │
+  │      dotnet-developer (implements)       │
+  └─────────────────────────────────────────┘
+```
+
+### How to invoke agents
+
+```
+# Explicitly
+"Use the architect agent to analyze if this feature fits the Application layer"
+"Use business-analyst and architect in parallel to analyze PBI #1234"
+
+# The correct agent is invoked automatically based on the task description
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ La matrix completa está en `.claude/skills/spec-driven-development/references/l
 >
 > **Claude responde:**
 > ```
-> Lanzando agente claude-opus-4-5 sobre AB302-B3...
+> Lanzando agente claude-opus-4-6 sobre AB302-B3...
 > Log en tiempo real: output/agent-runs/20260519-094512-AB302-B3-single.log
 >
 > [09:45:14] Agente iniciado — leyendo spec y contexto del proyecto
@@ -767,7 +767,7 @@ La matrix completa está en `.claude/skills/spec-driven-development/references/l
 > ✅ AB#302-B3 actualizada en Azure DevOps:
 >    Estado: In Review
 >    Tags añadidos: spec-driven; agent-implemented
->    Comentario: "Implementado por claude-opus-4-5. Build OK, 6/6 tests. Pendiente Code Review."
+>    Comentario: "Implementado por claude-opus-4-6. Build OK, 6/6 tests. Pendiente Code Review."
 > ```
 
 ---
@@ -842,8 +842,8 @@ Los patrones disponibles están documentados en `references/agent-team-patterns.
 > **Claude responde:**
 > ```
 > Patrón seleccionado: impl-test (código producción + tests en paralelo)
->   Agente 1 — Implementador: claude-opus-4-5  (handler + service)
->   Agente 2 — Tester:        claude-haiku-4-5 (unit tests + mocks)
+>   Agente 1 — Implementador: claude-opus-4-6  (handler + service)
+>   Agente 2 — Tester:        claude-haiku-4-5-20251001 (unit tests + mocks)
 >
 > Coste estimado: ~$1.40 USD
 > ¿Confirmas el lanzamiento?
@@ -858,8 +858,8 @@ Los patrones disponibles están documentados en `references/agent-team-patterns.
 > ```
 > Lanzando 2 agentes en paralelo...
 >
-> [Agente 1] 09:51:03 → Implementando SendCitaConfirmationCommandHandler...
-> [Agente 2] 09:51:04 → Generando unit tests para SendCitaConfirmationCommand...
+> [Agente 1 — opus] 09:51:03 → Implementando SendCitaConfirmationCommandHandler...
+> [Agente 2 — haiku] 09:51:04 → Generando unit tests para SendCitaConfirmationCommand...
 >
 > [Agente 1] 09:52:41 → Handler + EmailTemplateService completos. Build OK.
 > [Agente 2] 09:52:58 → 9 unit tests generados. Esperando implementación para ejecutar.
@@ -898,7 +898,8 @@ En proyectos de precio fijo, se puede ajustar: más peso en expertise y disponib
 ```yaml
 # En projects/{proyecto}/CLAUDE.md
 sdd_config:
-  model_agent: "claude-opus-4-5-20251101"
+  model_agent: "claude-opus-4-6"
+  model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   token_budget_usd: 30          # Presupuesto mensual en tokens
   max_parallel_agents: 5
@@ -935,6 +936,9 @@ sdd_config:
 >   growth:       0.00   # ← baja a 0: no arriesgar horas de aprendizaje
 >
 > sdd_config:
+>   model_agent: "claude-opus-4-6"
+>   model_mid:   "claude-sonnet-4-6"
+>   model_fast:  "claude-haiku-4-5-20251001"
 >   agentization_target: 0.40    # ← meta conservadora: solo 40% agentizado
 >   require_tech_lead_approval: true  # ← Carlos revisa CADA spec antes de lanzar agente
 >   cost_alert_per_spec_usd: 1.50     # ← alerta si una spec supera $1.50
@@ -1130,20 +1134,22 @@ Los ficheros en `projects/sala-reservas/test-data/` simulan respuestas reales de
 
 ## Equipo de Subagentes Especializados
 
-El workspace incluye 8 subagentes que Claude puede invocar en paralelo o en secuencia,
+El workspace incluye 11 subagentes que Claude puede invocar en paralelo o en secuencia,
 cada uno optimizado para su tarea con el modelo LLM más adecuado:
 
 | Agente | Modelo | Color | Cuándo se usa |
 |---|---|---|---|
-| `architect` | Opus | 🔵 azul | Diseño de arquitectura .NET, asignación de capas, decisiones técnicas |
-| `business-analyst` | Opus | 🟣 morado | Análisis de PBIs, reglas de negocio, criterios de aceptación |
-| `sdd-spec-writer` | Opus | 🩵 cyan | Generación y validación de Specs SDD ejecutables |
-| `code-reviewer` | Opus | 🔴 rojo | Quality gate: seguridad, SOLID, cumplimiento de spec |
-| `dotnet-developer` | Sonnet | 🟢 verde | Implementación C#/.NET siguiendo specs SDD aprobadas |
-| `test-engineer` | Sonnet | 🟡 amarillo | Tests xUnit/NUnit, TestContainers, cobertura |
-| `tech-writer` | Haiku | ⚪ blanco | README, CHANGELOG, comentarios XML C#, docs de proyecto |
-| `azure-devops-operator` | Haiku | ⬜ blanco brillante | Consultas WIQL, crear/actualizar work items, gestión de sprint |
-| `commit-guardian` | Sonnet | 🟠 naranja | Pre-commit: rama, secrets, build, tests, README, formato de mensaje |
+| `architect` | Opus 4.6 | 🔵 azul | Diseño de arquitectura .NET, asignación de capas, decisiones técnicas |
+| `business-analyst` | Opus 4.6 | 🟣 morado | Análisis de PBIs, reglas de negocio, criterios de aceptación |
+| `sdd-spec-writer` | Opus 4.6 | 🩵 cyan | Generación y validación de Specs SDD ejecutables |
+| `code-reviewer` | Opus 4.6 | 🔴 rojo | Quality gate: seguridad, SOLID, reglas SonarQube (`csharp-rules.md`) |
+| `security-guardian` | Opus 4.6 | 🔴 rojo | Auditoría de seguridad y confidencialidad pre-commit |
+| `dotnet-developer` | Sonnet 4.6 | 🟢 verde | Implementación C#/.NET siguiendo specs SDD aprobadas |
+| `test-engineer` | Sonnet 4.6 | 🟡 amarillo | Tests xUnit/NUnit, TestContainers, cobertura |
+| `test-runner` | Sonnet 4.6 | 🟣 magenta | Post-commit: ejecución de tests, cobertura ≥ `TEST_COVERAGE_MIN_PERCENT`, orquestación de mejora |
+| `commit-guardian` | Sonnet 4.6 | 🟠 naranja | Pre-commit: rama, security, build, tests, code review, README |
+| `tech-writer` | Haiku 4.5 | ⚪ blanco | README, CHANGELOG, comentarios XML C#, docs de proyecto |
+| `azure-devops-operator` | Haiku 4.5 | ⬜ blanco brillante | Consultas WIQL, crear/actualizar work items, gestión de sprint |
 
 ### Flujo SDD con agentes en paralelo
 
@@ -1171,18 +1177,30 @@ Usuario: /pbi:plan-sprint --project Alpha
   │  Implementa tasks B, C, D     │  │  Escribe tests para E, F  │   EN PARALELO
   └───────────────────────────────┘  └──────────────────────────┘
            ↓
-  ┌─ code-reviewer (Opus) ────────────────────┐
-  │  Quality gate antes de commit             │
-  └───────────────────────────────────────────┘
-           ↓
-  ┌─ tech-writer (Haiku) ─────────────────────┐
-  │  Actualiza README + docs del sprint       │
-  └───────────────────────────────────────────┘
-           ↓
   ┌─ commit-guardian (Sonnet) ────────────────┐
-  │  Verifica reglas → hace el commit         │
-  │  Si algo falla → delega corrección        │
-  └───────────────────────────────────────────┘
+  │  9 checks: rama → security-guardian →    │
+  │  build → tests → format → code-reviewer  │
+  │  → README → CLAUDE.md → commit message   │
+  │                                          │
+  │  Si code-reviewer RECHAZA:               │
+  │    → dotnet-developer corrige            │
+  │    → re-build → re-review (máx 2x)      │
+  │  Si todo ✅ → git commit                 │
+  └──────────────────────────────────────────┘
+           ↓
+  ┌─ test-runner (Sonnet) ──────────────────┐
+  │  Ejecuta TODOS los tests del proyecto   │
+  │  afectado por el commit                 │
+  │                                         │
+  │  Si tests fallan:                       │
+  │    → dotnet-developer corrige (máx 2x)  │
+  │  Si tests pasan → verifica cobertura    │
+  │    ≥ TEST_COVERAGE_MIN_PERCENT → ✅     │
+  │    < TEST_COVERAGE_MIN_PERCENT →        │
+  │      architect (análisis gaps) →        │
+  │      business-analyst (casos test) →    │
+  │      dotnet-developer (implementa)      │
+  └─────────────────────────────────────────┘
 ```
 
 ### Cómo invocar agentes

--- a/projects/proyecto-alpha/CLAUDE.md
+++ b/projects/proyecto-alpha/CLAUDE.md
@@ -180,8 +180,9 @@ tech_lead_alias: "juan.garcia@empresa.com"
 ```yaml
 sdd_config:
   # Modelo de agentes para este proyecto
-  model_agent: "claude-opus-4-5-20251101"   # Para código de producción complejo
-  model_fast: "claude-haiku-4-5-20251001"   # Para tests, DTOs, validators
+  model_agent: "claude-opus-4-6"            # Para código de producción complejo
+  model_mid:   "claude-sonnet-4-6"          # Para tareas medianas y balanceadas
+  model_fast:  "claude-haiku-4-5-20251001"  # Para tests, DTOs, validators
 
   # Directorio de specs de este proyecto
   specs_dir: "projects/proyecto-alpha/specs"

--- a/projects/proyecto-alpha/equipo.md
+++ b/projects/proyecto-alpha/equipo.md
@@ -141,7 +141,7 @@ Tabla de capacity estimada por persona para los próximos sprints:
 ### claude-agent-opus — Implementador Principal
 ```
 ID (Azure DevOps tag):  dev:agent
-Modelo:                 claude-opus-4-5-20251101
+Modelo:                 claude-opus-4-6
 Rol:                    Developer virtual — código de producción complejo
 Capacidad efectiva:     Ilimitada (paralelo), limitada por presupuesto de tokens
 Coste estimado:         ~$0.60-1.20 por spec implementada

--- a/projects/proyecto-beta/CLAUDE.md
+++ b/projects/proyecto-beta/CLAUDE.md
@@ -167,8 +167,9 @@ budget_alert: true
 ```yaml
 sdd_config:
   # Modelos
-  model_agent: "claude-opus-4-5-20251101"
-  model_fast: "claude-haiku-4-5-20251001"
+  model_agent: "claude-opus-4-6"
+  model_mid:   "claude-sonnet-4-6"
+  model_fast:  "claude-haiku-4-5-20251001"
 
   # Directorio de specs
   specs_dir: "projects/proyecto-beta/specs"

--- a/projects/proyecto-beta/equipo.md
+++ b/projects/proyecto-beta/equipo.md
@@ -58,7 +58,7 @@ Carlos Sánchez:  Sin vacaciones planificadas en Q1
 ### claude-agent-opus — Implementador Principal
 ```
 ID (Azure DevOps tag):  dev:agent
-Modelo:                 claude-opus-4-5-20251101
+Modelo:                 claude-opus-4-6
 Rol:                    Developer virtual — código de producción
 Coste estimado:         ~$0.60-1.20 por spec
 ```

--- a/projects/sala-reservas/CLAUDE.md
+++ b/projects/sala-reservas/CLAUDE.md
@@ -178,7 +178,8 @@ tech_lead_alias: "carlos.mendoza@empresa.com"
 
 ```yaml
 sdd_config:
-  model_agent: "claude-opus-4-5-20251101"
+  model_agent: "claude-opus-4-6"
+  model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   specs_dir: "projects/sala-reservas/specs"
   agentization_target: 0.65    # 65% de tasks técnicas por agente

--- a/projects/sala-reservas/equipo.md
+++ b/projects/sala-reservas/equipo.md
@@ -127,7 +127,7 @@ Ana:     Sin ausencias
 ### claude-agent-opus — Implementador
 ```
 ID (Azure DevOps tag):  dev:agent
-Modelo:                 claude-opus-4-5-20251101
+Modelo:                 claude-opus-4-6
 Rol:                    Application Layer + Infrastructure (cuando hay patrón de referencia)
 Coste estimado:         ~$0.60-1.20 por spec
 ```


### PR DESCRIPTION
…to 4.6

- Add test-runner agent: post-commit test execution with coverage verification (TEST_COVERAGE_MIN_PERCENT = 80%), orchestrates architect + business-analyst + dotnet-developer when coverage is below threshold
- Add csharp-rules.md: SonarQube-equivalent static analysis rules for code-reviewer
- Upgrade all agent models from claude-*-4-5 to claude-*-4-6
- Enhance code-reviewer with knowledge base references (rule IDs)
- Update commit-guardian with security-guardian delegation improvements
- Update README.md and README.en.md with new agent table (11 agents) and flow diagram
- Update CLAUDE.md with TEST_COVERAGE_MIN_PERCENT constant and test-runner in workflow
- Update pm-config.md with Testing y Calidad section
- Align example projects (alpha, beta, sala-reservas) with current conventions

## What does this PR add or fix?

<!-- 2-3 sentence summary -->

## Type of contribution

- [ ] New slash command
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Test suite addition
- [ ] Refactor (no behaviour change)
- [ ] Other: ___

## Files added / modified

<!-- List the key files and what each one does -->
- `.claude/commands/` —
- `.claude/skills/` —
- `scripts/` —
- `docs/` —

## How to test this

<!-- Step-by-step instructions for the reviewer to verify the change works -->

1.
2.
3.

## Test suite

- [ ] `./scripts/test-workspace.sh --mock` passes ≥ 93/96
- [ ] I added tests for new files (if applicable)

## Checklist

- [ ] Command/skill name follows existing conventions (`namespace:action`, kebab-case)
- [ ] I tested this in a real Claude Code conversation at least once
- [ ] No real PATs, org URLs, project names, or client data included
- [ ] Documentation in the file is sufficient for a PM to understand it without reading this PR
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (for features and fixes)

## Related issues

Closes #
