### PR TITLE
feat(commands): add /pr:pending and AZURE_DEVOPS_PM_USER config

### DIFF
--- a/.claude/commands/pr-pending.md
+++ b/.claude/commands/pr-pending.md
@@ -1,0 +1,118 @@
+---
+name: pr-pending
+description: >
+  Consulta los Pull Requests asignados al PM que están pendientes de revisión
+  en Azure DevOps. Muestra estado, votos, comentarios pendientes y antigüedad.
+---
+
+# Pull Requests Pendientes de Revisión
+
+**Filtro:** $ARGUMENTS
+
+> Uso: `/pr:pending` (todos los proyectos) · `/pr:pending --project Alpha` (un proyecto)
+
+---
+
+## Protocolo
+
+### 1. Leer configuración
+
+Obtener de `CLAUDE.md` o `pm-config.md`:
+- `AZURE_DEVOPS_ORG_URL` — URL de la organización
+- `AZURE_DEVOPS_PAT_FILE` — fichero con el PAT
+- `AZURE_DEVOPS_PM_USER` — email/uniqueName del PM
+
+Si `AZURE_DEVOPS_PM_USER` no está definido, preguntar al usuario y sugerir que lo añada a la configuración.
+
+### 2. Obtener proyectos
+
+- Si se pasa `--project`, usar solo ese proyecto
+- Si no, leer los proyectos activos de `CLAUDE.md` y `CLAUDE.local.md`
+
+### 3. Consultar PRs por proyecto
+
+Para cada proyecto, ejecutar:
+
+```bash
+curl -s -u ":$(cat $AZURE_DEVOPS_PAT_FILE)" \
+  "$AZURE_DEVOPS_ORG_URL/$PROJECT/_apis/git/pullrequests?searchCriteria.reviewerId=$PM_USER_ID&searchCriteria.status=active&api-version=7.1"
+```
+
+**Nota:** La API de PRs filtra por `reviewerId` (GUID), no por email. Primero resolver el ID:
+
+```bash
+curl -s -u ":$(cat $AZURE_DEVOPS_PAT_FILE)" \
+  "$AZURE_DEVOPS_ORG_URL/_apis/identities?searchFilter=General&filterValue=$AZURE_DEVOPS_PM_USER&api-version=7.1"
+```
+
+### 4. Para cada PR, obtener detalle
+
+Por cada PR activo donde el PM es reviewer:
+
+```bash
+# Threads (comentarios) del PR
+curl -s -u ":$(cat $AZURE_DEVOPS_PAT_FILE)" \
+  "$AZURE_DEVOPS_ORG_URL/$PROJECT/_apis/git/repositories/$REPO_ID/pullRequests/$PR_ID/threads?api-version=7.1"
+```
+
+Extraer:
+- **Estado del voto del PM**: `reviewers[].vote` → 10=Aprobado, 5=Aprobado con sugerencias, 0=Sin voto, -5=Esperando, -10=Rechazado
+- **Comentarios activos**: threads con `status=active` (no resueltos)
+- **Comentarios del PM pendientes de respuesta**: threads creados por PM donde la última respuesta no es del autor del PR
+- **Antigüedad**: `creationDate` → días desde creación
+
+### 5. Presentar resultado
+
+```
+══════════════════════════════════════════════════════
+  PULL REQUESTS PENDIENTES · {PM_DISPLAY_NAME}
+══════════════════════════════════════════════════════
+
+  📊 Resumen: {total} PRs pendientes en {n} proyectos
+
+  ─── Proyecto Alpha ───
+
+  PR #1234 · feat: add user registration
+    Autor:     Laura Sánchez
+    Rama:      feature/user-registration → main
+    Creado:    2026-02-20 (hace 6 días) ⚠️
+    Mi voto:   🔵 Sin votar
+    Hilos:     3 activos (1 mío sin respuesta)
+    Tamaño:    +245 / -18 (12 archivos)
+
+  PR #1267 · fix: session timeout handling
+    Autor:     Carlos Mendoza
+    Rama:      fix/session-timeout → main
+    Creado:    2026-02-25 (hace 1 día)
+    Mi voto:   🟡 Esperando autor
+    Hilos:     1 activo (esperando respuesta del autor)
+    Tamaño:    +32 / -8 (3 archivos)
+
+  ─── Proyecto Beta ───
+
+  (sin PRs pendientes)
+
+══════════════════════════════════════════════════════
+
+  ⚠️  2 PRs llevan > 3 días sin revisar
+  💬  1 comentario tuyo sin respuesta del autor
+
+══════════════════════════════════════════════════════
+```
+
+### 6. Alertas
+
+Generar alertas cuando:
+- Un PR lleva **> 3 días** sin voto del PM → ⚠️ alerta de antigüedad
+- Un PR tiene **comentarios del PM sin respuesta** del autor → 💬 seguimiento
+- Un PR tiene **0 reviewers con voto** → 🔴 bloqueado
+- Un PR tiene **conflictos de merge** → ⛔ requiere acción del autor
+
+---
+
+## Restricciones
+
+- **Solo lectura** — este comando no modifica ni aprueba PRs
+- **Solo PRs donde el PM es reviewer** — no lista todos los PRs del proyecto
+- Si el PAT no tiene scope `Code (Read)`, informar al usuario
+- Si `AZURE_DEVOPS_PM_USER` no está configurado, bloquear y pedir configuración

--- a/.claude/rules/pm-config.md
+++ b/.claude/rules/pm-config.md
@@ -10,6 +10,10 @@ AZURE_DEVOPS_ORG_NAME       = "MI-ORGANIZACION"
 AZURE_DEVOPS_PAT_FILE       = "$HOME/.azure/devops-pat"          # fichero con el PAT (sin comillas, sin salto de línea)
 AZURE_DEVOPS_API_VERSION    = "7.1"
 
+# ── PM / Scrum Master ────────────────────────────────────────────────────────
+AZURE_DEVOPS_PM_USER        = "nombre.apellido@miorganizacion.com"  # email o uniqueName del PM en Azure DevOps
+AZURE_DEVOPS_PM_DISPLAY     = "Nombre Apellido"                     # nombre para mostrar en informes
+
 # ── Proyectos activos ─────────────────────────────────────────────────────────
 # Los proyectos reales (privados) están en pm-config.local.md (git-ignorado).
 # Formato para añadir un proyecto Azure DevOps en pm-config.local.md:

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -44,6 +44,7 @@
 | `/pbi:jtbd {id}` | Generar documento Jobs to be Done para un PBI (discovery) |
 | `/pbi:prd {id}` | Generar Product Requirements Document para un PBI (discovery) |
 | `/pr:review [PR]` | Revisión multi-perspectiva de PR (BA, Dev, QA, Security, DevOps) |
+| `/pr:pending` | PRs asignados al PM pendientes de revisión: estado, votos, comentarios, antigüedad |
 | `/context:load` | Carga de contexto al iniciar sesión (proyecto, sprint, actividad) |
 | `/changelog:update` | Actualizar CHANGELOG.md desde commits convencionales |
 | `/evaluate:repo [URL]` | Auditoría de seguridad y calidad de un repo externo |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 AZURE_DEVOPS_ORG_URL    = "https://dev.azure.com/MI-ORGANIZACION"
 AZURE_DEVOPS_PAT_FILE   = "$HOME/.azure/devops-pat"          # sin comillas, sin salto de línea
 AZURE_DEVOPS_API_VERSION = "7.1"
+AZURE_DEVOPS_PM_USER    = "nombre.apellido@miorganizacion.com" # email del PM en Azure DevOps
 SPRINT_DURATION_WEEKS   = 2                      # TEAM_HOURS_PER_DAY = 8 · TEAM_FOCUS_FACTOR = 0.75
 CLAUDE_MODEL_AGENT      = "claude-opus-4-6"
 CLAUDE_MODEL_MID        = "claude-sonnet-4-6"
@@ -39,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 23 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 35 slash commands → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 36 slash commands → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas, convenciones, Language Packs (16) y entornos
 │   └── skills/                    ← 9 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README


### PR DESCRIPTION
## Summary
- Add `AZURE_DEVOPS_PM_USER` and `AZURE_DEVOPS_PM_DISPLAY` variables to `pm-config.md` and `CLAUDE.md` to identify the PM in Azure DevOps
- Create `/pr:pending` command that queries Azure DevOps for PRs assigned to the PM pending review
- Shows: PR status, reviewer vote, active comment threads, pending responses, age, merge conflicts
- Generates alerts for PRs > 3 days old, unanswered comments, blocked PRs
- Update `pm-workflow.md` command count (35→36)

## Test plan
- [ ] Verify `AZURE_DEVOPS_PM_USER` placeholder is present in both config files
- [ ] Verify `/pr:pending` command file loads correctly
- [ ] CI passes (lint + workspace validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)