### PR TITLE
feat: Slack connector — notify:slack + slack:search

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,8 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
+   **Conectores (2):** notify:slack {canal} {msg}, slack:search {query}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/notify-slack.md
+++ b/.claude/commands/notify-slack.md
@@ -1,0 +1,86 @@
+---
+name: notify-slack
+description: >
+  Enviar notificación o informe al canal de Slack del proyecto.
+  Soporta texto libre, resultados de otros comandos y formateo Slack.
+---
+
+# Notificar en Slack
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/notify:slack {canal} {mensaje}` o `/notify:slack --project {p} {mensaje}`
+
+## Parámetros
+
+- `{canal}` — Canal de Slack (ej: `#proyecto-alpha-dev`). Si empieza con `@`, envía DM
+- `--project {nombre}` — Usa el canal configurado en `projects/{p}/CLAUDE.md` (campo `SLACK_CHANNEL`)
+- `--thread {ts}` — Responder en un hilo existente (timestamp del mensaje padre)
+- `{mensaje}` — Texto a enviar. Soporta formato Slack (markdown, mentions, emojis)
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar que Slack está habilitado
+2. `projects/{proyecto}/CLAUDE.md` — Canal del proyecto (si se usa `--project`)
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar que el conector Slack está disponible
+   - Si no está activado → mostrar instrucciones de activación
+
+2. **Resolver canal**:
+   - Si se pasa `{canal}` explícito → usar ese canal
+   - Si se usa `--project` → buscar `SLACK_CHANNEL` en el CLAUDE.md del proyecto
+   - Si ninguno → usar `SLACK_DEFAULT_CHANNEL` de connectors-config
+   - Si ninguno configurado → pedir al usuario que especifique canal
+
+3. **Formatear mensaje** para Slack:
+   - Convertir tablas markdown a formato Slack (bloques de código)
+   - Respetar emojis y menciones (@usuario, @here, @channel)
+   - Si el mensaje es muy largo (>4000 chars) → dividir en múltiples mensajes
+   - Añadir pie: `_Enviado desde PM-Workspace_`
+
+4. **Enviar mensaje** usando el conector MCP de Slack
+   - Si `--thread` → responder en hilo
+   - Si no → mensaje nuevo en el canal
+
+5. **Confirmar envío**:
+   ```
+   ✅ Mensaje enviado a {canal}
+   ```
+
+## Uso desde otros comandos (flag --notify-slack)
+
+Otros comandos de PM-Workspace pueden usar el flag `--notify-slack` para publicar
+su resultado automáticamente. Cuando un comando incluye este flag:
+
+1. Ejecutar el comando normalmente
+2. Tomar el resumen/resultado principal
+3. Formatearlo para Slack (compacto, sin tablas complejas)
+4. Enviarlo al canal del proyecto
+5. Mostrar confirmación
+
+Comandos que soportan `--notify-slack`:
+- `/sprint:status` → Publica resumen de estado del sprint
+- `/sprint:review` → Publica items completados y velocity
+- `/board:flow` → Publica alertas de WIP y cuellos de botella
+- `/team:workload` → Publica distribución de carga
+- `/kpi:dashboard` → Publica KPIs principales
+- `/pbi:decompose` → Notifica asignaciones de tasks
+- `/diagram:status` → Publica estado de diagramas
+
+## Ejemplos
+
+```
+/notify:slack #dev-team Sprint 14 completado: 34 SP, velocity 32 📈
+/notify:slack --project ProyectoAlpha ⚠️ WIP limit superado en columna "In Progress"
+/notify:slack @maria.garcia Tu task #1234 ha sido asignada (4h estimadas)
+```
+
+## Restricciones
+
+- **SIEMPRE confirmar antes de enviar** si el mensaje contiene @channel o @here
+- No enviar mensajes vacíos
+- No enviar secrets, tokens o datos sensibles
+- Máximo 10 mensajes por ejecución de comando (protección contra spam)
+- Si el canal no existe → informar al usuario, no crear canal

--- a/.claude/commands/slack-search.md
+++ b/.claude/commands/slack-search.md
@@ -1,0 +1,71 @@
+---
+name: slack-search
+description: >
+  Buscar mensajes y decisiones en Slack como contexto para
+  reglas de negocio, retrospectivas o análisis de proyecto.
+---
+
+# Buscar en Slack
+
+**Búsqueda:** $ARGUMENTS
+
+> Uso: `/slack:search {query} [--channel {canal}] [--from {usuario}] [--since {fecha}]`
+
+## Parámetros
+
+- `{query}` — Texto a buscar en mensajes de Slack
+- `--channel {canal}` — Filtrar por canal específico
+- `--from {usuario}` — Filtrar por autor del mensaje
+- `--since {fecha}` — Mensajes desde esta fecha (formato: YYYY-MM-DD o "2 weeks ago")
+- `--project {nombre}` — Buscar en el canal configurado del proyecto
+- `--decisions` — Filtrar por mensajes que parezcan decisiones (contienen "decidimos", "aprobado", "acordamos")
+- `--limit {n}` — Máximo de resultados (default: 10)
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar que Slack está habilitado
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar que el conector Slack está disponible
+
+2. **Construir búsqueda**:
+   - Combinar query + filtros (canal, autor, fecha)
+   - Si `--decisions` → ampliar query con términos de decisión
+   - Si `--project` → resolver canal del proyecto
+
+3. **Ejecutar búsqueda** via conector MCP de Slack
+
+4. **Presentar resultados**:
+   ```
+   🔍 Resultados para "{query}" en {canal}
+
+   1. @maria (2026-02-20 en #alpha-dev):
+      "Decidimos usar PostgreSQL para el servicio de usuarios..."
+      🔗 [Ver en Slack](link)
+
+   2. @carlos (2026-02-18 en #alpha-dev):
+      "Acordamos que el rate limit será 100 req/min..."
+      🔗 [Ver en Slack](link)
+
+   Encontrados: {N} mensajes
+   ```
+
+5. **Si `--decisions`** → ofrecer:
+   ```
+   ¿Quieres que añada estas decisiones a reglas-negocio.md del proyecto?
+   ```
+
+## Casos de uso en PM-Workspace
+
+- **Input para `/diagram:import`**: Buscar decisiones arquitectónicas antes de importar
+- **Input para `/pbi:decompose`**: Buscar contexto funcional sobre un PBI
+- **Input para `/sprint:retro`**: Recopilar feedback del equipo durante el sprint
+- **Auditoría**: Buscar quién aprobó qué y cuándo
+
+## Restricciones
+
+- Solo lectura — no modifica mensajes ni canales
+- Respetar privacidad: no mostrar mensajes de canales privados sin acceso
+- No almacenar mensajes de Slack en ficheros del repo
+- Si no hay resultados → sugerir ampliar la búsqueda

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -1,0 +1,66 @@
+# Regla: Configuración de Conectores Claude
+
+> Constantes y configuración para los conectores externos integrados en PM-Workspace.
+> Los conectores se activan desde claude.ai/settings/connectors y se usan via MCP.
+
+```
+# ── Slack ────────────────────────────────────────────────────────────────────
+SLACK_CONNECTOR_ENABLED     = true                               # Activar desde claude.ai/settings/connectors
+SLACK_DEFAULT_CHANNEL       = ""                                 # Canal por defecto para notificaciones (#pm-updates)
+SLACK_THREAD_REPLIES        = true                               # Responder en hilo cuando se notifica en canal existente
+
+# ── GitHub ───────────────────────────────────────────────────────────────────
+GITHUB_CONNECTOR_ENABLED    = true
+GITHUB_DEFAULT_ORG          = ""                                 # Organización GitHub por defecto
+
+# ── Sentry ───────────────────────────────────────────────────────────────────
+SENTRY_CONNECTOR_ENABLED    = false
+SENTRY_DEFAULT_ORG          = ""                                 # Organización Sentry
+
+# ── Atlassian (Jira + Confluence) ────────────────────────────────────────────
+ATLASSIAN_CONNECTOR_ENABLED = false
+JIRA_DEFAULT_PROJECT        = ""                                 # Clave de proyecto Jira (ej: PROJ)
+CONFLUENCE_DEFAULT_SPACE    = ""                                 # Espacio Confluence para publicar
+
+# ── Google Drive ─────────────────────────────────────────────────────────────
+GDRIVE_CONNECTOR_ENABLED    = false
+GDRIVE_REPORTS_FOLDER       = ""                                 # ID de carpeta para informes
+
+# ── Notion ───────────────────────────────────────────────────────────────────
+NOTION_CONNECTOR_ENABLED    = false
+NOTION_DEFAULT_DATABASE     = ""                                 # ID de base de datos principal
+
+# ── Linear ───────────────────────────────────────────────────────────────────
+LINEAR_CONNECTOR_ENABLED    = false
+LINEAR_DEFAULT_TEAM         = ""                                 # Equipo Linear por defecto
+
+# ── Figma ────────────────────────────────────────────────────────────────────
+FIGMA_CONNECTOR_ENABLED     = false
+FIGMA_DEFAULT_PROJECT       = ""                                 # Proyecto Figma por defecto
+```
+
+## Configuración por proyecto
+
+Cada proyecto puede sobrescribir estos valores en `projects/{proyecto}/CLAUDE.md`:
+
+```markdown
+## Conectores
+SLACK_CHANNEL       = "#proyecto-alpha-dev"
+SENTRY_PROJECT      = "proyecto-alpha-api"
+GITHUB_REPO         = "org/proyecto-alpha"
+JIRA_PROJECT        = "ALPHA"
+```
+
+## Prerequisitos
+
+Los conectores de Claude requieren:
+1. Plan Pro, Max, Team o Enterprise en claude.ai
+2. Activar el conector en claude.ai/settings/connectors
+3. Autorizar el acceso OAuth cuando se solicite
+4. Configurar los valores del proyecto en su CLAUDE.md
+
+Si un conector no está activado y un comando intenta usarlo, mostrar:
+```
+⚠️ El conector {nombre} no está activado.
+Actívalo en: claude.ai/settings/connectors
+```

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -62,6 +62,8 @@
 | `/diagram:import {source}` | Importar diagrama → validar reglas negocio → crear Features/PBIs/Tasks |
 | `/diagram:config` | Configurar credenciales Draw.io/Miro y verificar conexión |
 | `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
+| `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
+| `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias
@@ -80,6 +82,7 @@
 - Multi-entorno: `.claude/rules/environment-config.md`
 - Confidencialidad: `.claude/rules/confidentiality-config.md`
 - Infrastructure as Code: `.claude/rules/infrastructure-as-code.md`
+- Conectores Claude: `.claude/rules/connectors-config.md`
 - Diagram Generation: `.claude/skills/diagram-generation/SKILL.md`
 - Diagram Import: `.claude/skills/diagram-import/SKILL.md`
 - Diagram Config: `.claude/rules/diagram-config.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 34 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 36 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 34 slash commands
+│   ├── commands/                ← 36 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,6 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
+│   │   ├── notify-slack.md ...  ← Conectores (2)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md
@@ -68,6 +69,7 @@
 │       ├── command-validation.md← Pre-commit: validar commands
 │       ├── file-size-limit.md   ← Regla 150 líneas
 │       ├── readme-update.md     ← Regla 12: actualizar READMEs
+│       ├── connectors-config.md ← Configuración conectores Claude (Slack, GitHub, Sentry...)
 │       ├── diagram-config.md    ← Configuración Draw.io/Miro
 │       ├── agents-catalog.md    ← Tabla de 24 agentes
 │       └── languages/           ← Convenciones por lenguaje (excluido de carga automática)

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 34 slash commands
+│   ├── commands/                ← 36 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,6 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
+│   │   ├── notify-slack.md ...  ← Connectors (2)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md
@@ -67,6 +68,7 @@
 │       ├── command-validation.md← Pre-commit: validate commands
 │       ├── file-size-limit.md   ← 150 lines rule
 │       ├── readme-update.md     ← Rule 12: update READMEs
+│       ├── connectors-config.md ← Claude connectors config (Slack, GitHub, Sentry...)
 │       ├── diagram-config.md    ← Draw.io/Miro configuration
 │       ├── agents-catalog.md    ← 24 agents table
 │       └── languages/           ← Per-language conventions (excluded from auto-loading)


### PR DESCRIPTION
## Summary

- Add `/notify:slack` command — send notifications/reports to project Slack channels
- Add `/slack:search` command — search messages and decisions as context for PBIs and business rules
- Add `connectors-config.md` rule — centralized config for all Claude connectors (Slack, GitHub, Sentry, Atlassian, Google Drive, Notion, Linear, Figma)
- Existing commands support `--notify-slack` flag for auto-publishing results (sprint:status, board:flow, kpi:dashboard, etc.)

## Test plan

- [ ] Verify `/notify:slack #test Hello` sends message to Slack channel
- [ ] Verify `/slack:search --decisions --project Alpha` finds relevant messages
- [ ] Verify `--notify-slack` flag works on sprint:status
- [ ] Verify all 36 commands pass validation (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)