### PR TITLE
feat: add Linear connector — issue sync with Azure DevOps

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
-   **Conectores (5):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}
+   **Conectores (6):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, gdrive, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, gdrive, linear, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/linear-sync.md
+++ b/.claude/commands/linear-sync.md
@@ -1,0 +1,92 @@
+---
+name: linear-sync
+description: >
+  Sincronizar issues de Linear con PBIs/Tasks de Azure DevOps.
+  Para equipos que usan Linear como tracker principal junto a Azure DevOps.
+---
+
+# Sync Linear ↔ Azure DevOps
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/linear:sync --project {p}` o `/linear:sync --project {p} --cycle {nombre}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--direction {linear-to-devops|devops-to-linear|bidirectional}` — Dirección (defecto: bidirectional)
+- `--cycle {nombre}` — Filtrar por ciclo de Linear (equivale a sprint)
+- `--team {nombre}` — Equipo de Linear (defecto: `LINEAR_DEFAULT_TEAM`)
+- `--label {etiqueta}` — Filtrar issues por label en Linear
+- `--dry-run` — Solo mostrar cambios propuestos
+- `--since {fecha}` — Solo sincronizar cambios desde esta fecha (YYYY-MM-DD)
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Linear habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `LINEAR_DEFAULT_TEAM`, `AZURE_DEVOPS_PROJECT`
+3. `projects/{proyecto}/equipo.md` — Para mapeo de asignaciones
+
+## Mapeo de campos
+
+| Linear | Azure DevOps |
+|---|---|
+| Title | Title (prefijado `[LIN#ID]`) |
+| Description (markdown) | Description |
+| Issue Type (Issue/Bug/Feature) | Work Item Type (Task/Bug/PBI) |
+| Priority (Urgent→Low) | Priority (1→4) |
+| Cycle | Iteration Path |
+| Assignee | Assigned To (mapeo via equipo.md) |
+| State | State (mapeo configurable) |
+| Estimate (puntos) | Story Points |
+| Labels | Tags |
+| Project | Area Path |
+| Parent Issue | Parent (Feature/PBI) |
+
+## Mapeo de estados (configurable)
+
+| Linear State | Azure DevOps State |
+|---|---|
+| Backlog / Triage | New |
+| Todo / In Progress / In Review | Active |
+| Done / Canceled | Closed |
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar Linear disponible
+2. **Leer configuración** del proyecto: LINEAR_DEFAULT_TEAM, mapeo de usuarios
+3. **Obtener issues** de Linear (filtro por cycle, team, label)
+4. **Obtener work items** de Azure DevOps (filtro por IterationPath)
+5. **Detectar correspondencias** por `[LIN#ID]` en título de DevOps
+6. **Calcular diff**:
+   - Nuevos en Linear → proponer crear en DevOps
+   - Nuevos en DevOps → proponer crear en Linear (si bidirectional)
+   - Cambios en ambos → detectar conflicto, proponer resolución
+7. **Presentar propuesta**:
+   ```
+   ## Sync Linear ↔ Azure DevOps — {proyecto}
+   | Acción | Linear | Azure DevOps | Campo |
+   |---|---|---|---|
+   | CREATE → | LIN-123 | (nuevo) | Feature: API Gateway |
+   | UPDATE → | LIN-124 | AB#456 | State: Done → Closed |
+   | ← UPDATE | (actualizar) | AB#789 | Estimate: 3 → 5 |
+   | ⚠️ CONFLICT | LIN-125 | AB#790 | Ambos modificados |
+   ```
+8. **Confirmar con PM** — NUNCA sincronizar sin confirmación
+9. Si confirmado → ejecutar cambios en ambos sistemas
+
+## Integración con otros comandos
+
+- `/sprint:plan` puede considerar issues de Linear como candidatos
+- `/board:flow` puede incluir métricas de cycle time de Linear
+- `/kpi:dashboard` puede agregar métricas de ambos trackers
+- Soporta `--notify-slack` para publicar resumen del sync
+
+## Restricciones
+
+- **NUNCA sincronizar sin confirmación** del PM
+- Conflictos se resuelven manualmente
+- Si `--dry-run` → solo mostrar propuesta
+- Máximo 50 items por ejecución
+- No eliminar issues en ningún sistema — solo crear y actualizar
+- No crear ciclos en Linear — solo usar existentes

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -31,7 +31,7 @@ NOTION_CONNECTOR_ENABLED    = false
 NOTION_DEFAULT_DATABASE     = ""                                 # ID de base de datos principal
 
 # ── Linear ───────────────────────────────────────────────────────────────────
-LINEAR_CONNECTOR_ENABLED    = false
+LINEAR_CONNECTOR_ENABLED    = true
 LINEAR_DEFAULT_TEAM         = ""                                 # Equipo Linear por defecto
 
 # ── Figma ────────────────────────────────────────────────────────────────────

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -67,6 +67,7 @@
 | `/sentry:health {--project p}` | Métricas de salud técnica desde Sentry: errores, crash rate, performance |
 | `/sentry:bugs {--project p}` | Crear PBIs (Bug) en Azure DevOps desde errores frecuentes en Sentry |
 | `/gdrive:upload {file}` | Subir informes y documentos generados a Google Drive |
+| `/linear:sync {--project p}` | Sincronizar issues Linear ↔ PBIs/Tasks Azure DevOps |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 39 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 40 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 39 slash commands
+│   ├── commands/                ← 40 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
-│   │   ├── notify-slack.md ...  ← Conectores (5: Slack, Sentry, GDrive)
+│   │   ├── notify-slack.md ...  ← Conectores (6: Slack, Sentry, GDrive, Linear)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 39 slash commands
+│   ├── commands/                ← 40 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
-│   │   ├── notify-slack.md ...  ← Connectors (5: Slack, Sentry, GDrive)
+│   │   ├── notify-slack.md ...  ← Connectors (6: Slack, Sentry, GDrive, Linear)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/linear:sync` command — bidirectional sync between Linear issues and Azure DevOps PBIs/Tasks with field mapping, cycle filtering, conflict detection, and dry-run support
- Supports Linear cycles mapped to Azure DevOps iteration paths, priority mapping, and state mapping
- Integrates with `/sprint:plan`, `/board:flow`, `/kpi:dashboard` for cross-tracker metrics
- Enable Linear in `connectors-config.md`, update help catalog (Connectors 5→6), pm-workflow, CLAUDE.md counters (39→40), READMEs (ES/EN)

## Test plan

- [ ] Verify `/linear:sync --project sala-reservas --dry-run` shows connector activation instructions when not connected
- [ ] Verify `/help linear` filters to show Linear commands
- [ ] Run `scripts/validate-commands.sh` — all 40 commands pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)