### PR TITLE
feat: add Google Drive connector — report upload

### DIFF
--- a/.claude/commands/gdrive-upload.md
+++ b/.claude/commands/gdrive-upload.md
@@ -1,0 +1,85 @@
+---
+name: gdrive-upload
+description: >
+  Subir informes y documentos generados a Google Drive. Organiza
+  automáticamente en la carpeta del proyecto y comparte el link.
+---
+
+# Upload a Google Drive
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/gdrive:upload {fichero} --project {p}` o `/gdrive:upload --project {p} --latest {tipo}`
+
+## Parámetros
+
+- `{fichero}` — Ruta al fichero a subir (relativa a `output/` o absoluta)
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--folder {id}` — ID de carpeta destino (defecto: `GDRIVE_REPORTS_FOLDER` del proyecto)
+- `--latest {tipo}` — Subir el informe más reciente de un tipo:
+  - `sprint-report` → último `output/sprints/YYYYMMDD-sprint-report-{p}.*`
+  - `executive` → último `output/reports/YYYYMMDD-executive-{p}.*`
+  - `hours` → último `output/reports/YYYYMMDD-hours-{p}.*`
+  - `capacity` → último `output/reports/YYYYMMDD-capacity-{p}.*`
+- `--share {email}` — Compartir con un email después de subir (viewer)
+- `--notify` — Enviar notificación por email al compartir
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Google Drive habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `GDRIVE_REPORTS_FOLDER`
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar Google Drive disponible
+   - Si no activado → mostrar instrucciones de activación
+
+2. **Resolver fichero**:
+   - Si `{fichero}` explícito → verificar que existe
+   - Si `--latest {tipo}` → buscar en `output/` el más reciente por patrón
+   - Si no se encuentra → informar al usuario
+
+3. **Resolver carpeta destino**:
+   - Si `--folder` → usar ese ID
+   - Si `--project` → buscar `GDRIVE_REPORTS_FOLDER` en CLAUDE.md del proyecto
+   - Si ninguno → usar `GDRIVE_REPORTS_FOLDER` global de connectors-config
+   - Si ninguno configurado → pedir al usuario
+
+4. **Organizar en subcarpeta**:
+   - Estructura en Drive: `{proyecto}/sprints/`, `{proyecto}/reports/`
+   - Crear subcarpeta si no existe (basada en el tipo de informe)
+
+5. **Confirmar upload**:
+   ```
+   📤 Subir a Google Drive:
+   Fichero: {nombre} ({tamaño})
+   Destino: {carpeta}/{subcarpeta}/
+   ¿Confirmar? (y/n)
+   ```
+
+6. **Subir fichero** usando el conector MCP de Google Drive
+
+7. Si `--share` → compartir el fichero con el email indicado
+
+8. **Confirmar**:
+   ```
+   ✅ Fichero subido a Google Drive
+   📎 Link: https://drive.google.com/file/d/{id}
+   ```
+
+## Integración con otros comandos
+
+- `/report:hours --upload-gdrive` → sube automáticamente tras generar
+- `/report:executive --upload-gdrive` → sube informe ejecutivo
+- `/report:capacity --upload-gdrive` → sube informe de capacidad
+- `/sprint:review --upload-gdrive` → sube resumen del sprint
+
+## Restricciones
+
+- **SIEMPRE confirmar antes de subir** (el fichero puede contener datos sensibles)
+- No eliminar ficheros existentes en Drive
+- No modificar permisos de carpetas — solo del fichero subido
+- Si la carpeta no existe → informar, no crear carpeta raíz
+- Máximo 5 ficheros por ejecución
+- No subir ficheros > 100MB
+- No subir secrets, `.env` ni credenciales

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
-   **Conectores (4):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}
+   **Conectores (5):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, gdrive, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -23,7 +23,7 @@ JIRA_DEFAULT_PROJECT        = ""                                 # Clave de proy
 CONFLUENCE_DEFAULT_SPACE    = ""                                 # Espacio Confluence para publicar
 
 # ── Google Drive ─────────────────────────────────────────────────────────────
-GDRIVE_CONNECTOR_ENABLED    = false
+GDRIVE_CONNECTOR_ENABLED    = true
 GDRIVE_REPORTS_FOLDER       = ""                                 # ID de carpeta para informes
 
 # ── Notion ───────────────────────────────────────────────────────────────────

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -66,6 +66,7 @@
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/sentry:health {--project p}` | Métricas de salud técnica desde Sentry: errores, crash rate, performance |
 | `/sentry:bugs {--project p}` | Crear PBIs (Bug) en Azure DevOps desde errores frecuentes en Sentry |
+| `/gdrive:upload {file}` | Subir informes y documentos generados a Google Drive |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 38 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 39 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 38 slash commands
+│   ├── commands/                ← 39 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
-│   │   ├── notify-slack.md ...  ← Conectores (4: Slack, Sentry)
+│   │   ├── notify-slack.md ...  ← Conectores (5: Slack, Sentry, GDrive)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 38 slash commands
+│   ├── commands/                ← 39 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
-│   │   ├── notify-slack.md ...  ← Connectors (4: Slack, Sentry)
+│   │   ├── notify-slack.md ...  ← Connectors (5: Slack, Sentry, GDrive)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/gdrive:upload` command — upload generated reports and documents to Google Drive with automatic folder organization by project and report type
- Supports `--latest {type}` for quick upload of most recent sprint reports, executive summaries, hours and capacity reports
- Integrates with existing report commands via `--upload-gdrive` flag
- Enable Google Drive in `connectors-config.md`, update help catalog (Connectors 4→5), pm-workflow, CLAUDE.md counters (38→39), READMEs (ES/EN)

## Test plan

- [ ] Verify `/gdrive:upload --project sala-reservas --latest sprint-report` shows connector activation instructions when not connected
- [ ] Verify `/help gdrive` filters to show Google Drive commands
- [ ] Run `scripts/validate-commands.sh` — all 39 commands pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)