### PR TITLE
release/v0.3.0 — Multi-language, Infra, Docs reorg, File size rule

### DIFF
--- a/.claude/rules/github-flow.md
+++ b/.claude/rules/github-flow.md
@@ -49,6 +49,7 @@ main
 - `docs/` — solo documentación (README, best-practices, reglas)
 - `refactor/` — reestructuración sin cambio de comportamiento
 - `chore/` — mantenimiento (actualizar .gitignore, limpieza, etc.)
+- `release/` — preparación de nueva versión (CHANGELOG, tag)
 
 ### Nombrado de rama: regla pre-commit
 
@@ -96,24 +97,19 @@ Configurar en GitHub → Settings → Branches → Branch protection rules:
 
 ---
 
-## Comandos habituales
+## Releases y Tags
 
-```bash
-# Crear y cambiar a nueva rama
-git checkout -b feature/nombre-descriptivo
+Toda release usa rama `release/vX.Y.Z` + tag anotado tras merge:
 
-# Ver ramas locales y remotas
-git branch -a
+1. `git checkout -b release/vX.Y.Z` desde `main`
+2. Actualizar `CHANGELOG.md` con versión y fecha
+3. Commit: `chore(release): prepare vX.Y.Z — Título breve`
+4. Push + PR hacia `main`
+5. Tras merge: `git checkout main && git pull && git tag -a vX.Y.Z -m "vX.Y.Z — Título" && git push origin vX.Y.Z`
 
-# Pushear rama nueva al remoto
-git push -u origin feature/nombre-descriptivo
+**SemVer**: Minor (0.X.0) = nuevos agentes/comandos/skills · Patch (0.0.X) = fixes/docs · Major (X.0.0) = cambios incompatibles
 
-# Actualizar rama con cambios de main (antes de PR)
-git fetch origin && git rebase origin/main
-
-# Después del merge: volver a main y limpiar
-git checkout main && git pull && git branch -d feature/nombre-descriptivo
-```
+**Prefijo de rama**: `release/` (se añade a los prefijos estándar de la tabla anterior)
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       value: |
         Before submitting, please search existing issues to avoid duplicates.
-        Check [ROADMAP.md](../../ROADMAP.md) — your idea might already be planned.
+        Check [ROADMAP.md](../../docs/ROADMAP.md) — your idea might already be planned.
 
   - type: dropdown
     id: type

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             "CONTRIBUTING.md"
             "CODE_OF_CONDUCT.md"
             "SECURITY.md"
-            "ROADMAP.md"
+            "docs/ROADMAP.md"
             ".github/pull_request_template.md"
             ".github/ISSUE_TEMPLATE/bug_report.yml"
             ".github/ISSUE_TEMPLATE/feature_request.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,49 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Planned for v0.3.0
+### Planned
 - `backlog:capture` — create PBIs from unstructured input (emails, meeting notes, support tickets)
 - `risk:log` — structured risk register updated automatically on each `/sprint:status`
 - `sprint:release-notes` — auto-generate release notes combining work items + commits
 - GitHub Actions: auto-label PRs by branch prefix (`feature/`, `fix/`, `docs/`)
+
+---
+
+## [0.3.0] — 2026-02-26
+
+Multi-language, multi-environment, infrastructure as code, documentation reorganization, and file size governance. Adds 16 Language Packs, 7 new commands, 1 new agent, 12 new developer agents, and a 150-line file size rule.
+
+### Added
+
+**Multi-language support (16 Language Packs)**
+- Per-language conventions, rules, developer agents, and layer matrices for: C#/.NET, TypeScript/Node.js, Angular, React, Java/Spring Boot, Python, Go, Rust, PHP/Laravel, Swift/iOS, Kotlin/Android, Ruby/Rails, VB.NET, COBOL, Terraform/IaC, Flutter/Dart
+- 12 new developer agents: `typescript-developer`, `frontend-developer`, `java-developer`, `python-developer`, `go-developer`, `rust-developer`, `php-developer`, `mobile-developer`, `ruby-developer`, `cobol-developer`, `terraform-developer`, `infrastructure-agent`
+- `language-packs.md` — centralized Language Pack catalog with auto-detection table
+- `agents-catalog.md` — centralized agent catalog with flow diagrams
+- `docs/guia-incorporacion-lenguajes.md` — step-by-step guide for adding new languages
+
+**Multi-environment and Infrastructure as Code**
+- `environment-config.md` — configurable multi-environment system (DEV/PRE/PRO by default, customizable names and counts)
+- `confidentiality-config.md` — secrets protection policy (Key Vault, SSM, Secret Manager, config.local/)
+- `infrastructure-as-code.md` — multi-cloud IaC support (Terraform, Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pulumi)
+- `infrastructure-agent` (Opus 4.6) — auto-detect existing resources, minimum viable tier, cost estimation, human approval for scaling
+- 7 new commands: `/infra:detect`, `/infra:plan`, `/infra:estimate`, `/infra:scale`, `/infra:status`, `/env:setup`, `/env:promote`
+
+**File size governance**
+- `file-size-limit.md` — max 150 lines per file (code, rules, docs, tests); legacy inherited code exempt unless PM requests refactor
+
+**Team evaluation and onboarding**
+- `/team:evaluate` — competency evaluation across 8 dimensions with radar charts
+- `business-analyst` agent extended with onboarding and GDPR-compliant evaluation capabilities
+- Onboarding proposal and evaluation framework in `docs/propuestas/`
+
+### Changed
+- README.md and README.en.md split into 12 sections each under `docs/readme/` and `docs/readme_en/`; root READMEs now serve as compact hub documents (~130 lines)
+- Documentation moved from root to `docs/`: ADOPTION_GUIDE, SETUP, ROADMAP, proposals, .docx guides
+- CLAUDE.md compacted from 217 to 127 lines; agent and language tables externalized to dedicated rule files
+- Workspace totals: 24 → 35 commands, 11 → 23 agents, 8 → 9 skills
+- All .NET-only references updated to multi-language throughout documentation
+- Cross-references updated across 6 files after reorganization
 
 ---
 
@@ -26,31 +64,26 @@ Quality, discovery, and operations expansion. Adds 6 new slash commands, 1 new s
 **Product Discovery workflow**
 - `/pbi:jtbd {id}` — generate Jobs to be Done document for a PBI before technical decomposition
 - `/pbi:prd {id}` — generate Product Requirements Document (MoSCoW prioritisation, Gherkin acceptance criteria, risks)
-- `product-discovery` skill (`.claude/skills/product-discovery/`) with JTBD and PRD reference templates
+- `product-discovery` skill with JTBD and PRD reference templates
 
 **Quality and operations commands**
-- `/pr:review [PR]` — multi-perspective PR review from 5 angles: Business Analyst, Developer, QA Engineer, Security, DevOps
-- `/context:load` — session initialisation: loads CLAUDE.md, checks git branches, summarises recent commits, verifies tools
-- `/changelog:update` — automates CHANGELOG.md updates from conventional commits with semantic version suggestion
-- `/evaluate:repo [URL]` — static security and quality evaluation of external repositories before adoption (6 criteria + Claude Code-specific checklist)
+- `/pr:review [PR]` — multi-perspective PR review from 5 angles
+- `/context:load` — session initialisation: loads CLAUDE.md, checks git, summarises commits, verifies tools
+- `/changelog:update` — automates CHANGELOG.md updates from conventional commits
+- `/evaluate:repo [URL]` — static security and quality evaluation of external repositories
 
 **Agents and rules enhancements**
-- `security-guardian` — new SEC-8: merge conflict markers and git artifacts detection (`.orig`, `.BACKUP`, `.BASE`, `.LOCAL`, `.REMOTE`)
-- `commit-guardian` — new CHECK 9: commit atomicity verification (signals: >3 unrelated root dirs, disparate file types, >300 lines diff; exceptions: related command+docs, fix+test, same-module refactor)
-- `csharp-rules.md` — knowledge base with 70+ static analysis rules equivalent to SonarQube (Vulnerabilities, Security Hotspots, Bugs, Code Smells) + 12 Clean Architecture/DDD rules (ARCH-01 to ARCH-12)
-- `test-runner` agent — post-commit test execution, coverage verification, improvement orchestration
+- `security-guardian` — SEC-8: merge conflict markers detection
+- `commit-guardian` — CHECK 9: commit atomicity verification
+- `csharp-rules.md` — 70+ static analysis rules + 12 Clean Architecture/DDD rules
+- `test-runner` agent — post-commit test execution and coverage orchestration
 - `CLAUDE_MODEL_MID` — new constant for mid-tier model (Sonnet)
 
 ### Changed
-- Models upgraded to generation 4.6: Opus `claude-opus-4-6`, Sonnet `claude-sonnet-4-6` (Haiku 4.5 maintained)
-- `commit-guardian` expanded from 8 to 10 checks — CHECK 6 (Code Review with auto-correction cycle) and CHECK 9 (atomicity)
-- `security-guardian` expanded from 8 to 9 checks — SEC-8 (merge conflict markers)
-- `code-reviewer` now references `csharp-rules.md` and cites rule IDs in each finding
-- `business-analyst` agent now covers JTBD and PRD generation
-- Updated all agent, config, skill, command, and project CLAUDE.md files with new model IDs
+- Models upgraded to generation 4.6: Opus `claude-opus-4-6`, Sonnet `claude-sonnet-4-6`
+- `commit-guardian` expanded from 8 to 10 checks
+- `security-guardian` expanded from 8 to 9 checks
 - Workspace totals: 19 → 24 commands, 7 → 8 skills, 9 → 11 agents
-- `README.md`, `README.en.md`, `.claude/README.md`, `CLAUDE.md`, `pm-workflow.md` aligned with new counts and capabilities
-- `github-flow.md` updated with branch naming conventions and main-return rules
 
 ---
 
@@ -62,73 +95,40 @@ Initial public release of PM-Workspace.
 
 **Core workspace**
 - `CLAUDE.md` — global entry point with org constants, project registry, and tool definitions
-- `docs/SETUP.md` — step-by-step setup guide (PAT, constants, npm install, git clone, first run)
-- Project template structure: `CLAUDE.md`, `equipo.md`, `reglas-negocio.md`, `sprints/`, `specs/`
+- `docs/SETUP.md` — step-by-step setup guide
 
-**Sprint management commands** (`.claude/commands/`)
-- `/sprint:status` — burndown, active items, WIP alerts, blocker detection, capacity remaining
-- `/sprint:plan` — sprint planning assistant: real capacity calculation + PBI candidate selection
-- `/sprint:review` — sprint review summary: velocity, completed items, demo preparation
-- `/sprint:retro` — retrospective with quantitative sprint data (what went well / improve)
+**Sprint management commands**
+- `/sprint:status`, `/sprint:plan`, `/sprint:review`, `/sprint:retro`
 
 **Reporting commands**
-- `/report:hours` — timesheet report (Excel, 4 tabs) from Azure DevOps data
-- `/report:executive` — multi-project executive report (PPT + Word with traffic lights)
-- `/report:capacity` — weekly team capacity status
-- `/team:workload` — per-person workload map with overload alerts
-- `/board:flow` — cycle time and bottleneck analysis
-- `/kpi:dashboard` — full KPI dashboard: velocity, cycle time, lead time, bug escape rate
+- `/report:hours`, `/report:executive`, `/report:capacity`
+- `/team:workload`, `/board:flow`, `/kpi:dashboard`
 
 **PBI decomposition commands**
-- `/pbi:decompose` — decompose a single PBI into tasks with hours, activity, assignee, and Developer Type
-- `/pbi:decompose-batch` — decompose multiple PBIs in a single session
-- `/pbi:assign` — (re)assign tasks for a PBI using the scoring algorithm
-- `/pbi:plan-sprint` — full sprint planning cycle: capacity → PBI selection → decomposition → assignment → AzDO creation
+- `/pbi:decompose`, `/pbi:decompose-batch`, `/pbi:assign`, `/pbi:plan-sprint`
 
-**Skills** (`.claude/skills/`)
-- `azure-devops-queries` — WIQL queries, REST API v7.1, Analytics OData
-- `sprint-management` — burndown calculation, WIP limits, velocity tracking
-- `capacity-planning` — capacity formula (`working_days × hours_day × focus_factor`), scoring algorithm
-- `time-tracking-report` — Excel/PPT generation from AzDO time entries
-- `executive-reporting` — multi-project Word + PowerPoint report generation
-- `pbi-decomposition` — task breakdown by activity type, assignment scoring reference
+**Skills**
+- `azure-devops-queries`, `sprint-management`, `capacity-planning`
+- `time-tracking-report`, `executive-reporting`, `pbi-decomposition`
 
 **Spec-Driven Development (SDD)**
-- `/spec:generate` — generate `.spec.md` contract from Azure DevOps task
-- `/spec:implement` — implement spec (routes to human or launches Claude agent)
-- `/spec:review` — validate spec quality or post-implementation correctness
-- `/spec:status` — sprint-wide SDD dashboard with per-spec status and cost tracking
-- `/agent:run` — launch Claude agent (single, team, or batch) against a spec file
-- `spec-driven-development` skill with three references:
-  - `spec-template.md` — 9-section spec template
-  - `layer-assignment-matrix.md` — Clean Architecture layer → human vs. agent matrix
-  - `agent-team-patterns.md` — five agent team patterns (single, impl-test, impl-test-review, full-stack, parallel-handlers)
+- `/spec:generate`, `/spec:implement`, `/spec:review`, `/spec:status`, `/agent:run`
+- `spec-driven-development` skill with spec template, layer matrix, agent patterns
 
 **Test project** (`projects/sala-reservas/`)
-- Full simulated project: meeting room booking app (.NET 8, Clean Architecture, CQRS/MediatR)
-- Team: 4 human developers + PM + Claude agent team
-- 16 documented business rules (RN-SALA, RN-RESERVA)
-- Sprint planning with 3 PBIs (11 SP), complete with task breakdown and Developer Type assignments
-- 2 complete SDD spec files ready to run against a real agent
-- Mock Azure DevOps data: `mock-workitems.json`, `mock-sprint.json`, `mock-capacities.json`
+- Meeting room booking app (.NET 8, Clean Architecture, CQRS/MediatR)
+- 16 business rules, 3 PBIs, 2 complete SDD specs
 
 **Test suite** (`scripts/test-workspace.sh`)
-- 96 tests across 9 categories: prereqs, structure, connection, capacity, sprint, imputacion, sdd, report, backlog
-- Mock mode (`--mock`) and real mode (`--real`)
-- `--only {category}` flag for targeted runs
-- `--verbose` flag for detailed output
-- Automatic Markdown report in `output/`
+- 96 tests across 9 categories with mock and real modes
 
 **Documentation**
-- `README.md` — comprehensive guide with 9 annotated real-usage examples
-- `docs/reglas-scrum.md` — Scrum rules and definitions
-- `docs/politica-estimacion.md` — estimation policy and Story Point reference
-- `docs/kpis-equipo.md` — KPI definitions and thresholds
-- `docs/plantillas-informes.md` — report template specifications
-- `docs/flujo-trabajo.md` — full workflow guide including SDD section
+- `README.md` with 9 annotated examples
+- `docs/` methodology: Scrum rules, estimation policy, KPIs, report templates, workflow guide
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/releases/tag/v0.1.0

--- a/scripts/test-workspace.sh
+++ b/scripts/test-workspace.sh
@@ -200,7 +200,7 @@ test_structure() {
   log_header "SUITE 2 — Estructura del Workspace"
 
   log_section "Ficheros raíz obligatorios"
-  local ROOT_FILES=("CLAUDE.md" "SETUP.md" "README.md" ".gitignore")
+  local ROOT_FILES=("CLAUDE.md" "README.md" ".gitignore")
   for f in "${ROOT_FILES[@]}"; do
     if [[ -f "$WORKSPACE_ROOT/$f" ]]; then
       pass "$f existe"


### PR DESCRIPTION
## Summary
- Add 16 Language Packs with per-language conventions, rules, agents and layer matrices
- Add multi-environment support (DEV/PRE/PRO), confidentiality config and Infrastructure as Code
- Add `infrastructure-agent` for multi-cloud resource management with cost optimization
- Add 7 new infrastructure/environment commands and 12 new developer agents
- Add file size governance rule: max 150 lines per file (legacy exempt)
- Split READMEs into 12 sections each under `docs/readme/` and `docs/readme_en/`
- Compact root READMEs as hub documents, move docs from root to `docs/`
- Compact CLAUDE.md (217→127 lines), externalize agent catalog and language packs
- Add release/tag rules to `github-flow.md`
- Add team evaluation and onboarding capabilities

## Test plan
- [ ] Verify all section links in README.md and README.en.md resolve correctly
- [ ] Verify cross-references in CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md point to moved files
- [ ] Confirm no file exceeds 150 lines (except pre-existing legacy)
- [ ] Verify tags v0.1.0 and v0.2.0 point to correct commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)