### PR TITLE
feat(team): add onboarding, competency evaluation and GDPR compliance

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -8,8 +8,8 @@ Directorio de configuración de Claude Code para PM-Workspace + Azure DevOps.
 
 ```
 .claude/
-├── commands/          ← 24 slash commands para flujos PM con Azure DevOps
-├── skills/            ← 8 skills especializadas en gestión de proyectos
+├── commands/          ← 27 slash commands para flujos PM con Azure DevOps
+├── skills/            ← 9 skills especializadas en gestión de proyectos
 │   ├── azure-devops-queries/       ← Prerequisito para el resto
 │   ├── sprint-management/
 │   ├── capacity-planning/
@@ -17,6 +17,7 @@ Directorio de configuración de Claude Code para PM-Workspace + Azure DevOps.
 │   ├── executive-reporting/
 │   ├── product-discovery/          ← JTBD + PRD antes de decompose
 │   ├── pbi-decomposition/
+│   ├── team-onboarding/            ← Onboarding + evaluación de competencias + RGPD
 │   └── spec-driven-development/
 ├── agents/            ← 11 subagentes especializados (architect, dotnet-developer, etc.)
 ├── rules/             ← Reglas modulares cargadas bajo demanda

--- a/.claude/agents/business-analyst.md
+++ b/.claude/agents/business-analyst.md
@@ -1,11 +1,12 @@
 ---
 name: business-analyst
 description: >
-  Análisis de reglas de negocio, descomposición de PBIs y criterios de aceptación. Usar
-  PROACTIVELY cuando: se analiza un PBI antes de descomponerlo, hay ambigüedades en los
-  requisitos, se necesita validar que una implementación cumple las reglas de negocio del
-  proyecto, se escriben criterios de aceptación, o se evalúa el impacto de un cambio en
-  las reglas. También para resolver conflictos entre requisitos o detectar casos no cubiertos.
+  Análisis de reglas de negocio, descomposición de PBIs, criterios de aceptación y evaluación
+  de competencias del equipo. Usar PROACTIVELY cuando: se analiza un PBI antes de descomponerlo,
+  hay ambigüedades en los requisitos, se necesita validar que una implementación cumple las
+  reglas de negocio del proyecto, se escriben criterios de aceptación, se evalúa el impacto
+  de un cambio en las reglas, o se calibra una evaluación de competencias de un programador.
+  También para resolver conflictos entre requisitos o detectar casos no cubiertos.
 tools:
   - Read
   - Glob
@@ -45,9 +46,26 @@ que permitan implementaciones sin ambigüedad.
 - **Preguntas sin respuesta** que deben resolverse antes de implementar
 - **Estimación de complejidad de negocio** (independiente de la técnica)
 
+## Tu proceso al evaluar competencias (delegado por `/team:evaluate`)
+
+Cuando se te pide calibrar una evaluación de competencias:
+
+1. **Leer la autoevaluación** del trabajador (respuestas raw del cuestionario)
+2. **Comparar con evidencia observable** — si el trabajador tiene historial en el proyecto:
+   - Revisar sus PRs recientes (`git log --author="{nombre}"`)
+   - Analizar el tipo de tasks que ha completado (capa, complejidad)
+   - Comprobar el resultado de sus code reviews (número de rondas, tipo de hallazgos)
+3. **Sugerir ajustes** si la discrepancia entre autoevaluación y evidencia es > ±1 nivel
+4. **Documentar el razonamiento** de cada ajuste propuesto
+5. **Presentar al Tech Lead** — tú NO tomas la decisión final, solo propones ajustes fundamentados
+
+**Importante:** esta evaluación es para asignación de tareas y formación, NUNCA para disciplina.
+No acceder a métricas de productividad individual (LOC, commits/día). No comparar con otros miembros.
+
 ## Restricciones
 
 - **No decides sobre arquitectura técnica** — eso es para `architect`
 - **No escribes código** — solo defines el comportamiento esperado
 - Si una regla de negocio no está documentada pero es evidente, señálalo y propón documentarla
 - Siempre indicar la fuente (fichero + línea) de cada regla que cites
+- **No mostrar niveles de competencia de otros miembros** durante una evaluación (privacidad RGPD)

--- a/.claude/commands/team-evaluate.md
+++ b/.claude/commands/team-evaluate.md
@@ -1,0 +1,173 @@
+---
+name: team-evaluate
+description: >
+  Ejecuta el cuestionario interactivo de evaluación de competencias para un
+  programador del equipo. Genera el perfil de expertise que alimenta el algoritmo
+  de asignación de tareas. Cumple con RGPD/LOPDGDD.
+---
+
+# Evaluación de Competencias
+
+**Programador:** $ARGUMENTS
+
+> Uso: `/team:evaluate "Laura Sánchez" --project GestiónClínica`
+>
+> Prerequisito obligatorio: la nota informativa RGPD debe estar firmada.
+> Si no existe en `projects/{proyecto}/privacy/`, este comando se detiene.
+
+---
+
+## Protocolo
+
+### 1. Leer la skill y referencias
+
+- Leer `.claude/skills/team-onboarding/SKILL.md`
+- Leer `.claude/skills/team-onboarding/references/questionnaire-template.md`
+- Leer `.claude/skills/team-onboarding/references/expertise-mapping.md`
+
+### 2. Verificar nota informativa RGPD (BLOQUEO)
+
+Comprobar si existe `projects/{proyecto}/privacy/{nombre}-nota-informativa-*.md`.
+
+- Si existe → continuar
+- Si NO existe → **DETENER**. Informar:
+  "La nota informativa RGPD es obligatoria antes de recoger datos de competencias
+  (Art. 13 RGPD). Ejecuta `/team:privacy-notice "{nombre}" --project {proyecto}` primero."
+
+### 3. Verificar contexto del proyecto
+
+- Leer `projects/{proyecto}/CLAUDE.md` — para conocer los módulos del proyecto
+- Leer `projects/{proyecto}/equipo.md` — para verificar si el miembro ya existe
+- Leer `projects/{proyecto}/reglas-negocio.md` — para personalizar sección C (dominio)
+
+Si el miembro ya tiene un perfil de expertise en equipo.md, informar:
+"Este miembro ya tiene una evaluación del {fecha}. ¿Quieres actualizarla o crear una nueva?"
+
+### 4. Personalizar sección C (dominio)
+
+A partir de los módulos del proyecto (detectados en CLAUDE.md o en la estructura del source/),
+generar la sección C del cuestionario con los módulos reales:
+
+Ejemplo:
+```
+Sección C — Conocimiento del Dominio (GestiónClínica)
+  C1: Módulo de Pacientes
+  C2: Módulo de Citas
+  C3: Módulo de Facturación
+  C4: Integraciones externas
+```
+
+### 5. Ejecutar cuestionario interactivo
+
+Presentar el cuestionario al usuario en bloques manejables. **No preguntar las 26 competencias de golpe.** Usar este flujo:
+
+**Bloque 1 — Sección A: Técnico .NET (A1-A12)**
+
+Para cada competencia, mostrar:
+- Nombre y descripción
+- Evidencia verificable (qué deberías poder hacer)
+- Pedir: nivel (1-5) e interés (S/N)
+
+Agrupar de 3 en 3 para no saturar:
+- Primero A1-A3 (C#, Clean Arch, CQRS)
+- Luego A4-A6 (EF Core, Validation, Unit Testing)
+- Luego A7-A9 (Integration Testing, API, SQL)
+- Finalmente A10-A12 (Security, SOLID, CI/CD)
+
+**Bloque 2 — Sección B: Transversal (B1-B7)**
+
+Todas juntas (son menos y más rápidas de evaluar).
+
+**Bloque 3 — Sección C: Dominio (C1-Cn)**
+
+Las competencias de dominio personalizadas para el proyecto.
+
+### 6. Calcular perfil de expertise
+
+Aplicar el algoritmo de `references/expertise-mapping.md`:
+
+1. Calcular `expertise[módulo]` para cada módulo del proyecto
+2. Identificar `growth_areas` (Interés=Sí AND Nivel<3)
+3. Establecer `ultima_evaluacion` = fecha actual
+
+### 7. Presentar resultado para calibración
+
+Mostrar el perfil calculado al usuario y solicitar validación del Tech Lead:
+
+```
+═══ PERFIL DE COMPETENCIAS ═══
+
+  Laura Sánchez — GestiónClínica
+
+  Expertise por módulo:
+    pacientes:     4.2  ████████░░  Experta
+    citas:         3.1  ██████░░░░  Competente
+    facturacion:   2.0  ████░░░░░░  Practicante
+    testing:       4.5  █████████░  Experta
+    integraciones: 2.8  █████░░░░░  Practicante
+
+  Áreas de crecimiento: facturación, seguridad
+
+  ¿El Tech Lead confirma estos niveles? (S/N/Ajustar)
+```
+
+Si hay ajustes, documentar el razonamiento del Tech Lead.
+
+### 8. Guardar resultados
+
+**a) Respuestas raw** (para auditoría RGPD):
+
+Guardar en `projects/{proyecto}/evaluaciones/{nombre}-competencias-{fecha}.yaml`:
+```yaml
+evaluado: "Laura Sánchez"
+fecha: "2026-02-26"
+evaluador_tech_lead: "Carlos Mendoza"
+secciones:
+  A:
+    A1: { nivel: 5, interes: false }
+    A2: { nivel: 4, interes: false }
+    # ...
+  B:
+    B1: { nivel: 4, interes: false }
+    # ...
+  C:
+    C1: { nivel: 3, interes: true }
+    # ...
+ajustes_tech_lead:
+  - competencia: A9
+    original: 3
+    ajustado: 2
+    razon: "No ha trabajado con planes de ejecución en este proyecto"
+```
+
+**b) Perfil en equipo.md:**
+
+Actualizar o añadir la entrada del miembro en `projects/{proyecto}/equipo.md` con:
+- `expertise:` (por módulo)
+- `growth_areas:` (lista)
+- `ultima_evaluacion:` (fecha)
+
+Respetar el formato existente de equipo.md. No borrar otros campos del miembro.
+
+---
+
+## Delegación
+
+Delegar al agente `business-analyst` la calibración de las respuestas:
+- Comparar la autoevaluación con evidencia observable (PRs del miembro en el proyecto, si hay histórico Git)
+- Sugerir ajustes si hay discrepancia > ±1 nivel
+- Documentar el razonamiento de cada ajuste
+
+El `business-analyst` NO tiene la decisión final — es el Tech Lead quien confirma.
+
+---
+
+## Restricciones
+
+- **BLOQUEO si no hay nota informativa RGPD firmada** — sin excepciones
+- **No recoger métricas de productividad** — ni LOC, ni commits/día, ni velocidad de cierre (AEPD)
+- **No mostrar niveles de otros miembros** — cada evaluación es individual y privada
+- **No ejecutar fuera de horario laboral** — Art. 88 LOPDGDD (desconexión digital)
+- **No usar como herramienta disciplinaria** — los datos son para asignación y formación, no para evaluación de rendimiento
+- **Conservación:** respuestas raw 4 años tras fin de relación laboral, después eliminación definitiva
+- Si el trabajador ejerce su derecho de oposición (Art. 21 RGPD), dejar de usar su perfil para asignación automática

--- a/.claude/commands/team-onboarding.md
+++ b/.claude/commands/team-onboarding.md
@@ -1,0 +1,144 @@
+---
+name: team-onboarding
+description: >
+  Genera una guía de onboarding personalizada para un nuevo programador que se incorpora
+  a un proyecto. Cubre las Fases 1-2: carga de contexto del proyecto y tour guiado
+  del codebase. El mentor humano valida cada checkpoint.
+---
+
+# Onboarding de Nuevo Miembro
+
+**Nuevo miembro:** $ARGUMENTS
+
+> Uso: `/team:onboarding "Laura Sánchez" --project GestiónClínica`
+>
+> Prerequisito: la nota informativa RGPD debe estar firmada antes de registrar
+> datos del trabajador. Si no existe, sugerir `/team:privacy-notice` primero.
+
+---
+
+## Protocolo
+
+### 1. Leer la skill de referencia
+
+Leer `.claude/skills/team-onboarding/SKILL.md` para entender el flujo completo de 5 fases.
+Leer `.claude/skills/team-onboarding/references/onboarding-checklist.md` para el checklist día a día.
+
+### 2. Identificar el proyecto
+
+- Leer `projects/{proyecto}/CLAUDE.md` — constantes, stack, configuración SDD
+- Leer `projects/{proyecto}/equipo.md` — miembros actuales, roles, especialización
+- Leer `projects/{proyecto}/reglas-negocio.md` — reglas que el nuevo miembro debe conocer
+
+Si el `--project` no se especifica, preguntar al usuario qué proyecto.
+
+### 3. Verificar nota informativa RGPD
+
+Comprobar si existe `projects/{proyecto}/privacy/{nombre}-nota-informativa-*.md`.
+
+- Si existe → continuar
+- Si no existe → informar al usuario que debe ejecutar `/team:privacy-notice` primero.
+  No bloquear el onboarding (la nota es necesaria para Fase 4, no para Fases 1-2),
+  pero recordar que es **obligatoria antes de ejecutar `/team:evaluate`**.
+
+### 4. Fase 1 — Contexto inmediato
+
+Ejecutar el equivalente de `/context:load` pero orientado al nuevo miembro:
+
+**a) Arquitectura general:**
+- Leer la estructura de carpetas del source (`projects/{proyecto}/source/`)
+- Identificar capas (Domain, Application, Infrastructure, API)
+- Listar los módulos/bounded contexts principales
+- Explicar los patrones usados (CQRS, MediatR, Clean Architecture, EF Core, etc.)
+
+**b) Convenciones del equipo:**
+- Leer `.claude/rules/dotnet-conventions.md` — naming, estructura, reglas de código
+- Leer `.claude/rules/github-flow.md` — branching, commits, PRs
+- Resumir las 5 convenciones más importantes para el nuevo miembro
+
+**c) Equipo y roles:**
+- Presentar los miembros del equipo (de equipo.md) con roles y especialización
+- Identificar quién es el mentor asignado y el Tech Lead
+- Explicar el concepto de agentes Claude como "developer" (developer_type: agent)
+
+### 5. Fase 2 — Tour del codebase
+
+Generar un tour guiado siguiendo un request típico de principio a fin:
+
+**a) Entry point → Response:**
+- Seleccionar un endpoint representativo del proyecto (preferir GET simple)
+- Mostrar: Controller → Handler/Query → Repository → Entity → DB
+- Explicar cada capa que atraviesa y qué responsabilidad tiene
+
+**b) Patrones con ejemplo real:**
+- Un Command + CommandHandler (escritura)
+- Un Query + QueryHandler (lectura)
+- Un Validator (FluentValidation)
+- Una Entity Configuration (Fluent API)
+- Un Unit Test (xUnit + Moq)
+
+**c) Dónde encontrar las cosas:**
+- Estructura de carpetas del solution
+- Dónde viven los tests y cómo ejecutarlos
+- Dónde están las specs SDD (si el proyecto usa SDD)
+- Cómo funciona el CI/CD (pipeline YAML)
+
+### 6. Generar guía personalizada
+
+Crear un documento Markdown que consolide Fases 1-2 con:
+- Diagrama de arquitectura (ASCII art o descripción de capas)
+- Listado de módulos con descripción de 1 línea
+- 5 convenciones clave del equipo
+- Tour del codebase con snippets reales del proyecto
+- Próximos pasos (Fase 3: primera task)
+
+Guardar en: `projects/{proyecto}/onboarding/{nombre}-guia.md`
+
+### 7. Presentar al humano
+
+Mostrar la guía generada y preguntar:
+- ¿El mentor quiere ajustar algo?
+- ¿Está listo para la Fase 3 (primera task asistida)?
+- Recordar que tras la Fase 3, el siguiente paso es `/team:evaluate`
+
+---
+
+## Formato del output
+
+```
+══════════════════════════════════════════════════════
+  ONBOARDING · {nombre} · {proyecto}
+══════════════════════════════════════════════════════
+
+  📋 Proyecto: {nombre_proyecto}
+  👥 Equipo: {N} miembros + agentes Claude
+  🏗️ Stack: .NET 8 / Clean Architecture / CQRS / EF Core
+  👤 Mentor: {nombre_mentor} ({rol_mentor})
+
+  ═══ FASE 1: CONTEXTO ═══
+
+  [Arquitectura, módulos, convenciones]
+
+  ═══ FASE 2: TOUR DEL CÓDIGO ═══
+
+  [Flujo request, patrones, estructura]
+
+  ═══ PRÓXIMOS PASOS ═══
+
+  → Fase 3: Mentor asigna primera task (complejidad B/C)
+  → Fase 4: /team:evaluate "{nombre}" --project {proyecto}
+
+  📄 Guía guardada en: projects/{proyecto}/onboarding/{nombre}-guia.md
+
+══════════════════════════════════════════════════════
+```
+
+---
+
+## Restricciones
+
+- **No asignar tasks** — eso es responsabilidad del mentor (Fase 3)
+- **No evaluar competencias** — eso es `/team:evaluate` (Fase 4)
+- **No modificar equipo.md** — solo lectura en esta fase
+- **No mostrar datos de competencias de otros miembros** — privacidad (RGPD)
+- Si el source del proyecto no está clonado, informar y sugerir cómo clonarlo

--- a/.claude/commands/team-privacy-notice.md
+++ b/.claude/commands/team-privacy-notice.md
@@ -1,0 +1,90 @@
+---
+name: team-privacy-notice
+description: >
+  Genera la nota informativa de protección de datos (Art. 13-14 RGPD) que debe
+  entregarse al trabajador ANTES de recoger datos de competencias. Rellena la
+  plantilla con los datos de la empresa y del trabajador.
+---
+
+# Generar Nota Informativa RGPD
+
+**Trabajador:** $ARGUMENTS
+
+> Uso: `/team:privacy-notice "Laura Sánchez" --project GestiónClínica`
+>
+> Este comando debe ejecutarse ANTES de `/team:evaluate`. La nota es obligatoria
+> conforme al Art. 13 del RGPD.
+
+---
+
+## Protocolo
+
+### 1. Leer la plantilla
+
+Leer `.claude/skills/team-onboarding/references/privacy-notice-template.md`.
+
+### 2. Obtener datos de la empresa
+
+Leer `CLAUDE.md` (raíz) para obtener:
+- `AZURE_DEVOPS_ORG_URL` → nombre de la organización
+- Cualquier constante de empresa definida
+
+Si no hay datos suficientes de la empresa en CLAUDE.md, preguntar al usuario:
+- Nombre de la empresa (razón social)
+- CIF
+- Dirección fiscal
+- Email de contacto para protección de datos
+- Nombre del DPO (si aplica)
+
+**Guardar estos datos** en `CLAUDE.md` o `CLAUDE.local.md` para no volver a preguntar.
+
+### 3. Rellenar la plantilla
+
+Sustituir los placeholders de la plantilla:
+- `[NOMBRE_EMPRESA]` → datos de la empresa
+- `[DIRECCIÓN_FISCAL]` → dirección
+- `[CIF]` → CIF
+- `[EMAIL_CONTACTO]` → email de contacto
+- `[NOMBRE_DPO]` / `[EMAIL_DPO]` → DPO o texto alternativo
+- Nombre del trabajador y fecha actual
+
+### 4. Guardar la nota
+
+```bash
+mkdir -p projects/{proyecto}/privacy
+```
+
+Guardar en: `projects/{proyecto}/privacy/{nombre}-nota-informativa-{fecha}.md`
+
+Donde `{nombre}` es el nombre en kebab-case (ej: "laura-sanchez") y `{fecha}` es YYYY-MM-DD.
+
+### 5. Presentar al usuario
+
+Mostrar la nota generada y el checklist de entrega:
+
+```
+═══ NOTA INFORMATIVA RGPD GENERADA ═══
+
+  📄 Archivo: projects/{proyecto}/privacy/{nombre}-nota-informativa-{fecha}.md
+
+  Checklist de entrega:
+  [ ] Imprimir la nota o enviarla por email al trabajador
+  [ ] El trabajador lee y comprende el contenido
+  [ ] El trabajador firma el acuse de recibo (sección 9 del documento)
+  [ ] Archivar la copia firmada (física o digital con firma electrónica)
+
+  ⚠️  IMPORTANTE: No ejecutar /team:evaluate hasta que el acuse
+     de recibo esté firmado. Es un requisito legal (Art. 13 RGPD).
+
+═══════════════════════════════════════
+```
+
+---
+
+## Restricciones
+
+- **Solo genera la nota** — no recoge datos de competencias (eso es `/team:evaluate`)
+- **No solicita consentimiento** — la base legal es interés legítimo, no consentimiento. La nota INFORMA, no pide permiso
+- **Si faltan datos de empresa**, preguntar al usuario antes de generar (no inventar)
+- **Un archivo por trabajador** — no reutilizar notas entre trabajadores
+- **Idioma:** español por defecto. Si se pasa `--lang en`, generar en inglés

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -47,6 +47,9 @@
 | `/context:load` | Carga de contexto al iniciar sesión (proyecto, sprint, actividad) |
 | `/changelog:update` | Actualizar CHANGELOG.md desde commits convencionales |
 | `/evaluate:repo [URL]` | Auditoría de seguridad y calidad de un repo externo |
+| `/team:onboarding {nombre}` | Guía de onboarding personalizada (Fases 1-2: contexto + código) |
+| `/team:evaluate {nombre}` | Cuestionario interactivo de competencias → perfil en equipo.md |
+| `/team:privacy-notice {nombre}` | Nota informativa RGPD obligatoria antes de evaluar competencias |
 
 ## 🔗 Referencias
 
@@ -60,4 +63,5 @@
 - SDD Template: `.claude/skills/spec-driven-development/references/spec-template.md`
 - SDD Layer Matrix: `.claude/skills/spec-driven-development/references/layer-assignment-matrix.md`
 - SDD Agent Patterns: `.claude/skills/spec-driven-development/references/agent-team-patterns.md`
+- Team Onboarding: `.claude/skills/team-onboarding/SKILL.md`
 - Azure DevOps API v7.1: https://learn.microsoft.com/en-us/rest/api/azure/devops/

--- a/.claude/skills/team-onboarding/SKILL.md
+++ b/.claude/skills/team-onboarding/SKILL.md
@@ -1,0 +1,93 @@
+# Skill: Team Onboarding & Expertise Evaluation
+
+## Cuándo usar esta skill
+
+Invocar cuando se incorpora un **nuevo programador** a un proyecto del workspace:
+- El miembro es nuevo en el equipo o en el proyecto
+- Se necesita acelerar su ramp-up (de 4-8 semanas a 5-10 días)
+- Se quiere registrar su perfil de competencias para el algoritmo de asignación
+
+## Qué produce
+
+Tres outputs que cubren el ciclo completo de incorporación:
+
+1. **Nota informativa RGPD** — documento de transparencia para el trabajador (obligatorio antes de recoger datos)
+2. **Guía de onboarding personalizada** — contexto, tour del codebase, checklist día a día
+3. **Perfil de competencias** — evaluación que alimenta el campo `expertise` en `equipo.md`
+
+## Flujo completo
+
+```
+Nuevo miembro se incorpora al proyecto
+    ↓
+/team:privacy-notice {nombre}     ← PM genera nota informativa RGPD
+    ↓                                (trabajador lee, firma, se archiva)
+/team:onboarding {nombre}         ← Fases 1-2: contexto + tour del código
+    ↓                                (mentor valida cada fase)
+  [Fase 3: primera task asistida]  ← Mentor asigna task B/C, pair programming con Claude
+    ↓                                (Code Review humano obligatorio)
+/team:evaluate {nombre}            ← Fase 4: cuestionario interactivo de competencias
+    ↓                                (autoevaluación + calibración Tech Lead)
+  [Fase 5: autonomía progresiva]   ← Semanas 1-3 con supervisión decreciente
+```
+
+**Fases 3 y 5 no son comandos** — son procesos humanos guiados por el mentor.
+
+## Cuándo NO usar
+
+- El miembro ya lleva >2 semanas productivo en el proyecto (ya está onboarded)
+- Cambio de proyecto de un miembro existente (usar solo `/team:evaluate` para actualizar dominio)
+- Becarios o personal de soporte que no escriben código (el cuestionario es para programadores)
+- Si no se ha entregado la nota informativa RGPD — `/team:evaluate` verificará esto
+
+## Almacenamiento
+
+Los documentos se guardan en el directorio del proyecto:
+```
+projects/{proyecto}/privacy/
+├── {nombre}-nota-informativa-{fecha}.md     ← Nota RGPD firmada
+
+projects/{proyecto}/onboarding/
+├── {nombre}-guia.md                         ← Guía personalizada
+
+projects/{proyecto}/evaluaciones/
+├── {nombre}-competencias-{fecha}.yaml       ← Respuestas raw del cuestionario
+```
+
+El perfil final se integra directamente en `projects/{proyecto}/equipo.md`.
+
+**Privacidad:** Los directorios `privacy/`, `onboarding/` y `evaluaciones/` están en `.gitignore`. Nunca se suben al repositorio público.
+
+## Plantillas
+
+Las plantillas están en `references/`:
+- `references/onboarding-checklist.md` — checklist día a día para mentor y nuevo miembro
+- `references/questionnaire-template.md` — cuestionario completo (A: .NET, B: transversal, C: dominio)
+- `references/expertise-mapping.md` — algoritmo de conversión respuestas → campo `expertise` en equipo.md
+- `references/privacy-notice-template.md` — plantilla de nota informativa Art. 13-14 RGPD
+
+## Agente responsable
+
+- **PM/Scrum Master** — orquesta el proceso completo y genera la nota informativa
+- **Mentor humano** — valida fases 1-3, aprueba checkpoints
+- **business-analyst** — ejecuta la calibración de competencias (Fase 4) vía `/team:evaluate`
+- **Tech Lead** — co-firma la evaluación final de competencias
+
+## Métricas de éxito
+
+| Métrica | Objetivo | Cómo se mide |
+|---------|----------|--------------|
+| Time-to-First-PR | ≤ 3 días | Timestamp del primer PR aprobado |
+| Calidad del primer PR | ≤ 3 rondas de review | Comentarios de code review |
+| Confianza autoreportada | ≥ 7/10 | Encuesta al día 5 y día 15 |
+| Independencia al día 10 | Puede tomar tasks sin spec | Validación del mentor |
+| Retención a 90 días | 100% | Seguimiento HR |
+
+## Conformidad legal
+
+Este skill procesa datos personales (competencias laborales). Ver `references/privacy-notice-template.md` para el marco legal completo. Resumen:
+
+- **Base legal:** Interés legítimo del empleador (Art. 6.1.f RGPD), NO consentimiento
+- **Minimización:** Solo competencias (1-5), interés (S/N), fecha. Sin métricas de productividad individual
+- **Derechos:** Acceso, Rectificación, Supresión, Oposición, Portabilidad (Arts. 15-21 RGPD)
+- **Nota informativa obligatoria** antes de recoger cualquier dato

--- a/.claude/skills/team-onboarding/references/expertise-mapping.md
+++ b/.claude/skills/team-onboarding/references/expertise-mapping.md
@@ -1,0 +1,103 @@
+# Algoritmo de Mapping: Cuestionario → equipo.md
+
+## Objetivo
+
+Convertir las respuestas del cuestionario de competencias (secciones A, B, C) en el campo `expertise` del archivo `equipo.md` que usa el algoritmo de asignación de pm-workspace.
+
+## Entrada
+
+Respuestas del cuestionario: 12 competencias técnicas (A1-A12), 7 transversales (B1-B7), N de dominio (C1-Cn). Cada una con nivel (1-5) e interés (S/N).
+
+## Algoritmo
+
+### Paso 1 — Calcular expertise por módulo del proyecto
+
+Cada módulo del proyecto tiene un conjunto de competencias relevantes. El `expertise[módulo]` es la **media aritmética** de los niveles de las competencias que aplican a ese módulo.
+
+```
+PARA CADA módulo del proyecto:
+    competencias_relevantes = mapeo_modulo_competencias[módulo]
+    niveles = [respuesta.nivel PARA CADA c EN competencias_relevantes]
+    expertise[módulo] = REDONDEAR(MEDIA(niveles), 1 decimal)
+```
+
+### Paso 2 — Definir el mapeo módulo → competencias
+
+El Tech Lead o Architect define qué competencias aplican a cada módulo. Ejemplo para un proyecto clínico:
+
+| Módulo | Competencias relevantes | Razonamiento |
+|--------|------------------------|--------------|
+| pacientes | A1, A2, A3, A4, A8, C1 | CRUD completo con queries EF Core |
+| citas | A1, A2, A3, A4, A5, A8, C2 | Incluye validaciones complejas |
+| facturacion | A1, A2, A4, A9, A10, C3 | SQL avanzado + seguridad |
+| testing | A6, A7 | Exclusivamente competencias de test |
+| integraciones | A8, A10, A12, C4 | APIs externas + CI/CD |
+
+**Si no hay mapeo definido:** usar la media de A1-A8 como `expertise` general del módulo (sin competencias de dominio C).
+
+### Paso 3 — Identificar growth_areas
+
+```
+growth_areas = []
+PARA CADA competencia CON interes = "Sí" Y nivel < 3:
+    growth_areas.AÑADIR(nombre_competencia)
+```
+
+Las growth_areas alimentan el factor `crecimiento × 0.10` del algoritmo de asignación. Cuando un miembro tiene un módulo en su growth_areas, el algoritmo puede asignarle tasks de ese módulo para que crezca (si el peso de growth lo permite).
+
+### Paso 4 — Calcular expertise transversal (opcional)
+
+Para roles que requieren competencias transversales (Tech Lead, QA Lead):
+
+```
+expertise_transversal = REDONDEAR(MEDIA(B1, B2, ..., B7), 1 decimal)
+```
+
+Este valor no entra directamente en el scoring de asignación pero informa al PM sobre capacidad de mentoring (B6), estimación (B5) y comunicación (B4).
+
+## Output: formato equipo.md
+
+```yaml
+miembros:
+  - nombre: "Laura Sánchez"
+    role: "Full Stack"
+    horas_dia: 7.5
+    expertise:
+      pacientes: 4.2      # Media de A1(5), A2(4), A3(4), A4(5), A8(4), C1(3)
+      citas: 3.1           # Media de A1(5), A2(4), A3(4), A4(5), A5(2), A8(4), C2(1)
+      facturacion: 2.0     # Media de A1(5), A2(4), A4(5), A9(1), A10(1), C3(1)
+      testing: 4.5         # Media de A6(5), A7(4)
+      integraciones: 2.8   # Media de A8(4), A10(1), A12(3), C4(3)
+    growth_areas:
+      - facturacion        # Interés=Sí, nivel<3
+      - seguridad          # A10: Interés=Sí, nivel=1
+    ultima_evaluacion: "2026-02-26"
+```
+
+## Compatibilidad con el algoritmo de asignación
+
+El campo `expertise[módulo]` alimenta directamente el componente `match_expertise` de la fórmula de `assignment-scoring.md`:
+
+```
+score = expertise × 0.40 + disponibilidad × 0.30 + balance × 0.20 + crecimiento × 0.10
+```
+
+Donde:
+- `expertise` (0.40): se busca `expertise[módulo_de_la_task]` en equipo.md
+- `crecimiento` (0.10): si el módulo está en `growth_areas`, el factor se incrementa
+
+La tabla de match_expertise de `assignment-scoring.md` mapea el nivel 1-5 a un factor 0.2-1.0.
+
+## Validaciones
+
+- Todos los niveles deben estar en rango 1.0 - 5.0
+- Si un módulo tiene 0 competencias relevantes, no generar entrada en expertise
+- Si el trabajador no completa la sección C (dominio), todos los módulos de dominio inician en 1.0
+- Redondear siempre a 1 decimal (4.166... → 4.2)
+
+## Frecuencia de actualización
+
+- **Primera evaluación:** al incorporarse (Fase 4 del onboarding)
+- **Trimestral:** autoevaluación rápida (≤15 min, solo cambios significativos)
+- **Anual:** revisión completa con Tech Lead
+- **Puntual:** tras formación significativa o liderazgo de módulo nuevo

--- a/.claude/skills/team-onboarding/references/onboarding-checklist.md
+++ b/.claude/skills/team-onboarding/references/onboarding-checklist.md
@@ -1,0 +1,104 @@
+# Checklist de Onboarding — Día a Día
+
+Checklist para el **mentor** y el **nuevo miembro**. Cada fase tiene un criterio de paso verificable. El mentor firma cada checkpoint antes de avanzar.
+
+---
+
+## Día 1 — Mañana: Contexto (Fase 1)
+
+**Responsable:** PM + Mentor
+
+- [ ] Nota informativa RGPD entregada y firmada (`/team:privacy-notice`)
+- [ ] Accesos configurados: Azure DevOps, repositorio Git, CI/CD, canales de comunicación
+- [ ] `/context:load` ejecutado en presencia del nuevo miembro
+- [ ] Claude explica la arquitectura general del proyecto
+- [ ] Mentor complementa con contexto que Claude no tiene (decisiones históricas, deuda técnica conocida, relaciones con el cliente)
+
+**Criterio de paso:** el nuevo miembro puede dibujar el diagrama de capas del proyecto sin ayuda y nombrar los 3-5 módulos principales.
+
+**Firma del mentor:** _________________ Fecha: _________
+
+---
+
+## Día 1 — Tarde: Navegación del Código (Fase 2)
+
+**Responsable:** Nuevo miembro (con Claude) + Mentor
+
+- [ ] Tour guiado del codebase con Claude: entry point → Controller → Handler → Repository → DB
+- [ ] Revisar un ejemplo real de cada patrón del proyecto (Command, Query, Validator, Entity Config)
+- [ ] Identificar dónde viven los tests y ejecutar `dotnet test` por primera vez
+- [ ] Revisar las convenciones del equipo: naming, estructura de carpetas, estilo de commits
+
+**Criterio de paso:** el nuevo miembro puede explicar el flujo completo de un endpoint al mentor, identificando qué clase interviene en cada capa.
+
+**Firma del mentor:** _________________ Fecha: _________
+
+---
+
+## Días 2-3: Primera Task Asistida (Fase 3)
+
+**Responsable:** Mentor (asigna) + Nuevo miembro (implementa)
+
+- [ ] Mentor selecciona una task de complejidad B o C (validator, DTO, unit test, query handler sencillo)
+- [ ] Nuevo miembro trabaja con patrón "Pausa y Resuelve": intentar solo 15-20 min → comparar con sugerencia de Claude
+- [ ] PR creado con descripción clara del cambio
+- [ ] Code Review pasado (puede requerir varias rondas — es esperable)
+- [ ] PR mergeado a la rama del sprint
+
+**Criterio de paso:** PR aprobado por el Tech Lead. El nuevo miembro puede explicar cada línea de su código.
+
+**Firma del mentor:** _________________ Fecha: _________
+
+---
+
+## Día 3: Cuestionario de Competencias (Fase 4)
+
+**Responsable:** PM + Nuevo miembro + Tech Lead
+
+- [ ] Verificar que la nota informativa RGPD está firmada
+- [ ] Ejecutar `/team:evaluate {nombre} --project {proyecto}`
+- [ ] Nuevo miembro responde las secciones A (técnico), B (transversal), C (dominio)
+- [ ] Tech Lead revisa y calibra las respuestas (ajustar si discrepancia > ±1 nivel)
+- [ ] Ambos confirman el perfil final
+- [ ] Perfil registrado en `equipo.md` con `expertise` y `growth_areas`
+
+**Criterio de paso:** perfil completo en `equipo.md`, consensuado entre el trabajador y el Tech Lead.
+
+**Firma del Tech Lead:** _________________ Fecha: _________
+
+---
+
+## Días 4-10: Autonomía Progresiva (Fase 5)
+
+**Responsable:** Mentor (supervisa) + Nuevo miembro (ejecuta)
+
+### Semana 1 (días 4-5)
+- [ ] Tasks de capa Application con spec SDD (el contrato elimina ambigüedad)
+- [ ] Mentor revisa TODOS los PRs (no solo E1)
+- [ ] Participación activa en la Daily Standup
+
+### Semana 2 (días 6-10)
+- [ ] Tasks de capas variadas (Application + Infrastructure)
+- [ ] Mentor revisa PRs con menor detalle (solo comentarios estructurales)
+- [ ] Primer intento de descomponer una task sin spec
+
+### Semana 3+ (post-onboarding)
+- [ ] Flujo normal del equipo
+- [ ] Mentor disponible bajo demanda (no revisión obligatoria de todos los PRs)
+- [ ] Encuesta de confianza día 15 (objetivo: ≥ 7/10)
+
+**Criterio de paso (día 10):** el nuevo miembro puede tomar una task del sprint sin spec SDD y resolverla de forma autónoma.
+
+**Firma del mentor:** _________________ Fecha: _________
+
+---
+
+## Notas para el Mentor
+
+1. **No comparar con Claude.** El objetivo es que el nuevo miembro aprenda, no que produzca. Si Claude da la respuesta perfecta, el valor educativo es bajo — fomentar el patrón "Pausa y Resuelve".
+
+2. **Ajustar el ritmo.** Si el nuevo miembro avanza más rápido, acelerar. Si necesita más tiempo en Fase 2, no hay problema — mejor 1 día extra entendiendo la arquitectura que 2 semanas debuggeando por no entenderla.
+
+3. **Documentar bloqueos.** Si algo tarda más de lo esperado, anotarlo. Esos bloqueos son inputs para mejorar la documentación del proyecto y las specs SDD.
+
+4. **Feedback bidireccional.** Al final del día 5 y del día 10, dedicar 15 minutos a: ¿qué fue útil? ¿qué faltó? ¿qué cambiarías del proceso?

--- a/.claude/skills/team-onboarding/references/privacy-notice-template.md
+++ b/.claude/skills/team-onboarding/references/privacy-notice-template.md
@@ -1,0 +1,125 @@
+# Nota Informativa sobre Protección de Datos — Evaluación de Competencias
+
+> **Plantilla conforme al RGPD (Reglamento UE 2016/679) Arts. 13-14 y la LOPDGDD (Ley Orgánica 3/2018)**
+>
+> Rellenar los campos entre [corchetes] con los datos reales antes de entregar al trabajador.
+
+---
+
+## 1. Responsable del Tratamiento
+
+**Empresa:** [NOMBRE_EMPRESA]
+**Dirección:** [DIRECCIÓN_FISCAL]
+**CIF:** [CIF]
+**Contacto:** [EMAIL_CONTACTO]
+**Delegado de Protección de Datos (DPO):** [NOMBRE_DPO] — [EMAIL_DPO]
+
+*(Si la empresa no tiene DPO obligatorio, indicar: "La empresa no está obligada a designar DPO conforme al Art. 37 RGPD. El contacto para cuestiones de protección de datos es [EMAIL_CONTACTO].")*
+
+---
+
+## 2. Finalidad del Tratamiento
+
+Sus datos de competencias profesionales serán tratados con las siguientes finalidades:
+
+1. **Asignación óptima de tareas** — asignar las tareas del sprint a los miembros del equipo según sus competencias reales, maximizando la eficiencia y evitando sobrecarga.
+2. **Identificación de necesidades formativas** — detectar áreas donde el trabajador podría beneficiarse de formación o mentoring para su desarrollo profesional.
+3. **Planificación de mentoring** — facilitar la relación mentor-aprendiz asignando mentores con expertise complementario.
+
+---
+
+## 3. Base Legal del Tratamiento
+
+El tratamiento se realiza al amparo del **interés legítimo del empleador** en la organización eficiente del trabajo, conforme al **Artículo 6.1.f) del RGPD**.
+
+Se ha realizado una **Evaluación de Interés Legítimo (LIA)** que concluye que los derechos e intereses del trabajador no se ven significativamente afectados, dado que:
+- Los datos no son de categoría especial (Art. 9 RGPD)
+- El trabajador tiene derecho de acceso y rectificación en todo momento
+- Los datos se usan exclusivamente para organización del trabajo
+- Se aplica el principio de minimización estricta
+
+---
+
+## 4. Datos Recogidos
+
+| Categoría | Datos específicos |
+|-----------|------------------|
+| Competencias técnicas | Nivel de dominio (escala 1-5) en 12 áreas técnicas .NET/C# |
+| Competencias transversales | Nivel de dominio (escala 1-5) en 7 áreas (Git, Code Review, Documentación, Comunicación, Estimación, Mentoring, Trabajo con IA) |
+| Conocimiento de dominio | Nivel de dominio (escala 1-5) en los módulos del proyecto |
+| Interés de crecimiento | Indicación (Sí/No) de áreas donde desea desarrollarse |
+| Fecha de evaluación | Fecha de la última evaluación de competencias |
+
+**Datos que NO se recogen:** métricas de productividad individual (líneas de código, commits por día, velocidad de cierre de tareas), datos médicos, información financiera, resultados de tests de personalidad.
+
+---
+
+## 5. Destinatarios
+
+Sus datos de competencias serán accesibles únicamente a:
+
+- **Tech Lead del proyecto** — para calibración de la evaluación y asignación técnica
+- **PM/Scrum Master del proyecto** — para planificación de sprint y asignación de tareas
+- **Sistema pm-workspace** — herramienta interna de gestión que usa un algoritmo determinista (no inteligencia artificial) para proponer asignaciones de tareas
+
+Sus datos de competencias **no se comunican** a terceros, clientes, ni a otros miembros del equipo. Los compañeros de equipo no tienen acceso a sus niveles individuales de competencia.
+
+---
+
+## 6. Uso de Algoritmo de Asignación
+
+El sistema pm-workspace utiliza un **algoritmo de scoring determinista** (no basado en machine learning) para proponer asignaciones de tareas. La fórmula combina cuatro factores con pesos configurables:
+
+- Expertise del trabajador en el módulo de la tarea (peso: 40%)
+- Disponibilidad horaria en el sprint (peso: 30%)
+- Balance de carga del equipo (peso: 20%)
+- Interés de crecimiento profesional (peso: 10%)
+
+**La decisión final de asignación es siempre del PM/Scrum Master.** El algoritmo genera una propuesta que el humano puede aceptar, modificar o rechazar.
+
+---
+
+## 7. Plazo de Conservación
+
+- **Durante la relación laboral:** los datos se mantienen activos y se actualizan periódicamente (trimestral o anualmente).
+- **Tras la finalización de la relación laboral:** los datos se conservan durante **4 años** conforme a las obligaciones de la legislación laboral española (Art. 4 del Estatuto de los Trabajadores en relación con plazos de prescripción). Transcurrido este plazo, se eliminan de forma definitiva.
+
+---
+
+## 8. Derechos del Trabajador
+
+Usted tiene los siguientes derechos en relación con sus datos de competencias:
+
+| Derecho | Descripción | Cómo ejercerlo |
+|---------|-------------|----------------|
+| **Acceso** (Art. 15 RGPD) | Obtener una copia de su perfil completo de competencias | Solicitar a [EMAIL_CONTACTO] |
+| **Rectificación** (Art. 16 RGPD) | Corregir niveles de competencia que considere inexactos | Solicitar revisión al Tech Lead |
+| **Supresión** (Art. 17 RGPD) | Eliminar sus datos cuando ya no sean necesarios | Solicitar a [EMAIL_CONTACTO] |
+| **Oposición** (Art. 21 RGPD) | Oponerse al tratamiento de sus datos | Solicitar a [EMAIL_CONTACTO] |
+| **Portabilidad** (Art. 20 RGPD) | Recibir sus datos en formato estructurado (YAML/JSON) | Solicitar a [EMAIL_CONTACTO] |
+| **Reclamación** | Presentar reclamación ante la AEPD | www.aepd.es |
+
+**Plazo de respuesta:** 30 días naturales desde la recepción de la solicitud.
+
+---
+
+## 9. Derecho a la Desconexión Digital
+
+Conforme al **Artículo 88 de la LOPDGDD**, las evaluaciones de competencias y cualquier actividad relacionada con este tratamiento se realizan **exclusivamente en horario laboral**. No se enviarán cuestionarios ni se analizará actividad fuera de la jornada de trabajo.
+
+---
+
+## Acuse de Recibo
+
+He leído y comprendo esta nota informativa sobre el tratamiento de mis datos de competencias profesionales. Conozco mis derechos y la forma de ejercerlos.
+
+**Nombre del trabajador:** ___________________________________
+
+**Firma:** ___________________________________
+
+**Fecha:** ___________________________________
+
+---
+
+*Documento generado por pm-workspace — `/team:privacy-notice`*
+*Este documento no constituye un contrato ni solicita consentimiento. Informa sobre un tratamiento basado en interés legítimo (Art. 6.1.f RGPD).*

--- a/.claude/skills/team-onboarding/references/questionnaire-template.md
+++ b/.claude/skills/team-onboarding/references/questionnaire-template.md
@@ -1,0 +1,83 @@
+# Cuestionario de Evaluación de Expertise
+
+## Instrucciones
+
+Este cuestionario evalúa las competencias técnicas y transversales del programador para alimentar el algoritmo de asignación de tareas de pm-workspace y planificar mentoring.
+
+**Formato:** autoevaluación validada por el Tech Lead.
+- El programador se evalúa en cada competencia (nivel 1-5 + interés S/N).
+- El Tech Lead revisa y ajusta si hay discrepancia > ±1 nivel.
+- Ambos confirman el resultado final.
+
+**Escala de niveles:**
+
+| Nivel | Nombre | Descripción |
+|-------|--------|-------------|
+| 1 | **Aprendiz** | Conoce la teoría básica. Necesita supervisión constante. |
+| 2 | **Practicante** | Trabaja con guía. Resuelve problemas conocidos siguiendo patrones. |
+| 3 | **Competente** | Trabaja de forma autónoma. Consulta con un experto en casos complejos. |
+| 4 | **Experto** | Resuelve problemas complejos, hace mentoring, propone mejoras. |
+| 5 | **Referente** | Diseña soluciones originales. Persona de referencia del equipo en esta área. |
+
+---
+
+## Sección A — Competencias Técnicas .NET/C#
+
+| # | Competencia | Evidencia verificable | Nivel (1-5) | Interés (S/N) |
+|---|-------------|----------------------|:-----------:|:--------------:|
+| A1 | **C# y OOP** — herencia, interfaces, genéricos, LINQ, async/await | Puede escribir un QueryHandler asíncrono con LINQ sin ayuda | | |
+| A2 | **Clean Architecture** — capas Domain, Application, Infrastructure, API | Sabe en qué capa va cada clase y por qué | | |
+| A3 | **CQRS y MediatR** — Commands, Queries, Handlers, Pipeline Behaviors | Puede crear un nuevo Command + Handler de cero | | |
+| A4 | **Entity Framework Core** — DbContext, Fluent API, Migrations, Queries | Puede configurar una entidad con relaciones y escribir consultas eficientes | | |
+| A5 | **FluentValidation** — Validators, reglas de negocio, mensajes custom | Puede crear un AbstractValidator completo para un DTO | | |
+| A6 | **Unit Testing** — xUnit/NUnit, Moq/NSubstitute, patrón AAA | Puede escribir tests con mocks para un Handler sin ver ejemplos | | |
+| A7 | **Integration Testing** — TestServer, TestContainers, fixtures | Puede montar un test que levante la API y haga requests reales | | |
+| A8 | **API REST** — Controllers, routing, model binding, Swagger, versionado | Puede diseñar un endpoint RESTful con status codes correctos | | |
+| A9 | **SQL y bases de datos** — T-SQL, índices, planes de ejecución, migraciones | Puede optimizar una query lenta analizando el plan de ejecución | | |
+| A10 | **Seguridad** — autenticación JWT, autorización basada en roles/políticas, OWASP | Puede implementar un middleware de autorización | | |
+| A11 | **SOLID y Design Patterns** — DI, Repository, Factory, Strategy | Sabe identificar violaciones SOLID en code review | | |
+| A12 | **CI/CD y DevOps básico** — Azure DevOps Pipelines, Docker, YAML | Puede leer y modificar un pipeline YAML existente | | |
+
+---
+
+## Sección B — Competencias Transversales
+
+| # | Competencia | Evidencia verificable | Nivel (1-5) | Interés (S/N) |
+|---|-------------|----------------------|:-----------:|:--------------:|
+| B1 | **Git avanzado** — branching, rebase, cherry-pick, resolución de conflictos | Puede resolver un merge conflict complejo sin perder código | | |
+| B2 | **Code Review** — dar y recibir feedback constructivo | Da reviews que mejoran el código sin generar conflicto | | |
+| B3 | **Documentación técnica** — XML docs, READMEs, ADRs | Documenta sus decisiones técnicas por escrito | | |
+| B4 | **Comunicación con stakeholders** — explicar técnico a no-técnicos | Puede explicar un problema técnico al Product Owner | | |
+| B5 | **Estimación de esfuerzo** — Story Points, descomposición de tareas | Sus estimaciones se desvían <30% del real | | |
+| B6 | **Mentoring** — capacidad de enseñar a otros | Ha guiado a un junior en una tarea completa | | |
+| B7 | **Trabajo con IA** — Claude Code, Copilot, prompting efectivo | Usa IA como acelerador sin perder comprensión del código | | |
+
+---
+
+## Sección C — Conocimiento del Dominio
+
+> **Nota:** Esta sección se personaliza para cada proyecto. Listar los módulos
+> o áreas de dominio del proyecto y evaluar el conocimiento del programador en cada uno.
+
+| # | Área de dominio | Nivel (1-5) | Interés (S/N) |
+|---|----------------|:-----------:|:--------------:|
+| C1 | [Módulo 1 — descripción] | | |
+| C2 | [Módulo 2 — descripción] | | |
+| C3 | [Módulo 3 — descripción] | | |
+| C4 | [Módulo 4 — descripción] | | |
+
+---
+
+## Resultado
+
+**Evaluado:** _________________________ Fecha: ___________
+
+**Tech Lead:** _________________________ Firma: ___________
+
+**Observaciones del Tech Lead:**
+
+(Anotar aquí cualquier ajuste realizado sobre la autoevaluación, con justificación)
+
+---
+
+**Próximo paso:** los resultados se procesan con el algoritmo de `references/expertise-mapping.md` y se registran en `equipo.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ projects/*/sprints/
 projects/*/test-data/
 projects/*/source/
 
+# ── Datos de equipo con información personal (RGPD) ──────────────────────────
+projects/*/evaluaciones/
+projects/*/privacy/
+projects/*/onboarding/
+
 # ── Outputs generados ────────────────────────────────────────────────────────
 output/
 /tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,9 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← Subagentes especializados (11 agentes)
-│   ├── commands/                  ← Slash commands (24 comandos)
+│   ├── commands/                  ← Slash commands (27 comandos)
 │   ├── rules/                     ← Reglas y configuración detallada
-│   └── skills/                    ← Skills reutilizables (8 skills)
+│   └── skills/                    ← Skills reutilizables (9 skills)
 ├── docs/                          ← Metodología (reglas Scrum, KPIs, plantillas...)
 ├── projects/                      ← Proyectos reales (git-ignorados por .gitignore)
 └── scripts/                       ← Scripts auxiliares Azure DevOps
@@ -86,7 +86,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 | Agente | Modelo | Especialidad |
 |---|---|---|
 | `architect` | Opus 4.6 | Diseño de capas, interfaces, patrones |
-| `business-analyst` | Opus 4.6 | Reglas de negocio, criterios de aceptación |
+| `business-analyst` | Opus 4.6 | Reglas de negocio, criterios de aceptación, evaluación de competencias |
 | `sdd-spec-writer` | Opus 4.6 | Specs ejecutables para agentes de código |
 | `code-reviewer` | Opus 4.6 | Calidad, seguridad, SOLID |
 | `security-guardian` | Opus 4.6 | Auditoría de seguridad y confidencialidad pre-commit |

--- a/README.en.md
+++ b/README.en.md
@@ -96,7 +96,7 @@ pm-workspace/
 │   ├── .env                     ← Environment variables (DO NOT commit)
 │   ├── mcp.json                 ← Optional MCP configuration
 │   │
-│   ├── commands/                ← 24 slash commands
+│   ├── commands/                ← 27 slash commands
 │   │   ├── sprint-status.md
 │   │   ├── sprint-plan.md
 │   │   ├── sprint-review.md
@@ -121,9 +121,12 @@ pm-workspace/
 │   │   ├── spec-implement.md     ← SDD
 │   │   ├── spec-review.md        ← SDD
 │   │   ├── spec-status.md        ← SDD
-│   │   └── agent-run.md          ← SDD
+│   │   ├── agent-run.md          ← SDD
+│   │   ├── team-onboarding.md    ← New member onboarding
+│   │   ├── team-evaluate.md      ← Competency assessment
+│   │   └── team-privacy-notice.md ← GDPR privacy notice
 │   │
-│   └── skills/                  ← 8 custom skills
+│   └── skills/                  ← 9 custom skills
 │       ├── azure-devops-queries/
 │       ├── sprint-management/
 │       ├── capacity-planning/
@@ -136,6 +139,12 @@ pm-workspace/
 │       ├── pbi-decomposition/
 │       │   └── references/
 │       │       └── assignment-scoring.md
+│       ├── team-onboarding/          ← Onboarding + competency assessment
+│       │   └── references/
+│       │       ├── onboarding-checklist.md
+│       │       ├── questionnaire-template.md
+│       │       ├── expertise-mapping.md
+│       │       └── privacy-notice-template.md
 │       └── spec-driven-development/
 │           ├── SKILL.md
 │           └── references/
@@ -1085,6 +1094,13 @@ The files in `projects/sala-reservas/test-data/` simulate real Azure DevOps API 
 /evaluate:repo [URL]             Security and quality audit of external repo
 ```
 
+### Team Management
+```
+/team:onboarding {name}          Personalized onboarding guide (context + code)
+/team:evaluate {name}            Interactive competency questionnaire → equipo.md profile
+/team:privacy-notice {name}      Mandatory GDPR privacy notice before assessment
+```
+
 ---
 
 ## Specialized Agent Team
@@ -1095,7 +1111,7 @@ each optimized for its task with the most suitable LLM model:
 | Agent | Model | Color | When to use |
 |---|---|---|---|
 | `architect` | Opus 4.6 | 🔵 blue | .NET architecture design, layer assignment, technical decisions |
-| `business-analyst` | Opus 4.6 | 🟣 purple | PBI analysis, business rules, acceptance criteria, JTBD, PRD |
+| `business-analyst` | Opus 4.6 | 🟣 purple | PBI analysis, business rules, acceptance criteria, JTBD, PRD, competency assessment |
 | `sdd-spec-writer` | Opus 4.6 | 🩵 cyan | Generation and validation of executable SDD Specs |
 | `code-reviewer` | Opus 4.6 | 🔴 red | Quality gate: security, SOLID, SonarQube rules (`csharp-rules.md`) |
 | `security-guardian` | Opus 4.6 | 🔴 red | Security and confidentiality audit before commit |
@@ -1195,6 +1211,7 @@ The following classic PM/Scrum Master responsibilities are automated or signific
 | Sprint Retrospective data | `/sprint:retro` | Medium — provides quantitative sprint data, but the retrospective dynamics are human |
 | Repetitive .NET task implementation | SDD + `/agent:run` | Very high — Command Handlers, Repositories, Validators, Unit Tests implemented without human intervention |
 | Spec quality control | `/spec:review` | High — automatically validates that a spec has sufficient detail before implementation |
+| New member onboarding | `/team:onboarding`, `/team:evaluate` | High — personalized onboarding guide + 26-competency questionnaire with GDPR compliance |
 
 ### 🔮 Not yet covered — candidates for the future
 
@@ -1207,8 +1224,6 @@ Areas that would be naturally automatable with Claude and represent a logical ev
 **Automatic release notes:** at sprint close, Claude has all the information to generate release notes from completed items and commits. The `/changelog:update` command partially covers this (generates CHANGELOG from commits), but a dedicated `/sprint:release-notes` that combines commits + work items would be the next step.
 
 **Technical debt management:** the workspace doesn't track or prioritize technical debt. A skill that analyzes the backlog for items tagged "refactor" or "tech-debt" and proposes them for maintenance sprints would be a useful addition.
-
-**New member onboarding:** when someone new joins the team, Claude could automatically generate a personalized onboarding guide (environment setup, project modules, code conventions) from workspace files.
 
 **Pull request integration:** the `/pr:review` command now covers multi-perspective review of PRs, but the workspace doesn't yet track associated PR status in AzDO (reviewers, pending comments, review time). Full integration with Azure DevOps Git API would complete the cycle.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 │   ├── .env                     ← Variables de entorno (git-ignorado)
 │   ├── mcp.json                 ← Configuración MCP opcional
 │   │
-│   ├── commands/                ← 24 slash commands
+│   ├── commands/                ← 27 slash commands
 │   │   ├── sprint-status.md
 │   │   ├── sprint-plan.md
 │   │   ├── sprint-review.md
@@ -122,9 +122,12 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 │   │   ├── spec-implement.md     ← SDD
 │   │   ├── spec-review.md        ← SDD
 │   │   ├── spec-status.md        ← SDD
-│   │   └── agent-run.md          ← SDD
+│   │   ├── agent-run.md          ← SDD
+│   │   ├── team-onboarding.md    ← Onboarding de nuevos miembros
+│   │   ├── team-evaluate.md      ← Evaluación de competencias
+│   │   └── team-privacy-notice.md ← Nota informativa RGPD
 │   │
-│   ├── skills/                  ← 8 skills personalizadas
+│   ├── skills/                  ← 9 skills personalizadas
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -137,6 +140,12 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 │   │   ├── pbi-decomposition/
 │   │   │   └── references/
 │   │   │       └── assignment-scoring.md
+│   │   ├── team-onboarding/          ← Onboarding + evaluación de competencias
+│   │   │   └── references/
+│   │   │       ├── onboarding-checklist.md
+│   │   │       ├── questionnaire-template.md
+│   │   │       ├── expertise-mapping.md
+│   │   │       └── privacy-notice-template.md
 │   │   └── spec-driven-development/
 │   │       ├── SKILL.md
 │   │       └── references/
@@ -265,7 +274,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 24 comandos y las 8 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 27 comandos y las 9 skills,
 y aplicará las reglas de `.claude/rules/` bajo demanda. Todas las buenas prácticas del
 flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 
@@ -1154,6 +1163,13 @@ Los ficheros en `projects/sala-reservas/test-data/` simulan respuestas reales de
 /evaluate:repo [URL]             Auditoría de seguridad y calidad de repo externo
 ```
 
+### Gestión de Equipo
+```
+/team:onboarding {nombre}       Guía de onboarding personalizada (contexto + código)
+/team:evaluate {nombre}         Cuestionario interactivo de competencias → perfil en equipo.md
+/team:privacy-notice {nombre}   Nota informativa RGPD obligatoria antes de evaluar
+```
+
 ---
 
 ## Equipo de Subagentes Especializados
@@ -1164,7 +1180,7 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | Agente | Modelo | Color | Cuándo se usa |
 |---|---|---|---|
 | `architect` | Opus 4.6 | 🔵 azul | Diseño de arquitectura .NET, asignación de capas, decisiones técnicas |
-| `business-analyst` | Opus 4.6 | 🟣 morado | Análisis de PBIs, reglas de negocio, criterios de aceptación, JTBD, PRD |
+| `business-analyst` | Opus 4.6 | 🟣 morado | Análisis de PBIs, reglas de negocio, criterios de aceptación, JTBD, PRD, evaluación de competencias |
 | `sdd-spec-writer` | Opus 4.6 | 🩵 cyan | Generación y validación de Specs SDD ejecutables |
 | `code-reviewer` | Opus 4.6 | 🔴 rojo | Quality gate: seguridad, SOLID, reglas SonarQube (`csharp-rules.md`) |
 | `security-guardian` | Opus 4.6 | 🔴 rojo | Auditoría de seguridad y confidencialidad pre-commit |
@@ -1274,6 +1290,7 @@ Las siguientes responsabilidades clásicas del PM/Scrum Master quedan automatiza
 | Sprint Retrospectiva (datos) | `/sprint:retro` | Media — proporciona los datos cuantitativos del sprint (qué fue bien, qué no), pero la dinámica es humana |
 | Implementación de tasks repetibles (.NET) | SDD + `/agent:run` | Muy alta — Command Handlers, Repositories, Validators, Unit Tests implementados sin intervención humana |
 | Control de calidad de specs | `/spec:review` | Alta — valida automáticamente que una spec tenga el nivel de detalle suficiente antes de implementar |
+| Onboarding de nuevos miembros | `/team:onboarding`, `/team:evaluate` | Alta — guía personalizada de incorporación + cuestionario de 26 competencias con conformidad RGPD |
 
 ### 🔮 No contemplado actualmente — candidatos para el futuro
 
@@ -1286,8 +1303,6 @@ Las siguientes responsabilidades clásicas del PM/Scrum Master quedan automatiza
 **Release notes automáticas:** al cierre del sprint, Claude tiene toda la información para generar las release notes desde los items completados y los commits. El comando `/changelog:update` cubre parcialmente este caso (genera CHANGELOG desde commits), pero un `/sprint:release-notes` específico que combine commits + work items sería el siguiente paso.
 
 **Gestión de deuda técnica:** el workspace no rastrea ni prioriza la deuda técnica. Un skill que analice el backlog en busca de items marcados como "refactor" o "tech-debt" y los proponga para sprints de mantenimiento sería un añadido útil.
-
-**Onboarding de nuevos miembros:** cuando llega alguien nuevo al equipo, Claude podría generar automáticamente una guía de incorporación personalizada (setup del entorno, módulos del proyecto, convenciones de código) desde los ficheros del workspace.
 
 **Seguimiento de bugs en producción:** el bug escape rate se calcula, pero no hay un flujo automatizado para priorizar bugs entrantes, relacionarlos con el sprint en curso y proponer si impactan en el sprint goal actual.
 

--- a/propuesta-onboarding-y-evaluacion.md
+++ b/propuesta-onboarding-y-evaluacion.md
@@ -1,0 +1,325 @@
+# Onboarding con IA + Evaluaci&oacute;n de Expertise del Equipo
+
+**Propuesta para pm-workspace** &mdash; febrero 2026
+
+---
+
+## 1. Onboarding de nuevos desarrolladores asistido por IA
+
+### 1.1 Problema actual
+
+Cuando un programador se incorpora a un proyecto .NET en curso, el ramp-up t&iacute;pico es de 4-8 semanas hasta alcanzar productividad plena. La mayor&iacute;a del tiempo se pierde en: entender la arquitectura, localizar c&oacute;digo relevante, descifrar convenciones no documentadas y esperar a que un senior est&eacute; disponible para resolver dudas.
+
+### 1.2 Propuesta: onboarding en 5 fases asistido por Claude
+
+El proceso se dise&ntilde;a para que un nuevo miembro del equipo llegue a su primera contribuci&oacute;n significativa en **3-5 d&iacute;as** (no semanas), usando la IA como acelerador y al mentor humano como validador.
+
+#### Fase 1 &mdash; Contexto inmediato (D&iacute;a 1, ma&ntilde;ana)
+
+**Qu&eacute; hace la persona nueva:** ejecuta `/context:load` y despu&eacute;s pregunta a Claude:
+
+```
+Soy nuevo en este proyecto. Expl&iacute;came la arquitectura general,
+los m&oacute;dulos principales, las convenciones del equipo y qu&eacute; debo
+saber antes de tocar c&oacute;digo.
+```
+
+**Qu&eacute; hace Claude:** lee el CLAUDE.md del proyecto, el equipo.md, las reglas-negocio.md, la estructura del source/ y genera un resumen ejecutivo personalizado con: diagrama de capas, m&oacute;dulos principales, patrones usados (CQRS, Clean Architecture, etc.), convenciones de naming y la cadena de dependencias cr&iacute;ticas.
+
+**Tiempo:** 30-60 minutos. **Verificable:** el nuevo miembro puede dibujar el diagrama de arquitectura sin ayuda.
+
+#### Fase 2 &mdash; Navegaci&oacute;n del c&oacute;digo (D&iacute;a 1, tarde)
+
+**Qu&eacute; hace la persona nueva:** Claude genera un tour guiado del codebase, empezando por el entry point de la API, siguiendo el flujo de un request t&iacute;pico hasta la base de datos, y mostrando el patr&oacute;n de cada capa con un ejemplo real del proyecto.
+
+```
+Mu&eacute;strame el flujo completo de un POST /salas desde el Controller
+hasta la base de datos, explicando cada capa que atraviesa.
+```
+
+**Herramientas complementarias:** Claude Code con `/evaluate:repo` sobre el propio proyecto para que el nuevo miembro entienda la calidad actual y las &aacute;reas de mejora.
+
+**Tiempo:** 2-3 horas. **Verificable:** la persona puede explicar el flujo de un endpoint al mentor.
+
+#### Fase 3 &mdash; Primera tarea asistida (D&iacute;as 2-3)
+
+**Qu&eacute; hace el mentor:** selecciona una task sencilla (complejidad B o C en la nomenclatura SDD &mdash; un validator, un DTO, un unit test) y la asigna al nuevo miembro.
+
+**Qu&eacute; hace la persona nueva:** usa Claude como pair programmer. Claude sugiere c&oacute;digo, la persona revisa, entiende y modifica. El mentor revisa el resultado final (Code Review humano obligatorio &mdash; regla E1 del SDD).
+
+**Patr&oacute;n clave: "Pausa y Resuelve"** &mdash; la persona intenta resolver el problema sola durante 15-20 minutos ANTES de pedir ayuda a Claude. Despu&eacute;s compara su soluci&oacute;n con la de la IA. Esto construye comprensi&oacute;n real, no dependencia.
+
+**Tiempo:** 1-2 d&iacute;as. **Verificable:** PR aprobado con code review del Tech Lead.
+
+#### Fase 4 &mdash; Cuestionario de competencias (D&iacute;a 3)
+
+La persona nueva completa el cuestionario de evaluaci&oacute;n de expertise (Secci&oacute;n 2 de este documento). Esto permite:
+
+- Registrar su perfil t&eacute;cnico para el algoritmo de asignaci&oacute;n.
+- Identificar &aacute;reas de mentoring espec&iacute;fico.
+- Ajustar el peso de `growth` en su scoring de asignaci&oacute;n para las primeras semanas.
+
+**Tiempo:** 30-45 minutos. **Verificable:** perfil registrado en equipo.md con consentimiento documentado.
+
+#### Fase 5 &mdash; Autonom&iacute;a progresiva (D&iacute;as 4-10)
+
+**Semana 1:** tasks de capa Application con spec SDD (el contrato elimina ambig&uuml;edad).
+**Semana 2:** tasks de capa m&aacute;s variada, incluyendo alguna de Infrastructure.
+**Semana 3+:** flujo normal del equipo, con mentor disponible bajo demanda.
+
+El mentor revisa c&oacute;digo de TODAS las tasks del nuevo miembro durante las primeras 3 semanas (no solo las E1 de SDD).
+
+### 1.3 M&eacute;tricas de &eacute;xito del onboarding
+
+| M&eacute;trica | Objetivo | C&oacute;mo se mide |
+|---------|----------|-----------------|
+| Time-to-First-PR | &le; 3 d&iacute;as | Timestamp del primer PR aprobado |
+| Calidad del primer PR | &le; 3 rondas de review | N&uacute;mero de comentarios de code review |
+| Confianza autoreportada | &ge; 7/10 | Encuesta al d&iacute;a 5 y d&iacute;a 15 |
+| Independencia al d&iacute;a 10 | Puede tomar tasks sin spec | Validaci&oacute;n del mentor |
+| Retenci&oacute;n a 90 d&iacute;as | 100% | Seguimiento HR |
+
+### 1.4 Lo que la IA NO sustituye en el onboarding
+
+- **El mentor humano.** Claude acelera, no reemplaza. Las preguntas de "por qu&eacute;" y "c&oacute;mo decidimos esto" necesitan contexto de equipo que la IA no tiene.
+- **La cultura de equipo.** Las din&aacute;micas de la Daily, la forma de comunicarse en PR, el estilo de los commits: eso se aprende conviviendo, no preguntando a un chatbot.
+- **El juicio sobre qu&eacute; tarea asignar.** El mentor decide la secuencia de tareas del onboarding seg&uacute;n el perfil del nuevo miembro.
+
+---
+
+## 2. Cuestionario de evaluaci&oacute;n de expertise
+
+### 2.1 Objetivo
+
+Construir un perfil de competencias de cada programador para alimentar el algoritmo de asignaci&oacute;n de pm-workspace (`expertise &times; 0.40 + disponibilidad &times; 0.30 + balance &times; 0.20 + crecimiento &times; 0.10`), identificar necesidades de formaci&oacute;n y planificar mentoring.
+
+### 2.2 Escala de evaluaci&oacute;n
+
+Se usa una escala de 5 niveles inspirada en el modelo Shu-Ha-Ri (aprendiz, practicante, competente, experto, referente):
+
+| Nivel | Nombre | Descripci&oacute;n operativa |
+|-------|--------|---------------------------|
+| 1 | **Aprendiz** | Conoce la teor&iacute;a b&aacute;sica. Necesita supervisi&oacute;n constante para producir c&oacute;digo. |
+| 2 | **Practicante** | Puede trabajar con gu&iacute;a. Resuelve problemas conocidos siguiendo patrones establecidos. |
+| 3 | **Competente** | Trabaja de forma aut&oacute;noma. Ocasionalmente consulta con un experto en casos complejos. |
+| 4 | **Experto** | Resuelve problemas complejos, hace mentoring a otros, propone mejoras arquitect&oacute;nicas. |
+| 5 | **Referente** | Dise&ntilde;a soluciones originales. Es la persona a quien el equipo acude para las decisiones m&aacute;s cr&iacute;ticas de esta &aacute;rea. |
+
+Cada competencia se eval&uacute;a en dos dimensiones:
+
+- **Nivel actual** (1-5): d&oacute;nde est&aacute; hoy.
+- **Inter&eacute;s** (S&iacute;/No): si quiere desarrollar esta competencia. Esto alimenta el peso `growth` del algoritmo.
+
+### 2.3 Formato del cuestionario
+
+El cuestionario es de **autoevaluaci&oacute;n validada por el Tech Lead**. La persona se eval&uacute;a a s&iacute; misma, el Tech Lead revisa y ajusta si hay discrepancias significativas (&plusmn;2 niveles), y ambos firman el resultado. Esto combina honestidad con calibraci&oacute;n objetiva.
+
+### 2.4 Secci&oacute;n A &mdash; Competencias t&eacute;cnicas .NET/C#
+
+| # | Competencia | Evidencia verificable | Nivel (1-5) | Inter&eacute;s (S/N) |
+|---|-------------|----------------------|-------------|------------------|
+| A1 | **C# y OOP** &mdash; herencia, interfaces, genricos, LINQ, async/await | Puede escribir un QueryHandler as&iacute;ncrono con LINQ sin ayuda | ___ | ___ |
+| A2 | **Clean Architecture** &mdash; capas Domain, Application, Infrastructure, API | Sabe en qu&eacute; capa va cada clase y por qu&eacute; | ___ | ___ |
+| A3 | **CQRS y MediatR** &mdash; Commands, Queries, Handlers, Pipeline Behaviors | Puede crear un nuevo Command + Handler de cero | ___ | ___ |
+| A4 | **Entity Framework Core** &mdash; DbContext, Fluent API, Migrations, Queries | Puede configurar una entidad con relaciones y escribir consultas eficientes | ___ | ___ |
+| A5 | **FluentValidation** &mdash; Validators, reglas de negocio, mensajes custom | Puede crear un AbstractValidator completo para un DTO | ___ | ___ |
+| A6 | **Unit Testing** &mdash; xUnit/NUnit, Moq/NSubstitute, AAA pattern | Puede escribir tests con mocks para un Handler sin ver ejemplos | ___ | ___ |
+| A7 | **Integration Testing** &mdash; TestServer, TestContainers, fixtures | Puede montar un test que levante la API y haga requests reales | ___ | ___ |
+| A8 | **API REST** &mdash; Controllers, routing, model binding, Swagger, versionado | Puede dise&ntilde;ar un endpoint RESTful con status codes correctos | ___ | ___ |
+| A9 | **SQL y bases de datos** &mdash; T-SQL, &iacute;ndices, planes de ejecuci&oacute;n, migraciones | Puede optimizar una query lenta analizando el plan de ejecuci&oacute;n | ___ | ___ |
+| A10 | **Seguridad** &mdash; autenticaci&oacute;n JWT, autorizaci&oacute;n basada en roles/pol&iacute;ticas, OWASP | Puede implementar un middleware de autorizaci&oacute;n | ___ | ___ |
+| A11 | **Principios SOLID y Design Patterns** &mdash; DI, Repository, Factory, Strategy | Sabe identificar violaciones SOLID en code review | ___ | ___ |
+| A12 | **CI/CD y DevOps b&aacute;sico** &mdash; Azure DevOps Pipelines, Docker, YAML | Puede leer y modificar un pipeline YAML existente | ___ | ___ |
+
+### 2.5 Secci&oacute;n B &mdash; Competencias transversales
+
+| # | Competencia | Evidencia verificable | Nivel (1-5) | Inter&eacute;s (S/N) |
+|---|-------------|----------------------|-------------|------------------|
+| B1 | **Git avanzado** &mdash; branching, rebase, cherry-pick, resoluci&oacute;n de conflictos | Puede resolver un merge conflict complejo sin perder c&oacute;digo | ___ | ___ |
+| B2 | **Code Review** &mdash; dar y recibir feedback constructivo | Da reviews que mejoran el c&oacute;digo sin generar conflicto | ___ | ___ |
+| B3 | **Documentaci&oacute;n t&eacute;cnica** &mdash; XML docs, READMEs, ADRs | Documenta sus decisiones t&eacute;cnicas por escrito | ___ | ___ |
+| B4 | **Comunicaci&oacute;n con stakeholders** &mdash; explicar t&eacute;cnico a no-t&eacute;cnicos | Puede explicar un problema t&eacute;cnico al Product Owner | ___ | ___ |
+| B5 | **Estimaci&oacute;n de esfuerzo** &mdash; Story Points, descomposici&oacute;n de tareas | Sus estimaciones se desv&iacute;an &lt;30% del real | ___ | ___ |
+| B6 | **Mentoring** &mdash; capacidad de ense&ntilde;ar a otros | Ha guiado a un junior en una tarea completa | ___ | ___ |
+| B7 | **Trabajo con IA** &mdash; Claude Code, Copilot, prompting efectivo | Usa IA como acelerador sin perder comprensi&oacute;n del c&oacute;digo | ___ | ___ |
+
+### 2.6 Secci&oacute;n C &mdash; Conocimiento del dominio (por proyecto)
+
+Esta secci&oacute;n se personaliza para cada proyecto. Ejemplo para un proyecto cl&iacute;nico:
+
+| # | &Aacute;rea de dominio | Nivel (1-5) | Inter&eacute;s (S/N) |
+|---|---------------------|-------------|------------------|
+| C1 | M&oacute;dulo de Pacientes &mdash; entidades, reglas de negocio, flujos | ___ | ___ |
+| C2 | M&oacute;dulo de Citas &mdash; reservas, cancelaciones, notificaciones | ___ | ___ |
+| C3 | M&oacute;dulo de Facturaci&oacute;n &mdash; tarifas, seguros, cobros | ___ | ___ |
+| C4 | Integraciones externas &mdash; APIs de terceros, pasarela de pago | ___ | ___ |
+
+### 2.7 C&oacute;mo se transforma en datos para el algoritmo
+
+El resultado del cuestionario se traduce al campo `expertise` del archivo `equipo.md` de cada proyecto:
+
+```yaml
+miembros:
+  - nombre: "Laura S&aacute;nchez"
+    role: "Full Stack"
+    horas_dia: 7.5
+    expertise:
+      # Promedio ponderado de las competencias relevantes para cada m&oacute;dulo
+      pacientes: 4.2    # Media de A1-A8 aplicadas al m&oacute;dulo Pacientes
+      citas: 3.1        # Baja porque no ha trabajado este m&oacute;dulo a&uacute;n
+      facturacion: 2.0   # &Aacute;rea de crecimiento identificada
+      testing: 4.5       # A6 + A7 altos
+    growth_areas: ["facturacion", "seguridad"]  # Derivado de Inter&eacute;s = S&iacute;
+    ultima_evaluacion: "2026-02-26"
+```
+
+El algoritmo de asignaci&oacute;n usa `expertise[modulo]` como input directo para el factor `expertise &times; 0.40` del scoring, y `growth_areas` para el factor `crecimiento &times; 0.10`.
+
+### 2.8 Frecuencia de actualizaci&oacute;n
+
+- **Primera evaluaci&oacute;n:** al incorporarse (Fase 4 del onboarding).
+- **Actualizaci&oacute;n trimestral:** autoevaluaci&oacute;n r&aacute;pida (&le;15 min, solo cambios).
+- **Evaluaci&oacute;n completa anual:** revisi&oacute;n conjunta con Tech Lead.
+- **Actualizaci&oacute;n puntual:** cuando alguien completa una formaci&oacute;n significativa o lidera un m&oacute;dulo nuevo.
+
+---
+
+## 3. Cumplimiento RGPD / LOPDGDD
+
+### 3.1 Marco legal aplicable
+
+Los datos de competencias de los programadores son **datos personales** seg&uacute;n el art&iacute;culo 4 del RGPD (Reglamento UE 2016/679) y est&aacute;n protegidos tanto por el RGPD como por la **LOPDGDD** (Ley Org&aacute;nica 3/2018 de Protecci&oacute;n de Datos Personales y Garant&iacute;a de Derechos Digitales).
+
+### 3.2 Base legal: inter&eacute;s leg&iacute;timo del empleador (Art. 6.1.f RGPD)
+
+La base legal para tratar datos de competencias es el **inter&eacute;s leg&iacute;timo del empleador** en organizar el trabajo de forma eficiente, no el consentimiento del trabajador. Razones:
+
+1. **El consentimiento no es libre en relaciones laborales** &mdash; existe desequilibrio de poder (el trabajador puede sentir que negarse tiene consecuencias). Por eso el RGPD desaconseja el consentimiento como base en contexto laboral.
+2. **El inter&eacute;s leg&iacute;timo** cubre la gesti&oacute;n y organizaci&oacute;n del trabajo, la asignaci&oacute;n de tareas seg&uacute;n capacidades, la planificaci&oacute;n de formaci&oacute;n y el desarrollo profesional.
+3. **Se requiere una Evaluaci&oacute;n de Inter&eacute;s Leg&iacute;timo (LIA)** documentada ANTES de empezar a recoger datos.
+
+**Evaluaci&oacute;n de inter&eacute;s leg&iacute;timo resumida:**
+
+| Test | Resultado |
+|------|-----------|
+| **Prop&oacute;sito** | Asignar tareas de forma eficiente seg&uacute;n las capacidades reales del equipo, identificar necesidades formativas, planificar mentoring. |
+| **Necesidad** | No existe alternativa menos intrusiva que capture la informaci&oacute;n necesaria para asignaci&oacute;n &oacute;ptima de trabajo. |
+| **Ponderaci&oacute;n** | Los derechos del trabajador no se ven significativamente afectados porque: (a) los datos no son sensibles (Art. 9), (b) el trabajador tiene acceso y rectificaci&oacute;n, (c) los datos se usan exclusivamente para organizaci&oacute;n del trabajo, (d) se aplica minimizaci&oacute;n estricta. |
+
+### 3.3 Principios de minimizaci&oacute;n (Art. 5.1.c RGPD + LOPDGDD)
+
+La AEPD (Agencia Espa&ntilde;ola de Protecci&oacute;n de Datos) interpreta la minimizaci&oacute;n de forma estricta en contexto laboral. Solo se recogen:
+
+| Se recoge | No se recoge |
+|-----------|-------------|
+| Competencias directamente relacionadas con las tareas del proyecto | Datos m&eacute;dicos, discapacidades, condiciones de salud |
+| Nivel de competencia (escala 1-5) | Resultados de tests de personalidad o psicot&eacute;cnicos |
+| Inter&eacute;s en &aacute;reas de crecimiento | Informaci&oacute;n financiera, salario, evaluaci&oacute;n de rendimiento num&eacute;rica |
+| Fecha de &uacute;ltima evaluaci&oacute;n | Datos de navegaci&oacute;n, productividad por hora, m&eacute;tricas de c&oacute;digo individuales |
+
+**Importante:** las m&eacute;tricas de productividad individual (l&iacute;neas de c&oacute;digo, commits/d&iacute;a, velocidad de cierre de tasks) **no se recogen como parte del perfil de competencias**. Estas m&eacute;tricas se usan solo a nivel de equipo (KPIs del sprint) y nunca se asocian a una persona individual.
+
+### 3.4 Derechos del trabajador (Arts. 15-21 RGPD)
+
+Cada trabajador tiene garantizados estos derechos sobre sus datos de competencias:
+
+| Derecho | C&oacute;mo se ejerce | Plazo |
+|---------|-------------------|-------|
+| **Acceso** (Art. 15) | El trabajador puede pedir una copia de su perfil completo de competencias en cualquier momento. | 30 d&iacute;as naturales |
+| **Rectificaci&oacute;n** (Art. 16) | Si el trabajador considera que un nivel est&aacute; mal evaluado, puede solicitar correcci&oacute;n. Se resuelve en reuni&oacute;n con el Tech Lead. | Sin demora indebida |
+| **Supresi&oacute;n** (Art. 17) | Al finalizar la relaci&oacute;n laboral, los datos se eliminan salvo obligaci&oacute;n legal de conservaci&oacute;n (4 a&ntilde;os por legislaci&oacute;n laboral espa&ntilde;ola). | 30 d&iacute;as naturales |
+| **Oposici&oacute;n** (Art. 21) | El trabajador puede oponerse al tratamiento. Se analiza caso a caso. Si la oposici&oacute;n es fundada, se deja de usar su perfil para asignaci&oacute;n autom&aacute;tica. | Sin demora indebida |
+| **Portabilidad** (Art. 20) | El trabajador puede pedir sus datos en formato estructurado (YAML/JSON) para llevarlos a otro empleador. | 30 d&iacute;as naturales |
+
+### 3.5 Transparencia obligatoria (Arts. 13-14 RGPD)
+
+Antes de recoger ning&uacute;n dato de competencias, se entrega al trabajador una **nota informativa** que incluye:
+
+1. **Responsable del tratamiento:** nombre de la empresa, datos de contacto, DPO si aplica.
+2. **Finalidad:** "Asignaci&oacute;n &oacute;ptima de tareas seg&uacute;n competencias, identificaci&oacute;n de necesidades formativas y planificaci&oacute;n de mentoring."
+3. **Base legal:** "Inter&eacute;s leg&iacute;timo del empleador en la organizaci&oacute;n eficiente del trabajo (Art. 6.1.f RGPD)."
+4. **Datos recogidos:** competencias t&eacute;cnicas (escala 1-5), inter&eacute;s en &aacute;reas de crecimiento, fecha de evaluaci&oacute;n.
+5. **Destinatarios:** Tech Lead del proyecto, PM/Scrum Master, sistema de asignaci&oacute;n pm-workspace.
+6. **Conservaci&oacute;n:** durante la vigencia de la relaci&oacute;n laboral + 4 a&ntilde;os tras la finalizaci&oacute;n (obligaci&oacute;n legal laboral).
+7. **Derechos:** acceso, rectificaci&oacute;n, supresi&oacute;n, oposici&oacute;n, portabilidad, reclamaci&oacute;n ante la AEPD (www.aepd.es).
+
+**Formato:** lenguaje claro y sencillo. No enterrada en un contrato de 40 p&aacute;ginas. Se recomienda documento independiente de 1-2 p&aacute;ginas con acuse de recibo firmado.
+
+### 3.6 Consideraciones de la Ley de IA de la UE (Reglamento UE 2024/1689)
+
+El algoritmo de asignaci&oacute;n de pm-workspace (`expertise &times; 0.40 + disponibilidad &times; 0.30 + balance &times; 0.20 + crecimiento &times; 0.10`) es **determinista y transparente** (no es machine learning), lo que reduce significativamente las obligaciones bajo la Ley de IA. Sin embargo:
+
+| Aspecto | Situaci&oacute;n | Acci&oacute;n requerida |
+|---------|------------|---------------------|
+| **Clasificaci&oacute;n de riesgo** | Si el algoritmo se usa como apoyo a la decisi&oacute;n humana (recomendaci&oacute;n, no decisi&oacute;n autom&aacute;tica), no es alto riesgo. | Mantener siempre la decisi&oacute;n final en el humano (PM/Scrum Master). |
+| **Supervisi&oacute;n humana** | pm-workspace ya la tiene: Claude propone, el PM confirma. | Documentar que ninguna asignaci&oacute;n es autom&aacute;tica. |
+| **Transparencia** | El trabajador debe saber que existe un algoritmo de scoring. | Incluir en la nota informativa: "Se utiliza un algoritmo de scoring basado en expertise, disponibilidad, balance de carga y crecimiento para proponer asignaciones de tareas. La decisi&oacute;n final es siempre del PM." |
+| **No discriminaci&oacute;n** | El algoritmo no debe producir sesgos por g&eacute;nero, edad, origen, etc. | Auditar peri&oacute;dicamente que las asignaciones no presentan patrones discriminatorios. |
+
+### 3.7 Derecho a la desconexi&oacute;n digital (Art. 88 LOPDGDD)
+
+Las evaluaciones de competencias y el seguimiento de skills **solo se realizan en horario laboral**. No se env&iacute;an cuestionarios fuera de jornada ni se analiza actividad (commits, PRs) fuera del horario de trabajo para inferir competencias.
+
+### 3.8 Medidas de seguridad
+
+| Medida | Implementaci&oacute;n en pm-workspace |
+|--------|--------------------------------------|
+| **Control de acceso** | Solo Tech Lead y PM del proyecto acceden al perfil completo. Los compa&ntilde;eros no ven niveles individuales. |
+| **Almacenamiento** | El archivo `equipo.md` est&aacute; en el directorio del proyecto, incluido en `.gitignore` (nunca se sube al repositorio p&uacute;blico). |
+| **Cifrado** | El disco del equipo con los datos est&aacute; cifrado (BitLocker/FileVault). |
+| **Retenci&oacute;n** | Datos activos mientras dure la relaci&oacute;n laboral. Archivado durante 4 a&ntilde;os tras la baja. Eliminaci&oacute;n definitiva despu&eacute;s. |
+| **Incidentes** | Cualquier acceso no autorizado se reporta al DPO y a la AEPD en &le;72 horas si supone riesgo para los derechos del trabajador (Art. 33 RGPD). |
+
+### 3.9 Checklist de cumplimiento antes de implementar
+
+- [ ] Completar y documentar la Evaluaci&oacute;n de Inter&eacute;s Leg&iacute;timo (LIA)
+- [ ] Redactar la nota informativa para los trabajadores
+- [ ] Obtener acuse de recibo firmado de cada trabajador
+- [ ] Verificar que equipo.md est&aacute; en .gitignore
+- [ ] Designar qui&eacute;n tiene acceso a los datos (Tech Lead + PM)
+- [ ] Establecer procedimiento para ejercicio de derechos ARCO-POL
+- [ ] Incluir en el Registro de Actividades de Tratamiento (RAT) de la empresa
+- [ ] Si hay comit&eacute; de empresa, informar a los representantes de los trabajadores
+- [ ] Auditar trimestralmente que no hay datos excesivos
+- [ ] Documentar que la asignaci&oacute;n de tareas es siempre decisi&oacute;n humana final
+
+---
+
+## 4. Resumen ejecutivo
+
+### Onboarding
+Proceso de 5 fases que reduce el ramp-up de 4-8 semanas a 5-10 d&iacute;as, usando Claude como acelerador y al mentor humano como validador. M&eacute;tricas verificables en cada fase. Compatible con el flujo SDD existente.
+
+### Evaluaci&oacute;n de expertise
+Cuestionario de autoevaluaci&oacute;n validada (19 competencias t&eacute;cnicas + 7 transversales + dominio por proyecto), con escala 1-5 y dimensi&oacute;n de inter&eacute;s. Se transforma directamente en el campo `expertise` del algoritmo de asignaci&oacute;n.
+
+### Cumplimiento legal
+Base legal: inter&eacute;s leg&iacute;timo (no consentimiento). Minimizaci&oacute;n estricta seg&uacute;n criterio AEPD. Transparencia obligatoria con nota informativa previa. Derechos ARCO-POL garantizados. Algoritmo determinista con decisi&oacute;n final humana. Datos en .gitignore, nunca en repo p&uacute;blico.
+
+---
+
+## 5. Fuentes consultadas
+
+### Onboarding con IA
+- Eesel Blog &mdash; "How to navigate any codebase with Claude Code" (2025)
+- Stack Overflow Blog &mdash; "Developers with AI assistants need pair programming model" (2024)
+- Marcel Moll &mdash; "Advice for Mentors: Teaching Juniors in the Age of AI" (2025)
+- ShyftLabs &mdash; "AI Onboarding Chatbot reduces integration time by 80%" (2025)
+- DEV Community &mdash; "AI-Assisted Development in 2026: Best Practices" (2026)
+- Moxo &mdash; "How to measure AI onboarding success: ROI, key metrics & benchmarks" (2025)
+
+### Evaluaci&oacute;n de competencias
+- Management 3.0 &mdash; "Team Competency Matrix" (practice guide)
+- Martin Fowler &mdash; "Shu Ha Ri" (Bliki)
+- TeamMeter &mdash; "Skills Matrix Software" (2025)
+- Vervoe &mdash; ".NET Developer Skills Assessment Test" (2025)
+- Sujin Joseph &mdash; "Programmer Competency Matrix"
+- Training Industry &mdash; "How to Create and Use a Skills Matrix in 5 Steps" (2024)
+
+### Normativa de protecci&oacute;n de datos
+- RGPD (Reglamento UE 2016/679) &mdash; Arts. 4, 5, 6, 13-17, 21, 33, 88
+- LOPDGDD (Ley Org&aacute;nica 3/2018) &mdash; Arts. 87, 88, 89
+- AEPD &mdash; "La protecci&oacute;n de datos en las relaciones laborales" (Gu&iacute;a 2021, actualizada 2023)
+- GDPRhub &mdash; "Data Protection in Spain" (2025)
+- ICO &mdash; "Legitimate Interests Assessment" (guidance)
+- Reglamento UE 2024/1689 (Ley de Inteligencia Artificial) &mdash; Art. 6, Anexo III


### PR DESCRIPTION
Implement the team onboarding and expertise assessment system for pm-workspace (v0.4.0 milestone). Includes 3 new slash commands, 1 new skill with 4 references, and RGPD/LOPDGDD-compliant privacy notice.

New commands: /team:onboarding, /team:evaluate, /team:privacy-notice
New skill: team-onboarding (5 files)
Extended: business-analyst agent with competency calibration
Updated: all READMEs (27 commands, 9 skills), .gitignore (RGPD patterns)

## What does this PR add or fix?

<!-- 2-3 sentence summary -->

## Type of contribution

- [ ] New slash command
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Test suite addition
- [ ] Refactor (no behaviour change)
- [ ] Other: ___

## Files added / modified

<!-- List the key files and what each one does -->
- `.claude/commands/` —
- `.claude/skills/` —
- `scripts/` —
- `docs/` —

## How to test this

<!-- Step-by-step instructions for the reviewer to verify the change works -->

1.
2.
3.

## Test suite

- [ ] `./scripts/test-workspace.sh --mock` passes ≥ 93/96
- [ ] I added tests for new files (if applicable)

## Checklist

- [ ] Command/skill name follows existing conventions (`namespace:action`, kebab-case)
- [ ] I tested this in a real Claude Code conversation at least once
- [ ] No real PATs, org URLs, project names, or client data included
- [ ] Documentation in the file is sufficient for a PM to understand it without reading this PR
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (for features and fixes)

## Related issues

Closes #
