### PR TITLE
feat: Azure Pipelines CI/CD commands and skill

### DIFF
--- a/.claude/commands/pipeline-artifacts.md
+++ b/.claude/commands/pipeline-artifacts.md
@@ -1,0 +1,65 @@
+---
+name: pipeline-artifacts
+description: >
+  Listar y descargar artefactos de una build de Azure Pipelines.
+  Soporta filtro por nombre y tipo.
+---
+
+# Pipeline Artifacts
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/pipeline:artifacts --project {p} --build {id}` o `/pipeline:artifacts --project {p} --pipeline {name}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--build {id}` — ID de la build (obligatorio, salvo `--pipeline`)
+- `--pipeline {nombre}` — Nombre de pipeline (usa última build con artefactos)
+- `--name {nombre}` — Filtrar por nombre de artefacto
+- `--download` — Descargar artefactos a `output/artifacts/`
+- `--list-only` — Solo listar, no descargar (defecto)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Nombre del proyecto en DevOps
+2. `.claude/skills/azure-pipelines/SKILL.md` — MCP tools
+
+## Pasos de ejecución
+
+1. **Resolver build:**
+   - Si `--build {id}` → usar directamente
+   - Si `--pipeline {name}` → MCP `get_builds` con `statusFilter=completed`
+     → primera build con artefactos
+2. **Listar artefactos** — MCP `list_artifacts`:
+   - Nombre, tipo, tamaño, fecha
+3. **Presentar listado:**
+
+```
+## Artefactos — Build #143 (backend-ci)
+
+| Nombre | Tipo | Tamaño | Fecha |
+|---|---|---|---|
+| drop | Build | 45.2 MB | 2026-02-27 10:28 |
+| test-results | Pipeline | 2.1 MB | 2026-02-27 10:27 |
+| coverage-report | Pipeline | 1.5 MB | 2026-02-27 10:27 |
+```
+
+4. **Si `--download`:**
+   - MCP `download_artifacts` para cada artefacto (o el filtrado)
+   - Guardar en `output/artifacts/{proyecto}/{build-id}/{nombre}/`
+   - Mostrar rutas de descarga
+5. **Si `--list-only`** → solo mostrar tabla
+
+## Integración
+
+- `/pipeline:logs --build {id}` → ver logs de la build
+- `/pipeline:status` → contexto del pipeline
+- Artefactos de test → correlacionar con `/kpi:dashboard` (coverage)
+
+## Restricciones
+
+- Descarga requiere espacio en disco — advertir si > 100 MB
+- NO descargar artefactos de builds de terceros (solo del proyecto)
+- Guardar siempre en `output/artifacts/` con estructura organizada
+- Artefactos de tipo `drop` pueden contener binarios grandes → confirmar descarga

--- a/.claude/commands/pipeline-create.md
+++ b/.claude/commands/pipeline-create.md
@@ -1,0 +1,80 @@
+---
+name: pipeline-create
+description: >
+  Crear una nueva pipeline en Azure Pipelines desde template YAML.
+  Preview y confirmación antes de crear.
+---
+
+# Pipeline Create
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/pipeline:create --project {p} --name {n} --repo {r}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--name {nombre}` — Nombre de la pipeline (obligatorio)
+- `--repo {nombre}` — Repositorio que contiene el YAML (obligatorio)
+- `--yaml-path {path}` — Ruta al fichero YAML (defecto: `azure-pipelines.yml`)
+- `--template {tipo}` — Template base: `build-test`, `multi-env`, `pr-validation`, `nightly`
+- `--language {lang}` — Lenguaje del proyecto (para adaptar template)
+- `--branch {rama}` — Rama por defecto (defecto: main)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Nombre del proyecto en DevOps, Language Pack
+2. `.claude/skills/azure-pipelines/SKILL.md` — Templates y patrones
+3. Skill `azure-pipelines` → `yaml-templates.md` — Templates YAML
+
+## Pasos de ejecución
+
+1. **Seleccionar template** según `--template` o inferir del proyecto:
+   - Si tiene entornos (DEV/PRE/PRO) → `multi-env`
+   - Si es librería/package → `build-test`
+   - Si solo validación de PRs → `pr-validation`
+2. **Adaptar template** al lenguaje del proyecto:
+   - Leer Language Pack del proyecto
+   - Ajustar: SDK version, build command, test command, publish
+3. **Generar YAML** adaptado y presentar al PM:
+
+```
+## Nueva Pipeline — {nombre}
+
+Template: multi-env ({language})
+Repo: {repo} (branch: main)
+YAML path: azure-pipelines.yml
+
+### YAML generado:
+(mostrar YAML completo)
+
+### Stages:
+1. Build → dotnet build
+2. Test → dotnet test (coverage >= 80%)
+3. Deploy DEV → auto
+4. Deploy PRE → approval: tech-lead
+5. Deploy PRO → approval: PM + PO
+```
+
+4. **Confirmar con PM:**
+   - ¿Crear pipeline con este YAML?
+   - ¿Necesita variables adicionales?
+   - ¿Ajustar triggers?
+5. **Preview** — MCP `preview_pipeline_run` para validar YAML
+6. **Crear** — MCP `create_pipeline`:
+   - Nombre, repositorio, YAML path, branch
+7. **Resultado:** link a la pipeline creada en Azure DevOps
+
+## Restricciones
+
+- **NUNCA crear sin confirmación** del PM
+- El YAML se genera como propuesta — el PM puede editar
+- No configurar approval gates automáticamente (eso requiere Azure DevOps UI)
+- Si el repo no existe en Azure Repos → informar y sugerir crearlo
+- Sugerir crear también la pipeline de PR Validation junto a la principal
+
+## Integración
+
+- `/pipeline:status` → verificar que la pipeline aparece
+- `/pipeline:run` → ejecutar primera build
+- `/env:setup` → configurar entornos si no existen

--- a/.claude/commands/pipeline-logs.md
+++ b/.claude/commands/pipeline-logs.md
@@ -1,0 +1,77 @@
+---
+name: pipeline-logs
+description: >
+  Ver logs de una build de Azure Pipelines: timeline de stages,
+  errores, warnings y duración por paso.
+---
+
+# Pipeline Logs
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/pipeline:logs --project {p} --build {id}` o `/pipeline:logs --project {p} --pipeline {name}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--build {id}` — ID de la build (obligatorio, salvo `--pipeline`)
+- `--pipeline {nombre}` — Nombre de pipeline (usa última build)
+- `--stage {nombre}` — Filtrar logs de un stage específico
+- `--errors-only` — Mostrar solo errores y warnings
+- `--tail {n}` — Últimas N líneas de cada step (defecto: 50)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Nombre del proyecto en DevOps
+2. `.claude/skills/azure-pipelines/SKILL.md` — MCP tools
+
+## Pasos de ejecución
+
+1. **Resolver build:**
+   - Si `--build {id}` → usar directamente
+   - Si `--pipeline {name}` → MCP `get_builds` top=1 → última build
+2. **Obtener status** — MCP `get_build_status`:
+   - Estado global, duración, resultado
+   - Timeline: stages → jobs → steps
+3. **Obtener logs** — MCP `get_build_logs`:
+   - Para cada step relevante (o filtrado por `--stage`)
+   - Extraer errores (líneas con `##[error]`)
+   - Extraer warnings (`##[warning]`)
+4. **Presentar resumen:**
+
+```
+## Build #143 — backend-ci — FAILED (12m 34s)
+
+Branch: main | Trigger: CI | Started: 2026-02-27 10:15
+
+### Timeline
+| Stage | Job | Status | Duración |
+|---|---|---|---|
+| Build | BuildJob | succeeded | 3m 12s |
+| Test | UnitTests | failed | 8m 55s |
+| Deploy DEV | — | skipped | — |
+
+### Errores (2)
+1. [Test/UnitTests] Step "Run tests":
+   `FAIL: AuthServiceTest.TestOAuthFlow — Expected 200, got 401`
+2. [Test/UnitTests] Step "Run tests":
+   `FAIL: AuthServiceTest.TestRefreshToken — Timeout after 30s`
+
+### Warnings (1)
+- [Build/BuildJob] Step "Restore packages":
+  `Package Newtonsoft.Json 13.0.1 is deprecated`
+```
+
+5. **Si `--errors-only`** → mostrar solo secciones de errores y warnings
+
+## Integración
+
+- `/pipeline:run` → re-ejecutar si el fallo es transitorio
+- `/pipeline:status` → contexto global del pipeline
+- `/sentry:health` → correlacionar errores de build con errores en runtime
+
+## Restricciones
+
+- Solo lectura — no modifica nada
+- Logs pueden ser extensos → limitar con `--tail` y `--stage`
+- NO mostrar variables secretas que aparezcan en logs (reemplazar con `***`)

--- a/.claude/commands/pipeline-run.md
+++ b/.claude/commands/pipeline-run.md
@@ -1,0 +1,75 @@
+---
+name: pipeline-run
+description: >
+  Ejecutar una pipeline de Azure Pipelines con confirmación previa.
+  Soporta selección de branch, variables y stages.
+---
+
+# Pipeline Run
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/pipeline:run --project {p} {pipeline}` o `/pipeline:run --project {p} {pipeline} --branch {b}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `{pipeline}` — Nombre o ID de la pipeline (obligatorio)
+- `--branch {rama}` — Rama source (defecto: main)
+- `--variables {key=val,...}` — Variables override (opcional)
+- `--stage {nombre}` — Ejecutar solo un stage específico (opcional)
+- `--watch` — Monitorizar estado hasta completar (opcional)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Nombre del proyecto en DevOps
+2. `.claude/skills/azure-pipelines/SKILL.md` — MCP tools y reglas
+
+## Pasos de ejecución
+
+1. **Resolver pipeline** — MCP `get_build_definitions` → buscar por nombre
+   - Si no se encuentra → listar disponibles y pedir selección
+2. **Preview** — MCP `preview_pipeline_run`:
+   - Stages que se ejecutarán
+   - Variables efectivas
+   - Rama source
+   - Pool/agent
+3. **Presentar confirmación:**
+
+```
+## Ejecutar Pipeline — {nombre}
+
+- Pipeline: backend-ci (#definitionId)
+- Branch: feature/auth-oauth
+- Stages: Build → Test → Deploy DEV
+- Variables: ENV=dev, DEBUG=false
+- Estimación: ~8 min (basado en media)
+
+⚠️ ¿Confirmar ejecución? (S/N)
+```
+
+4. **CONFIRMAR con PM** → NUNCA ejecutar sin confirmación (regla 3)
+5. **Ejecutar** — MCP `run_pipeline` con parámetros confirmados
+6. **Resultado inmediato:**
+   - Build ID y link directo a Azure DevOps
+   - Si `--watch` → polling cada 15s con `get_build_status`
+7. **Si `--watch`** → mostrar progreso:
+   ```
+   Build #143 — In Progress (3m 22s)
+   Stage Build: succeeded (2m 10s)
+   Stage Test: in progress...
+   ```
+
+## Restricciones
+
+- **NUNCA ejecutar sin confirmación** del PM
+- **Deploys a PRO:** requieren mención explícita del PBI/Release
+- Variables con `isSecret=true` NO se muestran en el preview
+- Si la pipeline requiere approval gates → informar que se necesitará aprobación manual en Azure DevOps
+- Timeout de `--watch`: 30 minutos máximo
+
+## Integración
+
+- `/pipeline:status` → ver resultado tras ejecución
+- `/pipeline:logs --build {id}` → si falla, ver logs
+- `/notify:slack` → notificar al canal del proyecto

--- a/.claude/commands/pipeline-status.md
+++ b/.claude/commands/pipeline-status.md
@@ -1,0 +1,69 @@
+---
+name: pipeline-status
+description: >
+  Estado de pipelines del proyecto: últimas builds, % éxito,
+  duración media y alertas de fallos recientes.
+---
+
+# Pipeline Status
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/pipeline:status --project {p}` o `/pipeline:status --project {p} --pipeline {name}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--pipeline {nombre}` — Pipeline específica (opcional, si no: todas)
+- `--last {n}` — Últimas N builds por pipeline (defecto: 5)
+- `--branch {rama}` — Filtrar por rama (opcional)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — `AZURE_REPOS_PROJECT` o nombre DevOps
+2. `.claude/skills/azure-pipelines/SKILL.md` — Referencia de estados y MCP tools
+
+## Pasos de ejecución
+
+1. **Leer proyecto** → resolver nombre en Azure DevOps
+2. **MCP `get_build_definitions`** → listar pipelines del proyecto
+3. **Para cada pipeline** (o la específica si `--pipeline`):
+   - MCP `get_builds` con `top=N` (defecto 5)
+   - Calcular métricas:
+     - % éxito (succeeded / total)
+     - Duración media
+     - Última ejecución (fecha + resultado)
+     - Trend (mejorando / empeorando / estable)
+4. **Detectar alertas:**
+   - Build fallida en últimas 24h → alerta roja
+   - Duración > 150% de la media → alerta amarilla
+   - Pipeline sin ejecutar > 7 días → alerta gris
+   - Coverage < `TEST_COVERAGE_MIN_PERCENT` → alerta naranja
+5. **Presentar resumen:**
+
+```
+## Pipeline Status — {proyecto}
+
+| Pipeline | Última build | Estado | % Éxito | Duración media | Alertas |
+|---|---|---|---|---|---|
+| backend-ci | #142 (hace 2h) | succeeded | 95% | 8m 23s | — |
+| frontend-ci | #89 (hace 1d) | failed | 78% | 12m 10s | Build fallida |
+| deploy-pre | #34 (hace 5d) | succeeded | 100% | 3m 45s | Sin ejecutar >5d |
+
+### Alertas activas
+- backend-ci: Coverage 72% (< 80% mínimo)
+- frontend-ci: Build #89 fallida hace 1d — revisar con `/pipeline:logs --project {p} --build 89`
+```
+
+## Integración con otros comandos
+
+- `/pipeline:logs --build {id}` → ver logs de build fallida
+- `/pipeline:run {pipeline}` → re-ejecutar pipeline
+- `/kpi:dashboard` → incluye métricas de pipelines
+- `/sprint:status` → muestra alertas de CI/CD si hay fallos
+
+## Restricciones
+
+- Solo lectura — no modifica nada
+- Si no hay pipelines configuradas → informar y sugerir `/pipeline:create`
+- Máximo 20 pipelines mostradas (ordenar por última actividad)

--- a/.claude/skills/azure-pipelines/SKILL.md
+++ b/.claude/skills/azure-pipelines/SKILL.md
@@ -1,0 +1,110 @@
+# Skill: azure-pipelines
+
+> Skill para gestión de CI/CD con Azure Pipelines via MCP.
+> Léela antes de cualquier operación con pipelines.
+
+## Contexto
+
+Azure Pipelines gestiona builds y releases de los proyectos.
+PM-Workspace accede via el MCP `azure-devops` (ya declarado en `mcp.json`).
+
+**MCP tools de pipelines disponibles:**
+- `get_build_definitions` — listar pipelines del proyecto
+- `get_builds` — listar builds (filtrar por pipeline, branch, status)
+- `get_build_status` — estado de una build específica
+- `get_build_logs` — logs de una build (timeline + contenido)
+- `run_pipeline` — ejecutar una pipeline (requiere confirmación PM)
+- `preview_pipeline_run` — preview de qué se ejecutará (sin ejecutar)
+- `create_pipeline` — crear pipeline desde YAML
+- `list_artifacts` — artefactos de una build
+- `download_artifacts` — descargar artefactos
+
+---
+
+## 1. Autenticación
+
+Usa el mismo PAT de Azure DevOps configurado en `pm-config.md`.
+
+**Scopes requeridos:** `Build R/W` (además de los existentes).
+
+```bash
+# El MCP lee el PAT del entorno automáticamente
+# Verificar: el PAT debe tener scope "Build (Read & Execute)"
+```
+
+---
+
+## 2. Reglas Críticas
+
+1. **NUNCA ejecutar pipeline sin confirmación** del PM (regla 3)
+2. **SIEMPRE preview antes de run** — usar `preview_pipeline_run`
+3. **Deploys a PRO** requieren doble confirmación + link al PBI/Release
+4. **Variables sensibles** (secrets) NO se muestran en logs
+5. **Artefactos** se guardan en `output/artifacts/{proyecto}/{build-id}/`
+
+---
+
+## 3. Patrones de uso
+
+### Obtener estado de pipelines
+```
+MCP: get_build_definitions(project=PROYECTO)
+→ Para cada definition: get_builds(project, definitionId, top=5)
+→ Calcular: % éxito, duración media, trends
+```
+
+### Ejecutar pipeline
+```
+MCP: preview_pipeline_run(project, pipelineId, branch)
+→ Mostrar resumen al PM → Confirmar
+→ MCP: run_pipeline(project, pipelineId, branch, variables)
+→ MCP: get_build_status(project, buildId) [polling si --watch]
+```
+
+### Crear pipeline
+```
+1. Seleccionar template (references/yaml-templates.md)
+2. Adaptar al proyecto (lenguaje, tests, deploy targets)
+3. MCP: preview_pipeline_run → validar YAML
+4. Confirmar con PM
+5. MCP: create_pipeline(project, name, yamlPath, repository)
+```
+
+---
+
+## 4. Interpretación de estados
+
+| Build Status | Significado | Acción PM |
+|---|---|---|
+| `succeeded` | Build OK | Ninguna |
+| `partiallySucceeded` | Warnings o tests flaky | Revisar logs |
+| `failed` | Error en build/test | Investigar + crear Bug si recurrente |
+| `canceled` | Cancelado por usuario/timeout | Verificar causa |
+| `inProgress` | Ejecutándose | Esperar o monitorizar |
+| `notStarted` | En cola | Normal si hay carga |
+
+---
+
+## 5. Multi-entorno (DEV → PRE → PRO)
+
+Los pipelines multi-stage siguen el patrón:
+
+```
+Build → Test → Deploy DEV (auto) → Deploy PRE (approval) → Deploy PRO (approval)
+```
+
+Ver `references/stage-patterns.md` para patrones detallados.
+
+**Gates de aprobación:**
+- DEV: automático tras build+test OK
+- PRE: aprobación del tech lead
+- PRO: aprobación del PM + PO (doble gate)
+
+---
+
+## 6. Referencias
+
+- Templates YAML: `references/yaml-templates.md`
+- Patrones de stages: `references/stage-patterns.md`
+- Config entornos: `@.claude/rules/environment-config.md`
+- MCP Azure DevOps: `@.claude/mcp.json`

--- a/.claude/skills/azure-pipelines/references/stage-patterns.md
+++ b/.claude/skills/azure-pipelines/references/stage-patterns.md
@@ -1,0 +1,103 @@
+# Patrones de Stages Multi-Entorno
+
+> Patrones para pipelines con deploy a DEV/PRE/PRO.
+
+---
+
+## 1. Flujo estándar (3 entornos)
+
+```
+Build → Test → Deploy DEV → Deploy PRE → Deploy PRO
+         │         │              │              │
+         │    (automático)   (approval:      (approval:
+         │                   tech-lead)      PM + PO)
+         │
+    coverage >= 80%
+```
+
+### Gates de aprobación
+
+| Entorno | Gate | Aprobadores | Timeout |
+|---|---|---|---|
+| DEV | Automático | Ninguno (si build OK) | — |
+| PRE | Manual | Tech Lead del proyecto | 48h |
+| PRO | Manual (doble) | PM + Product Owner | 72h |
+
+### Conditions recomendadas
+
+```yaml
+# Deploy DEV: solo si build OK
+condition: succeeded()
+
+# Deploy PRE: solo si DEV OK + rama main
+condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+
+# Deploy PRO: solo si PRE OK + tag de release
+condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+```
+
+---
+
+## 2. Patrón Canary (PRO)
+
+```yaml
+- stage: DeployPRO_Canary
+  dependsOn: DeployPRE
+  jobs:
+    - deployment: Canary
+      environment: 'PRO-Canary'
+      strategy:
+        canary:
+          increments: [10, 50]
+          deploy:
+            steps:
+              - script: echo "Deploy canary"
+          on:
+            success:
+              steps:
+                - script: echo "Promote to 100%"
+            failure:
+              steps:
+                - script: echo "Rollback canary"
+```
+
+---
+
+## 3. Patrón Blue-Green (PRO)
+
+```
+1. Deploy a slot "staging" (Blue)
+2. Smoke tests automáticos
+3. Swap slots (Blue ↔ Green)
+4. Si falla → swap back (rollback instantáneo)
+```
+
+---
+
+## 4. Variables por entorno
+
+```yaml
+variables:
+  - name: environment
+    value: 'DEV'
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+    - group: 'pre-variables'
+    - name: environment
+      value: 'PRE'
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
+    - group: 'pro-variables'
+    - name: environment
+      value: 'PRO'
+```
+
+---
+
+## 5. Integración con PM-Workspace
+
+| Evento pipeline | Acción PM-Workspace |
+|---|---|
+| Build fallida | `/pipeline:logs` → investigar → crear Bug si recurrente |
+| Deploy PRE OK | Notificar equipo → preparar Sprint Review demo |
+| Deploy PRO OK | Actualizar PBI state → Closed |
+| Approval pendiente | `/pipeline:status` muestra alerta |
+| Coverage < 80% | Alerta en `/kpi:dashboard` |

--- a/.claude/skills/azure-pipelines/references/yaml-templates.md
+++ b/.claude/skills/azure-pipelines/references/yaml-templates.md
@@ -1,0 +1,148 @@
+# Templates YAML para Azure Pipelines
+
+> Plantillas base para pipelines comunes. Adaptar al lenguaje y proyecto.
+
+---
+
+## 1. Build + Test (genérico)
+
+```yaml
+trigger:
+  branches:
+    include: [main, develop]
+  paths:
+    exclude: [docs/*, README.md]
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: Build
+    jobs:
+      - job: BuildAndTest
+        steps:
+          - task: UseDotNet@2       # Ajustar al lenguaje
+            inputs:
+              version: '8.x'
+          - script: dotnet build --configuration Release
+            displayName: 'Build'
+          - script: dotnet test --configuration Release --collect:"XPlat Code Coverage"
+            displayName: 'Test'
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'VSTest'
+              testResultsFiles: '**/*.trx'
+          - task: PublishCodeCoverageResults@2
+            inputs:
+              summaryFileLocation: '**/coverage.cobertura.xml'
+```
+
+## 2. Build + Deploy multi-entorno
+
+```yaml
+trigger:
+  branches:
+    include: [main]
+
+variables:
+  - group: 'common-variables'
+
+stages:
+  - stage: Build
+    jobs:
+      - job: Build
+        steps:
+          - script: echo "Build steps here"
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+              ArtifactName: 'drop'
+
+  - stage: DeployDEV
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - deployment: Deploy
+        environment: 'DEV'
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: echo "Deploy to DEV"
+
+  - stage: DeployPRE
+    dependsOn: DeployDEV
+    condition: succeeded()
+    jobs:
+      - deployment: Deploy
+        environment: 'PRE'    # Requires approval gate
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: echo "Deploy to PRE"
+
+  - stage: DeployPRO
+    dependsOn: DeployPRE
+    condition: succeeded()
+    jobs:
+      - deployment: Deploy
+        environment: 'PRO'    # Requires PM + PO approval
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: echo "Deploy to PRO"
+```
+
+## 3. PR Validation
+
+```yaml
+trigger: none
+pr:
+  branches:
+    include: [main, develop]
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+jobs:
+  - job: Validate
+    steps:
+      - script: echo "Lint + Build + Test"
+      - script: echo "Security scan"
+      - script: echo "Code coverage check >= $(TEST_COVERAGE_MIN)"
+```
+
+## 4. Scheduled (nightly)
+
+```yaml
+trigger: none
+schedules:
+  - cron: '0 2 * * 1-5'
+    displayName: 'Nightly build'
+    branches:
+      include: [main]
+    always: true
+
+stages:
+  - stage: NightlyBuild
+    jobs:
+      - job: FullSuite
+        timeoutInMinutes: 60
+        steps:
+          - script: echo "Full test suite + integration tests"
+          - script: echo "Dependency vulnerability scan"
+          - script: echo "Performance benchmarks"
+```
+
+---
+
+## Selección de template
+
+| Caso | Template | Trigger |
+|---|---|---|
+| Proyecto nuevo sin deploy | Build + Test | Push a main/develop |
+| Proyecto con entornos | Build + Deploy multi-entorno | Push a main |
+| Validación de PRs | PR Validation | PR a main/develop |
+| Tests nocturnos | Scheduled | Cron L-V 02:00 |


### PR DESCRIPTION
## Summary
- Add **5 new pipeline commands**: `pipeline:status`, `pipeline:run`, `pipeline:logs`, `pipeline:create`, `pipeline:artifacts`
- Add **azure-pipelines skill** with YAML templates (build+test, multi-env, PR validation, nightly) and stage patterns (DEV→PRE→PRO with approval gates)
- All commands use the Azure DevOps MCP (`@azure-devops/mcp`) for pipeline operations
- `pipeline:run` requires PM confirmation before execution (rule 3)
- `pipeline:create` generates YAML from templates adapted to project language

## Test plan
- [ ] Validate all 5 commands pass `scripts/validate-commands.sh` (0 errors)
- [ ] Verify `/pipeline:status` reads build definitions from MCP
- [ ] Verify `/pipeline:run` shows preview and requires confirmation
- [ ] Verify `/pipeline:create` generates correct YAML for project language
- [ ] Verify skill references are complete and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)