### PR TITLE
feat: add Sentry connector integration

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
-   **Conectores (2):** notify:slack {canal} {msg}, slack:search {query}
+   **Conectores (4):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/sentry-bugs.md
+++ b/.claude/commands/sentry-bugs.md
@@ -1,0 +1,99 @@
+---
+name: sentry-bugs
+description: >
+  Crear PBIs en Azure DevOps a partir de errores frecuentes en Sentry.
+  Analiza issues, agrupa por causa raíz y propone work items.
+---
+
+# Bugs desde Sentry → PBIs
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/sentry:bugs --project {p}` o `/sentry:bugs --project {p} --min-events {N}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--min-events {N}` — Umbral mínimo de eventos para considerar un issue (defecto: 10)
+- `--period {días}` — Período de análisis (defecto: 14)
+- `--env {entorno}` — Filtrar por entorno (defecto: production)
+- `--dry-run` — Solo mostrar propuesta, no crear nada
+- `--auto-assign` — Asignar automáticamente según equipo.md y área afectada
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Sentry habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `SENTRY_PROJECT`, `AZURE_DEVOPS_PROJECT`
+3. `projects/{proyecto}/equipo.md` — Para auto-asignación (opcional)
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar Sentry disponible
+   - Si no activado → mostrar instrucciones
+
+2. **Obtener issues de Sentry**:
+   - Filtrar por: período, entorno, `is:unresolved`, eventos >= min-events
+   - Ordenar por frecuencia descendente
+   - Obtener: título, culprit, stack trace resumido, primera/última vez, usuarios afectados
+
+3. **Analizar y agrupar**:
+   - Agrupar issues por causa raíz (mismo módulo/fichero/servicio)
+   - Detectar issues ya vinculados a PBIs existentes (buscar `[Sentry#ID]` en DevOps)
+   - Excluir issues ya resueltos o ignorados en Sentry
+
+4. **Generar propuesta de PBIs**:
+   ```
+   ## Bugs desde Sentry — {proyecto} ({período})
+
+   Se encontraron N issues con >= {min} eventos.
+   Ya vinculados a PBIs: M | Nuevos: K
+
+   | # | Sentry Issue | Eventos | Usuarios | Módulo | PBI propuesto |
+   |---|---|---|---|---|---|
+   | 1 | PROJ-ABC | 523 | 89 | api/auth | Fix: fallo autenticación OAuth... |
+   | 2 | PROJ-DEF | 201 | 45 | web/cart | Fix: error al calcular descuento... |
+   ...
+
+   ### Detalle por PBI propuesto
+
+   #### 1. Fix: fallo autenticación OAuth al renovar token
+   - **Sentry issues**: PROJ-ABC, PROJ-GHI (misma causa raíz)
+   - **Impacto**: 612 eventos, 89 usuarios, primera vez: 2026-02-15
+   - **Stack trace**: `auth/oauth.py:142 → refresh_token() → TokenExpiredError`
+   - **Severidad propuesta**: 2 (Alta) — afecta autenticación
+   - **Estimación**: 8h
+   ```
+
+5. **Confirmar con el PM** — Presentar tabla y pedir confirmación
+   - ⚠️ **NUNCA crear PBIs sin confirmación explícita** (Regla 7)
+   - Permitir editar títulos, severidad, estimación antes de crear
+
+6. Si confirmado → **Crear PBIs en Azure DevOps**:
+   - Tipo: Bug
+   - Título: `[Sentry#ID] Descripción del fix`
+   - Description: stack trace + impacto + link a Sentry
+   - Tags: `sentry`, `bug`, `{módulo}`
+   - Severity: según impacto (usuarios afectados × frecuencia)
+   - Link: URL del issue en Sentry
+
+7. **Confirmar creación**:
+   ```
+   ✅ Creados N PBIs (Bug) en Azure DevOps:
+   - AB#1234: [Sentry#ABC] Fix: fallo autenticación OAuth...
+   - AB#1235: [Sentry#DEF] Fix: error al calcular descuento...
+   ```
+
+## Integración con otros comandos
+
+- `/pbi:decompose` puede descomponer los bugs creados en tasks técnicas
+- `/sprint:plan` puede incluir bugs de Sentry como candidatos al sprint
+- `/notify:slack` puede publicar resumen de bugs detectados
+- `/sentry:health` complementa con visión general de salud
+
+## Restricciones
+
+- **NUNCA crear PBIs sin confirmación** del PM (Regla 7)
+- No duplicar: verificar siempre si ya existe PBI vinculado al Sentry issue
+- No modificar issues en Sentry (solo lectura desde Sentry)
+- Máximo 20 PBIs por ejecución (protección contra spam)
+- Si `--dry-run` → solo mostrar propuesta, no escribir en DevOps

--- a/.claude/commands/sentry-health.md
+++ b/.claude/commands/sentry-health.md
@@ -1,0 +1,85 @@
+---
+name: sentry-health
+description: >
+  Métricas de salud técnica del proyecto desde Sentry: errores, crash rate,
+  performance, alertas activas. Alimenta sprint:status y kpi:dashboard.
+---
+
+# Salud Técnica — Sentry
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/sentry:health --project {p}` o `/sentry:health --project {p} --period {días}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace. Busca `SENTRY_PROJECT` en su CLAUDE.md
+- `--period {días}` — Período de análisis (por defecto: 14 = duración del sprint)
+- `--env {entorno}` — Filtrar por entorno Sentry (production, staging, development)
+- `--compare` — Comparar con el período anterior (útil para sprint review)
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar que Sentry está habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `SENTRY_PROJECT` y `SENTRY_ORG` si difiere del default
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar que el conector Sentry está disponible
+   - Si no está activado → mostrar instrucciones de activación
+
+2. **Resolver proyecto Sentry**:
+   - Si `--project` → buscar `SENTRY_PROJECT` en CLAUDE.md del proyecto
+   - Si no encontrado → usar `SENTRY_DEFAULT_ORG` + pedir slug del proyecto
+   - Organización: `SENTRY_DEFAULT_ORG` de connectors-config o la del proyecto
+
+3. **Obtener métricas** usando el conector MCP de Sentry:
+   - **Errores**: total de eventos, errores únicos, top 5 por frecuencia
+   - **Crash Rate**: % de sesiones con crash (si aplica)
+   - **Performance**: p50, p75, p95 de transacciones principales
+   - **Alertas activas**: alertas no resueltas con severidad
+   - **Releases**: últimas releases y su estabilidad
+
+4. **Calcular indicadores de salud**:
+   ```
+   🟢 Saludable  — error rate < 1%, sin alertas críticas, p95 < objetivo
+   🟡 Atención   — error rate 1-5% o alertas warning activas
+   🔴 Crítico    — error rate > 5% o alertas critical activas
+   ```
+
+5. **Generar informe**:
+   ```
+   ## Salud Técnica — {proyecto} ({período})
+   Estado: 🟢/🟡/🔴
+
+   | Métrica | Valor | Tendencia |
+   |---|---|---|
+   | Errores únicos | N | ↑↓→ |
+   | Error rate | N% | ↑↓→ |
+   | P95 latencia | Nms | ↑↓→ |
+   | Alertas activas | N (M críticas) | — |
+
+   ### Top 5 errores por frecuencia
+   1. [Error] descripción — N eventos — última vez: fecha
+   ...
+
+   ### Alertas activas
+   - 🔴 {alerta}: descripción
+   ...
+   ```
+
+6. Si `--compare` → añadir columna "Sprint anterior" y calcular deltas
+
+## Integración con otros comandos
+
+- `/sprint:status` puede invocar `sentry:health` para incluir métricas técnicas
+- `/kpi:dashboard` usa los datos de salud como KPIs técnicos
+- `/sprint:review` incluye tendencia de salud técnica en el resumen
+- Soporta `--notify-slack` para publicar el informe en el canal del proyecto
+
+## Restricciones
+
+- **Solo lectura** — no modificar alertas ni configuración en Sentry
+- Si Sentry no tiene datos del período → informar, no inventar métricas
+- Respetar rate limits del conector
+- No exponer tokens ni API keys en la salida

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -14,7 +14,7 @@ GITHUB_CONNECTOR_ENABLED    = true
 GITHUB_DEFAULT_ORG          = ""                                 # Organización GitHub por defecto
 
 # ── Sentry ───────────────────────────────────────────────────────────────────
-SENTRY_CONNECTOR_ENABLED    = false
+SENTRY_CONNECTOR_ENABLED    = true
 SENTRY_DEFAULT_ORG          = ""                                 # Organización Sentry
 
 # ── Atlassian (Jira + Confluence) ────────────────────────────────────────────

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -64,6 +64,8 @@
 | `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
+| `/sentry:health {--project p}` | Métricas de salud técnica desde Sentry: errores, crash rate, performance |
+| `/sentry:bugs {--project p}` | Crear PBIs (Bug) en Azure DevOps desde errores frecuentes en Sentry |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 36 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 38 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 36 slash commands
+│   ├── commands/                ← 38 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
-│   │   ├── notify-slack.md ...  ← Conectores (2)
+│   │   ├── notify-slack.md ...  ← Conectores (4: Slack, Sentry)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 36 slash commands
+│   ├── commands/                ← 38 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
-│   │   ├── notify-slack.md ...  ← Connectors (2)
+│   │   ├── notify-slack.md ...  ← Connectors (4: Slack, Sentry)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/sentry:health` command — technical health metrics (error rate, crash rate, p95 latency, active alerts) that feed into `/sprint:status` and `/kpi:dashboard`
- Add `/sentry:bugs` command — analyze frequent Sentry errors and create Bug PBIs in Azure DevOps with confirmation workflow (respects Rule 7: never create PBIs without PM confirmation)
- Enable Sentry in `connectors-config.md`, update help catalog (Connectors 2→4), pm-workflow commands table, CLAUDE.md counters (36→38), READMEs (ES/EN)

## Test plan

- [ ] Verify `/sentry:health --project sala-reservas` shows connector activation instructions when Sentry not connected
- [ ] Verify `/sentry:bugs --project sala-reservas --dry-run` respects dry-run flag
- [ ] Verify `/help sentry` filters to show only Sentry commands
- [ ] Run `scripts/validate-commands.sh` — all 38 commands pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)