### PR TITLE
feat(rules): command validation script + pre-commit rule

### DIFF
--- a/.claude/rules/command-validation.md
+++ b/.claude/rules/command-validation.md
@@ -1,0 +1,42 @@
+# Regla: Validación de Comandos — Pre-commit obligatorio
+# ── Aplica cuando se crean o modifican ficheros en .claude/commands/ ──────────
+
+## Cuándo aplica
+
+ANTES de hacer commit, si los cambios incluyen ficheros en `.claude/commands/`:
+
+1. **Ejecutar `scripts/validate-commands.sh`** pasando los ficheros modificados
+2. Si hay ERRORES → corregir antes de commit
+3. Si hay WARNINGS → evaluar y justificar si se ignoran
+
+## Qué valida el script
+
+| Check | Tipo | Umbral |
+|---|---|---|
+| Líneas del comando | Error | ≤ 150 |
+| Prompt estimado (cmd + CLAUDE.md) | Warning | ≤ 200 |
+| Fichero no vacío | Error | > 0 líneas |
+| Referencias a ficheros existen | Error | Todos resueltos |
+| Nombre kebab-case | Warning | `^[a-z0-9]+(-[a-z0-9]+)*\.md$` |
+
+## Qué NO puede validar (limitaciones)
+
+- Ejecución real del comando (los slash commands se inyectan como prompt al usuario)
+- Contexto total real (depende de qué reglas `@` cargue Claude Code en la sesión)
+- Calidad del output que produce el comando
+
+## Umbral de prompt estimado
+
+El umbral de 200 líneas (comando + CLAUDE.md) es conservador.
+Si Claude Code carga además muchas reglas `@`, el prompt puede excederse aun así.
+En ese caso → reducir el comando o eliminar referencias externas.
+
+## Ejemplo de uso
+
+```bash
+# Validar todos los comandos
+scripts/validate-commands.sh
+
+# Validar solo los modificados
+scripts/validate-commands.sh .claude/commands/help.md .claude/commands/pr-pending.md
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 11. **150 líneas máx.** por fichero — dividir si crece · legacy heredado exento salvo petición PM · ver `@.claude/rules/file-size-limit.md`
 12. **README**: ANTES de cada commit, si los cambios tocan `commands/`, `agents/`, `skills/`, `rules/` o la estructura de directorios → actualizar `README.md` + `README.en.md` (conteos, tablas, referencia rápida) en el MISMO commit · ver `@.claude/rules/readme-update.md`
 13. **Git**: NUNCA commit directo en `main` — siempre rama + PR · ver `@.claude/rules/github-flow.md`
+14. **Comandos**: ANTES de commit que toque `commands/`, ejecutar `scripts/validate-commands.sh` · ver `@.claude/rules/command-validation.md`
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -125,6 +125,7 @@ Full documentation is organized into sections for easy reference:
 5. **Secrets**: NEVER connection strings, API keys, or passwords in the repository
 6. **Infrastructure**: NEVER `terraform apply` in PRE/PRO without human approval; always minimum tier
 7. **Git**: NEVER commit directly to `main` — always branch + PR
+8. **Commands**: validate with `scripts/validate-commands.sh` before committing
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 5. **Secrets**: NUNCA connection strings, API keys o passwords en el repositorio
 6. **Infraestructura**: NUNCA `terraform apply` en PRE/PRO sin aprobación humana; siempre tier mínimo
 7. **Git**: NUNCA commit directo en `main` — siempre rama + PR
+8. **Comandos**: validar con `scripts/validate-commands.sh` antes de commit
 
 ---
 

--- a/scripts/validate-commands.sh
+++ b/scripts/validate-commands.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────
+# validate-commands.sh — Validación estática de slash commands
+# Ejecutar ANTES de cada commit que toque .claude/commands/
+# ─────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+COMMANDS_DIR=".claude/commands"
+CLAUDE_MD="CLAUDE.md"
+MAX_PROMPT_LINES=200  # Umbral seguro: comando + CLAUDE.md cabe en contexto
+ERRORS=0
+WARNINGS=0
+
+# Colores
+RED='\033[0;31m'; YEL='\033[0;33m'; GRN='\033[0;32m'; NC='\033[0m'
+
+err()  { echo -e "${RED}ERROR${NC}  $1"; ERRORS=$((ERRORS + 1)); }
+warn() { echo -e "${YEL}WARN${NC}   $1"; WARNINGS=$((WARNINGS + 1)); }
+ok()   { echo -e "${GRN}OK${NC}     $1"; }
+
+# ── Si se pasan ficheros concretos, validar solo esos; si no, todos ──
+if [ $# -gt 0 ]; then
+  FILES=("$@")
+else
+  FILES=()
+  for f in "$COMMANDS_DIR"/*.md; do
+    [ -f "$f" ] && FILES+=("$f")
+  done
+fi
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "No hay comandos que validar."
+  exit 0
+fi
+
+CLAUDE_LINES=0
+[ -f "$CLAUDE_MD" ] && CLAUDE_LINES=$(wc -l < "$CLAUDE_MD")
+
+echo "══════════════════════════════════════════════════"
+echo "  Validando ${#FILES[@]} comando(s)"
+echo "  CLAUDE.md: ${CLAUDE_LINES} líneas"
+echo "══════════════════════════════════════════════════"
+echo ""
+
+for CMD in "${FILES[@]}"; do
+  NAME=$(basename "$CMD")
+  LINES=$(wc -l < "$CMD")
+  TOTAL=$((LINES + CLAUDE_LINES))
+  PREV_ERRORS=$ERRORS
+
+  echo "── $NAME ($LINES líneas, total estimado: $TOTAL) ──"
+
+  # 1. Tamaño del fichero (regla 150 líneas)
+  if [ "$LINES" -gt 150 ]; then
+    err "$NAME excede 150 líneas ($LINES)"
+  fi
+
+  # 2. Prompt total estimado (comando + CLAUDE.md)
+  if [ "$TOTAL" -gt "$MAX_PROMPT_LINES" ]; then
+    warn "$NAME prompt estimado $TOTAL líneas (umbral: $MAX_PROMPT_LINES)"
+  fi
+
+  # 3. Fichero no vacío
+  if [ "$LINES" -eq 0 ]; then
+    err "$NAME está vacío"
+    continue
+  fi
+
+  # 4. Referencias a ficheros — comprobar que existen
+  REFS=$(grep -oP '(?<=references/)[^\s\)]+\.md' "$CMD" 2>/dev/null || true)
+  for REF in $REFS; do
+    REF_PATH="$COMMANDS_DIR/references/$REF"
+    if [ ! -f "$REF_PATH" ]; then
+      err "$NAME referencia '$REF' pero no existe $REF_PATH"
+    fi
+  done
+
+  # 5. Referencias @rules — comprobar que existen
+  AT_REFS=$(grep -oP '@\.claude/rules/[^\s\)]+' "$CMD" 2>/dev/null || true)
+  for AREF in $AT_REFS; do
+    AREF_PATH="${AREF#@}"
+    if [ ! -f "$AREF_PATH" ]; then
+      err "$NAME referencia '$AREF' pero no existe $AREF_PATH"
+    fi
+  done
+
+  # 6. Comprobar que el nombre del fichero sigue convención (kebab-case)
+  if ! echo "$NAME" | grep -qP '^[a-z0-9]+(-[a-z0-9]+)*\.md$'; then
+    warn "$NAME no sigue kebab-case"
+  fi
+
+  # Si no hubo errores nuevos para este fichero
+  if [ "$ERRORS" -eq "$PREV_ERRORS" ]; then
+    ok "$NAME validado"
+  fi
+
+  echo ""
+done
+
+# ── Resumen ──────────────────────────────────────────────────────────
+echo "══════════════════════════════════════════════════"
+if [ "$ERRORS" -gt 0 ]; then
+  echo -e "${RED}FALLÓ${NC}: $ERRORS error(es), $WARNINGS advertencia(s)"
+  exit 1
+elif [ "$WARNINGS" -gt 0 ]; then
+  echo -e "${YEL}PASA con warnings${NC}: $WARNINGS advertencia(s)"
+  exit 0
+else
+  echo -e "${GRN}TODO OK${NC}: ${#FILES[@]} comando(s) validados"
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- `scripts/validate-commands.sh` — static validation: size ≤150 lines, prompt estimate ≤200, references exist, kebab-case naming
- `.claude/rules/command-validation.md` — pre-commit rule: run validation before committing changes to `commands/`
- Rule 14 added to CLAUDE.md, rule 8 summary in READMEs

## Context
`/help` was breaking with "Prompt is too long" (PR #20 fixed it). This rule prevents future occurrences by catching oversized commands before they reach main.

## Legacy debt detected
Initial scan found 22 errors in pre-existing commands (6 files >150 lines, 10 missing references). These will be fixed in a separate cleanup PR.

## Test plan
- [x] `scripts/validate-commands.sh` runs successfully and detects known issues
- [ ] Verify script catches new violations when adding/modifying commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)