### PR TITLE
feat: GitHub connector — github:activity + github:issues

### DIFF
--- a/.claude/commands/github-activity.md
+++ b/.claude/commands/github-activity.md
@@ -1,0 +1,76 @@
+---
+name: github-activity
+description: >
+  Analizar actividad de un repositorio GitHub: PRs, commits, contributors.
+  Usa el conector GitHub de Claude para acceso enriquecido.
+---
+
+# Actividad GitHub
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/github:activity {repo} [--since {fecha}] [--author {usuario}]`
+
+## Parámetros
+
+- `{repo}` — Repositorio en formato `org/repo` o solo `repo` (usa GITHUB_DEFAULT_ORG)
+- `--since {fecha}` — Actividad desde esta fecha (default: inicio del sprint actual)
+- `--author {usuario}` — Filtrar por contributor específico
+- `--project {nombre}` — Usar el repo configurado en `projects/{p}/CLAUDE.md` (campo `GITHUB_REPO`)
+- `--team` — Mostrar actividad de todos los miembros del equipo (cruza con `equipo.md`)
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar conector GitHub habilitado
+2. `projects/{proyecto}/CLAUDE.md` — Repo del proyecto
+3. `projects/{proyecto}/equipo.md` — Usernames GitHub del equipo (si `--team`)
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar que el conector GitHub está disponible
+
+2. **Resolver repo**:
+   - Si se pasa `{repo}` → usar directamente
+   - Si `--project` → buscar `GITHUB_REPO` en CLAUDE.md del proyecto
+   - Si ninguno → preguntar
+
+3. **Obtener datos** via conector MCP de GitHub:
+   - PRs abiertas, mergeadas y cerradas en el periodo
+   - Commits por autor
+   - Reviews realizadas
+   - Issues creados/cerrados
+
+4. **Si `--team`** → cruzar con `equipo.md`:
+   - Mapear nombres Azure DevOps ↔ usernames GitHub
+   - Mostrar actividad por persona del equipo
+
+5. **Presentar informe**:
+   ```
+   📊 Actividad GitHub — {repo}
+   Periodo: {desde} → {hasta}
+
+   PRs:     {N} abiertas · {N} mergeadas · {N} cerradas
+   Commits: {N} total ({N} autores)
+   Reviews: {N} aprobadas · {N} con cambios · {N} pendientes
+
+   👥 Por contributor:
+   ┌──────────────┬─────────┬────────┬─────────┬──────────┐
+   │ Contributor   │ Commits │ PRs    │ Reviews │ +/- LOC  │
+   ├──────────────┼─────────┼────────┼─────────┼──────────┤
+   │ @maria        │ 12      │ 3 PR   │ 5 rev   │ +340/-120│
+   │ @carlos       │ 8       │ 2 PR   │ 3 rev   │ +210/-80 │
+   └──────────────┴─────────┴────────┴─────────┴──────────┘
+   ```
+
+## Integración con otros comandos
+
+- `/team:workload` puede invocar este comando para añadir métricas de código
+- `/team:evaluate` usa estos datos como input para evaluación técnica
+- `/sprint:status` puede incluir sección "Actividad de código" con estos datos
+- `/kpi:dashboard` puede mostrar métricas de PR lead time y review time
+
+## Restricciones
+
+- Solo lectura — no modifica repos, PRs ni issues
+- No mostrar código fuente en el informe (solo métricas)
+- Respetar repos privados — el conector gestiona permisos OAuth

--- a/.claude/commands/github-issues.md
+++ b/.claude/commands/github-issues.md
@@ -1,0 +1,90 @@
+---
+name: github-issues
+description: >
+  Gestionar issues de GitHub: buscar, crear desde PBIs, sincronizar
+  con Azure DevOps work items.
+---
+
+# Issues GitHub
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/github:issues {repo} [--sync-from-azdo {ids}] [--search {query}] [--create {titulo}]`
+
+## Parámetros
+
+- `{repo}` — Repositorio en formato `org/repo`
+- `--project {nombre}` — Usar repo de `projects/{p}/CLAUDE.md`
+- `--search {query}` — Buscar issues por texto, labels o milestone
+- `--open` / `--closed` — Filtrar por estado
+- `--sync-from-azdo {pbi_ids}` — Crear issues desde PBIs de Azure DevOps (bidireccional)
+- `--sync-to-azdo` — Crear PBIs en Azure DevOps desde issues de GitHub abiertos
+- `--label {label}` — Filtrar por label
+- `--link {issue_id} {pbi_id}` — Vincular issue de GitHub con PBI de Azure DevOps
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar conector GitHub
+2. `projects/{proyecto}/CLAUDE.md` — Repo y proyecto Azure DevOps
+3. `.claude/rules/pm-config.md` — Config Azure DevOps para sync
+
+## Pasos de ejecución
+
+### Modo búsqueda (`--search`)
+
+1. Buscar issues en el repo via conector GitHub
+2. Mostrar resultados con: número, título, labels, asignado, fecha
+
+### Modo sync Azure DevOps → GitHub (`--sync-from-azdo`)
+
+1. Leer PBIs de Azure DevOps por IDs
+2. Para cada PBI → crear issue en GitHub:
+   - Título: `[AB#{id}] {titulo_pbi}`
+   - Body: descripción + criterios de aceptación
+   - Labels: mapeados desde tags del PBI
+   - Milestone: nombre del sprint si existe
+3. Añadir comentario en el PBI de Azure DevOps con link al issue
+4. Mostrar tabla de mapeo:
+   ```
+   ✅ Issues creados en GitHub
+
+   ┌───────────┬────────────┬──────────────────────────────┐
+   │ PBI AzDO  │ Issue GH   │ Título                       │
+   ├───────────┼────────────┼──────────────────────────────┤
+   │ AB#1234   │ #45        │ Implementar auth endpoint    │
+   │ AB#1235   │ #46        │ Schema base de datos users   │
+   └───────────┴────────────┴──────────────────────────────┘
+   ```
+
+### Modo sync GitHub → Azure DevOps (`--sync-to-azdo`)
+
+1. Listar issues abiertos sin link a PBI
+2. Para cada issue → proponer creación de PBI:
+   - Mapear labels → tags Azure DevOps
+   - Estimar SP si hay suficiente contexto
+3. Confirmar con el PM antes de crear
+4. Actualizar issue con link al PBI creado
+
+### Modo link (`--link`)
+
+1. Añadir comentario en issue de GitHub: `Linked to Azure DevOps: AB#{pbi_id}`
+2. Añadir comentario en PBI de Azure DevOps: `Linked to GitHub: {repo}#{issue_id}`
+3. Confirmar vinculación
+
+## Mapeo de campos
+
+| GitHub Issue | Azure DevOps PBI |
+|---|---|
+| Title | Title (prefijado con [AB#id]) |
+| Body | Description |
+| Labels | Tags |
+| Milestone | Iteration Path |
+| Assignees | Assigned To (requiere mapeo en equipo.md) |
+| State (open/closed) | State (New/Active/Closed) |
+
+## Restricciones
+
+- **Confirmar antes de crear** issues o PBIs — nunca crear sin aprobación
+- No duplicar: verificar que no exista ya un issue/PBI vinculado
+- Máximo 20 sync por ejecución (protección contra errores masivos)
+- Si el mapeo de usuario falla → dejar sin asignar y avisar

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,8 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
+   **Conectores (4):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, github, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -62,6 +62,10 @@
 | `/diagram:import {source}` | Importar diagrama → validar reglas negocio → crear Features/PBIs/Tasks |
 | `/diagram:config` | Configurar credenciales Draw.io/Miro y verificar conexión |
 | `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
+| `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
+| `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
+| `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |
+| `/github:issues {repo}` | Gestionar issues GitHub: buscar, crear, sincronizar con Azure DevOps |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 34 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 38 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 34 slash commands
+│   ├── commands/                ← 38 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,6 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
+│   │   ├── notify-slack.md ...  ← Conectores (4): Slack + GitHub
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 34 slash commands
+│   ├── commands/                ← 38 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,6 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
+│   │   ├── notify-slack.md ...  ← Connectors (4): Slack + GitHub
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/github:activity` command — analyze repo activity (PRs, commits, contributors) with team cross-reference
- Add `/github:issues` command — bidirectional sync between GitHub Issues and Azure DevOps PBIs
- Update help catalog with Connectors category (4 commands: 2 Slack + 2 GitHub)
- Update all documentation (CLAUDE.md, pm-workflow.md, READMEs ES/EN)

## Test plan

- [ ] Verify `/github:activity org/repo --since 2026-02-01` shows PR/commit stats
- [ ] Verify `/github:issues repo --sync-from-azdo 1234` creates issue from PBI
- [ ] Verify all 38 commands pass validation (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)