### PR TITLE
fix: .claudeignore to prevent worktree context bloat

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,6 @@
+# Worktrees de Claude Code — se crean con cada sesión de Código
+# y acumulan copias completas del workspace que inflan el contexto
+.claude/worktrees/
+
+# Language rules — se cargan bajo demanda, no en cada sesión
+.claude/rules/languages/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 23 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 37 slash commands → @.claude/rules/pm-workflow.md
-│   ├── rules/                     ← Reglas, convenciones, Language Packs (16) y entornos
+│   ├── commands/                  ← 30 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 9 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README
 ├── projects/                      ← Proyectos reales (git-ignorados)

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -5,129 +5,100 @@
 ```
 ~/claude/                        ← Raíz de trabajo Y repositorio GitHub
 ├── CLAUDE.md                    ← Punto de entrada de Claude Code (≤150 líneas)
-├── docs/SETUP.md                ← Guía de configuración paso a paso
-├── README.md                    ← Este fichero
+├── .claudeignore                ← Excluye worktrees y languages de carga automática
 ├── .gitignore                   ← Privacidad: proyectos reales, secrets, local config
+├── docs/SETUP.md                ← Guía de configuración paso a paso
+├── README.md / README.en.md     ← Documentación principal (ES/EN)
 │
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
-│   ├── .env                     ← Variables de entorno (git-ignorado)
-│   ├── mcp.json                 ← Configuración MCP opcional
 │   │
-│   ├── commands/                ← 35 slash commands
-│   │   ├── sprint-status.md
-│   │   ├── sprint-plan.md
-│   │   ├── sprint-review.md
-│   │   ├── sprint-retro.md
-│   │   ├── report-hours.md
-│   │   ├── report-executive.md
-│   │   ├── report-capacity.md
-│   │   ├── team-workload.md
-│   │   ├── board-flow.md
-│   │   ├── kpi-dashboard.md
-│   │   ├── pbi-decompose.md
-│   │   ├── pbi-decompose-batch.md
-│   │   ├── pbi-assign.md
-│   │   ├── pbi-plan-sprint.md
-│   │   ├── pbi-jtbd.md           ← Discovery: Jobs to be Done
-│   │   ├── pbi-prd.md            ← Discovery: Product Requirements
-│   │   ├── pr-review.md          ← Review multi-perspectiva de PR
-│   │   ├── context-load.md       ← Carga de contexto al iniciar sesión
-│   │   ├── changelog-update.md   ← Actualizar CHANGELOG desde commits
-│   │   ├── evaluate-repo.md      ← Auditoría de repos externos
-│   │   ├── spec-generate.md      ← SDD
-│   │   ├── spec-implement.md     ← SDD
-│   │   ├── spec-review.md        ← SDD
-│   │   ├── spec-status.md        ← SDD
-│   │   ├── agent-run.md          ← SDD
-│   │   ├── team-onboarding.md    ← Onboarding de nuevos miembros
-│   │   ├── team-evaluate.md      ← Evaluación de competencias
-│   │   └── team-privacy-notice.md ← Nota informativa RGPD
+│   ├── commands/                ← 30 slash commands
+│   │   ├── help.md              ← /help — catálogo + primeros pasos
+│   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
+│   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
+│   │   ├── spec-generate.md ... ← SDD (5)
+│   │   ├── pr-review.md ...     ← Calidad y PRs (4)
+│   │   ├── team-onboarding.md ..← Equipo (3)
+│   │   ├── infra-detect.md ...  ← Infraestructura (7)
+│   │   ├── context-load.md      ← Utilidades
+│   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
+│   │       ├── command-catalog.md
+│   │       ├── spec-template.md
+│   │       └── ... (11 ficheros)
 │   │
-│   ├── skills/                  ← 9 skills personalizadas
+│   ├── agents/                  ← 23 subagentes especializados
+│   │   ├── business-analyst.md
+│   │   ├── architect.md
+│   │   ├── code-reviewer.md
+│   │   ├── commit-guardian.md
+│   │   ├── security-guardian.md
+│   │   ├── test-runner.md
+│   │   ├── sdd-spec-writer.md
+│   │   ├── infrastructure-agent.md
+│   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
+│   │   └── ...
+│   │
+│   ├── skills/                  ← 9 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
 │   │   ├── time-tracking-report/
 │   │   ├── executive-reporting/
-│   │   ├── product-discovery/     ← JTBD + PRD antes de decompose
-│   │   │   └── references/
-│   │   │       ├── jtbd-template.md
-│   │   │       └── prd-template.md
+│   │   ├── product-discovery/
 │   │   ├── pbi-decomposition/
-│   │   │   └── references/
-│   │   │       └── assignment-scoring.md
-│   │   ├── team-onboarding/          ← Onboarding + evaluación de competencias
-│   │   │   └── references/
-│   │   │       ├── onboarding-checklist.md
-│   │   │       ├── questionnaire-template.md
-│   │   │       ├── expertise-mapping.md
-│   │   │       └── privacy-notice-template.md
+│   │   ├── team-onboarding/
 │   │   └── spec-driven-development/
-│   │       ├── SKILL.md
-│   │       └── references/
-│   │           ├── spec-template.md           ← Plantilla de specs
-│   │           ├── layer-assignment-matrix.md ← Qué va a agente vs humano
-│   │           └── agent-team-patterns.md     ← Patrones de equipos de agentes
+│   │       └── references/      ← Templates, matrices, patrones de equipo
 │   │
-│   └── rules/                   ← Reglas modulares (carga bajo demanda)
-│       ├── pm-config.md         ← Constantes completas Azure DevOps
+│   └── rules/                   ← Reglas modulares
+│       ├── pm-config.md         ← Constantes Azure DevOps
 │       ├── pm-workflow.md       ← Cadencia Scrum y tabla de comandos
-│       ├── {lang}-conventions.md← Convenciones por lenguaje (16 Language Packs)
-│       ├── {lang}-rules.md      ← Reglas de calidad por lenguaje
-│       ├── environment-config.md← Configuración multi-entorno (DEV/PRE/PRO)
-│       ├── confidentiality-config.md ← Protección de secrets y connection strings
-│       ├── infrastructure-as-code.md ← IaC multi-cloud (Azure, AWS, GCP)
-│       ├── readme-update.md     ← Cuándo y cómo actualizar este README
-│       └── github-flow.md       ← Branching workflow: ramas, PRs, protección de main
+│       ├── github-flow.md       ← Branching, PRs, releases, tags
+│       ├── environment-config.md
+│       ├── confidentiality-config.md
+│       ├── infrastructure-as-code.md
+│       ├── language-packs.md    ← Tabla de 16 lenguajes soportados
+│       ├── command-validation.md← Pre-commit: validar commands
+│       ├── file-size-limit.md   ← Regla 150 líneas
+│       ├── readme-update.md     ← Regla 12: actualizar READMEs
+│       ├── agents-catalog.md    ← Tabla de 23 agentes
+│       └── languages/           ← Convenciones por lenguaje (excluido de carga automática)
+│           ├── csharp-rules.md
+│           ├── dotnet-conventions.md
+│           └── ... (21 ficheros para 16 lenguajes)
 │
-├── docs/
-│   ├── reglas-scrum.md
-│   ├── politica-estimacion.md
-│   ├── kpis-equipo.md
-│   ├── plantillas-informes.md
-│   └── flujo-trabajo.md         ← Incluye sección 8: workflow SDD
+├── docs/                        ← Metodología, guías, secciones README
+│   ├── readme/ (13 secciones ES)
+│   ├── readme_en/ (13 secciones EN)
+│   ├── best-practices-claude-code.md
+│   ├── guia-incorporacion-lenguajes.md
+│   ├── ADOPTION_GUIDE.md / .en.md
+│   └── ...
 │
-├── projects/
-│   ├── proyecto-alpha/
-│   │   ├── CLAUDE.md            ← Constantes + config SDD del proyecto
-│   │   ├── equipo.md            ← Equipo humano + agentes Claude como developers
-│   │   ├── reglas-negocio.md
-│   │   ├── source/              ← git clone del repo aquí
-│   │   ├── sprints/
-│   │   └── specs/               ← Specs SDD
-│   │       ├── sdd-metrics.md
-│   │       ├── templates/
-│   │       └── sprint-YYYY-MM/
+├── projects/                    ← Proyectos reales (git-ignorados)
+│   ├── proyecto-alpha/          ← Ejemplo: CLAUDE.md, equipo.md, specs/
 │   ├── proyecto-beta/
-│   │   └── (misma estructura)
-│   └── sala-reservas/           ← ⚗️ PROYECTO DE TEST (ver sección abajo)
-│       ├── CLAUDE.md
-│       ├── equipo.md            ← 4 devs + PM + agentes Claude
-│       ├── reglas-negocio.md    ← 16 reglas de negocio documentadas
-│       ├── sprints/
-│       │   └── sprint-2026-04/
-│       │       └── planning.md
-│       ├── specs/
-│       │   ├── sdd-metrics.md
-│       │   └── sprint-2026-04/
-│       │       ├── AB101-B3-create-sala-handler.spec.md
-│       │       └── AB102-D1-unit-tests-salas.spec.md
-│       └── test-data/           ← Mock JSON de Azure DevOps API
-│           ├── mock-workitems.json
-│           ├── mock-sprint.json
-│           └── mock-capacities.json
+│   └── sala-reservas/           ← Proyecto de test con mock data
 │
 ├── scripts/
-│   ├── azdevops-queries.sh      ← Bash: queries a Azure DevOps REST API
-│   ├── capacity-calculator.py  ← Python: cálculo de capacity real
-│   └── report-generator.js     ← Node.js: generación de informes Excel/PPT
+│   ├── azdevops-queries.sh      ← Queries a Azure DevOps REST API
+│   ├── test-workspace.sh        ← Validación de estructura del workspace
+│   └── validate-commands.sh     ← Validación estática de slash commands
 │
-└── output/
+└── output/                      ← Informes generados (git-ignorado)
     ├── sprints/
     ├── reports/
-    ├── executive/
-    └── agent-runs/              ← Logs de ejecuciones de agentes Claude
+    └── agent-runs/              ← Logs de ejecuciones de agentes
 ```
 
 ---
+
+## `.claudeignore`
+
+Fichero que controla qué directorios **no se cargan en el contexto** de Claude Code:
+
+- `.claude/worktrees/` — Claude Code crea copias del workspace por sesión; sin excluirlas, saturan el contexto
+- `.claude/rules/languages/` — 21 ficheros de convenciones (6.900+ líneas) que se cargan bajo demanda cuando un agente los necesita
+
+> Sin `.claudeignore`, el contexto auto-cargado supera los límites y todos los slash commands fallan con "Prompt is too long".

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -1,130 +1,102 @@
 # Workspace Structure
 
+> **Note:** The workspace root (`~/claude/`) **is** the repository. Always work from the root. `.gitignore` manages what stays private (real projects, credentials, local config).
+
 ```
-pm-workspace/
-├── CLAUDE.md                    ← Claude Code entry point (global constants)
+~/claude/                        ← Working root AND GitHub repository
+├── CLAUDE.md                    ← Claude Code entry point (≤150 lines)
+├── .claudeignore                ← Excludes worktrees and languages from auto-loading
+├── .gitignore                   ← Privacy: real projects, secrets, local config
 ├── docs/SETUP.md                ← Step-by-step configuration guide
-├── README.md                    ← Spanish version
-├── README.en.md                 ← This file (English)
-├── .gitignore
+├── README.md / README.en.md     ← Main documentation (ES/EN)
 │
 ├── .claude/
-│   ├── settings.local.json      ← Claude Code permissions
-│   ├── .env                     ← Environment variables (DO NOT commit)
-│   ├── mcp.json                 ← Optional MCP configuration
+│   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 35 slash commands
-│   │   ├── sprint-status.md
-│   │   ├── sprint-plan.md
-│   │   ├── sprint-review.md
-│   │   ├── sprint-retro.md
-│   │   ├── report-hours.md
-│   │   ├── report-executive.md
-│   │   ├── report-capacity.md
-│   │   ├── team-workload.md
-│   │   ├── board-flow.md
-│   │   ├── kpi-dashboard.md
-│   │   ├── pbi-decompose.md
-│   │   ├── pbi-decompose-batch.md
-│   │   ├── pbi-assign.md
-│   │   ├── pbi-plan-sprint.md
-│   │   ├── pbi-jtbd.md           ← Discovery: Jobs to be Done
-│   │   ├── pbi-prd.md            ← Discovery: Product Requirements
-│   │   ├── pr-review.md          ← Multi-perspective PR review
-│   │   ├── context-load.md       ← Session context loading
-│   │   ├── changelog-update.md   ← Update CHANGELOG from commits
-│   │   ├── evaluate-repo.md      ← External repo audit
-│   │   ├── spec-generate.md      ← SDD
-│   │   ├── spec-implement.md     ← SDD
-│   │   ├── spec-review.md        ← SDD
-│   │   ├── spec-status.md        ← SDD
-│   │   ├── agent-run.md          ← SDD
-│   │   ├── team-onboarding.md    ← New member onboarding
-│   │   ├── team-evaluate.md      ← Competency assessment
-│   │   └── team-privacy-notice.md ← GDPR privacy notice
+│   ├── commands/                ← 30 slash commands
+│   │   ├── help.md              ← /help — catalog + first steps
+│   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
+│   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
+│   │   ├── spec-generate.md ... ← SDD (5)
+│   │   ├── pr-review.md ...     ← Quality & PRs (4)
+│   │   ├── team-onboarding.md ..← Team (3)
+│   │   ├── infra-detect.md ...  ← Infrastructure (7)
+│   │   ├── context-load.md      ← Utilities
+│   │   └── references/          ← Reference files (not loaded as commands)
+│   │       ├── command-catalog.md
+│   │       └── ... (11 files)
 │   │
-│   ├── skills/                  ← 9 custom skills
+│   ├── agents/                  ← 23 specialized subagents
+│   │   ├── business-analyst.md
+│   │   ├── architect.md
+│   │   ├── code-reviewer.md
+│   │   ├── commit-guardian.md
+│   │   ├── security-guardian.md
+│   │   ├── test-runner.md
+│   │   ├── sdd-spec-writer.md
+│   │   ├── infrastructure-agent.md
+│   │   ├── dotnet-developer.md  ← + 10 language-specific developers
+│   │   └── ...
+│   │
+│   ├── skills/                  ← 9 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
 │   │   ├── time-tracking-report/
 │   │   ├── executive-reporting/
-│   │   ├── product-discovery/     ← JTBD + PRD before decompose
-│   │   │   └── references/
-│   │   │       ├── jtbd-template.md
-│   │   │       └── prd-template.md
+│   │   ├── product-discovery/
 │   │   ├── pbi-decomposition/
-│   │   │   └── references/
-│   │   │       └── assignment-scoring.md
-│   │   ├── team-onboarding/          ← Onboarding + competency assessment
-│   │   │   └── references/
-│   │   │       ├── onboarding-checklist.md
-│   │   │       ├── questionnaire-template.md
-│   │   │       ├── expertise-mapping.md
-│   │   │       └── privacy-notice-template.md
+│   │   ├── team-onboarding/
 │   │   └── spec-driven-development/
-│   │       ├── SKILL.md
-│   │       └── references/
-│   │           ├── spec-template.md         ← Spec template
-│   │           ├── layer-assignment-matrix.md ← What goes to agent vs human
-│   │           └── agent-team-patterns.md   ← Agent team patterns
+│   │       └── references/      ← Templates, matrices, team patterns
 │   │
-│   └── rules/                   ← Modular rules (loaded on demand)
-│       ├── pm-config.md         ← Full Azure DevOps constants
+│   └── rules/                   ← Modular rules
+│       ├── pm-config.md         ← Azure DevOps constants
 │       ├── pm-workflow.md       ← Scrum cadence and command table
-│       ├── {lang}-conventions.md← Per-language conventions (16 Language Packs)
-│       ├── {lang}-rules.md      ← Per-language quality rules
-│       ├── environment-config.md← Multi-environment config (DEV/PRE/PRO)
-│       ├── confidentiality-config.md ← Secrets and connection string protection
-│       ├── infrastructure-as-code.md ← Multi-cloud IaC (Azure, AWS, GCP)
-│       ├── readme-update.md     ← When and how to update this README
-│       └── github-flow.md       ← Branching workflow: branches, PRs, main protection
+│       ├── github-flow.md       ← Branching, PRs, releases, tags
+│       ├── environment-config.md
+│       ├── confidentiality-config.md
+│       ├── infrastructure-as-code.md
+│       ├── language-packs.md    ← 16 supported languages table
+│       ├── command-validation.md← Pre-commit: validate commands
+│       ├── file-size-limit.md   ← 150 lines rule
+│       ├── readme-update.md     ← Rule 12: update READMEs
+│       ├── agents-catalog.md    ← 23 agents table
+│       └── languages/           ← Per-language conventions (excluded from auto-loading)
+│           ├── csharp-rules.md
+│           ├── dotnet-conventions.md
+│           └── ... (21 files for 16 languages)
 │
-├── docs/
-│   ├── reglas-scrum.md
-│   ├── politica-estimacion.md
-│   ├── kpis-equipo.md
-│   ├── plantillas-informes.md
-│   └── flujo-trabajo.md         ← Includes section 8: SDD workflow
+├── docs/                        ← Methodology, guides, README sections
+│   ├── readme/ (13 sections ES)
+│   ├── readme_en/ (13 sections EN)
+│   ├── best-practices-claude-code.md
+│   ├── ADOPTION_GUIDE.md / .en.md
+│   └── ...
 │
-├── projects/
-│   ├── project-alpha/
-│   │   ├── CLAUDE.md            ← Project constants + SDD config
-│   │   ├── equipo.md            ← Human team + Claude agents as developers
-│   │   ├── reglas-negocio.md
-│   │   ├── source/              ← git clone the repo here
-│   │   ├── sprints/
-│   │   └── specs/               ← SDD specs
-│   │       ├── sdd-metrics.md
-│   │       ├── templates/
-│   │       └── sprint-YYYY-MM/
-│   ├── project-beta/
-│   │   └── (same structure)
-│   └── sala-reservas/           ← ⚗️ TEST PROJECT (see section below)
-│       ├── CLAUDE.md
-│       ├── equipo.md            ← 4 devs + PM + Claude agents
-│       ├── reglas-negocio.md    ← 16 documented business rules
-│       ├── sprints/
-│       │   └── sprint-2026-04/
-│       │       └── planning.md
-│       ├── specs/
-│       │   ├── sdd-metrics.md
-│       │   └── sprint-2026-04/
-│       │       ├── AB101-B3-create-sala-handler.spec.md
-│       │       └── AB102-D1-unit-tests-salas.spec.md
-│       └── test-data/           ← Azure DevOps API mock JSON
-│           ├── mock-workitems.json
-│           ├── mock-sprint.json
-│           └── mock-capacities.json
+├── projects/                    ← Real projects (git-ignored)
+│   ├── proyecto-alpha/          ← Example: CLAUDE.md, equipo.md, specs/
+│   ├── proyecto-beta/
+│   └── sala-reservas/           ← Test project with mock data
 │
 ├── scripts/
-│   ├── azdevops-queries.sh      ← Bash: Azure DevOps REST API queries
-│   ├── capacity-calculator.py  ← Python: real capacity calculation
-│   └── report-generator.js     ← Node.js: Excel/PPT report generation
+│   ├── azdevops-queries.sh      ← Azure DevOps REST API queries
+│   ├── test-workspace.sh        ← Workspace structure validation
+│   └── validate-commands.sh     ← Static validation of slash commands
 │
-└── output/
+└── output/                      ← Generated reports (git-ignored)
     ├── sprints/
     ├── reports/
-    ├── executive/
-    └── agent-runs/              ← Claude agent execution logs
+    └── agent-runs/              ← Agent execution logs
 ```
+
+---
+
+## `.claudeignore`
+
+Controls which directories are **not loaded into context** by Claude Code:
+
+- `.claude/worktrees/` — Claude Code creates workspace copies per session; without exclusion, they saturate the context
+- `.claude/rules/languages/` — 21 convention files (6,900+ lines) loaded on-demand when an agent needs them
+
+> Without `.claudeignore`, auto-loaded context exceeds limits and all slash commands fail with "Prompt is too long".


### PR DESCRIPTION
## Root cause
Claude Code creates worktrees in `.claude/worktrees/` for each "Código" tab session, copying the entire workspace. These copies (**30K+ lines**) were loaded recursively into the prompt context, causing **"Prompt is too long"** on every slash command.

## Fix
- Added `.claudeignore` to exclude `worktrees/` and `rules/languages/` from context loading
- Removed tracked worktree submodule reference (`cool-benz`)

## Verified
- `/help` works correctly with all 31 commands, 23 agents, and 9 skills present
- `/test-ping` (minimal command) also works
- New sessions in Código tab create worktrees that are now ignored

## Note
This is a known Claude Code behavior (GitHub issues #14851, #14882). The `.claudeignore` file is the official workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)