### PR TITLE
feat(rules): add task ID in branch names, auto-reviewer, and PM notification filter

### DIFF
--- a/.claude/commands/pr-pending.md
+++ b/.claude/commands/pr-pending.md
@@ -45,9 +45,17 @@ curl -s -u ":$(cat $AZURE_DEVOPS_PAT_FILE)" \
   "$AZURE_DEVOPS_ORG_URL/_apis/identities?searchFilter=General&filterValue=$AZURE_DEVOPS_PM_USER&api-version=7.1"
 ```
 
-### 4. Para cada PR, obtener detalle
+### 4. Filtrar PRs con reviewer-asignado pendiente
 
-Por cada PR activo donde el PM es reviewer:
+Antes de mostrar un PR al PM, comprobar si el PR tiene **más de un reviewer** y uno de ellos es el **programador asignado a la tarea de DevOps** que originó el cambio (extraer task ID del nombre de rama `feature/#XXXX-...` o `fix/#XXXX-...` → consultar `System.AssignedTo` de esa task).
+
+- Si el programador asignado **aún no ha votado** (vote = 0) → **ocultar el PR** de la lista del PM. El PM no necesita revisarlo hasta que el propio programador lo valide primero.
+- Si el programador asignado **ya votó** (vote ≠ 0, cualquier valor) → mostrar el PR normalmente al PM.
+- Si el PR **no tiene task ID** en la rama, o la task **no tiene asignado**, o el PR **solo tiene un reviewer** → mostrar normalmente (sin filtro).
+
+### 5. Para cada PR visible, obtener detalle
+
+Por cada PR activo donde el PM es reviewer (y que haya pasado el filtro del paso 4):
 
 ```bash
 # Threads (comentarios) del PR
@@ -61,7 +69,7 @@ Extraer:
 - **Comentarios del PM pendientes de respuesta**: threads creados por PM donde la última respuesta no es del autor del PR
 - **Antigüedad**: `creationDate` → días desde creación
 
-### 5. Presentar resultado
+### 6. Presentar resultado
 
 ```
 ══════════════════════════════════════════════════════
@@ -100,13 +108,14 @@ Extraer:
 ══════════════════════════════════════════════════════
 ```
 
-### 6. Alertas
+### 7. Alertas
 
 Generar alertas cuando:
 - Un PR lleva **> 3 días** sin voto del PM → ⚠️ alerta de antigüedad
 - Un PR tiene **comentarios del PM sin respuesta** del autor → 💬 seguimiento
 - Un PR tiene **0 reviewers con voto** → 🔴 bloqueado
 - Un PR tiene **conflictos de merge** → ⛔ requiere acción del autor
+- Hay PRs **ocultos por validación pendiente del programador asignado** → 🕐 informar cuántos PRs están esperando revisión del dev asignado (sin listar detalle, solo contador)
 
 ---
 

--- a/.claude/commands/spec-implement.md
+++ b/.claude/commands/spec-implement.md
@@ -34,6 +34,8 @@ Si falla → informar problemas y sugerir `/spec:review`.
 
 Actualizar task en Azure DevOps: estado → "In Review", tags → "spec-driven;agent-implemented", historial con referencia al log.
 
+**Reviewer por asignación de tarea:** Si la task tiene un `System.AssignedTo` humano, añadir a ese programador como reviewer del PR. Esto aplica tanto a implementaciones por agente como a PRs creados manualmente desde una tarea DevOps.
+
 ## Restricciones
 
 - Implementación por agente SIEMPRE requiere Code Review humano antes de merge

--- a/.claude/rules/github-flow.md
+++ b/.claude/rules/github-flow.md
@@ -37,8 +37,9 @@ main
 |---|---|
 | Nombrar con prefijo | `feature/`, `fix/`, `docs/`, `refactor/`, `chore/` |
 | Nombre descriptivo | `feature/agente-architect` no `feature/rama1` |
-| Nombre ≤ 5 palabras | Máximo 5 palabras separadas por guiones tras el prefijo |
-| Refleja el PBI/tarea | Si existe PBI o tarea, el nombre debe reflejarlo; si no, sintetizar el concepto principal de los cambios |
+| Nombre ≤ 5 palabras | Máximo 5 palabras separadas por guiones tras el prefijo (sin contar el `#ID`) |
+| ID de tarea DevOps | Si la modificación viene de una tarea o PBI de Azure DevOps, poner `#ID` justo después del prefijo y antes de la descripción (ej: `feature/#12345-crud-sala-reservas`). Esto enlaza automáticamente los commits con la tarea en DevOps |
+| Refleja el PBI/tarea | Si existe PBI o tarea, el nombre debe reflejarlo; si no hay tarea DevOps, sintetizar el concepto principal de los cambios |
 | Ramas cortas | Merge en días, no semanas; evitar ramas de larga vida |
 | Una rama por PBI/tarea | No mezclar cambios no relacionados en la misma rama |
 
@@ -54,13 +55,13 @@ main
 ### Nombrado de rama: regla pre-commit
 
 Antes de hacer commit, verificar que el nombre de la rama actual cumple:
-1. **Si existe PBI o tarea** → el nombre refleja el PBI/tarea (ej: `feature/crud-sala-reservas`)
-2. **Si no existe PBI** → sintetizar el concepto principal de los cambios más importantes
-3. **Máximo 5 palabras** separadas por guiones tras el prefijo
+1. **Si existe tarea o PBI en DevOps** → incluir `#ID` tras el prefijo: `feature/#12345-crud-sala-reservas`, `fix/#6789-session-timeout`
+2. **Si no existe tarea DevOps** → sintetizar el concepto principal de los cambios más importantes
+3. **Máximo 5 palabras** separadas por guiones tras el prefijo (el `#ID` no cuenta como palabra)
 4. **Si la rama no cumple** → crear una nueva rama con nombre correcto y mover los cambios
 
-Ejemplos válidos: `feature/new-test-runner-agent`, `fix/capacity-formula-edge-case`, `docs/align-readme-agent-table`
-Ejemplos inválidos: `feature/rama1`, `fix/cosas`, `docs/rename-pm-workspace-and-align-examples-with-current-conventions` (demasiado largo)
+Ejemplos válidos: `feature/#12345-new-test-runner-agent`, `fix/#6789-capacity-formula-edge`, `feature/new-test-runner-agent` (sin tarea DevOps), `docs/align-readme-agent-table`
+Ejemplos inválidos: `feature/rama1`, `fix/cosas`, `feature/12345-algo` (falta el `#`), `docs/rename-pm-workspace-and-align-examples-with-current-conventions` (demasiado largo)
 
 ---
 
@@ -80,9 +81,10 @@ Ejemplos inválidos: `feature/rama1`, `fix/cosas`, `docs/rename-pm-workspace-and
 1. **Abrir PR** desde la feature branch hacia `main`
 2. **Título**: igual que el commit principal (convencional)
 3. **Descripción**: qué cambia y por qué; si cierra un PBI incluir `Closes #N`
-4. **Revisión**: al menos una aprobación antes de mergear
-5. **Merge**: Squash merge para commits pequeños, Merge commit para features completas
-6. **Delete branch**: eliminar la rama tras el merge
+4. **Reviewer asignado por tarea**: si la tarea de DevOps que originó el cambio tiene un programador humano asignado (`System.AssignedTo`), ese programador se añade automáticamente como reviewer del PR. Esto garantiza que quien conoce el contexto de la tarea valide el código
+5. **Revisión**: al menos una aprobación antes de mergear
+6. **Merge**: Squash merge para commits pequeños, Merge commit para features completas
+7. **Delete branch**: eliminar la rama tras el merge
 
 ---
 
@@ -118,7 +120,7 @@ Toda release usa rama `release/vX.Y.Z` + tag anotado tras merge:
 Claude Code **nunca** hace commit directamente en `main`. Siempre se parte de `main` y se vuelve a `main`:
 
 1. **Partir de `main`**: `git checkout main && git pull` antes de empezar cualquier tarea
-2. **Crear rama**: `git checkout -b feature/descripcion` (nombre ≤ 5 palabras, refleja PBI/tarea o síntesis del cambio)
+2. **Crear rama**: `git checkout -b feature/#ID-descripcion` si hay tarea DevOps, o `git checkout -b feature/descripcion` si no la hay (nombre ≤ 5 palabras, `#ID` no cuenta)
 3. Implementar + commit(s)
 4. **Antes de cada commit**: verificar que el nombre de la rama refleja los cambios; si no, crear rama nueva con nombre adecuado
 5. **Volver a `main`**: tras el commit, `git checkout main` — la rama queda lista para push/PR pero el workspace vuelve a `main`

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -13,7 +13,7 @@
 
 ## 📏 Convenciones
 
-- **Branches:** `feature/AB#XXXX-descripcion`, `bugfix/AB#XXXX-descripcion`
+- **Branches:** `feature/#XXXX-descripcion`, `fix/#XXXX-descripcion` (el `#ID` enlaza el commit con la tarea en DevOps)
 - **Commits:** `[AB#XXXX] Descripción corta en imperativo`
 - **Sprints:** `Sprint YYYY-NN` (ej: `Sprint 2026-04`)
 - **Informes:** `YYYYMMDD-tipo-proyecto.ext` (ej: `20260222-sprint-report-alpha.xlsx`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,9 @@ chmod +x scripts/test-workspace.sh
 | `test/` | Test suite or mock data changes |
 | `refactor/` | Restructuring without behaviour change |
 
-Examples: `feature/risk-log-command`, `fix/capacity-formula-zero-days`, `docs/add-jira-example`
+If the change originates from an Azure DevOps task or PBI, include `#ID` right after the prefix (before the description). This links commits to the task automatically.
+
+Examples: `feature/#12345-risk-log-command`, `fix/#6789-capacity-formula-zero-days`, `docs/add-jira-example` (no DevOps task)
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -40,6 +40,12 @@ Repite para cada proyecto en `projects/proyecto-alpha/CLAUDE.md` y `projects/pro
 ## Paso 3 — Instalar dependencias de scripts
 
 ```bash
+# GitHub CLI (necesario para crear PRs y gestionar repos desde Claude Code)
+sudo apt update && sudo apt install gh -y   # Ubuntu/Debian
+# o: brew install gh                         # macOS
+gh auth login
+
+# Node.js dependencies para report-generator
 cd scripts/
 npm install
 cd ..
@@ -184,6 +190,7 @@ output/agent-runs/                           ← Logs de ejecuciones de agentes
 | `TF400813: Not authorized` | Verificar PAT: `cat $HOME/.azure/devops-pat` + scopes |
 | `az: command not found` | Instalar Azure CLI: https://aka.ms/installazurecliwindows |
 | `jq: command not found` | `apt install jq` / `brew install jq` |
+| `gh: command not found` | `sudo apt install gh` / `brew install gh` + `gh auth login` |
 | Resultados vacíos del sprint | Verificar que el sprint está activo en Azure DevOps Team Settings |
 | Node modules faltantes | `cd scripts && npm install` |
 


### PR DESCRIPTION
## Summary

- **Branch naming with #ID**: Feature and fix branches now include `#ID` after the prefix when the change originates from a DevOps task/PBI, automatically linking commits to work items.
- **Auto-reviewer from task assignment**: When a DevOps task has a human programmer in `System.AssignedTo`, that programmer is automatically added as PR reviewer.
- **PM notification gating**: `pr:pending` hides PRs from the PM's list until the assigned programmer has voted, reducing review noise.
- **GitHub CLI as dependency**: Added `gh` to SETUP.md (step 3 + troubleshooting table).

## Test plan

- [ ] Verify `github-flow.md` examples are consistent with `pm-workflow.md` conventions
- [ ] Verify `CONTRIBUTING.md` examples align with the new naming rule
- [ ] Verify `pr-pending.md` step numbering is sequential (1-7)
- [ ] Verify `spec-implement.md` reviewer rule doesn't conflict with existing restrictions
- [ ] Run `./scripts/test-workspace.sh --mock` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)