### PR TITLE
feat: add Figma connector — UI extraction and PBI generation

### DIFF
--- a/.claude/commands/figma-extract.md
+++ b/.claude/commands/figma-extract.md
@@ -1,0 +1,99 @@
+---
+name: figma-extract
+description: >
+  Extraer componentes UI y especificaciones de diseño desde Figma.
+  Genera PBIs de UI, inventario de componentes y guías de implementación.
+---
+
+# Extraer Diseño desde Figma
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/figma:extract {url} --project {p}` o `/figma:extract --project {p} --page {nombre}`
+
+## Parámetros
+
+- `{url}` — URL del fichero o frame de Figma
+- `--project {nombre}` — Proyecto de PM-Workspace
+- `--page {nombre}` — Filtrar por página dentro del fichero Figma
+- `--type {tipo}` — Tipo de extracción:
+  - `components` → inventario de componentes UI (nombre, props, variantes)
+  - `screens` → lista de pantallas/vistas con descripción
+  - `design-tokens` → colores, tipografía, spacing, breakpoints
+  - `user-flows` → flujos de usuario extraídos de frames
+  - `all` → extracción completa
+- `--generate-pbis` — Generar PBIs de UI desde los componentes/pantallas extraídos
+- `--dry-run` — Solo mostrar extracción, no crear PBIs
+
+## Contexto requerido
+
+1. `.claude/rules/connectors-config.md` — Verificar Figma habilitado
+2. `projects/{proyecto}/CLAUDE.md` — `FIGMA_DEFAULT_PROJECT`
+
+## Pasos de ejecución
+
+1. **Verificar conector** — Comprobar Figma disponible
+   - Si no activado → mostrar instrucciones de activación
+
+2. **Resolver fichero Figma**:
+   - Si `{url}` → extraer file key y node ID de la URL
+   - Si `--project` → buscar `FIGMA_DEFAULT_PROJECT` en CLAUDE.md
+   - Si `--page` → filtrar por nombre de página
+
+3. **Extraer estructura** usando el conector MCP de Figma:
+   - Obtener árbol de nodos (pages → frames → components)
+   - Identificar componentes, variantes y auto-layouts
+   - Extraer estilos aplicados (colores, fuentes, efectos)
+
+4. **Según --type**:
+
+   **components** →
+   ```
+   ## Inventario de Componentes — {proyecto}
+   | Componente | Variantes | Props | Usado en |
+   |---|---|---|---|
+   | Button | primary, secondary, ghost | label, icon, disabled | Login, Dashboard |
+   | Card | default, compact | title, body, actions | Products, Dashboard |
+   ```
+
+   **screens** →
+   ```
+   ## Pantallas — {proyecto}
+   | Pantalla | Componentes | Flujo | Notas |
+   |---|---|---|---|
+   | Login | Button, Input, Logo | Auth Flow | Responsive |
+   | Dashboard | Card, Chart, NavBar | Main Flow | Admin only |
+   ```
+
+   **design-tokens** →
+   ```
+   ## Design Tokens — {proyecto}
+   ### Colores
+   --primary: #2563EB | --secondary: #64748B | ...
+   ### Tipografía
+   Heading: Inter 24/32 Bold | Body: Inter 16/24 Regular | ...
+   ```
+
+5. Si `--generate-pbis` → proponer PBIs:
+   - 1 PBI por pantalla/vista principal
+   - Tasks por componente a implementar
+   - Incluir link al frame de Figma en la descripción
+   - **Confirmar con PM antes de crear** (Regla 7)
+
+6. **Guardar resultado** en `output/reports/YYYYMMDD-figma-{proyecto}.md`
+
+## Integración con otros comandos
+
+- `/diagram:generate` puede usar la estructura de Figma como input
+- `/pbi:decompose` puede descomponer los PBIs generados en tasks
+- `/spec:generate` puede incluir specs de UI desde Figma
+- Soporta `--notify-slack` para publicar resumen
+
+## Restricciones
+
+- **Solo lectura** — no modificar ficheros en Figma
+- **NUNCA crear PBIs sin confirmación** del PM (Regla 7)
+- Si `--dry-run` → solo mostrar extracción
+- No descargar imágenes/assets (solo metadatos y estructura)
+- No acceder a proyectos Figma sin URL o config explícita
+- Máximo 100 componentes por extracción (paginación si más)

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,9 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
-   **Conectores (5):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}
+   **Conectores (6):** notify:slack {canal} {msg}, slack:search {query}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, gdrive, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, sentry, gdrive, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/rules/connectors-config.md
+++ b/.claude/rules/connectors-config.md
@@ -35,7 +35,7 @@ LINEAR_CONNECTOR_ENABLED    = false
 LINEAR_DEFAULT_TEAM         = ""                                 # Equipo Linear por defecto
 
 # ── Figma ────────────────────────────────────────────────────────────────────
-FIGMA_CONNECTOR_ENABLED     = false
+FIGMA_CONNECTOR_ENABLED     = true
 FIGMA_DEFAULT_PROJECT       = ""                                 # Proyecto Figma por defecto
 ```
 

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -67,6 +67,7 @@
 | `/sentry:health {--project p}` | Métricas de salud técnica desde Sentry: errores, crash rate, performance |
 | `/sentry:bugs {--project p}` | Crear PBIs (Bug) en Azure DevOps desde errores frecuentes en Sentry |
 | `/gdrive:upload {file}` | Subir informes y documentos generados a Google Drive |
+| `/figma:extract {url}` | Extraer componentes UI, pantallas y design tokens desde Figma |
 | `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
 
 ## 🔗 Referencias

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 39 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 40 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 11 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 39 slash commands
+│   ├── commands/                ← 40 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
-│   │   ├── notify-slack.md ...  ← Conectores (5: Slack, Sentry, GDrive)
+│   │   ├── notify-slack.md ...  ← Conectores (6: Slack, Sentry, GDrive, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
 │   │       ├── command-catalog.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 39 slash commands
+│   ├── commands/                ← 40 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,7 +22,7 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
-│   │   ├── notify-slack.md ...  ← Connectors (5: Slack, Sentry, GDrive)
+│   │   ├── notify-slack.md ...  ← Connectors (6: Slack, Sentry, GDrive, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
 │   │       ├── command-catalog.md


### PR DESCRIPTION
## Summary

- Add `/figma:extract` command — extract UI components, screens, design tokens, and user flows from Figma files
- Supports `--generate-pbis` to create PBIs from extracted design structure (1 PBI per screen, tasks per component)
- Extraction types: components inventory, screens list, design tokens, user flows
- Integrates with `/diagram:generate`, `/pbi:decompose`, `/spec:generate` for end-to-end design-to-code workflow
- Enable Figma in `connectors-config.md`, update help catalog (Connectors 5→6), pm-workflow, CLAUDE.md counters (39→40), READMEs (ES/EN)

## Test plan

- [ ] Verify `/figma:extract --project sala-reservas --type components --dry-run` shows connector activation instructions when not connected
- [ ] Verify `/help figma` filters to show Figma commands
- [ ] Run `scripts/validate-commands.sh` — all 40 commands pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)