### PR TITLE
feat(commands): absorb 7 resources from awesome-claude-code

### DIFF
--- a/.claude/agents/commit-guardian.md
+++ b/.claude/agents/commit-guardian.md
@@ -131,7 +131,33 @@ wc -l CLAUDE.md
 - 🟡 Avisar si está entre 130-150 líneas (margen reducido)
 - 🔴 > 150 líneas → delegar a `tech-writer` para comprimir
 
-### CHECK 9 — Mensaje de commit (Conventional Commits)
+### CHECK 9 — Atomicidad del commit (github-flow.md)
+
+Verificar que los cambios staged son un **solo cambio lógico** que puede revertirse
+de forma independiente (regla: "Cada commit = un cambio aislado y completo").
+
+```bash
+git diff --cached --stat
+git diff --cached --name-only | sed 's|/.*||' | sort -u
+```
+
+Señales de que el commit debería dividirse:
+- Cambios en **más de 3 directorios raíz** no relacionados (ej: `agents/` + `docs/` + `scripts/` sin relación)
+- Mezcla de **tipos de cambio dispares** (ej: nuevo agente + fix de config + docs de otra cosa)
+- Más de **300 líneas** de diff total (umbral orientativo, no absoluto)
+- Ficheros que pertenecen a **propósitos claramente diferentes**
+
+Excepciones válidas (NO dividir):
+- Un nuevo comando/skill + su entrada en README + su entrada en pm-workflow.md (es un solo cambio)
+- Un fix + su test (van juntos)
+- Un refactor que toca múltiples ficheros del mismo módulo
+
+Si se detecta que debería dividirse:
+- 🟡 Sugerir al humano cómo dividir (listar qué ficheros van en cada commit)
+- Esperar confirmación antes de proceder
+- Si el humano confirma que es un solo cambio lógico → continuar con CHECK 10
+
+### CHECK 10 — Mensaje de commit (Conventional Commits)
 Recibir el mensaje propuesto y verificar formato:
 - Formato: `tipo(scope): descripción` donde tipo ∈ {feat, fix, docs, refactor, chore, test, ci}
 - Descripción en inglés o español, ≤ 72 caracteres en la primera línea
@@ -153,6 +179,7 @@ Recibir el mensaje propuesto y verificar formato:
 | Code review (siempre si hay .cs) | `code-reviewer` | Revisar staged aplicando `.claude/rules/csharp-rules.md` |
 | README no actualizado | `tech-writer` | Lista de ficheros cambiados que requieren docs update |
 | CLAUDE.md > 150 líneas | `tech-writer` | Pedir compresión priorizando @imports |
+| Commit no atómico | ❌ Humano | Sugerir división con ficheros por commit — el humano decide |
 | Secrets/datos privados detectados | ❌ Humano | NUNCA delegar — escalar siempre al humano con informe security-guardian |
 | Code review rechazado 2 veces | ❌ Humano | Escalar con informe completo de ambos intentos |
 | Commit en main | ❌ Humano | NUNCA delegar a agente — escalar siempre al humano |
@@ -192,7 +219,8 @@ Antes de hacer el commit (o de bloquearlo), genera siempre este resumen:
              (delegado a code-reviewer: reglas csharp-rules.md)
   Check 7 — README actualizado ........... ✅ / 🔴 PENDIENTE
   Check 8 — CLAUDE.md ≤ 150 líneas ....... ✅ 122 líneas
-  Check 9 — Mensaje de commit ............ ✅ formato correcto
+  Check 9 — Atomicidad del commit ........ ✅ cambio lógico único / 🟡 sugerencia de dividir
+  Check 10 — Mensaje de commit ........... ✅ formato correcto
 
   RESULTADO: ✅ APROBADO / 🔴 BLOQUEADO (N checks fallidos)
 ═══════════════════════════════════════════════════════════

--- a/.claude/agents/security-guardian.md
+++ b/.claude/agents/security-guardian.md
@@ -48,7 +48,7 @@ Lo que SÍ es aceptable (no bloquear):
 
 ## PROTOCOLO DE AUDITORÍA
 
-Ejecuta SIEMPRE los 8 checks en orden. Para cada check, analiza el diff staged:
+Ejecuta SIEMPRE los 9 checks en orden. Para cada check, analiza el diff staged:
 
 ```bash
 git diff --cached
@@ -184,7 +184,24 @@ git diff --cached | grep "^+" | grep -v "^\+\+\+" | grep -iE \
 
 ---
 
-### SEC-8 — Metadatos y comentarios reveladores
+### SEC-8 — Marcadores de merge conflict y artefactos de Git
+
+Buscar en staged files marcadores de merge conflict no resueltos:
+
+```bash
+git diff --cached | grep "^+" | grep -v "^\+\+\+" | grep -E "^(\+<{7}|\+>{7}|\+={7})"
+```
+
+También buscar ficheros temporales de merge:
+```bash
+git diff --cached --name-only | grep -iE "\.(orig|BACKUP|BASE|LOCAL|REMOTE)\."
+```
+
+🔴 BLOQUEO ABSOLUTO si hay marcadores de merge conflict en staged files.
+
+---
+
+### SEC-9 — Metadatos y comentarios reveladores
 
 Buscar en el diff staged comentarios o metadatos que revelen información privada:
 
@@ -214,7 +231,8 @@ Genera SIEMPRE este informe antes de declarar el veredicto:
   SEC-5 — URLs de repos/servicios priv. .. ✅ / 🔴 [detalle]
   SEC-6 — Ficheros prohibidos staged ..... ✅ / 🔴 [detalle]
   SEC-7 — Infraestructura expuesta ....... ✅ / 🔴 [detalle]
-  SEC-8 — Metadatos reveladores .......... ✅ / 🟡 [detalle]
+  SEC-8 — Merge conflicts / artefactos .. ✅ / 🔴 [detalle]
+  SEC-9 — Metadatos reveladores .......... ✅ / 🟡 [detalle]
 
 ══════════════════════════════════════════════════════════════
   VEREDICTO: ✅ APROBADO — seguro para commit público

--- a/.claude/commands/changelog-update.md
+++ b/.claude/commands/changelog-update.md
@@ -1,0 +1,102 @@
+---
+name: changelog-update
+description: >
+  Actualiza CHANGELOG.md automáticamente analizando los commits desde la última
+  versión/release. Clasifica los cambios por tipo (feat, fix, docs, etc.) usando
+  los commits convencionales del workspace. Opcionalmente sugiere bump de versión
+  semántica. Delega la redacción final a tech-writer.
+---
+
+# Actualización de CHANGELOG
+
+> Analiza los commits desde la última versión y actualiza `CHANGELOG.md`
+> siguiendo el formato "Keep a Changelog" (https://keepachangelog.com).
+
+---
+
+## Protocolo
+
+### 1. Identificar la última versión
+
+```bash
+# Buscar el último tag de versión
+git tag --sort=-v:refname | head -5
+
+# Si no hay tags, buscar la última entrada en CHANGELOG.md
+head -30 CHANGELOG.md
+```
+
+### 2. Obtener commits desde la última versión
+
+```bash
+# Si hay tag
+git log v{LAST_VERSION}..HEAD --oneline --no-merges
+
+# Si no hay tag, desde el último cambio del CHANGELOG
+git log --oneline --no-merges -50
+```
+
+### 3. Clasificar commits por tipo
+
+Usando los tipos definidos en `.claude/rules/github-flow.md`:
+
+| Tipo | Sección CHANGELOG |
+|---|---|
+| `feat` | ### Added |
+| `fix` | ### Fixed |
+| `docs` | ### Documentation |
+| `refactor` | ### Changed |
+| `chore` | ### Maintenance |
+| `test` | ### Testing |
+| `ci` | ### CI/CD |
+
+Ignorar commits de merge y commits del tipo `wip`.
+
+### 4. Generar la nueva sección
+
+Formato de cada entrada:
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- Descripción clara del cambio (#PR o commit hash)
+
+### Fixed
+- Descripción del bug corregido
+
+### Changed
+- Descripción del cambio de comportamiento
+```
+
+### 5. Sugerir versión semántica
+
+Analizar los commits para proponer el bump:
+- **MAJOR** (X.0.0): si hay commits con `feat!:` o `BREAKING CHANGE`
+- **MINOR** (0.X.0): si hay commits `feat:` sin breaking changes
+- **PATCH** (0.0.X): si solo hay `fix:`, `docs:`, `chore:`
+
+Proponer al humano — **NUNCA** hacer bump automáticamente.
+
+### 6. Delegar redacción final
+
+Si el agente `tech-writer` está disponible, delegar la redacción final para
+garantizar consistencia de tono y estilo con el resto del CHANGELOG.
+
+### 7. Presentar al humano
+
+Mostrar la sección generada y preguntar:
+- ¿Versión propuesta es correcta?
+- ¿Alguna entrada necesita ajuste?
+- ¿Procedo a actualizar CHANGELOG.md?
+
+Solo tras confirmación, escribir en el fichero.
+
+---
+
+## Restricciones
+
+- **NO hacer bump de versión sin confirmación** del humano
+- **NO crear tags de Git** — eso es responsabilidad del humano
+- **NO modificar CHANGELOG.md** sin mostrar primero la propuesta
+- Respetar el formato existente del CHANGELOG.md del workspace
+- Si no hay commits nuevos desde la última versión, informar y no generar nada

--- a/.claude/commands/context-load.md
+++ b/.claude/commands/context-load.md
@@ -1,0 +1,110 @@
+---
+name: context-load
+description: >
+  Carga de contexto al inicio de una sesión de Claude Code. Lee el estado actual
+  del workspace, el proyecto activo, el sprint en curso y la actividad reciente
+  para arrancar la sesión con información completa.
+---
+
+# Carga de Contexto — Inicio de Sesión
+
+> Ejecuta este comando al empezar una sesión nueva para que Claude tenga
+> contexto completo sin que tengas que repetir información.
+
+---
+
+## Protocolo de carga (en orden)
+
+### 1. Identificar el workspace
+
+```bash
+pwd
+git branch --show-current
+```
+
+Verificar que estamos en la raíz del workspace (`~/claude/`).
+
+### 2. Leer configuración global
+
+Leer `CLAUDE.md` (raíz) — solo la sección de Proyectos Activos y Configuración Esencial.
+Leer `CLAUDE.local.md` si existe — proyectos privados configurados.
+
+### 3. Actividad reciente en Git
+
+```bash
+git log --oneline -10 --all --decorate
+git branch -a | grep -v "remotes/origin/HEAD"
+```
+
+Resumir: últimos 5 commits, ramas activas (no mergeadas).
+
+### 4. Estado del sprint (si Azure DevOps está disponible)
+
+Solo si existe el PAT configurado:
+```bash
+test -f "$HOME/.azure/devops-pat" && echo "PAT disponible" || echo "PAT no configurado"
+```
+
+Si está disponible: ejecutar el equivalente de `/sprint:status` en modo resumido
+(solo burndown y alertas, sin detalle por item).
+
+Si no está disponible: indicar que Azure DevOps no está conectado y que los
+comandos de sprint no funcionarán.
+
+### 5. Proyecto activo (si hay rama de feature)
+
+Si la rama actual sigue el patrón `feature/`, `fix/`, etc.:
+- Detectar a qué proyecto pertenece (por el path o por el nombre de la rama)
+- Leer su `CLAUDE.md` específico
+- Resumir el estado de la tarea en curso
+
+### 6. Verificar herramientas
+
+```bash
+claude --version 2>/dev/null || echo "Claude CLI: no disponible"
+az --version 2>/dev/null | head -1 || echo "Azure CLI: no disponible"
+dotnet --version 2>/dev/null || echo ".NET SDK: no disponible"
+jq --version 2>/dev/null || echo "jq: no disponible"
+```
+
+---
+
+## Formato del output
+
+```
+══════════════════════════════════════════════════
+  PM-WORKSPACE · Sesión iniciada
+══════════════════════════════════════════════════
+
+  📁 Workspace: ~/claude/ (rama: main)
+  🔧 Herramientas: Claude X.X ✅ | az CLI ✅ | .NET X ✅ | jq ✅
+
+  📋 Proyectos activos: N
+     • ProyectoAlpha — Sprint 2026-05 (día 4/10)
+     • ProyectoBeta  — Sprint 2026-05 (día 4/10)
+
+  📊 Sprint actual: [resumen de 1 línea del burndown]
+     [alerta más importante si hay alguna]
+
+  🌿 Ramas activas: N
+     • feature/nueva-funcionalidad (3 commits adelante de main)
+     • fix/capacity-edge-case (1 commit)
+
+  📝 Últimos cambios:
+     • feat(agents): add pr-review multi-perspective command
+     • docs(readme): update command reference table
+     • fix(rules): correct PAT reference in pm-config
+
+══════════════════════════════════════════════════
+  ¿Por dónde empezamos?
+══════════════════════════════════════════════════
+```
+
+---
+
+## Restricciones
+
+- **Solo lectura** — este comando no modifica nada
+- **Rápido** — no ejecutar queries pesadas a Azure DevOps; priorizar datos locales
+- **Conciso** — el output debe leerse en 30 segundos o menos
+- Si el PAT no está configurado, no mostrar error — simplemente indicar que AzDO no está disponible

--- a/.claude/commands/evaluate-repo.md
+++ b/.claude/commands/evaluate-repo.md
@@ -1,0 +1,180 @@
+---
+name: evaluate-repo
+description: >
+  Evaluación estática de seguridad y calidad de un repositorio externo antes de
+  incorporar herramientas, librerías, MCP servers o skills al workspace. Asigna
+  puntuación 1-10 en 6 categorías y genera un veredicto: Recomendar, Con reservas,
+  Requiere revisión manual o Rechazar.
+---
+
+# Evaluación de Repositorio Externo
+
+**Repositorio a evaluar:** $ARGUMENTS
+
+> Si no se pasa argumento, evalúa el repositorio en el que estés trabajando actualmente.
+
+---
+
+## Contexto de evaluación (ecosistema Claude Code + .NET)
+
+Estás evaluando un repositorio destinado a incorporarse al ecosistema pm-workspace,
+donde ciertas funciones (hooks, commands, scripts, MCP servers) pueden ejecutarse
+implícitamente una vez habilitadas por el usuario.
+
+El riesgo en este ecosistema no proviene de código malicioso obvio, sino de
+**superficies de ejecución implícita**: hooks que se disparan automáticamente,
+scripts que se ejecutan en el entorno local del usuario, o ficheros de estado
+persistente que controlan el flujo de ejecución.
+
+Tu tarea: revisión conservadora, basada en evidencia, solo lectura estática.
+
+---
+
+## Instrucciones
+
+1. **NO ejecutes código** — no instales dependencias, no lances scripts
+2. **Clona el repo** a `/tmp/` para inspección:
+   ```bash
+   git clone $ARGUMENTS /tmp/eval-repo-$(date +%s) --depth 1
+   ```
+3. Lee todos los ficheros relevantes: README, CLAUDE.md, package.json, *.csproj,
+   hooks, commands, scripts, configs
+4. Basa tu evaluación solo en el contenido observable
+
+---
+
+## Criterios de evaluación (1-10 cada uno)
+
+### 1. Calidad de código
+Estructura, legibilidad, corrección, consistencia interna.
+
+### 2. Seguridad y safety
+- Ejecución implícita (hooks, background, startup scripts)
+- Acceso a filesystem (qué lee, qué escribe, dónde)
+- Acceso a red (HTTP requests, telemetría, analytics)
+- Manejo de credenciales (¿pide tokens? ¿los almacena?)
+- Escalación de privilegios o asunciones de confianza
+
+### 3. Documentación y transparencia
+¿La documentación describe fielmente el comportamiento? ¿Revela side effects?
+¿Coincide la implementación con lo documentado?
+
+### 4. Funcionalidad y scope
+¿Hace lo que dice dentro de su scope declarado?
+
+### 5. Higiene del repositorio y mantenimiento
+Señales de cuidado, mantenibilidad, licencia, calidad de publicación.
+
+### 6. Compatibilidad con pm-workspace
+- ¿Es compatible con arquitectura Hexagonal/DDD?
+- ¿Respeta las convenciones .NET del workspace (`dotnet-conventions.md`)?
+- ¿No contradice las reglas de `github-flow.md`?
+- ¿No genera conflicto con los agentes o skills existentes?
+- ¿Se puede integrar sin modificar reglas críticas?
+
+---
+
+## Checklist específico Claude Code
+
+Responde explícitamente a cada punto:
+
+- [ ] Define hooks (stop, lifecycle, pre/post-commit)
+- [ ] Los hooks ejecutan shell scripts
+- [ ] Los commands invocan shell o herramientas externas
+- [ ] Escribe ficheros de estado persistente en el sistema local
+- [ ] Lee estado para controlar flujo de ejecución
+- [ ] Ejecuta acciones implícitas sin confirmación del usuario
+- [ ] Documenta los side effects de hooks/commands
+- [ ] Tiene defaults seguros (opt-in, no opt-out)
+- [ ] Tiene mecanismo claro de desactivar/desinstalar
+
+Explica brevemente cada punto marcado.
+
+---
+
+## Análisis de permisos y side effects
+
+### A. Permisos declarados (desde documentación/config)
+- Filesystem:
+- Red:
+- Ejecución/hooks:
+- APIs/herramientas:
+
+### B. Permisos inferidos (desde inspección estática)
+- Filesystem:
+- Red:
+- Ejecución/hooks:
+- APIs/herramientas:
+
+Marcar cada item como: **confirmado**, **probable** o **incierto**.
+
+### C. Discrepancias
+Listar las diferencias entre lo declarado y lo inferido.
+
+---
+
+## Scan de red flags
+
+Verificar y justificar cada uno:
+- [ ] Indicadores de malware o spyware
+- [ ] Ejecución implícita no documentada
+- [ ] Actividad de red o filesystem no documentada
+- [ ] Claims no respaldados por la implementación
+- [ ] Riesgos de supply-chain o confianza transitiva
+- [ ] Auto-updates que puedan modificar el comportamiento post-instalación
+
+---
+
+## Formato del informe
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║           EVALUACIÓN DE REPOSITORIO EXTERNO                  ║
+║           Repo: [nombre]                                     ║
+║           Fecha: [YYYY-MM-DD]                                ║
+╚══════════════════════════════════════════════════════════════╝
+
+  1. Calidad de código .............. X/10
+  2. Seguridad y safety ............ X/10
+  3. Documentación y transparencia . X/10
+  4. Funcionalidad y scope ......... X/10
+  5. Higiene y mantenimiento ....... X/10
+  6. Compatibilidad pm-workspace ... X/10
+
+  PUNTUACIÓN GLOBAL: X.X / 10
+
+══════════════════════════════════════════════════════════════
+
+  VEREDICTO:
+  ✅ RECOMENDAR — seguro para incorporar
+  🟡 CON RESERVAS — incorporar con las modificaciones listadas
+  🔍 REQUIERE REVISIÓN MANUAL — hallazgos que necesitan inspección humana
+  🔴 RECHAZAR — riesgos inaceptables
+
+══════════════════════════════════════════════════════════════
+
+  HEURÍSTICA DE RECHAZO RÁPIDO:
+  (Solo si RECHAZAR — indicar cuál aplica)
+  - Comportamiento malicioso claro
+  - Ejecución implícita de alto riesgo no documentada
+  - Discrepancia severa entre claims y comportamiento
+  - Defaults inseguros sin mitigación
+  - Otro: [explicar]
+
+══════════════════════════════════════════════════════════════
+
+  MEJORAS SUGERIDAS:
+  [Lista de cambios mínimos que cambiarían el veredicto]
+```
+
+---
+
+## Restricciones
+
+- **NUNCA** instalar dependencias ni ejecutar código del repo evaluado
+- **NUNCA** aprobar automáticamente — el veredicto es una recomendación al humano
+- Si hay duda entre 🟡 y 🔴, elevar siempre a 🔴
+- Limpiar el clon temporal tras la evaluación:
+  ```bash
+  rm -rf /tmp/eval-repo-*
+  ```

--- a/.claude/commands/pbi-jtbd.md
+++ b/.claude/commands/pbi-jtbd.md
@@ -1,0 +1,75 @@
+---
+name: pbi-jtbd
+description: >
+  Genera un documento Jobs to be Done (JTBD) para un PBI antes de descomponerlo
+  en tasks técnicas. Captura el por qué del usuario: situación, motivación,
+  resultado esperado, pain points y criterios de éxito.
+---
+
+# Generar JTBD para un PBI
+
+**PBI ID:** $ARGUMENTS
+
+> Uso: `/pbi:jtbd 302 --project GestiónClínica`
+> Solo para PBIs tipo feature o user story. No usar para bugs ni chores.
+
+---
+
+## Protocolo
+
+### 1. Leer la skill de referencia
+
+Leer `.claude/skills/product-discovery/SKILL.md` para entender el flujo completo.
+
+### 2. Obtener el PBI de Azure DevOps
+
+```bash
+az boards work-item show --id {PBI_ID} --output json
+```
+
+Extraer: título, descripción, criterios de aceptación, tipo, comentarios.
+
+### 3. Verificar tipo de PBI
+
+- Si es `Bug` o `Task` → informar al usuario que JTBD no aplica y sugerir `/pbi:decompose` directamente
+- Si es `Feature` o `User Story` o `Product Backlog Item` → continuar
+
+### 4. Leer contexto del proyecto
+
+- Leer `projects/{proyecto}/CLAUDE.md`
+- Leer `projects/{proyecto}/reglas-negocio.md` si existe
+- Identificar reglas de negocio que afecten a este PBI
+
+### 5. Generar JTBD
+
+Usar la plantilla de `.claude/skills/product-discovery/references/jtbd-template.md`.
+
+Delegar al agente `business-analyst` la generación del contenido:
+- Traducir la descripción técnica del PBI a un Job Statement centrado en el usuario
+- Identificar el contexto, frustración actual y resultado deseado
+- Listar los criterios de éxito desde la perspectiva del usuario (no técnicos)
+- Listar preguntas sin respuesta que deberían resolverse antes de implementar
+
+### 6. Guardar el JTBD
+
+```bash
+mkdir -p projects/{proyecto}/discovery
+```
+
+Guardar en: `projects/{proyecto}/discovery/PBI-{id}-jtbd.md`
+
+### 7. Presentar al humano
+
+Mostrar el JTBD generado y preguntar:
+- ¿Algún ajuste?
+- ¿Procedo a generar el PRD? → sugerir `/pbi:prd {id}`
+- ¿O prefieres ir directo a descomponer? → sugerir `/pbi:decompose {id}`
+
+---
+
+## Restricciones
+
+- **No incluir estimaciones de tiempo** — eso es para la fase de decompose
+- **No proponer arquitectura técnica** — eso es para el `architect`
+- El JTBD es un documento de producto, no de ingeniería
+- Si el PBI ya tiene criterios de aceptación detallados, usarlos como base (no ignorarlos)

--- a/.claude/commands/pbi-prd.md
+++ b/.claude/commands/pbi-prd.md
@@ -1,0 +1,81 @@
+---
+name: pbi-prd
+description: >
+  Genera un Product Requirements Document (PRD) para un PBI. Lee el JTBD previo
+  (si existe) y formaliza los requisitos funcionales, no funcionales, dependencias,
+  riesgos y criterios de aceptación enriquecidos. Paso previo a /pbi:decompose.
+---
+
+# Generar PRD para un PBI
+
+**PBI ID:** $ARGUMENTS
+
+> Uso: `/pbi:prd 302 --project GestiónClínica`
+> Idealmente ejecutar después de `/pbi:jtbd`. Si no hay JTBD, se genera igual
+> pero con menos contexto de usuario.
+
+---
+
+## Protocolo
+
+### 1. Leer la skill de referencia
+
+Leer `.claude/skills/product-discovery/SKILL.md`.
+
+### 2. Obtener el PBI de Azure DevOps
+
+```bash
+az boards work-item show --id {PBI_ID} --output json
+```
+
+### 3. Buscar JTBD previo
+
+```bash
+ls projects/{proyecto}/discovery/PBI-{id}-jtbd.md 2>/dev/null
+```
+
+Si existe, leerlo y usarlo como base.
+Si no existe, informar al usuario que el PRD tendrá menos contexto de usuario
+y sugerir ejecutar `/pbi:jtbd {id}` primero.
+
+### 4. Leer contexto del proyecto
+
+- `projects/{proyecto}/CLAUDE.md` — config del proyecto
+- `projects/{proyecto}/reglas-negocio.md` — reglas de negocio
+- `projects/{proyecto}/equipo.md` — capacidades del equipo (para evaluar viabilidad)
+
+### 5. Generar PRD
+
+Usar la plantilla de `.claude/skills/product-discovery/references/prd-template.md`.
+
+Delegar al agente `business-analyst`:
+- Formalizar requisitos funcionales con prioridades (Must/Should/Could)
+- Identificar requisitos no funcionales (rendimiento, seguridad, escalabilidad)
+- Documentar el scope explícito y lo que queda fuera
+- Listar dependencias con otros PBIs o módulos
+- Identificar riesgos con probabilidad, impacto y plan de mitigación
+- Enriquecer los criterios de aceptación con escenarios Gherkin
+
+### 6. Guardar el PRD
+
+```bash
+mkdir -p projects/{proyecto}/discovery
+```
+
+Guardar en: `projects/{proyecto}/discovery/PBI-{id}-prd.md`
+
+### 7. Presentar al humano
+
+Mostrar el PRD y preguntar:
+- ¿Los requisitos son correctos?
+- ¿El scope está bien delimitado?
+- ¿Procedo a descomponer en tasks? → sugerir `/pbi:decompose {id}`
+
+---
+
+## Restricciones
+
+- **No incluir estimaciones de tiempo** — eso es para decompose
+- **No proponer soluciones técnicas** — solo requisitos de producto
+- **No crear tasks en Azure DevOps** — eso es para `/pbi:decompose`
+- Si el humano ya validó el JTBD, no repetir preguntas ya respondidas

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,187 @@
+---
+name: pr-review
+description: >
+  Revisión multi-perspectiva de un Pull Request desde 5 ángulos: Business Analyst,
+  Developer (code-reviewer), QA Engineer, Security, DevOps. Opcionalmente incluye
+  verificación de cumplimiento de Spec SDD. Genera un informe consolidado con
+  hallazgos priorizados y veredicto final.
+---
+
+# Revisión Multi-Perspectiva de Pull Request
+
+**PR:** $ARGUMENTS
+
+> Acepta: número de PR de Azure DevOps, URL de PR, o nombre de rama local.
+> Si no se pasa argumento, usa la rama actual y compara contra `main`.
+
+---
+
+## Instrucciones generales
+
+Ejecuta cada tarea en orden. Cada perspectiva genera hallazgos clasificados como:
+- 🔴 **Bloqueante** — debe corregirse antes del merge
+- 🟡 **Recomendado** — debería hacerse, no bloquea
+- 🔵 **Nota** — sugerencia menor o informativa
+
+**Principio clave:** cualquier mejora identificada como "para el futuro" debe
+tratarse como mejora inmediata. No se difieren correcciones.
+
+---
+
+## Paso 0 — Obtener el diff
+
+```bash
+# Si es rama local
+git diff main...HEAD --stat
+git diff main...HEAD
+
+# Si es PR de Azure DevOps
+az repos pr show --id {PR_ID} --output json
+```
+
+Identificar: ficheros modificados, líneas añadidas/eliminadas, tipos de cambio.
+
+---
+
+## Tarea 1 — Perspectiva Business Analyst
+
+**Objetivo:** Verificar que los cambios cumplen los criterios de aceptación del PBI.
+
+Delegar al agente `business-analyst`:
+- ¿Los cambios implementan lo que el PBI pide? ¿Ni más ni menos?
+- ¿Los criterios de aceptación están cubiertos?
+- ¿Hay reglas de negocio afectadas que no se hayan considerado?
+- ¿El comportamiento en casos límite es el esperado?
+
+Si hay Spec SDD asociada:
+- ¿El código implementa exactamente el contrato de la spec?
+- ¿Los ficheros creados/modificados son los indicados en la spec?
+
+---
+
+## Tarea 2 — Perspectiva Developer (Code Review)
+
+**Objetivo:** Evaluar calidad de código, arquitectura y mantenibilidad.
+
+Delegar al agente `code-reviewer` existente:
+```
+Prompt: Revisa los cambios del PR (git diff main...HEAD) aplicando las reglas de
+        .claude/rules/csharp-rules.md. Prioriza: Vulnerabilities > Bugs > Code Smells.
+        Incluye hallazgos Blocker, Critical y Major. Devuelve informe completo con
+        veredicto: APROBADO, APROBADO_CON_CAMBIOS_MENORES o RECHAZADO.
+```
+
+Puntos adicionales no cubiertos por `code-reviewer`:
+- ¿El código es fácil de entender para alguien que no lo escribió?
+- ¿Hay oportunidades de simplificación evidentes?
+- ¿Se han actualizado los comentarios XML si las firmas cambiaron?
+
+---
+
+## Tarea 3 — Perspectiva QA Engineer
+
+**Objetivo:** Verificar cobertura de tests, edge cases y riesgo de regresión.
+
+1. **Cobertura de tests:**
+   ```bash
+   dotnet test --filter "Category=Unit" --no-build --collect:"XPlat Code Coverage" 2>&1
+   ```
+   - ¿Los tests cubren los cambios del PR?
+   - ¿Hay paths de código nuevos sin test?
+   - ¿La cobertura está por encima de TEST_COVERAGE_MIN_PERCENT (80%)?
+
+2. **Edge cases:**
+   - ¿Se consideran: null, vacío, límites numéricos, concurrencia?
+   - ¿Los tests de la Spec SDD (sección Test Scenarios) están implementados?
+
+3. **Riesgo de regresión:**
+   - ¿Los cambios afectan código existente que ya tiene tests?
+   - ¿Se han ejecutado los tests de integración afectados?
+
+---
+
+## Tarea 4 — Perspectiva Security Engineer
+
+**Objetivo:** Detectar vulnerabilidades de seguridad en los cambios.
+
+Delegar al agente `security-guardian` para verificar:
+- SQL injection (WIQL, ADO.NET directo)
+- XSS en respuestas de API
+- Secrets hardcodeados
+- Insecure deserialization
+- CORS mal configurado
+- Missing `[Authorize]`
+- Validación de inputs
+
+Puntos adicionales:
+- ¿Se han añadido dependencias NuGet con CVEs conocidos?
+- ¿Los cambios afectan la superficie de autenticación/autorización?
+- ¿Se exponen datos sensibles en logs o respuestas de error?
+
+---
+
+## Tarea 5 — Perspectiva DevOps
+
+**Objetivo:** Evaluar impacto en build, deployment y monitorización.
+
+1. **Pipeline CI/CD:**
+   ```bash
+   dotnet build --configuration Release 2>&1
+   ```
+   - ¿El PR compila sin warnings en Release?
+   - ¿Se ha modificado el Jenkinsfile o docker-compose?
+   - ¿Hay cambios que requieran actualizar configuración de K8s?
+
+2. **Infraestructura:**
+   - ¿Se necesitan nuevas variables de entorno?
+   - ¿Hay cambios en connection strings o configuración de servicios?
+   - ¿Se ha actualizado la documentación de deployment?
+
+3. **Observabilidad:**
+   - ¿Los nuevos endpoints tienen logging adecuado (Serilog)?
+   - ¿Se han añadido métricas o traces de OpenTelemetry donde corresponde?
+
+---
+
+## Formato del informe consolidado
+
+```markdown
+## PR Review Multi-Perspectiva: [Título del PR]
+
+### Resumen
+- Ficheros modificados: N
+- Líneas añadidas: +N / eliminadas: -N
+- Specs SDD asociadas: [lista o N/A]
+
+### 🔴 Bloqueantes (corregir antes del merge)
+1. [PERSPECTIVA] [Problema] en [fichero:línea] → [solución]
+
+### 🟡 Recomendados (no bloquean pero deberían hacerse)
+1. [PERSPECTIVA] [Problema] en [fichero:línea] → [solución]
+
+### 🔵 Notas
+- [...]
+
+### Veredicto por perspectiva
+| Perspectiva | Veredicto | Hallazgos |
+|---|---|---|
+| Business Analyst | ✅/🟡/🔴 | N hallazgos |
+| Developer | ✅/🟡/🔴 | N hallazgos |
+| QA Engineer | ✅/🟡/🔴 | N hallazgos |
+| Security | ✅/🟡/🔴 | N hallazgos |
+| DevOps | ✅/🟡/🔴 | N hallazgos |
+
+### Veredicto Final
+- [ ] ✅ APROBADO — listo para merge
+- [ ] 🟡 APROBADO CON CAMBIOS — corregir los amarillos y merge
+- [ ] 🔴 RECHAZADO — corregir bloqueantes y repetir review
+```
+
+---
+
+## Restricciones
+
+- **No corriges el código** — señalas problemas y propones soluciones
+- Las perspectivas Developer y Security delegan a los agentes existentes (`code-reviewer`, `security-guardian`)
+- Si el PR toca código de Domain Layer, señalar que el Code Review E1 SIEMPRE es humano
+- El informe se genera localmente — publicar en Azure DevOps solo si el humano lo confirma

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -41,6 +41,12 @@
 | `/spec:review {spec_file}` | Revisar calidad de Spec o validar implementación resultante |
 | `/spec:status` | Dashboard de estado de todas las Specs del sprint |
 | `/agent:run {spec_file}` | Lanzar agente Claude directamente sobre una Spec |
+| `/pbi:jtbd {id}` | Generar documento Jobs to be Done para un PBI (discovery) |
+| `/pbi:prd {id}` | Generar Product Requirements Document para un PBI (discovery) |
+| `/pr:review [PR]` | Revisión multi-perspectiva de PR (BA, Dev, QA, Security, DevOps) |
+| `/context:load` | Carga de contexto al iniciar sesión (proyecto, sprint, actividad) |
+| `/changelog:update` | Actualizar CHANGELOG.md desde commits convencionales |
+| `/evaluate:repo [URL]` | Auditoría de seguridad y calidad de un repo externo |
 
 ## 🔗 Referencias
 
@@ -49,6 +55,7 @@
 - Plantillas: `docs/plantillas-informes.md`
 - Política estimación: `docs/politica-estimacion.md`
 - Queries WIQL: `.claude/skills/azure-devops-queries/references/wiql-patterns.md`
+- Product Discovery: `.claude/skills/product-discovery/SKILL.md`
 - Scoring asignación: `.claude/skills/pbi-decomposition/references/assignment-scoring.md`
 - SDD Template: `.claude/skills/spec-driven-development/references/spec-template.md`
 - SDD Layer Matrix: `.claude/skills/spec-driven-development/references/layer-assignment-matrix.md`

--- a/.claude/skills/product-discovery/SKILL.md
+++ b/.claude/skills/product-discovery/SKILL.md
@@ -1,0 +1,58 @@
+# Skill: Product Discovery
+
+## Cuándo usar esta skill
+
+Invocar **antes** de descomponer un PBI en tasks técnicas cuando:
+- El PBI es de tipo **feature** o **user story** (no bug ni chore)
+- Los criterios de aceptación son vagos o inexistentes
+- Se necesita formalizar el *por qué* del usuario antes del *cómo* técnico
+- El `business-analyst` necesita un workflow estructurado de análisis
+
+## Qué produce
+
+Dos documentos que preceden la descomposición técnica:
+
+1. **JTBD (Jobs to be Done)** — captura el *por qué* del comportamiento del usuario
+2. **PRD (Product Requirements Document)** — captura el *qué* del producto
+
+## Flujo completo
+
+```
+PBI en Azure DevOps
+    ↓
+/pbi:jtbd {id}          ← business-analyst genera JTBD
+    ↓
+/pbi:prd {id}           ← business-analyst genera PRD (lee JTBD)
+    ↓
+/pbi:decompose {id}     ← flujo existente (architect + spec-writer + ...)
+```
+
+## Cuándo NO usar
+
+- PBIs tipo `Bug` → no necesitan discovery, necesitan diagnóstico
+- PBIs tipo `Chore` → mantenimiento técnico sin impacto de usuario
+- PBIs con criterios de aceptación ya detallados y validados por el PO
+- Tasks individuales que ya tienen spec SDD aprobada
+
+## Almacenamiento
+
+Los documentos se guardan en el directorio del proyecto:
+```
+projects/{proyecto}/discovery/
+├── PBI-{id}-jtbd.md
+└── PBI-{id}-prd.md
+```
+
+Si el directorio `discovery/` no existe, crearlo automáticamente.
+
+## Plantillas
+
+Las plantillas JTBD y PRD están en `references/`:
+- `references/jtbd-template.md` — plantilla Jobs to be Done
+- `references/prd-template.md` — plantilla Product Requirements Document
+
+## Agente responsable
+
+El agente `business-analyst` es quien ejecuta ambos documentos.
+No delegar a `architect` ni a `sdd-spec-writer` — esto es análisis de producto,
+no diseño técnico.

--- a/.claude/skills/product-discovery/references/jtbd-template.md
+++ b/.claude/skills/product-discovery/references/jtbd-template.md
@@ -1,0 +1,70 @@
+# JTBD — Jobs to be Done
+
+## PBI: {PBI_ID} — {PBI_TITLE}
+## Proyecto: {PROJECT_NAME}
+## Fecha: {DATE}
+
+---
+
+## 1. Job Statement
+
+> Cuando [SITUACIÓN], quiero [MOTIVACIÓN], para poder [RESULTADO ESPERADO].
+
+---
+
+## 2. Contexto del usuario
+
+- **¿Quién es el usuario?** [Rol, perfil, nivel técnico]
+- **¿Cuándo surge la necesidad?** [Trigger o situación que activa el job]
+- **¿Qué hace hoy para resolver esto?** [Workaround actual, si existe]
+- **¿Qué frustraciones tiene con la solución actual?** [Pain points]
+
+---
+
+## 3. Resultado funcional deseado
+
+¿Qué necesita lograr el usuario? (sin mencionar tecnología)
+
+1. [Resultado 1]
+2. [Resultado 2]
+3. [Resultado 3]
+
+---
+
+## 4. Resultado emocional deseado
+
+¿Cómo quiere sentirse el usuario tras completar el job?
+
+- [Ej: Seguro de que no se le escapó ningún dato]
+- [Ej: Tranquilo porque el proceso fue rápido]
+
+---
+
+## 5. Restricciones del job
+
+- **Tiempo:** [¿En cuánto tiempo debe completarse el job?]
+- **Frecuencia:** [¿Cada cuánto se realiza?]
+- **Volumen:** [¿Cuántos datos/elementos maneja?]
+- **Contexto:** [¿Desde dónde lo hace? ¿Con qué dispositivo?]
+
+---
+
+## 6. Criterios de éxito (desde la perspectiva del usuario)
+
+| # | El usuario considera exitoso si... |
+|---|---|
+| 1 | [Criterio observable y medible] |
+| 2 | [Criterio observable y medible] |
+| 3 | [Criterio observable y medible] |
+
+---
+
+## 7. Preguntas sin respuesta
+
+| # | Pregunta | Impacto si no se resuelve |
+|---|---|---|
+| 1 | [Pregunta] | [Qué pasa si no la resolvemos antes de implementar] |
+
+---
+
+*Generado por business-analyst · Fuente: PBI {PBI_ID} en Azure DevOps*

--- a/.claude/skills/product-discovery/references/prd-template.md
+++ b/.claude/skills/product-discovery/references/prd-template.md
@@ -1,0 +1,102 @@
+# PRD — Product Requirements Document
+
+## PBI: {PBI_ID} — {PBI_TITLE}
+## Proyecto: {PROJECT_NAME}
+## Fecha: {DATE}
+## JTBD asociado: `discovery/PBI-{PBI_ID}-jtbd.md`
+
+---
+
+## 1. Resumen ejecutivo
+
+[1-3 frases: qué se va a construir, para quién y por qué importa]
+
+---
+
+## 2. Problema
+
+[Descripción del problema que el usuario experimenta hoy. Basado en el JTBD.]
+
+---
+
+## 3. Objetivos del producto
+
+| # | Objetivo | Métrica de éxito |
+|---|---|---|
+| 1 | [Qué queremos lograr] | [Cómo sabemos que lo logramos] |
+| 2 | [Qué queremos lograr] | [Cómo sabemos que lo logramos] |
+
+---
+
+## 4. Requisitos funcionales
+
+Basados en los criterios de éxito del JTBD y los criterios de aceptación del PBI:
+
+| # | Requisito | Prioridad | Fuente |
+|---|---|---|---|
+| RF-1 | [Requisito] | Must | PBI / JTBD |
+| RF-2 | [Requisito] | Must | PBI / JTBD |
+| RF-3 | [Requisito] | Should | JTBD |
+| RF-4 | [Requisito] | Could | Análisis |
+
+Prioridades: **Must** (sin esto no se entrega) · **Should** (importante) · **Could** (nice to have)
+
+---
+
+## 5. Requisitos no funcionales
+
+| # | Requisito | Detalle |
+|---|---|---|
+| RNF-1 | Rendimiento | [Ej: Respuesta < 200ms para listados paginados] |
+| RNF-2 | Seguridad | [Ej: Solo usuarios autenticados con rol X] |
+| RNF-3 | Escalabilidad | [Ej: Soportar hasta N registros simultáneos] |
+
+---
+
+## 6. Fuera de scope
+
+Lo que explícitamente NO se incluye en este PBI:
+
+1. [Lo que no se hace y por qué]
+2. [Lo que queda para un PBI futuro]
+
+---
+
+## 7. Dependencias
+
+| Dependencia | Tipo | Estado |
+|---|---|---|
+| [PBI o módulo] | Bloqueante / Informativa | Resuelta / Pendiente |
+
+---
+
+## 8. Riesgos identificados
+
+| # | Riesgo | Probabilidad | Impacto | Mitigación |
+|---|---|---|---|---|
+| 1 | [Riesgo] | Alta/Media/Baja | Alto/Medio/Bajo | [Plan] |
+
+---
+
+## 9. Criterios de aceptación (formalizados)
+
+Basados en el PBI original y enriquecidos con el análisis JTBD:
+
+```gherkin
+Scenario: [Nombre del escenario]
+  Given [contexto]
+  When [acción del usuario]
+  Then [resultado esperado]
+```
+
+---
+
+## 10. Aprobación
+
+- [ ] Product Owner / Stakeholder confirma los requisitos
+- [ ] Business Analyst valida la coherencia con reglas de negocio
+- [ ] Listo para pasar a `architect` y `pbi:decompose`
+
+---
+
+*Generado por business-analyst · Fuente: PBI {PBI_ID} + JTBD · No incluye estimaciones de tiempo*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,10 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ~/claude/                          ← Raíz de trabajo Y repositorio GitHub
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
-│   ├── agents/                    ← Subagentes especializados (8 agentes)
-│   ├── commands/                  ← Comandos slash personalizados
+│   ├── agents/                    ← Subagentes especializados (11 agentes)
+│   ├── commands/                  ← Slash commands (24 comandos)
 │   ├── rules/                     ← Reglas y configuración detallada
-│   └── skills/                    ← Skills reutilizables
+│   └── skills/                    ← Skills reutilizables (8 skills)
 ├── docs/                          ← Metodología (reglas Scrum, KPIs, plantillas...)
 ├── projects/                      ← Proyectos reales (git-ignorados por .gitignore)
 └── scripts/                       ← Scripts auxiliares Azure DevOps
@@ -97,8 +97,8 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, XML docs |
 | `azure-devops-operator` | Haiku 4.5 | WIQL, work items, sprint, capacity |
 
-Flujo SDD: `business-analyst` → `architect` → `sdd-spec-writer` → `dotnet-developer` ‖ `test-engineer` → `code-reviewer`
-Antes de cualquier commit → `commit-guardian` (incluye code review automático via `code-reviewer`)
+Flujo SDD: `business-analyst` (JTBD+PRD opcionales) → `architect` → `sdd-spec-writer` → `dotnet-developer` ‖ `test-engineer` → `code-reviewer`
+Antes de cualquier commit → `commit-guardian` (10 checks: rama, security, build, tests, format, code review, README, CLAUDE.md, atomicidad, mensaje)
 Tras commit → `test-runner` (tests completos + cobertura ≥ `TEST_COVERAGE_MIN_PERCENT`; si falla → `dotnet-developer`; si cobertura baja → `architect` + `business-analyst` + `dotnet-developer`)
 
 ---
@@ -106,8 +106,10 @@ Tras commit → `test-runner` (tests completos + cobertura ≥ `TEST_COVERAGE_MI
 ## 🛠️ Para cualquier operación
 
 - **Azure DevOps** → leer primero `.claude/skills/azure-devops-queries/SKILL.md`
+- **Discovery (JTBD/PRD)** → `.claude/skills/product-discovery/SKILL.md`
 - **Descomponer PBIs** → `.claude/skills/pbi-decomposition/SKILL.md`
 - **Specs y agentes** → `.claude/skills/spec-driven-development/SKILL.md`
+- **Evaluar repos externos** → `/evaluate-repo`
 - **Comandos** → lista completa en `@.claude/rules/pm-workflow.md`
 - **Formateo .md** → `.vscode/settings.json` (extensión Highlight requerida)
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 │   ├── .env                     ← Variables de entorno (git-ignorado)
 │   ├── mcp.json                 ← Configuración MCP opcional
 │   │
-│   ├── commands/                ← 19 slash commands
+│   ├── commands/                ← 24 slash commands
 │   │   ├── sprint-status.md
 │   │   ├── sprint-plan.md
 │   │   ├── sprint-review.md
@@ -112,18 +112,28 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 │   │   ├── pbi-decompose-batch.md
 │   │   ├── pbi-assign.md
 │   │   ├── pbi-plan-sprint.md
+│   │   ├── pbi-jtbd.md           ← Discovery: Jobs to be Done
+│   │   ├── pbi-prd.md            ← Discovery: Product Requirements
+│   │   ├── pr-review.md          ← Review multi-perspectiva de PR
+│   │   ├── context-load.md       ← Carga de contexto al iniciar sesión
+│   │   ├── changelog-update.md   ← Actualizar CHANGELOG desde commits
+│   │   ├── evaluate-repo.md      ← Auditoría de repos externos
 │   │   ├── spec-generate.md      ← SDD
 │   │   ├── spec-implement.md     ← SDD
 │   │   ├── spec-review.md        ← SDD
 │   │   ├── spec-status.md        ← SDD
 │   │   └── agent-run.md          ← SDD
 │   │
-│   ├── skills/                  ← 7 skills personalizadas
+│   ├── skills/                  ← 8 skills personalizadas
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
 │   │   ├── time-tracking-report/
 │   │   ├── executive-reporting/
+│   │   ├── product-discovery/     ← JTBD + PRD antes de decompose
+│   │   │   └── references/
+│   │   │       ├── jtbd-template.md
+│   │   │       └── prd-template.md
 │   │   ├── pbi-decomposition/
 │   │   │   └── references/
 │   │   │       └── assignment-scoring.md
@@ -255,7 +265,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 19 comandos y las 7 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 24 comandos y las 8 skills,
 y aplicará las reglas de `.claude/rules/` bajo demanda. Todas las buenas prácticas del
 flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 
@@ -1130,6 +1140,20 @@ Los ficheros en `projects/sala-reservas/test-data/` simulan respuestas reales de
 /agent:run {spec_file} [--team]   Lanzar agente Claude sobre una Spec
 ```
 
+### Product Discovery
+```
+/pbi:jtbd {id}                   Generar JTBD (Jobs to be Done) para un PBI
+/pbi:prd {id}                    Generar PRD (Product Requirements) para un PBI
+```
+
+### Calidad y Operaciones
+```
+/pr:review [PR]                  Revisión multi-perspectiva de PR (BA, Dev, QA, Sec, DevOps)
+/context:load                    Carga de contexto al iniciar sesión
+/changelog:update                Actualizar CHANGELOG.md desde commits convencionales
+/evaluate:repo [URL]             Auditoría de seguridad y calidad de repo externo
+```
+
 ---
 
 ## Equipo de Subagentes Especializados
@@ -1140,14 +1164,14 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | Agente | Modelo | Color | Cuándo se usa |
 |---|---|---|---|
 | `architect` | Opus 4.6 | 🔵 azul | Diseño de arquitectura .NET, asignación de capas, decisiones técnicas |
-| `business-analyst` | Opus 4.6 | 🟣 morado | Análisis de PBIs, reglas de negocio, criterios de aceptación |
+| `business-analyst` | Opus 4.6 | 🟣 morado | Análisis de PBIs, reglas de negocio, criterios de aceptación, JTBD, PRD |
 | `sdd-spec-writer` | Opus 4.6 | 🩵 cyan | Generación y validación de Specs SDD ejecutables |
 | `code-reviewer` | Opus 4.6 | 🔴 rojo | Quality gate: seguridad, SOLID, reglas SonarQube (`csharp-rules.md`) |
 | `security-guardian` | Opus 4.6 | 🔴 rojo | Auditoría de seguridad y confidencialidad pre-commit |
 | `dotnet-developer` | Sonnet 4.6 | 🟢 verde | Implementación C#/.NET siguiendo specs SDD aprobadas |
 | `test-engineer` | Sonnet 4.6 | 🟡 amarillo | Tests xUnit/NUnit, TestContainers, cobertura |
 | `test-runner` | Sonnet 4.6 | 🟣 magenta | Post-commit: ejecución de tests, cobertura ≥ `TEST_COVERAGE_MIN_PERCENT`, orquestación de mejora |
-| `commit-guardian` | Sonnet 4.6 | 🟠 naranja | Pre-commit: rama, security, build, tests, code review, README |
+| `commit-guardian` | Sonnet 4.6 | 🟠 naranja | Pre-commit: 10 checks (rama, security, build, tests, format, code review, README, CLAUDE.md, atomicidad, mensaje) |
 | `tech-writer` | Haiku 4.5 | ⚪ blanco | README, CHANGELOG, comentarios XML C#, docs de proyecto |
 | `azure-devops-operator` | Haiku 4.5 | ⬜ blanco brillante | Consultas WIQL, crear/actualizar work items, gestión de sprint |
 
@@ -1258,13 +1282,11 @@ Las siguientes responsabilidades clásicas del PM/Scrum Master quedan automatiza
 
 **Gestión de riesgos (risk log):** el workspace detecta alertas de WIP y burndown, pero no mantiene un registro estructurado de riesgos con probabilidad, impacto y plan de mitigación. Un skill de `risk:log` que actualice el registro en cada `/sprint:status` y escale riesgos críticos al PM sería valioso.
 
-**Release notes automáticas:** al cierre del sprint, Claude tiene toda la información para generar las release notes desde los items completados y los commits. No está implementado, pero sería un `/sprint:release-notes` directo.
+**Release notes automáticas:** al cierre del sprint, Claude tiene toda la información para generar las release notes desde los items completados y los commits. El comando `/changelog:update` cubre parcialmente este caso (genera CHANGELOG desde commits), pero un `/sprint:release-notes` específico que combine commits + work items sería el siguiente paso.
 
 **Gestión de deuda técnica:** el workspace no rastrea ni prioriza la deuda técnica. Un skill que analice el backlog en busca de items marcados como "refactor" o "tech-debt" y los proponga para sprints de mantenimiento sería un añadido útil.
 
 **Onboarding de nuevos miembros:** cuando llega alguien nuevo al equipo, Claude podría generar automáticamente una guía de incorporación personalizada (setup del entorno, módulos del proyecto, convenciones de código) desde los ficheros del workspace.
-
-**Integración con pull requests:** el workspace gestiona tasks en AzDO pero no hace seguimiento del estado de los PRs asociados (reviewers, comentarios pendientes, tiempo en revisión). Una integración con la API de Git de Azure DevOps completaría el ciclo.
 
 **Seguimiento de bugs en producción:** el bug escape rate se calcula, pero no hay un flujo automatizado para priorizar bugs entrantes, relacionarlos con el sprint en curso y proponer si impactan en el sprint goal actual.
 

--- a/propuesta-incorporacion-awesome-claude-code.md
+++ b/propuesta-incorporacion-awesome-claude-code.md
@@ -1,0 +1,264 @@
+# Propuesta de Incorporación: Awesome Claude Code → pm-workspace
+
+**Fecha:** 2026-02-26
+**Fuente analizada:** [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) v2.0.1
+**Destino:** pm-workspace (github.com/gonzalezpazmonica/pm-workspace)
+
+---
+
+## Resumen ejecutivo
+
+Tras un análisis exhaustivo del repositorio awesome-claude-code (209 recursos curados, 10 categorías, 50+ scripts, 11 workflows) y su cruce con la arquitectura actual de pm-workspace, se identifican **7 incorporaciones viables** que enriquecen el workspace sin generar conflictos con las reglas existentes, y **5 elementos descartados** por redundancia o incompatibilidad.
+
+---
+
+## Parte 1 — Incorporaciones propuestas
+
+### 1. Comando `/evaluate-repo` — Auditoría de dependencias externas
+
+**Origen:** `.claude/commands/evaluate-repository.md`
+**Tipo:** Nuevo slash command
+**Ubicación propuesta:** `.claude/commands/evaluate-repo.md`
+
+**Qué hace:** Evaluación estática de seguridad y calidad de cualquier repositorio externo antes de incorporar herramientas, librerías o recursos al workspace. Asigna puntuación 1-10 en 5 categorías y tiene un checklist específico para Claude Code (hooks implícitos, ejecución sin confirmación, side effects no documentados).
+
+**Por qué tiene sentido:** pm-workspace ya tiene `security-guardian` para auditoría pre-commit, pero no tiene un mecanismo para evaluar **herramientas externas antes de adoptarlas**. Este comando cierra ese gap. Cada vez que se considere agregar un MCP server, un skill externo, una librería NuGet o cualquier dependencia, este comando da un veredicto estructurado.
+
+**Adaptación necesaria:**
+
+- Traducir a español (consistencia con el workspace)
+- Agregar criterios específicos para el ecosistema .NET/Azure DevOps:
+  - ¿Usa NuGet packages con vulnerabilidades conocidas?
+  - ¿Tiene dependencias de versiones EOL de .NET?
+  - ¿Accede a Azure DevOps API sin PAT seguro?
+- Integrar con la tabla de delegación del `commit-guardian`: si se añade una nueva dependencia en un `.csproj`, sugerir ejecutar `/evaluate-repo` primero
+- Agregar categoría de evaluación: **Compatibilidad con Arquitectura Hexagonal/DDD**
+
+**Conflictos:** Ninguno. Complementa a `security-guardian` sin solaparse (uno audita código propio, el otro audita código externo).
+
+---
+
+### 2. Comando `/pr-review` — Revisión multi-perspectiva de Pull Requests
+
+**Origen:** `resources/slash-commands/pr-review/pr-review.md`
+**Tipo:** Nuevo slash command
+**Ubicación propuesta:** `.claude/commands/pr-review.md`
+
+**Qué hace:** Estructura una revisión de PR desde 6 perspectivas diferentes: Product Manager, Developer Senior, QA Engineer, Security Engineer, DevOps y UI/UX. Cada perspectiva tiene su propio checklist y produce hallazgos categorizados.
+
+**Por qué tiene sentido:** El `code-reviewer` actual cubre la perspectiva técnica (.NET, SOLID, seguridad de código), pero no evalúa un PR desde la óptica de producto, QA o DevOps. Para los proyectos gestionados en Azure DevOps, una revisión multi-perspectiva asegura que el PR no solo es código limpio, sino que cumple la historia de usuario, tiene tests de integración, y no rompe el pipeline CI/CD.
+
+**Adaptación necesaria:**
+
+- Eliminar la perspectiva UI/UX (los proyectos actuales son APIs/microservicios backend; agregar solo si se incorporan proyectos frontend)
+- Reemplazar la perspectiva "Product Manager" por **"Business Analyst"** alineada con el agente existente `business-analyst`
+- La perspectiva "Developer" debe delegar al `code-reviewer` existente en lugar de duplicar su lógica
+- La perspectiva "DevOps" debe verificar contra los 9 stages del Jenkinsfile existente
+- La perspectiva "QA" debe verificar cobertura ≥ 80% (constante `TEST_COVERAGE_MIN_PERCENT`)
+- Agregar perspectiva **"Spec Compliance"**: verificar que el PR implementa exactamente lo que dice la spec SDD aprobada
+- El resultado debe publicarse como comentario en el PR de Azure DevOps (via `az repos pr`)
+
+**Conflictos:** Parcial con `code-reviewer`. Solución: `/pr-review` **orquesta** las perspectivas, y una de ellas delega al `code-reviewer` como subagente. No se duplica lógica.
+
+---
+
+### 3. Workflow de Producto — JTBD + PRD antes de descomponer PBIs
+
+**Origen:** `resources/slash-commands/create-jtbd/` y `resources/slash-commands/create-prd/`
+**Tipo:** Nuevo skill + 2 nuevos slash commands
+**Ubicación propuesta:**
+- `.claude/skills/product-discovery/SKILL.md`
+- `.claude/commands/pbi-jtbd.md`
+- `.claude/commands/pbi-prd.md`
+
+**Qué hace:** Antes de descomponer un PBI en tareas técnicas, documenta el *por qué* del usuario (Jobs to be Done) y el *qué* del producto (Product Requirements Document). Esto enriquece la cadena: JTBD → PRD → PBI → Tasks.
+
+**Por qué tiene sentido:** Actualmente, `/pbi:decompose` toma un PBI de Azure DevOps y lo descompone directamente en tareas técnicas. Pero los PBIs a veces llegan sin contexto suficiente sobre la necesidad del usuario. Agregar una fase de discovery formaliza lo que el `business-analyst` debería hacer antes de que el `architect` diseñe la solución.
+
+**Adaptación necesaria:**
+
+- Adaptar las plantillas JTBD/PRD al contexto de Azure DevOps:
+  - El JTBD se almacena como attachment del PBI o en `docs/jtbd/PBI-{id}.md`
+  - El PRD se almacena como attachment del PBI o en `docs/prd/PBI-{id}.md`
+- Integrar en el flujo SDD existente:
+  ```
+  ANTES:  PBI → architect → spec-writer → developer → ...
+  AHORA:  PBI → business-analyst (JTBD+PRD) → architect → spec-writer → developer → ...
+  ```
+- El agente `business-analyst` lee el PBI, genera JTBD, luego genera PRD, y solo entonces pasa al `architect`
+- No generar PRDs para PBIs tipo "bug" o "chore" — solo para "feature" y "user story"
+
+**Conflictos:** Ninguno. Extiende la cadena SDD sin modificar nada existente. El `business-analyst` ya existe pero no tiene un workflow formalizado de discovery.
+
+---
+
+### 4. Comando `/context-load` — Carga de contexto al inicio de sesión
+
+**Origen:** `resources/slash-commands/context-prime/context-prime.md`
+**Tipo:** Nuevo slash command
+**Ubicación propuesta:** `.claude/commands/context-load.md`
+
+**Qué hace:** Al iniciar una nueva sesión de Claude Code, carga automáticamente el contexto necesario: lee el README, la estructura del proyecto activo, el estado del sprint actual, y las reglas relevantes.
+
+**Por qué tiene sentido:** Cada sesión de Claude Code empieza sin contexto previo. Hoy, el usuario tiene que recordar qué proyecto está activo y qué sprint está en curso. Un comando de carga de contexto reduce la fricción y evita que Claude opere con información incompleta.
+
+**Adaptación necesaria:**
+
+- Leer `CLAUDE.md` raíz + `CLAUDE.md` del proyecto activo
+- Ejecutar `/sprint:status` para obtener el estado actual del sprint
+- Listar las ramas activas (`git branch -a | grep -v main`)
+- Resumir los últimos 5 commits para entender en qué se estuvo trabajando
+- Verificar si hay PBIs asignados sin empezar en el sprint actual
+- NO ejecutar queries pesadas a Azure DevOps — solo contexto local + resumen de sprint
+- Output: un resumen de ~20 líneas que el usuario puede leer en 30 segundos
+
+**Conflictos:** Ninguno. Es un comando de lectura que no modifica nada.
+
+---
+
+### 5. Automatización de CHANGELOG — Actualización por release
+
+**Origen:** `resources/slash-commands/release/release.md` y `resources/slash-commands/add-to-changelog/`
+**Tipo:** Nuevo slash command
+**Ubicación propuesta:** `.claude/commands/changelog-update.md`
+
+**Qué hace:** Analiza los commits desde la última versión, clasifica los cambios por tipo (feat, fix, docs, etc.), actualiza `CHANGELOG.md` siguiendo el formato "Keep a Changelog", y opcionalmente sugiere bump de versión semántica.
+
+**Por qué tiene sentido:** pm-workspace ya tiene un `CHANGELOG.md` pero se actualiza manualmente. Con los commits convencionales que ya enforce el `commit-guardian`, el CHANGELOG puede generarse automáticamente. Esto es especialmente útil antes de un release o al final de un sprint.
+
+**Adaptación necesaria:**
+
+- Respetar el formato existente del CHANGELOG.md de pm-workspace
+- Clasificar commits usando los tipos ya definidos en `github-flow.md`: feat, fix, docs, refactor, chore, test, ci
+- Agregar contexto de sprint: cada sección del CHANGELOG puede agruparse por sprint si se desea
+- Delegar a `tech-writer` la redacción final (consistencia de tono y estilo)
+- NO hacer bump de versión automáticamente — solo proponer y que el humano confirme
+
+**Conflictos:** Ninguno. `tech-writer` ya es responsable de documentación; este comando le da un workflow específico.
+
+---
+
+### 6. Patrones regex para detección de secrets
+
+**Origen:** `.pre-commit-config.yaml` — hooks `detect-private-key` y `check-merge-conflict`
+**Tipo:** Mejora a agente existente
+**Ubicación propuesta:** Actualización de `.claude/agents/security-guardian.md`
+
+**Qué hace:** Agrega patrones de detección adicionales al `security-guardian`: claves privadas (RSA, ECDSA, ed25519), tokens de API (formatos conocidos de Azure, GitHub, AWS), archivos de configuración sensibles (.env, appsettings.Development.json con datos reales), y marcadores de merge conflict.
+
+**Por qué tiene sentido:** El `security-guardian` actual busca credenciales y datos privados, pero no tiene una lista explícita de patrones regex para detectar formatos específicos de secrets. Los hooks de pre-commit-config del repo fuente tienen patrones probados y maduros.
+
+**Adaptación necesaria:**
+
+- Agregar al `security-guardian` una sección de patrones regex:
+  ```
+  PRIVATE_KEY:    -----BEGIN (RSA|EC|DSA|OPENSSH) PRIVATE KEY-----
+  AZURE_PAT:      [a-z2-7]{52}
+  GITHUB_TOKEN:   ghp_[A-Za-z0-9]{36}
+  AWS_KEY:        AKIA[0-9A-Z]{16}
+  CONNECTION_STR: (Server|Data Source)=.*Password=
+  MERGE_CONFLICT: ^[<>=]{7}
+  ```
+- Verificar contra staged files, no contra todo el repo (rendimiento)
+- Mantener la escalación existente: BLOQUEADO → escalar al humano
+
+**Conflictos:** Ninguno. Enriquece un agente existente sin cambiar su comportamiento ni su flujo de delegación.
+
+---
+
+### 7. Check de atomicidad de commits
+
+**Origen:** `resources/slash-commands/commit/commit.md`
+**Tipo:** Mejora al agente `commit-guardian`
+**Ubicación propuesta:** Actualización de `.claude/agents/commit-guardian.md` (nuevo CHECK entre 8 y 9)
+
+**Qué hace:** Antes de construir el mensaje de commit, analiza el diff para detectar si los cambios staged contienen múltiples cambios lógicos no relacionados. Si es así, sugiere dividir en commits atómicos separados.
+
+**Por qué tiene sentido:** La regla actual de `github-flow.md` dice "Cada commit = un cambio aislado y completo (puede revertirse solo)", pero no hay un check automatizado que lo verifique. Este patrón agrega esa verificación.
+
+**Adaptación necesaria:**
+
+- Agregar como **CHECK 8.5** (entre README y mensaje de commit)
+- Analizar `git diff --cached --stat` para detectar:
+  - Cambios en más de 3 directorios no relacionados
+  - Mezcla de tipos de archivos dispares (ej: `.cs` + `.md` + `.yaml` en el mismo commit sin relación obvia)
+  - Más de 300 líneas de diff (umbral configurable en `pm-config.md`)
+- Si se detectan múltiples cambios lógicos:
+  - Sugerir la división al humano (NO dividir automáticamente)
+  - Proponer qué archivos van en cada commit
+  - Esperar confirmación antes de proceder
+- NO adoptar emojis del repo fuente en los mensajes de commit (conflicto con el formato convencional existente)
+- El `commit-guardian` ya controla el mensaje en CHECK 9; este check complementa validando la **atomicidad** antes del mensaje
+
+**Conflictos:** Parcial con CHECK 9. Solución: CHECK 8.5 valida atomicidad del *contenido*, CHECK 9 valida formato del *mensaje*. Son complementarios.
+
+---
+
+## Parte 2 — Elementos descartados
+
+### Descartado 1: Emojis en commits (Gitmoji)
+
+**Razón:** El workspace usa formato convencional `tipo(scope): descripción` sin emojis. Agregar emojis contradiría `github-flow.md` y rompería la consistencia del historial de commits. El mapeo gitmoji → tipo convencional del repo fuente es interesante pero innecesario cuando ya se tiene la convención funcionando.
+
+### Descartado 2: Ralph Wiggum Technique (iteraciones autónomas)
+
+**Razón:** Esta técnica permite que Claude itere autónomamente sin supervisión humana. Contradice directamente la regla SDD de pm-workspace: "Code Review es SIEMPRE humano" y el principio de que ciertos pasos nunca se automatizan. El riesgo de iteraciones sin control es alto en un workspace de producción.
+
+### Descartado 3: Infraestructura de curación (CSV, generadores, workflows de submission)
+
+**Razón:** Toda esta infraestructura (el 80% del repo) sirve para gestionar una lista curada de recursos. No es aplicable a un workspace de gestión de proyectos. Es la plomería interna del repo, no un recurso transferible.
+
+### Descartado 4: Assets SVG y sistema multi-estilo de README
+
+**Razón:** Visualmente impresionante pero no relevante para pm-workspace. El README del workspace es funcional y documentativo, no una vitrina visual.
+
+### Descartado 5: Comando `/todo` local (gestión de tareas en markdown)
+
+**Razón:** pm-workspace gestiona tareas en Azure DevOps con work items, no en archivos markdown locales. Agregar un sistema paralelo de todos crearía duplicidad y confusión sobre cuál es la fuente de verdad. Las tareas siempre deben vivir en Azure DevOps.
+
+---
+
+## Parte 3 — Plan de implementación sugerido
+
+### Fase 1 — Quick wins (no requieren cambios estructurales)
+
+| # | Incorporación | Esfuerzo | Impacto |
+|---|---|---|---|
+| 1 | `/evaluate-repo` | Bajo | Alto — cierra gap de seguridad en adopción de herramientas |
+| 6 | Patrones regex en `security-guardian` | Bajo | Medio — mejora detección de secrets |
+| 4 | `/context-load` | Bajo | Alto — reduce fricción al iniciar sesiones |
+
+### Fase 2 — Mejoras al flujo existente
+
+| # | Incorporación | Esfuerzo | Impacto |
+|---|---|---|---|
+| 7 | Check de atomicidad en `commit-guardian` | Medio | Medio — mejora calidad del historial git |
+| 5 | `/changelog-update` | Medio | Medio — automatiza mantenimiento de CHANGELOG |
+
+### Fase 3 — Extensiones del workflow SDD
+
+| # | Incorporación | Esfuerzo | Impacto |
+|---|---|---|---|
+| 3 | JTBD + PRD workflow | Alto | Alto — formaliza discovery antes de implementación |
+| 2 | `/pr-review` multi-perspectiva | Alto | Alto — eleva la calidad de las revisiones de PR |
+
+---
+
+## Parte 4 — Compatibilidad verificada
+
+Cada propuesta fue cruzada con las siguientes reglas existentes:
+
+| Regla | Estado |
+|---|---|
+| `CLAUDE.md` — Restricciones absolutas (PAT, IterationPath, main) | Sin conflicto |
+| `github-flow.md` — Branching y commits convencionales | Sin conflicto (check 7 refuerza atomicidad) |
+| `pm-workflow.md` — Cadencia Scrum y operaciones | Sin conflicto (JTBD/PRD extiende, no reemplaza) |
+| `csharp-rules.md` — Análisis estático SonarQube-equivalent | Sin conflicto |
+| `dotnet-conventions.md` — Estándares de codificación | Sin conflicto |
+| `readme-update.md` — Triggers de actualización de README | Compatible (nuevos commands/skills requieren actualizar README) |
+| SDD — Spec-Driven Development flow | Sin conflicto (JTBD/PRD precede al flujo, /pr-review lo cierra) |
+| Tabla de delegación del `commit-guardian` | Compatible (nuevos checks se integran en la secuencia) |
+
+---
+
+*Propuesta generada a partir del análisis cruzado de awesome-claude-code v2.0.1 y pm-workspace.*


### PR DESCRIPTION
Add 5 new slash commands (/evaluate:repo, /pr:review, /context:load, /changelog:update, /pbi:jtbd, /pbi:prd) and 1 new skill (product-discovery) with JTBD and PRD templates. Enhance security-guardian with merge conflict detection (SEC-8) and commit-guardian with atomicity check (CHECK 9). Update CLAUDE.md, README.md, and pm-workflow.md to reflect 24 commands and 8 skills.

## What does this PR add or fix?

<!-- 2-3 sentence summary -->

## Type of contribution

- [ ] New slash command
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Test suite addition
- [ ] Refactor (no behaviour change)
- [ ] Other: ___

## Files added / modified

<!-- List the key files and what each one does -->
- `.claude/commands/` —
- `.claude/skills/` —
- `scripts/` —
- `docs/` —

## How to test this

<!-- Step-by-step instructions for the reviewer to verify the change works -->

1.
2.
3.

## Test suite

- [ ] `./scripts/test-workspace.sh --mock` passes ≥ 93/96
- [ ] I added tests for new files (if applicable)

## Checklist

- [ ] Command/skill name follows existing conventions (`namespace:action`, kebab-case)
- [ ] I tested this in a real Claude Code conversation at least once
- [ ] No real PATs, org URLs, project names, or client data included
- [ ] Documentation in the file is sufficient for a PM to understand it without reading this PR
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (for features and fixes)

## Related issues

Closes #
