### PR TITLE
feat: diagram architecture — generate and import with Draw.io/Miro

### DIFF
--- a/.claude/agents/diagram-architect.md
+++ b/.claude/agents/diagram-architect.md
@@ -1,0 +1,83 @@
+# Agent: Diagram Architect
+
+## Rol
+
+Agente especializado en análisis de diagramas de arquitectura. Valida consistencia arquitectónica, detecta problemas de diseño y sugiere la descomposición óptima en Features/PBIs/Tasks.
+
+## Cuándo se invoca
+
+- Desde `/diagram:generate` cuando el proyecto tiene >10 componentes
+- Desde `/diagram:import` para validar la arquitectura antes de generar work items
+- Petición directa: "analiza la arquitectura del diagrama"
+
+## Modelo
+
+`claude-sonnet-4-6` — Balance entre capacidad de análisis y velocidad
+
+## Contexto que recibe
+
+1. Diagrama en formato Mermaid (siempre disponible como copia local)
+2. `projects/{proyecto}/CLAUDE.md` — Stack y decisiones arquitectónicas
+3. `projects/{proyecto}/reglas-negocio.md` — Reglas de dominio
+4. `.claude/rules/diagram-config.md` — Configuración de la feature
+
+## Tareas
+
+### 1. Validación de consistencia
+
+- **Dependencias circulares** — Detectar ciclos entre servicios
+- **Layering** — Verificar que capas superiores no son accedidas por inferiores
+- **Single Responsibility** — Servicios con demasiadas conexiones (>5 dependencias)
+- **Base de datos compartida** — Antipatrón: múltiples servicios accediendo a la misma DB
+- **Missing observability** — Componentes sin logging/monitoring identificado
+- **Missing resilience** — Llamadas síncronas sin circuit breaker/retry
+
+### 2. Análisis de completitud
+
+Para cada entidad del diagrama, verificar que tiene:
+
+| Entidad | Campos esperados |
+|---|---|
+| Microservicio | Nombre, interfaz, DB propia, entorno deploy |
+| API | Método, path, auth, rate limiting |
+| Base de datos | Tecnología, esquema referencia, backup |
+| Cola | Formato mensaje, reintentos, DLQ |
+| Frontend | Framework, servidor, CDN |
+
+### 3. Propuesta de descomposición
+
+Sugerir agrupación de entidades en:
+- **Features** — Un Feature por bounded context o módulo mayor
+- **PBIs** — Un PBI por funcionalidad implementable de forma independiente
+- **Tasks** — Derivadas de la skill `pbi-decomposition` (no duplicar lógica)
+
+### 4. Informe
+
+```markdown
+## 🏗️ Análisis Arquitectónico — {proyecto}
+
+### Consistencia
+- ✅ No hay dependencias circulares
+- ⚠️ {Servicio X} tiene 7 dependencias directas → considerar desacoplar
+- ❌ {DB compartida} accedida por 3 servicios → separar por bounded context
+
+### Completitud
+- {N}/{M} entidades con información completa
+- Entidades incompletas: {lista con campos faltantes}
+
+### Descomposición sugerida
+- Feature 1: {nombre} ({N} PBIs estimados)
+- Feature 2: {nombre} ({N} PBIs estimados)
+...
+
+### Recomendaciones
+1. {Recomendación priorizada}
+2. ...
+```
+
+## Restricciones
+
+- Solo analiza y recomienda — no crea work items directamente
+- Si detecta problemas ❌ bloqueantes → recomendar corregir diagrama antes de importar
+- No accede a APIs externas — trabaja con el modelo de datos que recibe
+- Informe en español (idioma del workspace)

--- a/.claude/commands/diagram-config.md
+++ b/.claude/commands/diagram-config.md
@@ -1,0 +1,76 @@
+---
+name: diagram-config
+description: >
+  Configurar credenciales y conexión con Draw.io y/o Miro MCP.
+  Verifica la conexión y guía en el setup inicial.
+---
+
+# Configuración de Herramientas de Diagramas
+
+**Tool:** $ARGUMENTS
+
+> Uso: `/diagram:config --tool draw.io|miro [--test] [--list]`
+
+## Parámetros
+
+- `--tool {draw.io|miro}` — Herramienta a configurar (obligatorio salvo `--list`)
+- `--test` — Verificar conexión al MCP sin modificar nada
+- `--list` — Mostrar estado de configuración de todas las herramientas
+- `--set-token` — Configurar token/credencial (solo Miro; Draw.io no requiere)
+
+## Contexto requerido
+
+1. `.claude/rules/diagram-config.md` — Constantes y URLs
+2. `.claude/mcp.json` — Configuración MCP actual
+3. `.claude/rules/pm-config.md` — Credenciales generales
+
+## Pasos de ejecución
+
+### Si `--list`
+
+Mostrar tabla de estado:
+
+```
+🔧 Herramientas de Diagramas
+
+┌──────────┬──────────────┬────────────┬──────────────────┐
+│ Tool     │ MCP URL      │ Auth       │ Estado           │
+├──────────┼──────────────┼────────────┼──────────────────┤
+│ Draw.io  │ mcp.draw.io  │ No req.    │ ✅ Configurado   │
+│ Miro     │ mcp.miro.com │ OAuth 2.1  │ ⚠️ Sin token    │
+└──────────┴──────────────┴────────────┴──────────────────┘
+```
+
+### Si `--tool draw.io`
+
+1. Verificar que `.claude/mcp.json` contiene la entrada `draw-io`
+2. Si no existe → informar al usuario que debe añadirla (mostrar JSON exacto)
+3. Si `--test` → intentar listar diagramas via MCP draw-io
+4. Mostrar resultado: ✅ Conexión OK / ❌ Error + detalle
+
+### Si `--tool miro`
+
+1. Verificar que `.claude/mcp.json` contiene la entrada `miro`
+2. Verificar que existe `$HOME/.azure/miro-token` con contenido
+3. Si falta token → guiar al usuario:
+   ```
+   Para configurar Miro:
+   1. Ve a https://miro.com/app/settings/user-profile/apps
+   2. Crea una app o usa una existente
+   3. Copia el Access Token
+   4. Guárdalo: echo "TU_TOKEN" > $HOME/.azure/miro-token
+   ```
+4. Si `--test` → intentar listar boards via MCP miro
+5. Si `--set-token` → solicitar token al usuario, validar formato, guardar en fichero
+6. Mostrar resultado: ✅ Conexión OK / ❌ Error + detalle
+
+### Si `--tool` sin `--test` ni `--set-token`
+
+Mostrar configuración actual del tool y estado de conexión.
+
+## Restricciones
+
+- **No almacenar tokens en código ni en ficheros trackeados por git**
+- Tokens van en `$HOME/.azure/` (mismo patrón que PAT Azure DevOps)
+- Solo mostrar últimos 4 caracteres del token en pantalla
+- Si el usuario pega un token en el chat → advertir que debe guardarlo en fichero

--- a/.claude/commands/diagram-generate.md
+++ b/.claude/commands/diagram-generate.md
@@ -1,0 +1,82 @@
+---
+name: diagram-generate
+description: >
+  Genera diagrama de arquitectura, flujo o secuencia a partir de la
+  infraestructura y código del proyecto. Exporta a Draw.io, Miro o local.
+---
+
+# Generar Diagrama de Arquitectura
+
+**Proyecto:** $ARGUMENTS
+
+> Uso: `/diagram:generate {proyecto} [--tool draw.io|miro|local] [--type architecture|flow|sequence]`
+
+## Parámetros
+
+- `{proyecto}` — Nombre del proyecto en `projects/` (obligatorio)
+- `--tool {draw.io|miro|local}` — Herramienta destino (default: valor de `DIAGRAM_DEFAULT_TOOL` o `local`)
+- `--type {architecture|flow|sequence}` — Tipo de diagrama (default: `architecture`)
+
+## Contexto requerido
+
+Leer en este orden (Progressive Disclosure):
+
+1. `CLAUDE.md` (raíz)
+2. `projects/{proyecto}/CLAUDE.md` — Stack, arquitectura, repos
+3. `projects/{proyecto}/infrastructure/` — Terraform, Docker, K8s
+4. `.claude/rules/diagram-config.md` — Constantes de la feature
+5. `.claude/rules/pm-config.md` — Credenciales si tool ≠ local
+
+## Pasos de ejecución
+
+1. **Validar proyecto** — Verificar que `projects/{proyecto}/` existe y tiene `CLAUDE.md`
+
+2. **Invocar la skill** completa:
+   → `.claude/skills/diagram-generation/SKILL.md`
+
+3. **Fase 1 — Detectar componentes**:
+   - Escanear fuentes del proyecto (IaC, código, docs)
+   - Identificar: servicios, DBs, colas, almacenamiento, frontends, externos
+   - Extraer relaciones: HTTP, mensajería, acceso a datos, dependencias
+
+4. **Fase 2 — Generar Mermaid**:
+   - Usar plantillas de la skill (`diagram-generation` → mermaid-templates)
+   - Tipo `architecture` → graph TB con subgraphs por capa
+   - Tipo `flow` → flowchart LR con decisiones y caminos
+   - Tipo `sequence` → sequenceDiagram con participantes y mensajes
+
+5. **Fase 3 — Exportar** según `--tool`:
+   - `local` → Guardar `.mermaid` en `projects/{p}/diagrams/local/`
+   - `draw.io` → Convertir a XML, llamar MCP `draw-io`, obtener URL
+   - `miro` → Crear shapes/connectors en board, obtener URL
+
+6. **Fase 4 — Guardar metadata** en `projects/{p}/diagrams/{tool}/{tipo}.meta.json`
+
+7. **Presentar resultado**:
+   ```
+   ✅ Diagrama generado: {tipo} — {proyecto}
+   🔗 URL: {link}
+   📊 Elementos: {N} servicios, {N} DBs, {N} conexiones
+   📁 Local: projects/{p}/diagrams/local/{tipo}.mermaid
+
+   ¿Quieres importar este diagrama para generar Features/PBIs?
+   → /diagram:import {url_o_fichero} --project {proyecto}
+   ```
+
+## Validaciones previas
+
+- Si `--tool draw.io` → verificar entrada `draw-io` en `mcp.json`
+- Si `--tool miro` → verificar token Miro existe (`/diagram:config --tool miro --test`)
+- Si proyecto no tiene código ni infraestructura → advertir: "No se detectaron componentes. ¿Quieres crear un diagrama desde cero?"
+
+## Invocar agente (opcional)
+
+Si `--type architecture` y el proyecto tiene >10 componentes:
+→ Delegar validación de consistencia al agente `diagram-architect`
+
+## Restricciones
+
+- Crear directorio `diagrams/` si no existe
+- No sobrescribir diagramas existentes sin confirmar
+- Siempre generar copia local en Mermaid además de la exportación al tool
+- No incluir secrets, connection strings ni tokens en el diagrama

--- a/.claude/commands/diagram-import.md
+++ b/.claude/commands/diagram-import.md
@@ -1,0 +1,83 @@
+---
+name: diagram-import
+description: >
+  Importa un diagrama de arquitectura (Draw.io, Miro o local) y genera
+  Features, PBIs y Tasks en Azure DevOps. Valida reglas de negocio antes.
+---
+
+# Importar Diagrama → Generar Work Items
+
+**Fuente:** $ARGUMENTS
+
+> Uso: `/diagram:import {source} --project {nombre} [--validate-only] [--dry-run]`
+
+## Parámetros
+
+- `{source}` — URL de Draw.io, URL de Miro, fichero local (.drawio, .xml, .mermaid), o ID de meta.json existente
+- `--project {nombre}` — Proyecto destino en Azure DevOps (obligatorio)
+- `--validate-only` — Analiza y valida sin crear work items
+- `--dry-run` — Muestra la propuesta sin crear nada (comportamiento por defecto)
+
+## Contexto requerido
+
+Leer en este orden (Progressive Disclosure):
+
+1. `CLAUDE.md` (raíz)
+2. `projects/{proyecto}/CLAUDE.md` — Stack, arquitectura
+3. `projects/{proyecto}/reglas-negocio.md` — **CRÍTICO**: reglas de dominio
+4. `projects/{proyecto}/equipo.md` — Para asignación posterior
+5. `.claude/rules/diagram-config.md` — Constantes y checklist validación
+6. `.claude/rules/pm-config.md` — Credenciales
+
+## Pasos de ejecución
+
+1. **Invocar la skill** completa:
+   → `.claude/skills/diagram-import/SKILL.md`
+
+2. **Fase 1 — Obtener diagrama** según tipo de source:
+   - URL Draw.io → MCP `draw-io` para leer XML
+   - URL Miro → MCP `miro` para leer board
+   - Fichero local → leer directamente
+   - Parsear → modelo normalizado (entidades + relaciones)
+
+3. **Fase 2 — Validar arquitectura**:
+   - Invocar agente `diagram-architect`
+   - Si hay problemas ❌ bloqueantes → informar y recomendar corregir
+
+4. **Fase 3 — Validar reglas de negocio** ⚠️ PASO CRÍTICO:
+   - Leer `projects/{p}/reglas-negocio.md`
+   - Si no existe → solicitar al PM, NO continuar
+   - Verificar checklist por entidad (ver skill `diagram-import` → business-rules-validation)
+   - Si falta información obligatoria → mostrar informe detallado
+   - Ofrecer opciones: completar info, generar parcial, generar draft
+
+5. **Fase 4 — Generar jerarquía** (si reglas OK o PM elige parcial/draft):
+   - Features por bounded context / módulo
+   - PBIs por funcionalidad / endpoint / user story
+   - Tasks por requisito técnico
+   - Usar templates de la skill (`diagram-import` → pbi-generation-templates)
+
+6. **Fase 5 — Presentar propuesta** en tabla con SP estimados
+   - Preguntar: "¿Creo estos work items en Azure DevOps?"
+
+7. **Fase 6 — Crear en Azure DevOps** (tras confirmación):
+   - Features → PBIs → Tasks con links jerárquicos
+   - Tags: `diagram-import`, tipo de entidad
+   - Link al diagrama source en Description
+   - Actualizar metadata local
+
+## Ejemplo
+
+```
+/diagram:import https://miro.com/app/board/uXjVN... --project ProyectoAlpha
+/diagram:import projects/alpha/diagrams/local/architecture.mermaid --project ProyectoAlpha
+/diagram:import --validate-only projects/alpha/diagrams/local/flow.mermaid --project ProyectoAlpha
+```
+
+## Restricciones
+
+- ❌ **NUNCA crear PBIs sin validar reglas de negocio primero**
+- Siempre modo dry-run por defecto — requiere confirmación explícita para crear
+- No sobrescribir work items existentes — detectar duplicados por tag + nombre
+- Si `--validate-only` → solo análisis + informe, no ofrece crear
+- Máximo 50 PBIs por importación — si hay más, dividir en lotes

--- a/.claude/commands/diagram-status.md
+++ b/.claude/commands/diagram-status.md
@@ -1,0 +1,63 @@
+---
+name: diagram-status
+description: >
+  Lista diagramas por proyecto y su estado de sincronización
+  con Draw.io/Miro. Muestra links y metadata.
+---
+
+# Estado de Diagramas
+
+**Filtro:** $ARGUMENTS
+
+> Uso: `/diagram:status [--project {nombre}] [--tool draw.io|miro]`
+
+## Parámetros
+
+- `--project {nombre}` — Filtrar por proyecto (default: todos los proyectos)
+- `--tool {draw.io|miro}` — Filtrar por herramienta (default: todas)
+
+## Contexto requerido
+
+1. `.claude/rules/diagram-config.md` — Constantes
+2. `projects/*/diagrams/` — Directorios de diagramas de cada proyecto
+
+## Pasos de ejecución
+
+1. **Escanear proyectos** — Listar directorios en `projects/` que tengan `diagrams/`
+
+2. **Para cada proyecto** (o solo el filtrado):
+   - Leer todos los `*.meta.json` en `diagrams/draw-io/` y `diagrams/miro/`
+   - Extraer: nombre, tipo, URL, última sincronización, nº elementos, estado reglas negocio
+
+3. **Mostrar tabla consolidada**:
+
+```
+📊 Diagramas — {proyecto}
+
+┌────────────────────┬──────────┬───────────────┬──────────────┬────────────────┬─────────────┐
+│ Diagrama           │ Tool     │ Tipo          │ Elementos    │ Última sync    │ Reglas neg. │
+├────────────────────┼──────────┼───────────────┼──────────────┼────────────────┼─────────────┤
+│ System Architecture│ Draw.io  │ architecture  │ 24           │ 2026-02-25     │ ✅ 20/24    │
+│ Data Flow          │ Miro     │ flow          │ 18           │ 2026-02-20     │ ⚠️ 12/18   │
+└────────────────────┴──────────┴───────────────┴──────────────┴────────────────┴─────────────┘
+
+🔗 Links:
+  • System Architecture: https://draw.io/edit/...
+  • Data Flow: https://miro.com/app/board/...
+```
+
+4. **Si hay entidades sin reglas de negocio completas**:
+   - Mostrar resumen: "⚠️ {N} entidades pendientes de reglas de negocio"
+   - Listar las entidades y qué información falta
+
+5. **Si no hay diagramas**:
+   ```
+   📊 No hay diagramas registrados.
+   Usa /diagram:generate para crear uno, o /diagram:import para cargar uno existente.
+   ```
+
+## Restricciones
+
+- Solo lectura — no modifica ningún fichero
+- No accede a APIs externas — solo lee metadata local
+- Si un meta.json tiene formato inválido → advertir y continuar con los demás

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -24,8 +24,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Calidad y PRs (4):** pr:review [PR], pr:pending [--project p], evaluate:repo [URL], changelog:update
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
+   **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "MCP Server opcional de Azure DevOps (Microsoft oficial). Activar si se necesitan operaciones encadenadas avanzadas. Requiere npx instalado.",
+  "_comment": "MCP Servers para PM-Workspace. Requiere npx instalado para servidores stdio.",
   "mcpServers": {
     "azure-devops": {
       "command": "npx",
@@ -9,6 +9,19 @@
         "AZURE_DEVOPS_PAT": "CARGAR_DESDE_FICHERO"
       },
       "_note": "Sustituir CARGAR_DESDE_FICHERO por el PAT real, o configurar el entorno antes de iniciar Claude Code con: export AZURE_DEVOPS_PAT=$(cat $HOME/.azure/devops-pat)"
+    },
+    "draw-io": {
+      "type": "url",
+      "url": "https://mcp.draw.io/mcp",
+      "_note": "Draw.io MCP oficial (HTTP). No requiere autenticación para operaciones básicas de lectura/escritura."
+    },
+    "miro": {
+      "type": "url",
+      "url": "https://mcp.miro.com",
+      "headers": {
+        "Authorization": "Bearer CARGAR_DESDE_FICHERO"
+      },
+      "_note": "Miro MCP oficial (HTTP, OAuth 2.1). Sustituir CARGAR_DESDE_FICHERO por el token real, o configurar: export MIRO_TOKEN=$(cat $HOME/.azure/miro-token). Configurar con /diagram:config --tool miro"
     }
   }
 }

--- a/.claude/rules/agents-catalog.md
+++ b/.claude/rules/agents-catalog.md
@@ -1,4 +1,4 @@
-# Catálogo de Subagentes (23)
+# Catálogo de Subagentes (24)
 
 | Agente | Modelo | Especialidad |
 |---|---|---|
@@ -20,6 +20,7 @@
 | `cobol-developer` | Opus 4.6 | Asistencia COBOL (documentación, copybooks, tests) |
 | `terraform-developer` | Sonnet 4.6 | Terraform/IaC (NUNCA ejecuta apply) |
 | `infrastructure-agent` | Opus 4.6 | Infra multi-cloud: detectar, crear (tier mínimo), escalar (aprobación humana) |
+| `diagram-architect` | Sonnet 4.6 | Análisis de diagramas: consistencia, layering, decomposición Features/PBIs |
 | `test-engineer` | Sonnet 4.6 | Testing multi-lenguaje, TestContainers, cobertura |
 | `test-runner` | Sonnet 4.6 | Ejecución de tests, cobertura ≥ TEST_COVERAGE_MIN_PERCENT, orquestación de mejora |
 | `commit-guardian` | Sonnet 4.6 | Pre-commit checks: rama, secrets, build, tests, code review, README |
@@ -31,6 +32,7 @@
 - **SDD**: `business-analyst` → `architect` → `sdd-spec-writer` → `{lang}-developer` ‖ `test-engineer` → `code-reviewer`
 - **Infra**: `architect` → `infrastructure-agent` → (detectar → crear tier mínimo → propuesta) → humano aprueba → apply
 - **Pre-commit**: `commit-guardian` (10 checks: rama, security, build, tests, format, code review, README, CLAUDE.md, atomicidad, mensaje)
+- **Diagramas**: `diagram-architect` → analizar consistencia → validar reglas negocio → proponer decomposición
 - **Post-commit**: `test-runner` (tests completos + cobertura ≥ `TEST_COVERAGE_MIN_PERCENT`)
 
 El agente developer se selecciona según el Language Pack del proyecto.

--- a/.claude/rules/diagram-config.md
+++ b/.claude/rules/diagram-config.md
@@ -1,0 +1,50 @@
+# Regla: Configuración de Diagramas de Arquitectura
+# ── Constantes y configuración para generación e importación de diagramas ────
+
+> Esta regla se carga bajo demanda cuando se ejecutan comandos `diagram:*`.
+
+```
+# ── MCP Tools disponibles ────────────────────────────────────────────────────
+DIAGRAM_TOOL_DRAWIO         = "draw-io"                          # Draw.io oficial (HTTP, sin auth básica)
+DIAGRAM_TOOL_MIRO           = "miro"                             # Miro oficial (HTTP, OAuth 2.1)
+DIAGRAM_DEFAULT_TOOL        = "draw-io"                          # Tool por defecto si no se especifica
+
+# ── URLs MCP ─────────────────────────────────────────────────────────────────
+DRAWIO_MCP_URL              = "https://mcp.draw.io/mcp"          # Endpoint HTTP oficial Draw.io
+MIRO_MCP_URL                = "https://mcp.miro.com"             # Endpoint HTTP oficial Miro
+
+# ── Credenciales ─────────────────────────────────────────────────────────────
+MIRO_TOKEN_FILE             = "$HOME/.azure/miro-token"           # OAuth token Miro (una línea, sin salto)
+# Draw.io HTTP oficial no requiere auth para operaciones básicas
+
+# ── Tipos de diagrama soportados ─────────────────────────────────────────────
+DIAGRAM_TYPES               = "architecture,flow,sequence"
+DIAGRAM_DEFAULT_TYPE        = "architecture"
+
+# ── Formatos ─────────────────────────────────────────────────────────────────
+DIAGRAM_FORMAT_DRAWIO       = "xml"                              # Draw.io nativo: XML (.drawio)
+DIAGRAM_FORMAT_MIRO         = "json"                             # Miro API: JSON
+DIAGRAM_FORMAT_LOCAL        = "mermaid"                          # Local: Mermaid (.mermaid)
+
+# ── Estructura por proyecto ──────────────────────────────────────────────────
+# projects/{proyecto}/diagrams/draw-io/    ← metadata de diagramas Draw.io
+# projects/{proyecto}/diagrams/miro/       ← metadata de boards Miro
+# projects/{proyecto}/diagrams/local/      ← diagramas locales (.mermaid, .xml)
+DIAGRAM_DIR                 = "diagrams"
+DIAGRAM_META_EXTENSION      = ".meta.json"
+```
+
+## Validación de reglas de negocio
+
+Antes de crear PBIs desde un diagrama, se DEBE verificar que existan reglas de negocio suficientes. El fichero `projects/{proyecto}/reglas-negocio.md` debe contener información para cada entidad del diagrama según su tipo:
+
+| Tipo entidad | Información requerida |
+|---|---|
+| Microservicio | Interfaz/contrato, esquema DB, entorno deploy |
+| API/Endpoint | Método HTTP, path, autenticación, rate limit |
+| Base de datos | Esquema, política backup, plan escalado |
+| UI/Frontend | User stories, requisitos accesibilidad |
+| Cola/Mensajería | Formato mensaje, política reintentos, DLQ |
+| Integración externa | Proveedor, SLA, fallback |
+
+Si falta información → NO se crean PBIs. Se genera informe de info faltante para el PM.

--- a/.claude/rules/pm-config.md
+++ b/.claude/rules/pm-config.md
@@ -84,3 +84,16 @@ curl -X POST "https://login.microsoftonline.com/$GRAPH_TENANT_ID/oauth2/v2.0/tok
 ```
 
 **Scopes PAT requeridos:** Work Items R/W · Project and Team R · Analytics R · Code R · Build R
+
+```
+# ── Diagram Tools (Draw.io / Miro) ──────────────────────────────────────────
+DRAWIO_MCP_URL              = "https://mcp.draw.io/mcp"           # MCP HTTP oficial, sin auth
+MIRO_MCP_URL                = "https://mcp.miro.com"              # MCP HTTP oficial, OAuth 2.1
+MIRO_TOKEN_FILE             = "$HOME/.azure/miro-token"            # fichero con OAuth token (sin salto de línea)
+
+# ── Per-Project Diagram Settings (en pm-config.local.md) ────────────────────
+# Formato:
+#   PROJECT_XXX_DRAWIO_FOLDER   = "Folder/Path"                   # carpeta en Draw.io
+#   PROJECT_XXX_MIRO_BOARD_ID   = "uXjVN..."                      # ID del board en Miro
+#   PROJECT_XXX_DIAGRAM_TOOL    = "draw-io"                        # tool preferido (draw-io|miro)
+```

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -58,6 +58,10 @@
 | `/infra:status {proyecto}` | Estado de la infraestructura actual del proyecto |
 | `/env:setup {proyecto}` | Configurar entornos (DEV/PRE/PRO) para un proyecto |
 | `/env:promote {proyecto} {origen} {destino}` | Promover deploy entre entornos (PRE→PRO requiere aprobación) |
+| `/diagram:generate {proy}` | Generar diagrama de arquitectura/flujo → Draw.io, Miro o local |
+| `/diagram:import {source}` | Importar diagrama → validar reglas negocio → crear Features/PBIs/Tasks |
+| `/diagram:config` | Configurar credenciales Draw.io/Miro y verificar conexión |
+| `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias
@@ -76,4 +80,7 @@
 - Multi-entorno: `.claude/rules/environment-config.md`
 - Confidencialidad: `.claude/rules/confidentiality-config.md`
 - Infrastructure as Code: `.claude/rules/infrastructure-as-code.md`
+- Diagram Generation: `.claude/skills/diagram-generation/SKILL.md`
+- Diagram Import: `.claude/skills/diagram-import/SKILL.md`
+- Diagram Config: `.claude/rules/diagram-config.md`
 - Azure DevOps API v7.1: https://learn.microsoft.com/en-us/rest/api/azure/devops/

--- a/.claude/skills/diagram-generation/SKILL.md
+++ b/.claude/skills/diagram-generation/SKILL.md
@@ -1,0 +1,188 @@
+# Skill: Diagram Generation — Arquitectura y Flujo
+
+## Propósito
+
+Generar diagramas de arquitectura, flujo de datos y secuencia a partir de la infraestructura y código fuente de un proyecto. Exportar a Draw.io, Miro o formato local (Mermaid).
+
+---
+
+## Triggers
+
+- Comando `/diagram:generate` — Genera diagrama completo
+- Petición directa: "genera el diagrama de arquitectura del proyecto X"
+
+---
+
+## Contexto Requerido (Progressive Disclosure)
+
+1. `CLAUDE.md` (raíz) — Contexto global
+2. `projects/{proyecto}/CLAUDE.md` — Stack, arquitectura, repos
+3. `projects/{proyecto}/infrastructure/` — Terraform, Docker, K8s si existen
+4. `.claude/rules/diagram-config.md` — Constantes y configuración
+5. `.claude/rules/pm-config.md` — Credenciales MCP
+
+---
+
+## Fase 1: Detección de Componentes
+
+Analizar el proyecto para identificar componentes arquitectónicos:
+
+### 1.1 Fuentes de detección (en orden de prioridad)
+
+1. **Infraestructura como código** — `*.tf`, `docker-compose.yml`, `k8s/`, `helm/`
+2. **Código fuente** — `*.csproj`, `package.json`, `pom.xml`, `go.mod`, etc.
+3. **Documentación existente** — `CLAUDE.md` del proyecto, `architecture.md`
+4. **Azure DevOps** — Repos, pipelines, service connections (via MCP)
+
+### 1.2 Entidades a detectar
+
+| Entidad | Detección | Icono Mermaid |
+|---|---|---|
+| Microservicio / API | `*.csproj` con `Sdk="Microsoft.NET.Sdk.Web"`, `Dockerfile` | `[Nombre]` box |
+| Base de datos | `ConnectionString`, `DbContext`, recursos `azurerm_sql_*` en TF | `[(DB)]` cylinder |
+| Cola / Bus | `ServiceBus`, `RabbitMQ`, `AzureServiceBus` en config | `{{Cola}}` hexagon |
+| Almacenamiento | `BlobStorage`, `S3`, `azurerm_storage_*` | `[/Storage/]` parallelogram |
+| API Gateway | `Ocelot`, `YARP`, `Kong`, `azurerm_api_management` | `[[Gateway]]` subroutine |
+| Frontend / SPA | `angular.json`, `next.config.*`, `vite.config.*` | `(Frontend)` rounded |
+| Servicio externo | Referencias a APIs externas, SDKs de terceros | `>Externo]` asymmetric |
+| CDN / Cache | `Redis`, `azurerm_cdn_*`, `CloudFront` | `{Cache}` rhombus |
+
+### 1.3 Relaciones a detectar
+
+- **HTTP/REST** — Referencias entre proyectos, `HttpClient`, Swagger refs
+- **Mensajería** — Productores/consumidores de colas/topics
+- **Base de datos** — Qué servicios acceden a qué DBs
+- **Dependencia directa** — Project references, imports, packages compartidos
+
+---
+
+## Fase 2: Generación de Modelo Mermaid
+
+Construir la representación en Mermaid según el tipo de diagrama:
+
+### Architecture (C4-style)
+
+```mermaid
+graph TB
+    subgraph "Frontend"
+        SPA[Angular App]
+    end
+    subgraph "Backend"
+        API[API Gateway]
+        SVC1[User Service]
+        SVC2[Order Service]
+    end
+    subgraph "Data"
+        DB1[(Users DB)]
+        DB2[(Orders DB)]
+        CACHE{Redis}
+    end
+    SPA -->|REST| API
+    API --> SVC1
+    API --> SVC2
+    SVC1 --> DB1
+    SVC2 --> DB2
+    SVC1 --> CACHE
+```
+
+### Flow (Data Flow)
+
+```mermaid
+flowchart LR
+    A[Cliente] -->|Request| B[API Gateway]
+    B -->|Route| C{Load Balancer}
+    C --> D[Service A]
+    C --> E[Service B]
+    D -->|Event| F{{Message Bus}}
+    F -->|Subscribe| E
+    D --> G[(Database)]
+```
+
+### Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Cliente
+    participant G as API Gateway
+    participant S as Service
+    participant D as Database
+    C->>G: POST /resource
+    G->>S: Forward request
+    S->>D: INSERT
+    D-->>S: OK
+    S-->>G: 201 Created
+    G-->>C: Response
+```
+
+---
+
+## Fase 3: Exportar a Herramienta MCP
+
+### 3.1 Draw.io (MCP `draw-io`)
+
+1. Convertir Mermaid → XML Draw.io (usar las tools del MCP)
+2. Crear o actualizar diagrama en Draw.io
+3. Obtener URL compartible
+4. Si el proyecto tiene `DRAWIO_FOLDER` configurado → usar esa carpeta
+
+### 3.2 Miro (MCP `miro`)
+
+1. Verificar token OAuth válido
+2. Crear frame en board del proyecto (o crear board nuevo)
+3. Convertir entidades a shapes de Miro + conectores
+4. Obtener URL del board
+5. Si el proyecto tiene `MIRO_BOARD_ID` configurado → añadir al board existente
+
+### 3.3 Local (sin MCP)
+
+1. Guardar fichero `.mermaid` en `projects/{p}/diagrams/local/`
+2. Mostrar el Mermaid en la respuesta para preview
+
+---
+
+## Fase 4: Guardar Metadata
+
+Crear/actualizar `projects/{p}/diagrams/{tool}/{tipo}.meta.json`:
+
+```json
+{
+  "tool": "draw-io",
+  "type": "architecture",
+  "name": "System Architecture — {proyecto}",
+  "url": "https://...",
+  "remote_id": "...",
+  "local_mermaid": "diagrams/local/architecture.mermaid",
+  "created": "2026-02-26T...",
+  "last_sync": "2026-02-26T...",
+  "elements": {
+    "services": 4,
+    "databases": 2,
+    "queues": 1,
+    "external": 2,
+    "connections": 12
+  }
+}
+```
+
+---
+
+## Fase 5: Presentar Resultado
+
+```
+✅ Diagrama generado: {tipo} — {proyecto}
+
+🔗 URL: {link}
+📊 Elementos: {N} servicios, {N} DBs, {N} colas, {N} conexiones
+📁 Metadata: projects/{p}/diagrams/{tool}/{tipo}.meta.json
+📝 Mermaid local: projects/{p}/diagrams/local/{tipo}.mermaid
+
+¿Quieres importar este diagrama para generar Features/PBIs? → /diagram:import
+```
+
+---
+
+## Referencias
+
+- `references/mermaid-templates.md` — Plantillas base por tipo de diagrama
+- `references/draw-io-shapes.md` — Mapeo entidades → shapes Draw.io
+- `references/miro-board-structure.md` — Estructura de boards Miro

--- a/.claude/skills/diagram-generation/references/draw-io-shapes.md
+++ b/.claude/skills/diagram-generation/references/draw-io-shapes.md
@@ -1,0 +1,51 @@
+# Mapeo Entidades → Shapes Draw.io
+
+> Referencia para la skill `diagram-generation`. Define cómo representar cada tipo de entidad al exportar a Draw.io XML.
+
+## Shapes por tipo de entidad
+
+| Entidad | Draw.io Shape | Style |
+|---|---|---|
+| Microservicio | `mxgraph.aws4.lambda` o rectángulo rounded | `rounded=1;whiteSpace=wrap;fillColor=#dae8fc;strokeColor=#6c8ebf` |
+| API Gateway | `mxgraph.aws4.api_gateway` o doble borde | `shape=mxgraph.flowchart.multi-document;fillColor=#d5e8d4;strokeColor=#82b366` |
+| Base de datos | Cilindro | `shape=cylinder3;whiteSpace=wrap;fillColor=#fff2cc;strokeColor=#d6b656` |
+| Cola/Bus | Hexágono | `shape=hexagon;fillColor=#e1d5e7;strokeColor=#9673a6` |
+| Almacenamiento | Paralelogramo | `shape=parallelogram;fillColor=#f8cecc;strokeColor=#b85450` |
+| Frontend/SPA | Rectángulo rounded | `rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1` |
+| Servicio externo | Rectángulo gris | `fillColor=#f5f5f5;strokeColor=#666666;dashed=1` |
+| Cache | Rombo | `rhombus;fillColor=#fff2cc;strokeColor=#d6b656` |
+| Load Balancer | Elipse | `ellipse;fillColor=#d5e8d4;strokeColor=#82b366` |
+| CDN | Nube | `shape=cloud;fillColor=#dae8fc;strokeColor=#6c8ebf` |
+
+## Conectores
+
+| Relación | Style Draw.io |
+|---|---|
+| HTTP/REST sync | `endArrow=classic;strokeColor=#0000FF` |
+| Mensajería async | `endArrow=classic;dashed=1;strokeColor=#9900FF` |
+| Lectura DB | `endArrow=classic;strokeColor=#009900` |
+| Escritura DB | `endArrow=classic;strokeWidth=2;strokeColor=#CC0000` |
+| Dependencia | `endArrow=open;dashed=1;strokeColor=#999999` |
+
+## Layout recomendado
+
+- **Horizontal (LR)**: Para flujos de datos (request → response)
+- **Vertical (TB)**: Para arquitectura por capas (frontend → backend → data)
+- **Spacing**: minX=80, minY=60 entre nodos
+- **Subgraphs**: Usar containers/groups para capas o bounded contexts
+
+## XML base para diagrama vacío
+
+```xml
+<mxfile>
+  <diagram name="Architecture">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <!-- Entities and connections go here -->
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>
+```

--- a/.claude/skills/diagram-generation/references/mermaid-templates.md
+++ b/.claude/skills/diagram-generation/references/mermaid-templates.md
@@ -1,0 +1,96 @@
+# Plantillas Mermaid para Diagramas de Arquitectura
+
+> Referencia para la skill `diagram-generation`. Plantillas base que se adaptan según los componentes detectados.
+
+## Architecture (C4-style simplificado)
+
+```mermaid
+graph TB
+    subgraph "Presentation Layer"
+        %% Frontends, SPAs, apps móviles
+    end
+    subgraph "API Layer"
+        %% Gateways, BFFs, APIs públicas
+    end
+    subgraph "Service Layer"
+        %% Microservicios, workers, funciones
+    end
+    subgraph "Data Layer"
+        %% Bases de datos, caches, almacenamiento
+    end
+    subgraph "Infrastructure"
+        %% Colas, buses, CDN, monitoring
+    end
+    subgraph "External"
+        %% Servicios externos, APIs de terceros
+    end
+```
+
+### Convenciones de forma
+
+| Entidad | Sintaxis Mermaid | Ejemplo |
+|---|---|---|
+| Servicio/API | `[Nombre]` | `SVC1[User Service]` |
+| Base de datos | `[(Nombre)]` | `DB1[(Users DB)]` |
+| Cola/Bus | `{{Nombre}}` | `BUS{{Service Bus}}` |
+| Cache | `{Nombre}` | `CACHE{Redis}` |
+| Almacenamiento | `[/Nombre/]` | `BLOB[/Blob Storage/]` |
+| Gateway | `[[Nombre]]` | `GW[[API Gateway]]` |
+| Frontend/SPA | `(Nombre)` | `WEB(Angular App)` |
+| Externo | `>Nombre]` | `EXT>Stripe API]` |
+
+### Convenciones de flecha
+
+| Relación | Sintaxis | Significado |
+|---|---|---|
+| HTTP/REST sync | `-->` | Llamada síncrona |
+| HTTP con label | `-->|verb /path|` | Endpoint específico |
+| Mensajería async | `-.->` | Evento/mensaje asíncrono |
+| Lectura DB | `-->` | Query/Read |
+| Escritura DB | `==>` | Write/Command |
+| Dependencia | `..>` | Dependencia indirecta |
+
+## Flow (Flujo de datos)
+
+```mermaid
+flowchart LR
+    START([Inicio]) --> STEP1[Paso 1]
+    STEP1 --> DECISION{¿Condición?}
+    DECISION -->|Sí| PATH_A[Ruta A]
+    DECISION -->|No| PATH_B[Ruta B]
+    PATH_A --> END_A([Fin A])
+    PATH_B --> END_B([Fin B])
+```
+
+## Sequence (Diagrama de secuencia)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant G as Gateway
+    participant S as Service
+    participant D as Database
+
+    C->>G: Request
+    activate G
+    G->>S: Forward
+    activate S
+    S->>D: Query
+    D-->>S: Result
+    S-->>G: Response
+    deactivate S
+    G-->>C: Response
+    deactivate G
+```
+
+## Colores recomendados (classDef)
+
+```mermaid
+classDef frontend fill:#4FC3F7,stroke:#0288D1,color:#fff
+classDef backend fill:#81C784,stroke:#388E3C,color:#fff
+classDef database fill:#FFB74D,stroke:#F57C00,color:#fff
+classDef queue fill:#BA68C8,stroke:#7B1FA2,color:#fff
+classDef external fill:#E0E0E0,stroke:#616161,color:#333
+classDef cache fill:#FFD54F,stroke:#FFA000,color:#333
+```

--- a/.claude/skills/diagram-generation/references/miro-board-structure.md
+++ b/.claude/skills/diagram-generation/references/miro-board-structure.md
@@ -1,0 +1,62 @@
+# Estructura de Boards Miro para Diagramas
+
+> Referencia para la skill `diagram-generation`. Define cómo organizar boards y frames en Miro.
+
+## Estructura del Board
+
+Cada proyecto tiene un board en Miro con la siguiente organización:
+
+```
+Board: "{Proyecto} — Diagrams"
+├── Frame: "Architecture"           ← Diagrama de arquitectura principal
+├── Frame: "Data Flow"              ← Flujos de datos entre componentes
+├── Frame: "Sequence — {caso}"      ← Diagrama de secuencia por caso de uso
+├── Frame: "Deployment"             ← Topología de despliegue
+└── Frame: "Notes & Decisions"      ← Notas de arquitectura, ADRs
+```
+
+## Mapeo Entidades → Items Miro
+
+| Entidad | Miro Item | Color | Tamaño |
+|---|---|---|---|
+| Microservicio | Shape (rectangle) | `#4FC3F7` (azul) | 200x100 |
+| Base de datos | Shape (cylinder/circle) | `#FFB74D` (naranja) | 150x100 |
+| Cola/Bus | Shape (hexagon) | `#BA68C8` (púrpura) | 180x80 |
+| Frontend | Shape (rounded rect) | `#81C784` (verde) | 200x100 |
+| Externo | Shape (rectangle dashed) | `#E0E0E0` (gris) | 180x80 |
+| Cache | Shape (diamond) | `#FFD54F` (amarillo) | 120x120 |
+
+## Conectores Miro
+
+| Relación | Estilo | Color |
+|---|---|---|
+| HTTP sync | Línea sólida con flecha | `#1565C0` |
+| Async/Evento | Línea discontinua con flecha | `#7B1FA2` |
+| Lectura DB | Línea sólida fina | `#2E7D32` |
+| Escritura DB | Línea sólida gruesa | `#C62828` |
+
+## Uso del MCP Miro
+
+El MCP `miro` (mcp.miro.com) expone herramientas para:
+- Crear/listar boards
+- Crear shapes, connectors, sticky notes, frames
+- Leer contenido de un board (shapes + connectors)
+- Buscar items por texto
+
+### Flujo de creación
+
+1. Verificar `MIRO_BOARD_ID` del proyecto → si no existe, crear board nuevo
+2. Crear frame con nombre del tipo de diagrama
+3. Dentro del frame, crear shapes por cada entidad detectada
+4. Crear connectors entre shapes según relaciones
+5. Añadir sticky notes con metadata (versión, fecha, autor)
+6. Retornar URL del board + frame
+
+### Flujo de lectura (para import)
+
+1. Obtener board por ID
+2. Leer todos los items del board/frame
+3. Clasificar shapes por tipo visual → entidad de dominio
+4. Extraer texto de cada shape como nombre/descripción
+5. Leer connectors para extraer relaciones
+6. Retornar modelo normalizado de entidades + relaciones

--- a/.claude/skills/diagram-import/SKILL.md
+++ b/.claude/skills/diagram-import/SKILL.md
@@ -1,0 +1,272 @@
+# Skill: Diagram Import — Parsing, Validación y Generación de Work Items
+
+## Propósito
+
+Importar diagramas de arquitectura (Draw.io, Miro, Mermaid local), extraer entidades y relaciones, validar que existan reglas de negocio suficientes y generar Features/PBIs/Tasks en Azure DevOps.
+
+**Principio fundamental:** NO se crean PBIs si falta información de reglas de negocio. Se solicita al PM.
+
+---
+
+## Triggers
+
+- Comando `/diagram:import` — Importación completa
+- Petición directa: "importa el diagrama y crea los PBIs"
+
+---
+
+## Contexto Requerido (Progressive Disclosure)
+
+1. `CLAUDE.md` (raíz) — Contexto global, conexión Azure DevOps
+2. `projects/{proyecto}/CLAUDE.md` — Stack, arquitectura, repos
+3. `projects/{proyecto}/reglas-negocio.md` — **CRÍTICO**: reglas de dominio
+4. `projects/{proyecto}/equipo.md` — Perfiles para asignación posterior
+5. `.claude/rules/diagram-config.md` — Constantes y checklist de validación
+6. `.claude/rules/pm-config.md` — Credenciales MCP y Azure DevOps
+7. `docs/politica-estimacion.md` — Para estimar PBIs generados
+
+---
+
+## Fase 1: Obtener y Parsear el Diagrama
+
+### 1.1 Fuentes soportadas
+
+| Fuente | Detección | Método de lectura |
+|---|---|---|
+| URL Draw.io | `draw.io/`, `.drawio.com` en URL | MCP `draw-io` → leer diagrama XML |
+| URL Miro | `miro.com/app/board/` en URL | MCP `miro` → leer items del board |
+| Fichero local `.drawio` / `.xml` | Extensión `.drawio`, `.xml` | Leer XML directamente |
+| Fichero local `.mermaid` | Extensión `.mermaid`, `.md` con bloques mermaid | Parsear sintaxis Mermaid |
+| Meta existente | ID de `diagrams/*.meta.json` | Leer meta → obtener source |
+
+### 1.2 Parsing → Modelo normalizado
+
+Independiente del formato de origen, producir un modelo interno:
+
+```json
+{
+  "entities": [
+    {
+      "id": "svc-users",
+      "name": "User Service",
+      "type": "microservice",
+      "description": "Gestión de usuarios y autenticación",
+      "metadata": { "framework": ".NET 8", "db": "PostgreSQL" }
+    }
+  ],
+  "relationships": [
+    {
+      "from": "api-gateway",
+      "to": "svc-users",
+      "type": "http-sync",
+      "label": "POST /api/users"
+    }
+  ]
+}
+```
+
+### 1.3 Reconocimiento de entidades
+
+Usar `references/diagram-to-domain-mapping.md` para clasificar shapes:
+- Rectángulos → servicios/APIs
+- Cilindros → bases de datos
+- Hexágonos → colas/buses
+- Rombos → decisiones o caches
+- Rectángulos redondeados → frontends
+- Rectángulos grises/dashed → servicios externos
+- Flechas sólidas → sync, discontinuas → async
+
+---
+
+## Fase 2: Validación Arquitectónica
+
+Invocar agente `diagram-architect` para:
+1. Detectar dependencias circulares
+2. Validar layering correcto
+3. Identificar antipatrones (DB compartida, god service)
+4. Evaluar completitud de cada entidad
+
+Si hay problemas ❌ bloqueantes → informar al PM y recomendar corregir el diagrama.
+
+---
+
+## Fase 3: Validación de Reglas de Negocio ⚠️ CRÍTICO
+
+### 3.1 Cargar reglas de negocio
+
+Leer `projects/{proyecto}/reglas-negocio.md`. Si no existe:
+```
+❌ No existe el fichero de reglas de negocio.
+
+Para importar un diagrama y generar work items, necesito que el proyecto
+tenga reglas de negocio documentadas en:
+  → projects/{proyecto}/reglas-negocio.md
+
+Este fichero debe contener las reglas de dominio, restricciones funcionales
+y requisitos de cada componente del sistema.
+
+¿Quieres que genere una plantilla para que la completes?
+```
+
+### 3.2 Verificar por cada entidad
+
+Para cada entidad del diagrama, verificar checklist según tipo (ver `references/business-rules-validation.md`):
+
+| Tipo | Campos obligatorios |
+|---|---|
+| Microservicio | Interfaz/contrato definido, esquema DB, entorno deploy, escalado |
+| API/Endpoint | Método HTTP, path, autenticación, rate limit, validaciones |
+| Base de datos | Tecnología, esquema, política backup, plan escalado, retención |
+| UI/Frontend | User stories vinculadas, requisitos accesibilidad, responsive |
+| Cola/Mensajería | Formato mensaje, política reintentos, DLQ, orden garantizado |
+| Integración ext. | Proveedor, SLA, fallback, credenciales, formato datos |
+
+### 3.3 Generar informe de información faltante
+
+Si hay entidades con campos faltantes:
+
+```
+⚠️ Reglas de Negocio Incompletas
+
+Se han detectado {N} entidades en el diagrama.
+{M} entidades tienen reglas de negocio completas.
+{N-M} entidades necesitan información adicional:
+
+┌─────────────────────┬──────────────┬───────────────────────────────────┐
+│ Entidad             │ Tipo         │ Información faltante              │
+├─────────────────────┼──────────────┼───────────────────────────────────┤
+│ Payment Service     │ Microservice │ Entorno deploy, proveedor pagos   │
+│ Orders DB           │ Database     │ Política backup, plan escalado    │
+│ Notification Queue  │ Queue        │ Formato mensaje, política DLQ     │
+└─────────────────────┴──────────────┴───────────────────────────────────┘
+
+❌ NO se crearán PBIs hasta completar esta información.
+
+Opciones:
+  [1] Proporciona la información ahora (interactivo)
+  [2] Actualiza reglas-negocio.md y vuelve a ejecutar
+  [3] Genera solo las entidades completas (parcial)
+  [4] Genera todo como Draft (requiere revisión humana)
+```
+
+### 3.4 Opciones del PM
+
+- **Opción 1**: Preguntar interactivamente campo por campo
+- **Opción 2**: Esperar a que el PM actualice el fichero
+- **Opción 3**: Generar solo Features/PBIs de entidades completas, marcar resto como pendiente
+- **Opción 4**: Generar todo con tag `draft` y estado `New` (no `Committed`)
+
+---
+
+## Fase 4: Generación de Jerarquía Work Items
+
+### 4.1 Reglas de generación
+
+| Diagrama → | Azure DevOps Work Item |
+|---|---|
+| Bounded context / Módulo mayor | **Feature** |
+| Funcionalidad / Endpoint / User Story | **PBI** |
+| Tarea técnica (migración, test, CI/CD) | **Task** (hijo de PBI) |
+
+### 4.2 Agrupación en Features
+
+Agrupar entidades en Features por:
+1. **Bounded context** — Si el diagrama tiene subgraphs/containers, cada uno es un Feature
+2. **Dominio funcional** — Entidades del mismo dominio (users, orders, payments)
+3. **Independencia de deploy** — Componentes que se despliegan juntos
+4. Si no hay agrupación clara → 1 Feature = 1 entidad principal (microservicio/módulo)
+
+### 4.3 Generación de PBIs por entidad
+
+Para cada entidad, generar PBIs usando `references/pbi-generation-templates.md`:
+
+- **Microservicio**: PBI de scaffolding + PBI por endpoint principal + PBI de tests + PBI de deploy
+- **Base de datos**: PBI de schema/migración + PBI de seeders + PBI de backup config
+- **Cola**: PBI de productor + PBI de consumidor + PBI de DLQ handling
+- **Frontend**: PBI por vista/página + PBI de integración API + PBI de accesibilidad
+- **Integración**: PBI de cliente SDK + PBI de fallback + PBI de monitoring
+
+### 4.4 Estimación preliminar
+
+Usar rangos estándar de `docs/politica-estimacion.md`:
+- Scaffolding microservicio: 3-5 SP
+- Endpoint CRUD: 2-3 SP
+- Schema + migraciones: 2-3 SP
+- Tests unitarios: 1-2 SP
+- Tests integración: 2-3 SP
+- Pipeline CI/CD: 1-2 SP
+
+---
+
+## Fase 5: Presentar Propuesta
+
+```
+📋 Importación de Diagrama — {proyecto}
+
+Fuente: {url_o_fichero}
+Entidades detectadas: {N}
+Reglas de negocio: ✅ {M}/{N} completas
+
+Jerarquía propuesta:
+
+Feature 1: {nombre} ({X} SP estimados)
+├── PBI 1.1: {título} ({Y} SP)
+│   ├── Task: Scaffolding
+│   ├── Task: Implementación
+│   └── Task: Tests
+├── PBI 1.2: {título} ({Y} SP)
+...
+
+Feature 2: {nombre} ({X} SP estimados)
+├── PBI 2.1: {título} ({Y} SP)
+...
+
+Total: {F} Features, {P} PBIs, {T} Tasks, ~{SP} SP
+
+¿Creo estos work items en Azure DevOps? ¿Quieres ajustar algo?
+```
+
+---
+
+## Fase 6: Crear en Azure DevOps
+
+Tras confirmación del PM:
+
+1. Crear Features con descripción + link al diagrama source
+2. Crear PBIs como hijos de Features, con:
+   - Título descriptivo
+   - Descripción generada desde template
+   - Criterios de aceptación derivados de reglas de negocio
+   - Tags: `diagram-import`, `{tipo-entidad}`
+   - Link al diagrama source en campo Description
+3. Crear Tasks como hijos de PBIs (scaffolding, implementación, tests)
+4. Actualizar metadata: `diagrams/{tool}/{tipo}.meta.json` con IDs generados
+5. Comentario en cada Feature: "Generado desde diagrama: {source}"
+
+---
+
+## Fase 7: Resumen Final
+
+```
+✅ Work items creados en Azure DevOps
+
+Features: {F} creados (IDs: ...)
+PBIs:     {P} creados
+Tasks:    {T} creadas
+SP total: ~{SP}
+
+📊 Metadata actualizada: projects/{p}/diagrams/{tool}/{tipo}.meta.json
+
+Siguiente paso recomendado:
+  → /pbi:decompose-batch {ids} para refinar estimaciones y asignaciones
+  → /sprint:plan para planificar el sprint con los nuevos PBIs
+```
+
+---
+
+## Referencias
+
+- `references/diagram-to-domain-mapping.md` — Reconocimiento de entidades
+- `references/pbi-generation-templates.md` — Plantillas de PBIs
+- `references/business-rules-validation.md` — Checklist de validación
+- `references/missing-info-request-template.md` — Solicitud de info al PM

--- a/.claude/skills/diagram-import/references/business-rules-validation.md
+++ b/.claude/skills/diagram-import/references/business-rules-validation.md
@@ -1,0 +1,103 @@
+# Validación de Reglas de Negocio para Importación de Diagramas
+
+> Referencia para la skill `diagram-import`. Checklist de campos obligatorios por tipo de entidad antes de poder generar PBIs.
+
+## Principio
+
+**No se crean PBIs sin reglas de negocio suficientes.** Cada entidad del diagrama debe tener información funcional mínima documentada en `projects/{proyecto}/reglas-negocio.md` para poder generar work items de calidad.
+
+---
+
+## Checklist por tipo de entidad
+
+### Microservicio / API Service
+
+| Campo | Obligatorio | Descripción |
+|---|---|---|
+| Interfaz / Contrato | ✅ Sí | Endpoints expuestos, request/response schemas |
+| Base de datos propia | ✅ Sí | Tecnología y entidades principales del schema |
+| Entorno de deploy | ✅ Sí | Cloud provider, servicio (AKS, App Service, ECS) |
+| Autenticación | ✅ Sí | JWT, API Key, OAuth, mTLS |
+| Escalado | ⚠️ Recom. | Horizontal/vertical, métricas de auto-scale |
+| Observabilidad | ⚠️ Recom. | Logging, tracing, métricas, alertas |
+
+### API Endpoint (individual)
+
+| Campo | Obligatorio | Descripción |
+|---|---|---|
+| Método HTTP + Path | ✅ Sí | GET /api/v1/users/{id} |
+| Request schema | ✅ Sí | Body, query params, headers requeridos |
+| Response schema | ✅ Sí | Códigos HTTP, body de respuesta |
+| Autenticación | ✅ Sí | Anónimo, autenticado, rol requerido |
+| Rate limiting | ⚠️ Recom. | Límites por usuario/IP/global |
+| Validaciones | ⚠️ Recom. | Reglas de validación de inputs |
+
+### Base de datos
+
+| Campo | Obligatorio | Descripción |
+|---|---|---|
+| Tecnología | ✅ Sí | PostgreSQL, SQL Server, MongoDB, etc. |
+| Esquema / Entidades | ✅ Sí | Tablas/colecciones principales y relaciones |
+| Política de backup | ✅ Sí | Frecuencia, retención, RPO/RTO |
+| Plan de escalado | ⚠️ Recom. | Read replicas, sharding, partitioning |
+| Retención de datos | ⚠️ Recom. | RGPD, política de borrado |
+
+### UI / Frontend
+
+| Campo | Obligatorio | Descripción |
+|---|---|---|
+| User stories vinculadas | ✅ Sí | Qué funcionalidad ve/usa el usuario |
+| Requisitos accesibilidad | ✅ Sí | Nivel WCAG (AA mínimo) |
+| Responsive | ⚠️ Recom. | Breakpoints, mobile-first |
+| Framework / tecnología | ⚠️ Recom. | Angular, React, Vue, etc. |
+
+### Cola / Bus de mensajería
+
+| Campo | Obligatorio | Descripción |
+|---|---|---|
+| Formato de mensaje | ✅ Sí | JSON schema, Avro, Protobuf |
+| Política de reintentos | ✅ Sí | Max retries, backoff strategy |
+| Dead Letter Queue | ✅ Sí | Sí/No, política de revisión |
+| Orden garantizado | ⚠️ Recom. | FIFO requerido o no |
+| Tecnología | ⚠️ Recom. | Azure Service Bus, RabbitMQ, Kafka |
+
+### Integración con servicio externo
+
+| Campo | Obligatorio | Descripción |
+|---|---|---|
+| Proveedor | ✅ Sí | Nombre del servicio (Stripe, Twilio, etc.) |
+| SLA esperado | ✅ Sí | Uptime, latencia máxima aceptable |
+| Estrategia de fallback | ✅ Sí | Qué hacer si el servicio no responde |
+| Formato de datos | ⚠️ Recom. | REST, GraphQL, SOAP, webhooks |
+| Credenciales | ⚠️ Recom. | Tipo (API Key, OAuth), gestión (Key Vault) |
+
+---
+
+## Algoritmo de validación
+
+```
+Para cada entidad E del diagrama:
+  1. Buscar E.name en reglas-negocio.md (match por nombre o alias)
+  2. Si no encontrada → marcar como "sin reglas" (❌)
+  3. Si encontrada:
+     a. Obtener tipo de E (microservice, database, etc.)
+     b. Cargar checklist del tipo
+     c. Verificar cada campo ✅ obligatorio
+     d. Si todos ✅ presentes → status = "complete"
+     e. Si falta algún ✅ → status = "incomplete", listar missing_fields
+     f. Campos ⚠️ ausentes → warning (no bloquea)
+
+Resultado:
+  - complete_count: entidades con toda la info obligatoria
+  - incomplete_count: entidades con info faltante
+  - missing_entities: entidades no encontradas en reglas-negocio.md
+```
+
+## Niveles de bloqueo
+
+| Estado | Acción |
+|---|---|
+| Todas completas | ✅ Proceder a generar Features/PBIs/Tasks |
+| Algunas incompletas | ⚠️ Ofrecer opciones (parcial, draft, esperar) |
+| Ninguna encontrada | ❌ No generar nada. Solicitar reglas-negocio.md al PM |
+| Fichero no existe | ❌ No generar nada. Crear plantilla para el PM |

--- a/.claude/skills/diagram-import/references/diagram-to-domain-mapping.md
+++ b/.claude/skills/diagram-import/references/diagram-to-domain-mapping.md
@@ -1,0 +1,95 @@
+# Mapeo Diagrama → Entidades de Dominio
+
+> Referencia para la skill `diagram-import`. Reglas de reconocimiento para clasificar shapes/nodos del diagrama en entidades de dominio.
+
+## Reconocimiento por forma visual
+
+### Draw.io XML
+
+| Style attribute | Entidad |
+|---|---|
+| `shape=cylinder3` | Base de datos |
+| `shape=hexagon` | Cola / Bus de mensajería |
+| `rhombus` | Cache o punto de decisión |
+| `shape=cloud` | CDN o servicio cloud |
+| `rounded=1` + color azul | Frontend / SPA |
+| `dashed=1` | Servicio externo |
+| `shape=mxgraph.flowchart.multi-document` | API Gateway |
+| Rectángulo estándar | Microservicio / API |
+
+### Mermaid
+
+| Sintaxis | Entidad |
+|---|---|
+| `[(nombre)]` | Base de datos |
+| `{{nombre}}` | Cola / Bus |
+| `{nombre}` | Cache / Decisión |
+| `(nombre)` | Frontend (rounded) |
+| `>nombre]` | Servicio externo |
+| `[[nombre]]` | API Gateway / Subroutine |
+| `[nombre]` | Microservicio / API |
+
+### Miro shapes
+
+| Shape type | Entidad |
+|---|---|
+| Circle / Cylinder | Base de datos |
+| Hexagon | Cola / Bus |
+| Diamond | Cache / Decisión |
+| Rounded rectangle (verde) | Frontend |
+| Rectangle (gris/dashed) | Servicio externo |
+| Rectangle (azul) | Microservicio / API |
+
+## Reconocimiento por texto/nombre
+
+Si la forma no es determinante, analizar el nombre/label:
+
+| Patrón en nombre | Entidad |
+|---|---|
+| `*DB`, `*Database`, `*Store`, `SQL*`, `Mongo*`, `Postgres*` | Base de datos |
+| `*Queue`, `*Bus`, `*Topic`, `Service Bus`, `RabbitMQ`, `Kafka` | Cola / Bus |
+| `*Cache`, `Redis`, `Memcached` | Cache |
+| `*Gateway`, `*Proxy`, `BFF`, `Ocelot`, `YARP`, `Kong` | API Gateway |
+| `*UI`, `*App`, `*Web`, `*SPA`, `Angular*`, `React*`, `*Frontend` | Frontend |
+| `*CDN`, `CloudFront`, `Akamai` | CDN |
+| `*Storage`, `Blob*`, `S3*`, `*Bucket` | Almacenamiento |
+| Nombre de empresa externa (Stripe, Twilio, SendGrid, etc.) | Servicio externo |
+
+## Reconocimiento de relaciones
+
+| Patrón | Tipo de relación |
+|---|---|
+| Flecha sólida con label HTTP verb (GET, POST, PUT, DELETE) | HTTP sync |
+| Flecha sólida sin label entre servicio y servicio | HTTP sync (inferir) |
+| Flecha discontinua / con label event/message | Async / Mensajería |
+| Flecha hacia DB | Acceso a datos (R/W según contexto) |
+| Flecha bidireccional | Dependencia mutua (⚠️ posible antipatrón) |
+| Línea sin flecha | Asociación / pertenencia al mismo grupo |
+
+## Modelo de salida normalizado
+
+Cada entidad parseada produce:
+
+```json
+{
+  "id": "kebab-case-unico",
+  "name": "Nombre legible",
+  "type": "microservice|database|queue|cache|frontend|gateway|storage|external|cdn",
+  "description": "Extraído del label o generado",
+  "metadata": {},
+  "business_rules_status": "pending|complete|partial",
+  "missing_fields": []
+}
+```
+
+Cada relación produce:
+
+```json
+{
+  "from": "id-origen",
+  "to": "id-destino",
+  "type": "http-sync|async|data-read|data-write|dependency",
+  "label": "Texto del label si existe",
+  "bidirectional": false
+}
+```

--- a/.claude/skills/diagram-import/references/missing-info-request-template.md
+++ b/.claude/skills/diagram-import/references/missing-info-request-template.md
@@ -1,0 +1,137 @@
+# Plantilla de Solicitud de Información al PM
+
+> Referencia para la skill `diagram-import`. Templates para solicitar al PM la información faltante de reglas de negocio.
+
+## Informe general de información faltante
+
+```markdown
+# ⚠️ Información faltante para importar diagrama — {proyecto}
+
+**Fuente del diagrama:** {source}
+**Entidades detectadas:** {total}
+**Completas:** {complete} ✅
+**Incompletas:** {incomplete} ⚠️
+**Sin reglas:** {missing} ❌
+
+## Detalle por entidad
+
+{tabla_detalle}
+
+## Acciones requeridas
+
+Para completar la importación, necesito que proporciones la información
+marcada como faltante. Puedes:
+
+1. **Actualizar `projects/{proyecto}/reglas-negocio.md`** con la información
+   y volver a ejecutar `/diagram:import`
+2. **Proporcionar la información aquí** y la añado al fichero
+3. **Generar solo las entidades completas** (parcial)
+
+---
+Generado por PM-Workspace — /diagram:import
+```
+
+## Solicitud por entidad (para modo interactivo)
+
+### Microservicio
+
+```
+📋 {nombre_servicio} (Microservicio)
+
+Necesito la siguiente información:
+
+1. **Interfaz/Contrato**: ¿Qué endpoints expone este servicio?
+   Formato: [VERB] /path → descripción
+   Ejemplo: [POST] /api/users → Crear usuario
+
+2. **Base de datos**: ¿Qué tecnología y entidades principales?
+   Ejemplo: PostgreSQL — tablas: users, roles, sessions
+
+3. **Entorno de deploy**: ¿Dónde se desplegará?
+   Ejemplo: Azure AKS, namespace: users-service
+
+4. **Autenticación**: ¿Cómo se autentican las llamadas?
+   Ejemplo: JWT Bearer token, roles: admin, user
+```
+
+### Base de datos
+
+```
+📋 {nombre_db} (Base de datos)
+
+Necesito la siguiente información:
+
+1. **Tecnología**: ¿Qué motor de base de datos?
+   Opciones: PostgreSQL, SQL Server, MongoDB, MySQL, DynamoDB, CosmosDB...
+
+2. **Esquema principal**: ¿Cuáles son las entidades/tablas principales?
+   Formato: tabla (campo1, campo2, ...) → relaciones
+
+3. **Política de backup**: ¿Frecuencia y retención?
+   Ejemplo: Backup diario, retención 30 días, RPO 1h, RTO 4h
+```
+
+### Cola / Bus
+
+```
+📋 {nombre_cola} (Cola/Mensajería)
+
+Necesito la siguiente información:
+
+1. **Formato de mensaje**: ¿Qué estructura tiene el mensaje?
+   Ejemplo: JSON { "eventType": "...", "payload": { ... } }
+
+2. **Política de reintentos**: ¿Cuántos reintentos y estrategia?
+   Ejemplo: 3 reintentos, exponential backoff (1s, 5s, 30s)
+
+3. **Dead Letter Queue**: ¿Se usa DLQ? ¿Cómo se revisan?
+   Ejemplo: Sí, revisión manual diaria + alerta automática
+```
+
+### Integración externa
+
+```
+📋 {nombre_integracion} (Servicio externo)
+
+Necesito la siguiente información:
+
+1. **Proveedor**: ¿Qué servicio externo es?
+   Ejemplo: Stripe Payment API v2
+
+2. **SLA esperado**: ¿Qué uptime y latencia aceptamos?
+   Ejemplo: 99.9% uptime, <500ms p95
+
+3. **Fallback**: ¿Qué hacer si el servicio no responde?
+   Ejemplo: Cola de reintentos + notificación al usuario
+```
+
+## Plantilla para reglas-negocio.md (nueva)
+
+Si el fichero no existe, generar esta plantilla:
+
+```markdown
+# Reglas de Negocio — {proyecto}
+
+> Documentar aquí las reglas de dominio, restricciones funcionales y
+> requisitos de cada componente del sistema. Esta información es necesaria
+> para generar PBIs de calidad desde diagramas de arquitectura.
+
+## {Componente 1}
+
+**Tipo:** Microservicio | Database | Cola | Frontend | Externo
+**Descripción:** ...
+
+### Interfaz / Contrato
+...
+
+### Reglas de dominio
+...
+
+### Restricciones
+...
+
+---
+
+## {Componente 2}
+...
+```

--- a/.claude/skills/diagram-import/references/pbi-generation-templates.md
+++ b/.claude/skills/diagram-import/references/pbi-generation-templates.md
@@ -1,0 +1,183 @@
+# Plantillas de Generación de PBIs desde Diagrama
+
+> Referencia para la skill `diagram-import`. Templates para crear PBIs automáticamente según el tipo de entidad detectada.
+
+## Feature Template
+
+```markdown
+# Feature: {nombre_bounded_context}
+
+## Descripción
+Implementación del módulo {nombre} del sistema, que incluye {N} componentes:
+{lista_componentes}.
+
+**Origen:** Diagrama de arquitectura — {source_url_o_fichero}
+
+## Componentes incluidos
+{tabla_entidades_del_feature}
+
+## Criterios de aceptación del Feature
+- [ ] Todos los PBIs hijos completados y validados
+- [ ] Tests de integración entre componentes del módulo
+- [ ] Documentación de arquitectura actualizada
+- [ ] Deploy funcional en entorno DEV
+```
+
+## PBI Templates por tipo de entidad
+
+### Microservicio — Scaffolding
+
+```markdown
+**Título:** Scaffolding {nombre_servicio}
+
+**Descripción:**
+Crear la estructura base del microservicio {nombre}, incluyendo proyecto,
+configuración, health checks y pipeline CI básico.
+
+**Criterios de aceptación:**
+- [ ] Proyecto creado con template estándar ({framework})
+- [ ] Health check endpoint /health respondiendo
+- [ ] Dockerfile funcional
+- [ ] Pipeline CI: build + test
+- [ ] Configuración de entorno (appsettings/env vars)
+- [ ] Logging configurado (Serilog/equivalente)
+
+**Tags:** diagram-import, microservice, scaffolding
+**SP estimados:** 3-5
+```
+
+### Microservicio — Endpoint
+
+```markdown
+**Título:** Endpoint {verb} {path} en {nombre_servicio}
+
+**Descripción:**
+Implementar el endpoint {verb} {path} que {descripcion_funcional}.
+Relación: {from} → {to} ({tipo_relacion}).
+
+**Criterios de aceptación:**
+- [ ] Endpoint implementado con validación de inputs
+- [ ] Autenticación/autorización configurada
+- [ ] Tests unitarios (≥80% cobertura)
+- [ ] Swagger/OpenAPI documentado
+- [ ] Manejo de errores estándar (ProblemDetails)
+
+**Tags:** diagram-import, microservice, endpoint
+**SP estimados:** 2-3
+```
+
+### Base de datos — Schema
+
+```markdown
+**Título:** Schema y migraciones {nombre_db}
+
+**Descripción:**
+Crear el esquema de base de datos {nombre} ({tecnologia}).
+Incluye migraciones, seeders de datos de prueba y configuración de backup.
+
+**Criterios de aceptación:**
+- [ ] Schema creado según diseño de reglas de negocio
+- [ ] Migraciones aplicables y reversibles
+- [ ] Seeders de datos de prueba para DEV
+- [ ] Índices para queries frecuentes
+- [ ] Connection string configurada por entorno
+- [ ] Política de backup documentada
+
+**Tags:** diagram-import, database, schema
+**SP estimados:** 2-3
+```
+
+### Cola/Bus — Productor
+
+```markdown
+**Título:** Productor de mensajes para {nombre_cola}
+
+**Descripción:**
+Implementar el productor de mensajes hacia {nombre_cola} desde {servicio_origen}.
+Formato: {formato_mensaje}.
+
+**Criterios de aceptación:**
+- [ ] Productor implementado con serialización correcta
+- [ ] Mensajes publicados en formato acordado
+- [ ] Retry policy configurada
+- [ ] Tests unitarios del productor
+- [ ] Logging de mensajes enviados
+
+**Tags:** diagram-import, queue, producer
+**SP estimados:** 2
+```
+
+### Cola/Bus — Consumidor
+
+```markdown
+**Título:** Consumidor de mensajes de {nombre_cola}
+
+**Descripción:**
+Implementar el consumidor de mensajes de {nombre_cola} en {servicio_destino}.
+Procesamiento: {descripcion_procesamiento}.
+
+**Criterios de aceptación:**
+- [ ] Consumidor implementado con deserialización
+- [ ] Idempotencia garantizada
+- [ ] Dead Letter Queue (DLQ) configurada
+- [ ] Manejo de errores y reintentos
+- [ ] Tests unitarios del consumidor
+- [ ] Monitoring de cola (backlog, errors)
+
+**Tags:** diagram-import, queue, consumer
+**SP estimados:** 3
+```
+
+### Frontend — Vista/Página
+
+```markdown
+**Título:** Vista {nombre_vista} en {nombre_frontend}
+
+**Descripción:**
+Implementar la vista/página {nombre} que permite al usuario {funcionalidad}.
+Integración con API: {endpoints_consumidos}.
+
+**Criterios de aceptación:**
+- [ ] Componente implementado según diseño
+- [ ] Integración con API funcional
+- [ ] Responsive design (mobile/tablet/desktop)
+- [ ] Accesibilidad WCAG 2.1 AA
+- [ ] Tests de componente
+- [ ] Loading states y manejo de errores
+
+**Tags:** diagram-import, frontend, view
+**SP estimados:** 3-5
+```
+
+### Integración externa — Cliente
+
+```markdown
+**Título:** Cliente SDK para {nombre_servicio_externo}
+
+**Descripción:**
+Implementar cliente para integración con {proveedor} ({tipo_integracion}).
+SLA esperado: {sla}.
+
+**Criterios de aceptación:**
+- [ ] Cliente implementado con interfaz abstraída
+- [ ] Circuit breaker / retry configurado
+- [ ] Fallback definido para indisponibilidad
+- [ ] Credenciales gestionadas por config (no hardcoded)
+- [ ] Tests con mock del servicio externo
+- [ ] Logging de llamadas y tiempos de respuesta
+
+**Tags:** diagram-import, integration, external
+**SP estimados:** 3
+```
+
+## Tasks comunes (hijos de cada PBI)
+
+| Task | Horas est. | Actividad |
+|---|---|---|
+| Scaffolding / Setup | 2h | Dev |
+| Implementación core | 4-8h | Dev |
+| Tests unitarios | 2-4h | Dev |
+| Tests integración | 2-4h | Dev |
+| Documentación API | 1-2h | Dev |
+| Code review | 1h | Review |
+| Config CI/CD | 1-2h | DevOps |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,10 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ~/claude/                          ← Raíz de trabajo Y repositorio GitHub
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
-│   ├── agents/                    ← 23 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 30 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
+│   ├── commands/                  ← 34 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
-│   └── skills/                    ← 9 skills reutilizables
+│   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README
 ├── projects/                      ← Proyectos reales (git-ignorados)
 └── scripts/                       ← Scripts auxiliares Azure DevOps
@@ -90,6 +90,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 Flujos principales:
 - **SDD**: business-analyst → architect → sdd-spec-writer → {lang}-developer ‖ test-engineer → code-reviewer
 - **Infra**: architect → infrastructure-agent → (detectar → tier mínimo → propuesta) → humano aprueba
+- **Diagramas**: diagram-architect analiza consistencia → genera/importa → valida reglas negocio → Features/PBIs/Tasks
 - **Pre-commit**: commit-guardian (10 checks) · **Post-commit**: test-runner (cobertura ≥ 80%)
 
 ---
@@ -111,6 +112,7 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 - **Discovery** → `.claude/skills/product-discovery/SKILL.md`
 - **PBIs** → `.claude/skills/pbi-decomposition/SKILL.md`
 - **SDD** → `.claude/skills/spec-driven-development/SKILL.md`
+- **Diagramas** → `.claude/skills/diagram-generation/SKILL.md` · `.claude/skills/diagram-import/SKILL.md`
 - **Comandos** → `@.claude/rules/pm-workflow.md`
 - Explorar → Planificar → Implementar → Commit · `/compact` al 50% · `/clear` entre tareas
 - Arquitectura: **Command → Agent → Skills** — subagentes solo con `Task`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 
 ## 🤖 Subagentes y Flujos
 
-> Catálogo completo (23 agentes): `@.claude/rules/agents-catalog.md`
+> Catálogo completo (24 agentes): `@.claude/rules/agents-catalog.md`
 
 Flujos principales:
 - **SDD**: business-analyst → architect → sdd-spec-writer → {lang}-developer ‖ test-engineer → code-reviewer

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 30 slash commands
+│   ├── commands/                ← 34 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -21,13 +21,14 @@
 │   │   ├── pr-review.md ...     ← Calidad y PRs (4)
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
+│   │   ├── diagram-generate.md..← Diagramas (4)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md
 │   │       ├── spec-template.md
 │   │       └── ... (11 ficheros)
 │   │
-│   ├── agents/                  ← 23 subagentes especializados
+│   ├── agents/                  ← 24 subagentes especializados
 │   │   ├── business-analyst.md
 │   │   ├── architect.md
 │   │   ├── code-reviewer.md
@@ -36,10 +37,11 @@
 │   │   ├── test-runner.md
 │   │   ├── sdd-spec-writer.md
 │   │   ├── infrastructure-agent.md
+│   │   ├── diagram-architect.md ← Análisis arquitectónico de diagramas
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 9 skills reutilizables
+│   ├── skills/                  ← 11 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -48,8 +50,12 @@
 │   │   ├── product-discovery/
 │   │   ├── pbi-decomposition/
 │   │   ├── team-onboarding/
-│   │   └── spec-driven-development/
-│   │       └── references/      ← Templates, matrices, patrones de equipo
+│   │   ├── spec-driven-development/
+│   │   │   └── references/      ← Templates, matrices, patrones de equipo
+│   │   ├── diagram-generation/  ← Generación de diagramas (Draw.io, Miro, Mermaid)
+│   │   │   └── references/      ← Plantillas Mermaid, shapes, boards
+│   │   └── diagram-import/      ← Importación de diagramas → Features/PBIs/Tasks
+│   │       └── references/      ← Mapping, templates PBI, validación reglas negocio
 │   │
 │   └── rules/                   ← Reglas modulares
 │       ├── pm-config.md         ← Constantes Azure DevOps
@@ -62,7 +68,8 @@
 │       ├── command-validation.md← Pre-commit: validar commands
 │       ├── file-size-limit.md   ← Regla 150 líneas
 │       ├── readme-update.md     ← Regla 12: actualizar READMEs
-│       ├── agents-catalog.md    ← Tabla de 23 agentes
+│       ├── diagram-config.md    ← Configuración Draw.io/Miro
+│       ├── agents-catalog.md    ← Tabla de 24 agentes
 │       └── languages/           ← Convenciones por lenguaje (excluido de carga automática)
 │           ├── csharp-rules.md
 │           ├── dotnet-conventions.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 30 slash commands
+│   ├── commands/                ← 34 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -21,12 +21,13 @@
 │   │   ├── pr-review.md ...     ← Quality & PRs (4)
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
+│   │   ├── diagram-generate.md..← Diagrams (4)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md
 │   │       └── ... (11 files)
 │   │
-│   ├── agents/                  ← 23 specialized subagents
+│   ├── agents/                  ← 24 specialized subagents
 │   │   ├── business-analyst.md
 │   │   ├── architect.md
 │   │   ├── code-reviewer.md
@@ -35,10 +36,11 @@
 │   │   ├── test-runner.md
 │   │   ├── sdd-spec-writer.md
 │   │   ├── infrastructure-agent.md
+│   │   ├── diagram-architect.md ← Architecture diagram analysis
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 9 reusable skills
+│   ├── skills/                  ← 11 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -47,8 +49,12 @@
 │   │   ├── product-discovery/
 │   │   ├── pbi-decomposition/
 │   │   ├── team-onboarding/
-│   │   └── spec-driven-development/
-│   │       └── references/      ← Templates, matrices, team patterns
+│   │   ├── spec-driven-development/
+│   │   │   └── references/      ← Templates, matrices, team patterns
+│   │   ├── diagram-generation/  ← Diagram generation (Draw.io, Miro, Mermaid)
+│   │   │   └── references/      ← Mermaid templates, shapes, boards
+│   │   └── diagram-import/      ← Diagram import → Features/PBIs/Tasks
+│   │       └── references/      ← Mapping, PBI templates, business rules validation
 │   │
 │   └── rules/                   ← Modular rules
 │       ├── pm-config.md         ← Azure DevOps constants
@@ -61,7 +67,8 @@
 │       ├── command-validation.md← Pre-commit: validate commands
 │       ├── file-size-limit.md   ← 150 lines rule
 │       ├── readme-update.md     ← Rule 12: update READMEs
-│       ├── agents-catalog.md    ← 23 agents table
+│       ├── diagram-config.md    ← Draw.io/Miro configuration
+│       ├── agents-catalog.md    ← 24 agents table
 │       └── languages/           ← Per-language conventions (excluded from auto-loading)
 │           ├── csharp-rules.md
 │           ├── dotnet-conventions.md


### PR DESCRIPTION
## Summary

- Add **4 new commands**: `diagram:generate`, `diagram:import`, `diagram:config`, `diagram:status`
- Add **2 new skills**: `diagram-generation` (with 3 references) and `diagram-import` (with 4 references)
- Add **1 new agent**: `diagram-architect` for architectural consistency analysis
- Add **MCP configuration** for Draw.io (HTTP, no auth) and Miro (OAuth 2.1)
- Add **business rules validation** — refuses to create PBIs without documented business rules
- Update credentials in `pm-config.md` with Draw.io/Miro section
- Update all documentation: `help.md`, `CLAUDE.md`, `pm-workflow.md`, `agents-catalog.md`, READMEs (ES/EN)

## Key Design Decisions

- **Business rules first**: `diagram:import` will NOT create Features/PBIs/Tasks if `reglas-negocio.md` is missing or incomplete
- **Per-project diagrams**: Each project gets `diagrams/` directory with `.meta.json` metadata
- **Mermaid as universal format**: All diagrams saved locally as `.mermaid` regardless of export tool
- **Credential security**: Miro token in `$HOME/.azure/miro-token` (same pattern as Azure DevOps PAT)

## Validation

- All 34 commands pass `scripts/validate-commands.sh` (0 errors)
- CLAUDE.md: 131 lines (within 150 limit)

## Files Changed (23 files, +1694 lines)

**New (15):** 4 commands, 2 skills, 7 skill references, 1 agent, 1 rule
**Modified (8):** help.md, CLAUDE.md, mcp.json, pm-config.md, pm-workflow.md, agents-catalog.md, 02-estructura.md (ES/EN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)