### PR TITLE
feat: add Atlassian connector — Jira sync + Confluence publish

### DIFF
--- a/.claude/commands/confluence-publish.md
+++ b/.claude/commands/confluence-publish.md
@@ -1,0 +1,88 @@
+---
+name: confluence-publish
+description: >
+  Publicar documentación del proyecto en Confluence. Convierte markdown
+  a formato Confluence y crea/actualiza páginas en el espacio del proyecto.
+---
+
+# Publicar en Confluence
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/confluence:publish {fichero} --project {p}` o `/confluence:publish --project {p} --type {tipo}`
+
+## Parámetros
+
+- `{fichero}` — Ruta al fichero markdown a publicar (relativa al proyecto)
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--space {clave}` — Espacio Confluence (defecto: `CONFLUENCE_DEFAULT_SPACE` del proyecto)
+- `--parent {título}` — Página padre bajo la que crear la nueva página
+- `--type {tipo}` — Tipo de contenido predefinido:
+  - `sprint-report` → publica resultado de `/sprint:review`
+  - `spec` → publica una SDD Spec
+  - `architecture` → publica diagrama de arquitectura
+  - `onboarding` → publica guía de onboarding
+  - `retro` → publica resultado de `/sprint:retro`
+- `--update` — Actualizar página existente en vez de crear nueva
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Atlassian habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `CONFLUENCE_DEFAULT_SPACE`, `JIRA_PROJECT`
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar Atlassian disponible
+
+2. **Resolver contenido**:
+   - Si `{fichero}` → leer el markdown del fichero
+   - Si `--type` → generar contenido desde el comando correspondiente
+   - Si `--type sprint-report` → ejecutar `/sprint:review` y usar su salida
+
+3. **Convertir markdown → Confluence Storage Format**:
+   - Tablas markdown → macro `{table}`
+   - Código → macro `{code}` con lenguaje
+   - Diagramas Mermaid → imagen renderizada o macro compatible
+   - Links internos → ajustar a URLs de Confluence
+   - Mantener estructura de headings
+
+4. **Resolver destino**:
+   - Espacio: `--space` o `CONFLUENCE_DEFAULT_SPACE`
+   - Página padre: `--parent` o raíz del espacio
+   - Título: derivado del H1 del markdown o nombre del fichero
+
+5. **Verificar si la página ya existe**:
+   - Si existe y `--update` → actualizar contenido
+   - Si existe y no `--update` → preguntar: ¿actualizar o crear nueva?
+   - Si no existe → crear nueva
+
+6. **Confirmar publicación**:
+   ```
+   📄 Publicar en Confluence:
+   Espacio: {space} | Padre: {parent} | Título: {title}
+   Contenido: {líneas} líneas, {tablas} tablas, {imágenes} imágenes
+   ¿Confirmar? (y/n)
+   ```
+
+7. **Publicar** usando el conector MCP de Atlassian
+8. **Confirmar**:
+   ```
+   ✅ Página publicada en Confluence
+   URL: https://org.atlassian.net/wiki/spaces/{space}/pages/{id}
+   ```
+
+## Integración con otros comandos
+
+- `/sprint:review --publish-confluence` → publica automáticamente
+- `/sprint:retro --publish-confluence` → publica retrospectiva
+- `/spec:generate --publish-confluence` → publica la Spec en Confluence
+- `/report:executive --publish-confluence` → publica informe ejecutivo
+
+## Restricciones
+
+- **SIEMPRE confirmar antes de publicar** (contenido puede ser sensible)
+- No publicar secrets, tokens ni datos confidenciales
+- No eliminar páginas existentes
+- Si el espacio no existe → informar, no crear espacio
+- Máximo 1 publicación por ejecución (evitar spam)
+- Respetar permisos del espacio Confluence

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
-   **Conectores (2):** notify:slack {canal} {msg}, slack:search {query}
+   **Conectores (4):** notify:slack {canal} {msg}, slack:search {query}, jira:sync --project {p}, confluence:publish {file} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, jira, confluence, atlassian, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/jira-sync.md
+++ b/.claude/commands/jira-sync.md
@@ -1,0 +1,82 @@
+---
+name: jira-sync
+description: >
+  Sincronizar issues de Jira con PBIs de Azure DevOps. Soporta sync
+  bidireccional, mapeo de campos y detección de conflictos.
+---
+
+# Sync Jira ↔ Azure DevOps
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/jira:sync --project {p}` o `/jira:sync --project {p} --direction {dir}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--direction {jira-to-devops|devops-to-jira|bidirectional}` — Dirección del sync (defecto: bidirectional)
+- `--jql {query}` — Filtro JQL personalizado (ej: `sprint = "Sprint 2026-04"`)
+- `--dry-run` — Solo mostrar cambios propuestos, no ejecutar
+- `--since {fecha}` — Solo sincronizar cambios desde esta fecha (YYYY-MM-DD)
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Atlassian habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `JIRA_PROJECT`, `AZURE_DEVOPS_PROJECT`
+
+## Mapeo de campos
+
+| Jira | Azure DevOps PBI |
+|---|---|
+| Summary | Title (prefijado `[Jira#KEY]`) |
+| Description | Description |
+| Issue Type (Story/Bug/Task) | Work Item Type (PBI/Bug/Task) |
+| Priority (Highest→Lowest) | Priority (1→4) |
+| Sprint | Iteration Path |
+| Assignee | Assigned To (requiere mapeo en equipo.md) |
+| Status | State (mapeo configurable) |
+| Story Points | Story Points |
+| Labels | Tags |
+| Epic Link | Parent (Feature) |
+
+## Mapeo de estados (configurable por proyecto)
+
+| Jira Status | Azure DevOps State |
+|---|---|
+| To Do / Backlog | New |
+| In Progress / In Review | Active |
+| Done / Closed | Closed |
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar Atlassian disponible
+2. **Leer configuración** del proyecto: JIRA_PROJECT, mapeo de usuarios
+3. **Obtener issues** de Jira (usando JQL o filtro por sprint)
+4. **Obtener PBIs** de Azure DevOps (filtro por IterationPath)
+5. **Detectar correspondencias** por `[Jira#KEY]` en título de DevOps
+6. **Calcular diff**:
+   - Nuevos en Jira → proponer crear en DevOps
+   - Nuevos en DevOps → proponer crear en Jira (si bidirectional)
+   - Cambios en ambos → detectar conflicto, proponer resolución
+7. **Presentar propuesta**:
+   ```
+   ## Sync Jira ↔ Azure DevOps — {proyecto}
+
+   | Acción | Jira | Azure DevOps | Campo |
+   |---|---|---|---|
+   | CREATE → | PROJ-123 | (nuevo) | Story: Login OAuth |
+   | UPDATE → | PROJ-124 | AB#456 | Status: Done → Closed |
+   | ← UPDATE | (actualizar) | AB#789 | Points: 5 → 8 |
+   | ⚠️ CONFLICT | PROJ-125 | AB#790 | Ambos modificados |
+   ```
+8. **Confirmar con PM** — NUNCA sincronizar sin confirmación
+9. Si confirmado → ejecutar cambios en ambos sistemas
+10. **Resumen**: items creados, actualizados, conflictos pendientes
+
+## Restricciones
+
+- **NUNCA sincronizar sin confirmación** del PM
+- Conflictos se resuelven manualmente (mostrar ambas versiones)
+- Si `--dry-run` → solo mostrar propuesta
+- Máximo 50 items por ejecución
+- No eliminar items en ningún sistema — solo crear y actualizar

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -18,7 +18,7 @@ SENTRY_CONNECTOR_ENABLED    = false
 SENTRY_DEFAULT_ORG          = ""                                 # Organización Sentry
 
 # ── Atlassian (Jira + Confluence) ────────────────────────────────────────────
-ATLASSIAN_CONNECTOR_ENABLED = false
+ATLASSIAN_CONNECTOR_ENABLED = true
 JIRA_DEFAULT_PROJECT        = ""                                 # Clave de proyecto Jira (ej: PROJ)
 CONFLUENCE_DEFAULT_SPACE    = ""                                 # Espacio Confluence para publicar
 

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -64,6 +64,8 @@
 | `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
+| `/jira:sync {--project p}` | Sincronizar issues Jira ↔ PBIs Azure DevOps (bidireccional) |
+| `/confluence:publish {file}` | Publicar documentación/informes en Confluence |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 36 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 38 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 36 slash commands
+│   ├── commands/                ← 38 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
-│   │   ├── notify-slack.md ...  ← Conectores (2)
+│   │   ├── notify-slack.md ...  ← Conectores (4: Slack, Atlassian)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 36 slash commands
+│   ├── commands/                ← 38 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
-│   │   ├── notify-slack.md ...  ← Connectors (2)
+│   │   ├── notify-slack.md ...  ← Connectors (4: Slack, Atlassian)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/jira:sync` command — bidirectional sync between Jira issues and Azure DevOps PBIs with field mapping, conflict detection, state mapping, and dry-run support
- Add `/confluence:publish` command — publish markdown docs, sprint reports, specs and retros to Confluence with automatic format conversion (markdown → Confluence Storage Format)
- Enable Atlassian in `connectors-config.md`, update help catalog (Connectors 2→4), pm-workflow commands table, CLAUDE.md counters (36→38), READMEs (ES/EN)

## Test plan

- [ ] Verify `/jira:sync --project sala-reservas --dry-run` shows sync proposal without executing
- [ ] Verify `/confluence:publish --project sala-reservas --type sprint-report` shows connector activation instructions when not connected
- [ ] Verify `/help atlassian` filters to show Atlassian commands
- [ ] Run `scripts/validate-commands.sh` — all 38 commands pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)