### PR TITLE
feat: Azure Repos commands and dual Git provider

### DIFF
--- a/.claude/commands/repos-branches.md
+++ b/.claude/commands/repos-branches.md
@@ -1,0 +1,59 @@
+---
+name: repos-branches
+description: >
+  Gestión de branches en Azure Repos: listar, crear, comparar
+  y verificar políticas de branch.
+---
+
+# Repos Branches
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/repos:branches --project {p} --repo {r}` o `/repos:branches --project {p} --repo {r} --create {name}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--repo {nombre}` — Repositorio (obligatorio, o usa `AZURE_REPOS_DEFAULT_REPO`)
+- `--create {nombre}` — Crear nueva branch (formato: `feature/#XXXX-desc`)
+- `--from {ref}` — Branch origen para `--create` (defecto: main)
+- `--compare {branch1} {branch2}` — Comparar dos branches
+- `--active-only` — Solo branches con actividad reciente (< 30 días)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — `AZURE_REPOS_PROJECT`, `AZURE_REPOS_DEFAULT_REPO`
+2. @.claude/rules/azure-repos-config.md — Convenciones de naming
+
+## Pasos de ejecución
+
+### Listar branches
+1. **MCP `list_branches`** → branches del repo
+2. **Clasificar:**
+   - Activas (commit < 30d)
+   - Stale (commit > 30d)
+   - Ahead/behind respecto a main
+3. **Presentar:**
+
+```
+## Branches — {repo}
+
+| Branch | Último commit | Ahead/Behind | Autor |
+|---|---|---|---|
+| main | hace 2h | — | — |
+| feature/#1234-auth | hace 1d | +5 / -0 | Ana García |
+| fix/#1235-login | hace 3d | +2 / -3 | Pedro López |
+| (stale) old-feature | hace 45d | +12 / -28 | — |
+```
+
+### Crear branch
+1. **Validar naming** contra patrón `BRANCH_PATTERN`
+2. **Verificar** que no existe ya
+3. **MCP `create_branch`** desde `--from`
+4. **Confirmar** creación con link
+
+## Restricciones
+
+- Crear branch requiere confirmación del PM (regla 3)
+- Branch naming debe seguir convención: `feature/#XXXX-desc` o `fix/#XXXX-desc`
+- No eliminar branches — solo listar y crear

--- a/.claude/commands/repos-list.md
+++ b/.claude/commands/repos-list.md
@@ -1,0 +1,50 @@
+---
+name: repos-list
+description: >
+  Listar repositorios del proyecto en Azure DevOps con estadísticas
+  de actividad, tamaño y última actualización.
+---
+
+# Repos List
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/repos:list --project {p}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--sort {campo}` — Ordenar por: `name`, `updated`, `size` (defecto: updated)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — `AZURE_REPOS_PROJECT`
+2. @.claude/rules/azure-repos-config.md — Config de Azure Repos
+
+## Pasos de ejecución
+
+1. **Leer proyecto** → resolver nombre en Azure DevOps
+2. **MCP `list_repositories`** → obtener repos del proyecto
+3. **Para cada repo:**
+   - Nombre, URL de clone, rama por defecto
+   - Tamaño del repo
+   - Última fecha de push
+4. **Presentar tabla:**
+
+```
+## Repositorios — {proyecto}
+
+| Repo | Rama default | Último push | Tamaño |
+|---|---|---|---|
+| backend-api | main | hace 2h | 45 MB |
+| frontend-app | main | hace 1d | 23 MB |
+| shared-libs | develop | hace 5d | 8 MB |
+| infra-terraform | main | hace 2w | 3 MB |
+
+Total: 4 repositorios
+```
+
+## Restricciones
+
+- Solo lectura
+- No mostrar repos archivados salvo petición explícita

--- a/.claude/commands/repos-pr-create.md
+++ b/.claude/commands/repos-pr-create.md
@@ -1,0 +1,80 @@
+---
+name: repos-pr-create
+description: >
+  Crear Pull Request en Azure Repos con linking automático
+  a work items, asignación de reviewers y auto-complete.
+---
+
+# Repos PR Create
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/repos:pr-create --project {p} --repo {r}` o con todos los params
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--repo {nombre}` — Repositorio (obligatorio o `AZURE_REPOS_DEFAULT_REPO`)
+- `--source {branch}` — Rama source (obligatorio)
+- `--target {branch}` — Rama target (defecto: main)
+- `--title {título}` — Título del PR (o inferir de commits)
+- `--description {desc}` — Descripción (o generar desde commits)
+- `--work-items {ids}` — IDs de work items a vincular (AB#1234,AB#1235)
+- `--reviewers {emails}` — Reviewers (o asignar desde equipo.md)
+- `--auto-complete` — Activar auto-complete tras aprobaciones
+- `--draft` — Crear como draft PR
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del repo
+2. `projects/{proyecto}/equipo.md` — Reviewers disponibles
+3. @.claude/rules/azure-repos-config.md — Políticas y convenciones
+
+## Pasos de ejecución
+
+1. **Resolver repo y branches**
+2. **Verificar PR duplicado** — MCP `list_pull_requests` filtrando por source
+   - Si existe → informar y mostrar link
+3. **Inferir datos si no se proporcionan:**
+   - Título: del patrón `[AB#XXXX] Descripción` o del último commit
+   - Descripción: resumen de commits entre source y target
+   - Work items: extraer `AB#XXXX` de commits
+   - Reviewers: del equipo.md (tech lead + 1 developer)
+4. **Presentar propuesta:**
+
+```
+## Nuevo PR — {repo}
+
+- Source: feature/#1234-auth-oauth
+- Target: main
+- Título: [AB#1234] Implementar OAuth 2.0
+- Work items: AB#1234, AB#1235
+- Reviewers: Ana García, Pedro López
+- Auto-complete: Sí
+- Draft: No
+
+### Commits incluidos (3):
+- feat: add OAuth provider configuration
+- feat: implement token refresh flow
+- test: add OAuth integration tests
+
+¿Crear PR? (S/N)
+```
+
+5. **CONFIRMAR con PM** → NUNCA crear sin confirmación
+6. **MCP `create_pull_request`** con todos los datos
+7. **Si `--auto-complete`** → MCP `update_pull_request` con auto-complete
+8. **Resultado:** link al PR creado
+
+## Integración
+
+- `/repos:pr-list` → ver PRs del repo
+- `/repos:pr-review` → review multi-perspectiva del PR
+- `/pipeline:status` → verificar que la build de validación pasa
+
+## Restricciones
+
+- **NUNCA crear PR sin confirmación** del PM
+- Validar naming del título según `PR_TITLE_PATTERN`
+- Si no hay work items vinculados → warning (política lo recomienda)
+- Si la build de validación falla → advertir antes de crear

--- a/.claude/commands/repos-pr-list.md
+++ b/.claude/commands/repos-pr-list.md
@@ -1,0 +1,66 @@
+---
+name: repos-pr-list
+description: >
+  Listar Pull Requests en Azure Repos: pendientes, asignados
+  al PM, por reviewer, con estado de builds y votos.
+---
+
+# Repos PR List
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/repos:pr-list --project {p}` o `/repos:pr-list --project {p} --repo {r} --status {s}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--repo {nombre}` — Repositorio específico (opcional, si no: todos)
+- `--status {estado}` — Filtro: `active`, `completed`, `abandoned`, `all` (defecto: active)
+- `--assigned-to-me` — Solo PRs donde el PM es reviewer
+- `--created-by {email}` — Filtrar por creador
+- `--last {n}` — Últimos N PRs (defecto: 20)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — `AZURE_REPOS_PROJECT`
+2. @.claude/rules/pm-config.md — `AZURE_DEVOPS_PM_USER` (para --assigned-to-me)
+
+## Pasos de ejecución
+
+1. **Resolver proyecto y repos**
+2. **MCP `list_pull_requests`** con filtros aplicados
+3. **Para cada PR:**
+   - ID, título, autor, fecha de creación
+   - Source → target branch
+   - Estado de votos (approve, reject, wait)
+   - Estado de build (si hay pipeline de validación)
+   - Work items vinculados
+   - Antigüedad (días desde creación)
+4. **Presentar tabla:**
+
+```
+## Pull Requests — {proyecto} (active)
+
+| PR | Título | Autor | Branch | Votos | Build | Edad |
+|---|---|---|---|---|---|---|
+| #42 | [AB#1234] OAuth 2.0 | Ana | feature/#1234 → main | 1/2 ✅ | passed | 2d |
+| #41 | [AB#1230] Fix login | Pedro | fix/#1230 → main | 0/2 | failed | 3d |
+| #39 | [AB#1228] Refactor DB | Ana | feature/#1228 → main | 2/2 ✅ | passed | 5d |
+
+### Resumen
+- 3 PRs activos, 1 listo para merge (#39)
+- 1 build fallida (#41) — revisar con `/repos:pr-review`
+- Antigüedad media: 3.3 días
+```
+
+## Integración
+
+- `/repos:pr-review --pr {id}` → review detallado
+- `/pr:pending` → similar pero para GitHub (equivalente Azure Repos)
+- `/pipeline:logs` → si build fallida, ver logs
+
+## Restricciones
+
+- Solo lectura
+- Máximo 50 PRs por consulta
+- Si `--assigned-to-me` y no hay PM configurado → error con sugerencia

--- a/.claude/commands/repos-pr-review.md
+++ b/.claude/commands/repos-pr-review.md
@@ -1,0 +1,75 @@
+---
+name: repos-pr-review
+description: >
+  Review multi-perspectiva de un PR en Azure Repos. Analiza
+  desde BA, Dev, QA, Security y DevOps (reutiliza patrón pr:review).
+---
+
+# Repos PR Review
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/repos:pr-review --project {p} --pr {id}` o `/repos:pr-review --project {p} --repo {r} --pr {id}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--repo {nombre}` — Repositorio (obligatorio o `AZURE_REPOS_DEFAULT_REPO`)
+- `--pr {id}` — ID del Pull Request (obligatorio)
+- `--perspective {tipo}` — Perspectiva específica: `ba`, `dev`, `qa`, `security`, `devops`, `all` (defecto: all)
+- `--add-comments` — Añadir comentarios al PR en Azure Repos (requiere confirmación)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto y repo
+2. `projects/{proyecto}/reglas-negocio.md` — Para perspectiva BA
+3. @.claude/rules/azure-repos-config.md — Políticas de branch
+
+## Pasos de ejecución
+
+1. **Obtener PR** — MCP `list_pull_requests` + filtrar por ID
+2. **Obtener diff** — Obtener cambios del PR (files changed)
+3. **Obtener comentarios existentes** — MCP `get_pull_request_comments`
+4. **Analizar desde cada perspectiva:**
+
+### Business Analyst
+- ¿Los cambios implementan lo descrito en los work items vinculados?
+- ¿Se respetan las reglas de negocio del proyecto?
+- ¿Faltan criterios de aceptación por cubrir?
+
+### Developer
+- Calidad del código: naming, SOLID, DRY, complejidad
+- Patrones del proyecto respetados
+- Gestión de errores y edge cases
+
+### QA / Test Engineer
+- ¿Hay tests nuevos para el código nuevo?
+- ¿Coverage estimado se mantiene >= 80%?
+- ¿Hay tests de integración si aplica?
+
+### Security
+- Secrets hardcodeados, SQL injection, XSS
+- Dependencias con vulnerabilidades conocidas
+- Autenticación y autorización correctas
+
+### DevOps
+- ¿El cambio afecta a la pipeline?
+- ¿Hay migraciones de DB?
+- ¿Requiere cambios en infra/config?
+
+5. **Presentar informe** estructurado por perspectiva
+6. **Si `--add-comments`:**
+   - Confirmar con PM antes de publicar
+   - MCP `create_pr_comment` para cada hallazgo relevante
+
+## Integración
+
+- `/repos:pr-list` → contexto de PRs activos
+- `/pipeline:logs` → si la build falla
+- `/pr:review` → equivalente para PRs de GitHub
+
+## Restricciones
+
+- Añadir comentarios al PR requiere confirmación del PM
+- No aprobar/rechazar el PR automáticamente — eso es decisión humana
+- Si el diff es muy grande (>500 ficheros) → advertir y sugerir scope

--- a/.claude/commands/repos-search.md
+++ b/.claude/commands/repos-search.md
@@ -1,0 +1,61 @@
+---
+name: repos-search
+description: >
+  Buscar código en repositorios de Azure DevOps. Soporta filtro
+  por repo, tipo de fichero y ruta.
+---
+
+# Repos Search
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/repos:search --project {p} {query}` o con filtros
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `{query}` — Texto a buscar (obligatorio)
+- `--repo {nombre}` — Filtrar por repositorio (opcional)
+- `--path {ruta}` — Filtrar por ruta (ej: `src/services/`)
+- `--extension {ext}` — Filtrar por extensión (ej: `cs`, `ts`, `py`)
+- `--top {n}` — Máximo resultados (defecto: 25)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — `AZURE_REPOS_PROJECT`
+
+## Pasos de ejecución
+
+1. **Construir query** con filtros aplicados
+2. **MCP `search_code`** → buscar en repos del proyecto
+3. **Agrupar resultados** por repo y fichero
+4. **Presentar:**
+
+```
+## Búsqueda: "{query}" — {proyecto}
+
+### backend-api (8 resultados)
+| Fichero | Línea | Coincidencia |
+|---|---|---|
+| src/services/AuthService.cs | L45 | `public async Task<Token> RefreshOAuth(...)` |
+| src/controllers/AuthController.cs | L23 | `// OAuth refresh endpoint` |
+
+### frontend-app (3 resultados)
+| Fichero | Línea | Coincidencia |
+|---|---|---|
+| src/auth/oauth.ts | L12 | `export const refreshToken = async ()` |
+
+Total: 11 resultados en 2 repositorios
+```
+
+## Integración
+
+- `/repos:pr-create` → si buscas código para entender el impacto de un cambio
+- `/spec:generate` → buscar implementación existente antes de generar spec
+
+## Restricciones
+
+- Solo lectura
+- Máximo 100 resultados por búsqueda
+- Requiere Azure DevOps Search habilitado en la organización
+- Si Search no está habilitado → informar al PM

--- a/.claude/rules/azure-repos-config.md
+++ b/.claude/rules/azure-repos-config.md
@@ -1,0 +1,52 @@
+# Regla: Configuración Azure Repos
+
+> Configuración para gestión de repositorios Git en Azure DevOps.
+> Carga bajo demanda cuando se usan comandos `repos:*`.
+
+## Proveedor Git por proyecto
+
+```
+# En projects/{p}/CLAUDE.md — elegir proveedor
+GIT_PROVIDER                = "github"              # github | azure-repos
+AZURE_REPOS_PROJECT         = "NombreProyectoDevOps"
+AZURE_REPOS_DEFAULT_REPO    = "backend-api"         # repo por defecto
+AZURE_REPOS_DEFAULT_BRANCH  = "main"                # rama principal
+```
+
+## Convenciones de branches (consistente con pm-workflow.md)
+
+```
+BRANCH_FEATURE_PREFIX       = "feature/"
+BRANCH_FIX_PREFIX           = "fix/"
+BRANCH_PATTERN              = "{prefix}#XXXX-descripcion"
+PR_TITLE_PATTERN            = "[AB#XXXX] Descripción corta"
+```
+
+## Políticas de rama recomendadas
+
+| Política | main | develop |
+|---|---|---|
+| Reviewers mínimos | 2 | 1 |
+| Build validation | Sí (pipeline PR) | Sí |
+| Work item linking | Obligatorio | Recomendado |
+| Comment resolution | Todos resueltos | Todos resueltos |
+| Merge strategy | Squash | Squash |
+
+## PAT Scopes requeridos
+
+```
+Code (Read & Write)  — para crear branches, PRs, comments
+```
+
+## MCP tools de Azure Repos
+
+- `list_repositories` — listar repos del proyecto
+- `get_repository` — detalles de un repo
+- `list_branches` — branches de un repo
+- `create_branch` — crear branch desde ref
+- `list_pull_requests` — PRs del repo (filtro: status, creator, reviewer)
+- `create_pull_request` — crear PR con title, description, reviewers
+- `update_pull_request` — actualizar PR (status, auto-complete)
+- `get_pull_request_comments` — comentarios de un PR
+- `create_pr_comment` — añadir comentario a PR
+- `search_code` — buscar código en repos del proyecto


### PR DESCRIPTION
## Summary
- Add **6 new Azure Repos commands**: `repos:list`, `repos:branches`, `repos:pr-create`, `repos:pr-list`, `repos:pr-review`, `repos:search`
- Add **azure-repos-config rule** with dual Git provider support (`GIT_PROVIDER = "github" | "azure-repos"` configurable per project)
- All commands use the Azure DevOps MCP for repository operations
- `repos:pr-create` requires PM confirmation and supports work item linking, auto-complete, and draft PRs
- `repos:pr-review` reuses the multi-perspective review pattern from `pr:review` (BA, Dev, QA, Security, DevOps)

## Test plan
- [ ] Validate all 6 commands pass `scripts/validate-commands.sh` (0 errors)
- [ ] Verify `/repos:list` reads repositories from MCP
- [ ] Verify `/repos:pr-create` requires confirmation and links work items
- [ ] Verify `/repos:pr-review` generates multi-perspective analysis
- [ ] Verify azure-repos-config.md documents all MCP tools used

🤖 Generated with [Claude Code](https://claude.com/claude-code)