### PR TITLE
feat(commands): add /help with command catalog and setup detection

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -1,0 +1,83 @@
+---
+name: help
+description: >
+  Muestra todos los comandos disponibles agrupados por categoría, con parámetros
+  y ejemplos. Detecta el estado del workspace y recomienda primeros pasos si
+  hay configuración pendiente.
+---
+
+# Ayuda de PM-Workspace
+
+**Filtro:** $ARGUMENTS
+
+> Uso: `/help` (todo) · `/help sprint` (categoría) · `/help --setup` (solo primeros pasos)
+
+---
+
+## Protocolo
+
+### 1. Detectar estado del workspace (memoria de primeros pasos)
+
+Comprobar cada punto y registrar los pendientes:
+
+| Paso | Qué comprobar | Cómo |
+|---|---|---|
+| 1. PAT | Existe fichero en `AZURE_DEVOPS_PAT_FILE` | `test -f $HOME/.azure/devops-pat` |
+| 2. Organización | `AZURE_DEVOPS_ORG_URL` no contiene "MI-ORGANIZACION" | Leer CLAUDE.md |
+| 3. PM identificado | `AZURE_DEVOPS_PM_USER` no es placeholder | Leer pm-config.md |
+| 4. Proyecto registrado | Existe `projects/*/CLAUDE.md` | Buscar en projects/ |
+| 5. Equipo definido | Existe `projects/*/equipo.md` | Buscar en projects/ |
+| 6. Conexión verificada | Existe `output/test-workspace-*.md` | Buscar en output/ |
+
+### 2. Presentar primeros pasos (si hay pendientes)
+
+Si hay pasos pendientes, mostrarlos ANTES del catálogo:
+
+```
+══════════════════════════════════════════════════════
+  🚀 PRIMEROS PASOS — {N} pendientes de 6
+══════════════════════════════════════════════════════
+
+  ⬜/✅ Paso 1: Configurar PAT → crear $HOME/.azure/devops-pat
+  ⬜/✅ Paso 2: Configurar organización → editar CLAUDE.md
+  ⬜/✅ Paso 3: Identificar PM → editar pm-config.md (AZURE_DEVOPS_PM_USER)
+  ⬜/✅ Paso 4: Registrar primer proyecto → /context:load o crear projects/{nombre}/
+  ⬜/✅ Paso 5: Definir equipo → crear equipo.md en el proyecto
+  ⬜/✅ Paso 6: Verificar conexión → ejecutar scripts/test-workspace.sh --mock
+
+  📖 Guía completa: docs/SETUP.md
+══════════════════════════════════════════════════════
+```
+
+Si todos completados → `✅ Workspace configurado — todos los pasos completados.`
+
+### 3. Mostrar catálogo de comandos
+
+Leer `.claude/commands/references/command-catalog.md` y presentar los comandos.
+
+Si `$ARGUMENTS` contiene un filtro, mostrar solo la categoría:
+
+| Argumento | Categoría |
+|---|---|
+| `sprint`, `report`, `kpi`, `board` | Sprint y Reporting |
+| `pbi`, `discovery`, `jtbd`, `prd` | PBI y Discovery |
+| `spec`, `sdd`, `agent` | SDD |
+| `pr`, `review`, `quality` | Calidad y PRs |
+| `team`, `onboarding`, `evaluate` | Equipo y Onboarding |
+| `infra`, `env`, `cloud` | Infraestructura y Entornos |
+| `--setup`, `setup`, `start` | Solo primeros pasos (omitir catálogo) |
+| (vacío) | Todo |
+
+### 4. Formato de presentación
+
+Para cada comando mostrar: nombre, descripción de una línea, parámetros (obligatorios y opcionales), y un ejemplo de uso.
+
+Agrupar por categoría con separadores visuales. Ver formato completo en `references/command-catalog.md`.
+
+---
+
+## Restricciones
+
+- **Solo lectura** — no modifica ningún fichero
+- Si no puede determinar el estado de un paso, marcarlo como ⚠️ (no verificable)
+- No mostrar datos sensibles (PAT, secrets) en el output

--- a/.claude/commands/references/command-catalog.md
+++ b/.claude/commands/references/command-catalog.md
@@ -1,0 +1,84 @@
+# Catálogo de Comandos PM-Workspace (37)
+
+## 📅 Sprint y Reporting (10)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/sprint:status` | — | Burndown, progreso, alertas WIP, blockers |
+| `/sprint:plan` | — | Planning: capacity real + PBIs candidatos |
+| `/sprint:review` | — | Review: velocity, completados, demo |
+| `/sprint:retro` | — | Retro con datos cuantitativos del sprint |
+| `/report:hours` | — | Imputación de horas (Excel, 4 pestañas) |
+| `/report:executive` | — | Multi-proyecto (PPT + Word, semáforos) |
+| `/report:capacity` | — | Capacidades del equipo por persona |
+| `/team:workload` | — | Carga por persona + alertas sobrecarga |
+| `/board:flow` | — | Cycle time, WIP, cuellos de botella |
+| `/kpi:dashboard` | — | Velocity, cycle time, lead time, bug escape rate |
+
+## 📦 PBI y Discovery (6)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/pbi:decompose` | `{id}` | Descomponer PBI en tasks con estimación |
+| `/pbi:decompose-batch` | `{ids}` (coma) | Descomponer varios PBIs a la vez |
+| `/pbi:assign` | `{pbi_id}` | (Re)asignar tasks con scoring |
+| `/pbi:plan-sprint` | — | Planning completo: capacity → PBIs → tasks → asignación |
+| `/pbi:jtbd` | `{id}` | Jobs to be Done (discovery pre-técnico) |
+| `/pbi:prd` | `{id}` | Product Requirements Document |
+
+## ⚙️ SDD — Spec-Driven Development (5)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/spec:generate` | `{task_id}` | Spec ejecutable desde Task de Azure DevOps |
+| `/spec:implement` | `{spec_file}` | Implementar Spec (agente Claude o humano) |
+| `/spec:review` | `{spec_file}` | Revisar calidad o validar implementación |
+| `/spec:status` | — | Dashboard de Specs del sprint |
+| `/agent:run` | `{spec_file}` | Lanzar agente Claude sobre Spec |
+
+## 🔍 Calidad y PRs (4)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/pr:review` | `[PR]` (opcional) | Revisión 5 perspectivas: BA, Dev, QA, Sec, DevOps |
+| `/pr:pending` | `--project {p}` (opc.) | PRs del PM pendientes: votos, comentarios, antigüedad |
+| `/evaluate:repo` | `[URL]` | Auditoría seguridad/calidad de repo externo |
+| `/changelog:update` | — | CHANGELOG.md desde commits convencionales |
+
+## 👥 Equipo y Onboarding (3)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/team:privacy-notice` | `{nombre}` `--project {p}` | Nota RGPD (obligatoria antes de evaluar) |
+| `/team:onboarding` | `{nombre}` `--project {p}` | Guía: contexto + tour del código (Fases 1-2) |
+| `/team:evaluate` | `{nombre}` `--project {p}` | Competencias → perfil expertise en equipo.md |
+
+## 🏗️ Infraestructura y Entornos (7)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/infra:detect` | `{proy}` `{env}` | Detectar infra existente en un entorno |
+| `/infra:plan` | `{proy}` `{env}` | Plan IaC (Terraform/CLI) para un entorno |
+| `/infra:estimate` | `{proy}` | Costes mensuales estimados por entorno |
+| `/infra:scale` | `{recurso}` | Proponer escalado (aprobación humana) |
+| `/infra:status` | `{proy}` | Estado actual de la infra del proyecto |
+| `/env:setup` | `{proy}` | Configurar entornos (DEV/PRE/PRO) |
+| `/env:promote` | `{proy}` `{orig}` `{dest}` | Promover deploy (PRE→PRO = aprobación) |
+
+## 🔧 Utilidades (2)
+
+| Comando | Params | Descripción |
+|---|---|---|
+| `/context:load` | — | Inicializar sesión: CLAUDE.md, git, commits, tools |
+| `/help` | `[filtro]` (opc.) | Esta ayuda. Filtros: sprint, pbi, sdd, pr, team, infra, --setup |
+
+## Ejemplos rápidos por escenario
+
+```
+Empezar el día:       /context:load → /sprint:status → /pr:pending
+Sprint Planning:      /sprint:plan → /pbi:plan-sprint
+Revisar un PR:        /pr:review 42
+Nuevo miembro:        /team:privacy-notice "Ana" --project Alpha → /team:onboarding "Ana" --project Alpha
+Crear infraestructura:/infra:detect Alpha DEV → /infra:plan Alpha DEV → /infra:estimate Alpha
+Generar informe:      /report:executive
+```

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -58,6 +58,7 @@
 | `/infra:status {proyecto}` | Estado de la infraestructura actual del proyecto |
 | `/env:setup {proyecto}` | Configurar entornos (DEV/PRE/PRO) para un proyecto |
 | `/env:promote {proyecto} {origen} {destino}` | Promover deploy entre entornos (PRE→PRO requiere aprobación) |
+| `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 23 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 36 slash commands → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 37 slash commands → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas, convenciones, Language Packs (16) y entornos
 │   └── skills/                    ← 9 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/README.en.md
+++ b/README.en.md
@@ -67,7 +67,7 @@ Full documentation is organized into sections for easy reference:
 | [Test project](docs/readme_en/09-test-project.md) | `sala-reservas`: tests, mock data, validation |
 | [KPIs, rules, and roadmap](docs/readme_en/10-kpis-rules.md) | Metrics, critical rules, adoption plan |
 | [Onboarding new team members](docs/readme_en/11-onboarding.md) | 5-phase onboarding, competency evaluation, GDPR |
-| [Commands and agents](docs/readme_en/12-commands-agents.md) | 35 commands + 23 specialized agents |
+| [Commands and agents](docs/readme_en/12-commands-agents.md) | 37 commands + 23 specialized agents |
 | [Coverage and contributing](docs/readme_en/13-coverage-contributing.md) | What's covered, what's not, how to contribute |
 
 ### Other Documents
@@ -109,8 +109,9 @@ Full documentation is organized into sections for easy reference:
 
 ### Quality and Team
 ```
-/pr:review [PR]    /context:load    /changelog:update    /evaluate:repo [URL]
+/pr:review [PR]    /pr:pending    /context:load    /changelog:update    /evaluate:repo [URL]
 /team:onboarding {name}    /team:evaluate {name}    /team:privacy-notice {name}
+/help [filter]
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 | [Proyecto de test](docs/readme/09-proyecto-test.md) | `sala-reservas`: tests, datos mock, validación |
 | [KPIs, reglas y roadmap](docs/readme/10-kpis-reglas.md) | Métricas, reglas críticas, plan de adopción |
 | [Onboarding de nuevos miembros](docs/readme/11-onboarding.md) | Incorporación en 5 fases, evaluación de competencias, RGPD |
-| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 35 comandos + 23 agentes especializados |
+| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 37 comandos + 23 agentes especializados |
 | [Cobertura y contribución](docs/readme/13-cobertura-contribucion.md) | Qué cubre, qué no, cómo contribuir |
 
 ### Otros documentos
@@ -109,8 +109,9 @@ La documentación completa está organizada en secciones para facilitar la consu
 
 ### Calidad y Equipo
 ```
-/pr:review [PR]    /context:load    /changelog:update    /evaluate:repo [URL]
+/pr:review [PR]    /pr:pending    /context:load    /changelog:update    /evaluate:repo [URL]
 /team:onboarding {nombre}    /team:evaluate {nombre}    /team:privacy-notice {nombre}
+/help [filtro]
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `/help` command with full catalog of 37 commands grouped by category
- Each command shows: description, parameters (required/optional), and usage example
- Detects workspace setup state (6 checkpoints: PAT, org, PM user, project, team, tests) and recommends pending first steps
- Supports filtering: `/help sprint`, `/help sdd`, `/help team`, `/help --setup`
- Includes quick-start scenarios for common workflows
- Split into command file (83 lines) + reference catalog (84 lines) to comply with 150-line rule

## Test plan
- [ ] Verify `/help` command file loads correctly
- [ ] Verify command-catalog.md lists all 37 commands
- [ ] CI passes (lint + workspace validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)