### PR TITLE
feat: add Notion connector — documentation sync

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
-   **Conectores (4):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}
+   **Conectores (5):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}, notion:sync --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, notion, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/notion-sync.md
+++ b/.claude/commands/notion-sync.md
@@ -1,0 +1,83 @@
+---
+name: notion-sync
+description: >
+  Sincronizar documentación del proyecto con Notion. Import/export de
+  specs, decisiones arquitectónicas, onboarding y documentación técnica.
+---
+
+# Sync Documentación ↔ Notion
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/notion:sync --project {p} --direction {dir}` o `/notion:sync {page} --project {p}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--direction {to-notion|from-notion|bidirectional}` — Dirección (defecto: to-notion)
+- `{page}` — URL o ID de página Notion específica (para import)
+- `--type {tipo}` — Tipo de contenido a sincronizar:
+  - `specs` → SDD Specs del proyecto
+  - `decisions` → Decisiones arquitectónicas (ADRs)
+  - `onboarding` → Guía de onboarding del equipo
+  - `reglas-negocio` → Reglas de negocio del proyecto
+  - `all` → Toda la documentación del proyecto
+- `--database {id}` — ID de database Notion (defecto: `NOTION_DEFAULT_DATABASE`)
+- `--dry-run` — Solo mostrar cambios propuestos
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Notion habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `NOTION_DEFAULT_DATABASE`
+
+## Pasos de ejecución — Export (to-notion)
+
+1. **Verificar conector** — Comprobar Notion disponible
+2. **Recopilar documentación** del proyecto:
+   - Specs: `projects/{p}/specs/*.md`
+   - Decisiones: `projects/{p}/decisions/*.md` o ADRs
+   - Onboarding: `projects/{p}/onboarding.md`
+   - Reglas negocio: `projects/{p}/reglas-negocio.md`
+3. **Convertir markdown → Notion blocks**:
+   - Headings → heading blocks
+   - Tablas → table blocks
+   - Código → code blocks con lenguaje
+   - Listas → bulleted/numbered list blocks
+4. **Detectar páginas existentes** (buscar por título en database)
+5. **Presentar propuesta**:
+   ```
+   ## Sync → Notion — {proyecto}
+   | Acción | Documento | Página Notion |
+   |---|---|---|
+   | CREATE | specs/auth-oauth.md | (nueva) |
+   | UPDATE | reglas-negocio.md | Reglas de Negocio (mod. hace 3d) |
+   | SKIP | onboarding.md | Sin cambios |
+   ```
+6. **Confirmar con PM** → ejecutar sync
+
+## Pasos de ejecución — Import (from-notion)
+
+1. **Verificar conector** y resolver página/database
+2. **Leer contenido** de Notion usando el conector MCP
+3. **Convertir Notion blocks → markdown**
+4. **Guardar** en el directorio del proyecto:
+   - Si es spec → `projects/{p}/specs/{título}.md`
+   - Si es decisión → `projects/{p}/decisions/{título}.md`
+   - Si es genérico → `projects/{p}/docs/{título}.md`
+5. **Confirmar con PM** antes de sobrescribir ficheros existentes
+
+## Integración con otros comandos
+
+- `/spec:generate --publish-notion` → publica Spec en Notion tras generarla
+- `/team:onboarding --publish-notion` → publica guía en Notion
+- `/sprint:retro --publish-notion` → publica retrospectiva en Notion
+- `/pbi:prd --publish-notion` → publica PRD en Notion
+
+## Restricciones
+
+- **SIEMPRE confirmar antes de sobrescribir** (import puede pisar ficheros locales)
+- No eliminar páginas en Notion — solo crear y actualizar
+- No modificar databases (estructura) — solo páginas dentro de ellas
+- Si `--dry-run` → solo mostrar propuesta
+- Máximo 20 páginas por ejecución
+- No sincronizar secrets ni credenciales

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -27,7 +27,7 @@ GDRIVE_CONNECTOR_ENABLED    = false
 GDRIVE_REPORTS_FOLDER       = ""                                 # ID de carpeta para informes
 
 # ── Notion ───────────────────────────────────────────────────────────────────
-NOTION_CONNECTOR_ENABLED    = false
+NOTION_CONNECTOR_ENABLED    = true
 NOTION_DEFAULT_DATABASE     = ""                                 # ID de base de datos principal
 
 # ── Linear ───────────────────────────────────────────────────────────────────

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -66,6 +66,7 @@
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/sentry:health {--project p}` | Métricas de salud técnica desde Sentry: errores, crash rate, performance |
 | `/sentry:bugs {--project p}` | Crear PBIs (Bug) en Azure DevOps desde errores frecuentes en Sentry |
+| `/notion:sync {--project p}` | Sincronizar documentación del proyecto con Notion (import/export) |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 38 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 39 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 38 slash commands
+│   ├── commands/                ← 39 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
-│   │   ├── notify-slack.md ...  ← Conectores (4: Slack, Sentry)
+│   │   ├── notify-slack.md ...  ← Conectores (5: Slack, Sentry, Notion)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 38 slash commands
+│   ├── commands/                ← 39 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
-│   │   ├── notify-slack.md ...  ← Connectors (4: Slack, Sentry)
+│   │   ├── notify-slack.md ...  ← Connectors (5: Slack, Sentry, Notion)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/notion:sync` command — bidirectional documentation sync between project files and Notion databases
- Supports exporting specs, ADRs, onboarding guides, business rules to Notion and importing Notion pages as local markdown
- Integrates with existing commands via `--publish-notion` flag (spec:generate, team:onboarding, sprint:retro, pbi:prd)
- Enable Notion in `connectors-config.md`, update help catalog (Connectors 4→5), pm-workflow, CLAUDE.md counters (38→39), READMEs (ES/EN)

## Test plan

- [ ] Verify `/notion:sync --project sala-reservas --dry-run` shows connector activation instructions when not connected
- [ ] Verify `/help notion` filters to show Notion commands
- [ ] Run `scripts/validate-commands.sh` — all 39 commands pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)