### PR TITLE
docs: update for Azure Pipelines and Repos features

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -25,9 +25,11 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Equipo (3):** team:privacy-notice {nombre} --project {p}, team:onboarding {nombre} --project {p}, team:evaluate {nombre} --project {p}
    **Infra (7):** infra:detect {proy} {env}, infra:plan {proy} {env}, infra:estimate {proy}, infra:scale {recurso}, infra:status {proy}, env:setup {proy}, env:promote {proy} {orig} {dest}
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
+   **Pipelines (5):** pipeline:status --project {p}, pipeline:run --project {p} {pipeline}, pipeline:logs --project {p} --build {id}, pipeline:create --project {p} --name {n} --repo {r}, pipeline:artifacts --project {p} --build {id}
+   **Azure Repos (6):** repos:list --project {p}, repos:branches --project {p} --repo {r}, repos:pr-create --project {p} --repo {r}, repos:pr-list --project {p}, repos:pr-review --project {p} --pr {id}, repos:search --project {p} {query}
    **Conectores (12):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}, jira:sync --project {p}, confluence:publish {file} --project {p}, notion:sync --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/rules/pm-config.md
+++ b/.claude/rules/pm-config.md
@@ -83,7 +83,7 @@ curl -X POST "https://login.microsoftonline.com/$GRAPH_TENANT_ID/oauth2/v2.0/tok
   -d "client_id=$GRAPH_CLIENT_ID&client_secret=$(cat $HOME/.azure/graph-secret)&scope=https://graph.microsoft.com/.default&grant_type=client_credentials"
 ```
 
-**Scopes PAT requeridos:** Work Items R/W · Project and Team R · Analytics R · Code R · Build R
+**Scopes PAT requeridos:** Work Items R/W · Project and Team R · Analytics R · Code R/W · Build R/W · Release R
 
 ```
 # ── Diagram Tools (Draw.io / Miro) ──────────────────────────────────────────
@@ -96,4 +96,10 @@ MIRO_TOKEN_FILE             = "$HOME/.azure/miro-token"            # fichero con
 #   PROJECT_XXX_DRAWIO_FOLDER   = "Folder/Path"                   # carpeta en Draw.io
 #   PROJECT_XXX_MIRO_BOARD_ID   = "uXjVN..."                      # ID del board en Miro
 #   PROJECT_XXX_DIAGRAM_TOOL    = "draw-io"                        # tool preferido (draw-io|miro)
+
+# ── Azure Repos (Git provider por proyecto) ───────────────────────────────
+# Formato en pm-config.local.md:
+#   PROJECT_XXX_GIT_PROVIDER        = "github"                       # github | azure-repos
+#   PROJECT_XXX_AZURE_REPOS_REPO    = "backend-api"                  # repo por defecto en Azure Repos
+#   PROJECT_XXX_AZURE_REPOS_BRANCH  = "main"                         # rama principal
 ```

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -62,6 +62,17 @@
 | `/diagram:import {source}` | Importar diagrama → validar reglas negocio → crear Features/PBIs/Tasks |
 | `/diagram:config` | Configurar credenciales Draw.io/Miro y verificar conexión |
 | `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
+| `/pipeline:status {--project p}` | Estado de pipelines: últimas builds, % éxito, duración, alertas |
+| `/pipeline:run {--project p} {pipeline}` | Ejecutar pipeline con preview y confirmación previa |
+| `/pipeline:logs {--project p} {--build id}` | Logs de una build: timeline, errores, warnings |
+| `/pipeline:create {--project p} {--name n}` | Crear pipeline YAML desde template con preview |
+| `/pipeline:artifacts {--project p} {--build id}` | Listar/descargar artefactos de una build |
+| `/repos:list {--project p}` | Listar repositorios del proyecto en Azure DevOps |
+| `/repos:branches {--project p} {--repo r}` | Gestión de branches: listar, crear, comparar |
+| `/repos:pr-create {--project p} {--repo r}` | Crear PR en Azure Repos con work item linking |
+| `/repos:pr-list {--project p}` | Listar PRs: pendientes, asignados al PM, por reviewer |
+| `/repos:pr-review {--project p} {--pr id}` | Review multi-perspectiva de PR en Azure Repos |
+| `/repos:search {--project p} {query}` | Buscar código en repositorios de Azure DevOps |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |
@@ -96,4 +107,6 @@
 - Diagram Generation: `.claude/skills/diagram-generation/SKILL.md`
 - Diagram Import: `.claude/skills/diagram-import/SKILL.md`
 - Diagram Config: `.claude/rules/diagram-config.md`
+- Azure Pipelines: `.claude/skills/azure-pipelines/SKILL.md`
+- Azure Repos Config: `.claude/rules/azure-repos-config.md`
 - Azure DevOps API v7.1: https://learn.microsoft.com/en-us/rest/api/azure/devops/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 46 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 57 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
-│   └── skills/                    ← 11 skills reutilizables
+│   └── skills/                    ← 12 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README
 ├── projects/                      ← Proyectos reales (git-ignorados)
 └── scripts/                       ← Scripts auxiliares Azure DevOps
@@ -113,6 +113,8 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 - **PBIs** → `.claude/skills/pbi-decomposition/SKILL.md`
 - **SDD** → `.claude/skills/spec-driven-development/SKILL.md`
 - **Diagramas** → `.claude/skills/diagram-generation/SKILL.md` · `.claude/skills/diagram-import/SKILL.md`
+- **Pipelines** → `.claude/skills/azure-pipelines/SKILL.md`
+- **Azure Repos** → `@.claude/rules/azure-repos-config.md`
 - **Comandos** → `@.claude/rules/pm-workflow.md`
 - Explorar → Planificar → Implementar → Commit · `/compact` al 50% · `/clear` entre tareas
 - Arquitectura: **Command → Agent → Skills** — subagentes solo con `Task`

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 46 slash commands
+│   ├── commands/                ← 57 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -22,6 +22,8 @@
 │   │   ├── team-onboarding.md ..← Equipo (3)
 │   │   ├── infra-detect.md ...  ← Infraestructura (7)
 │   │   ├── diagram-generate.md..← Diagramas (4)
+│   │   ├── pipeline-status.md ..← Pipelines CI/CD (5)
+│   │   ├── repos-list.md ...   ← Azure Repos (6)
 │   │   ├── notify-slack.md ...  ← Conectores (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)
@@ -42,7 +44,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 11 skills reutilizables
+│   ├── skills/                  ← 12 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -55,8 +57,10 @@
 │   │   │   └── references/      ← Templates, matrices, patrones de equipo
 │   │   ├── diagram-generation/  ← Generación de diagramas (Draw.io, Miro, Mermaid)
 │   │   │   └── references/      ← Plantillas Mermaid, shapes, boards
-│   │   └── diagram-import/      ← Importación de diagramas → Features/PBIs/Tasks
-│   │       └── references/      ← Mapping, templates PBI, validación reglas negocio
+│   │   ├── diagram-import/      ← Importación de diagramas → Features/PBIs/Tasks
+│   │   │   └── references/      ← Mapping, templates PBI, validación reglas negocio
+│   │   └── azure-pipelines/     ← CI/CD con Azure Pipelines (YAML templates, stages)
+│   │       └── references/      ← Templates YAML, patrones de stages multi-entorno
 │   │
 │   └── rules/                   ← Reglas modulares
 │       ├── pm-config.md         ← Constantes Azure DevOps
@@ -71,6 +75,7 @@
 │       ├── readme-update.md     ← Regla 12: actualizar READMEs
 │       ├── connectors-config.md ← Configuración conectores Claude (Slack, GitHub, Sentry...)
 │       ├── diagram-config.md    ← Configuración Draw.io/Miro
+│       ├── azure-repos-config.md ← Configuración Azure Repos (dual Git provider)
 │       ├── agents-catalog.md    ← Tabla de 24 agentes
 │       └── languages/           ← Convenciones por lenguaje (excluido de carga automática)
 │           ├── csharp-rules.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 46 slash commands
+│   ├── commands/                ← 57 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -22,6 +22,8 @@
 │   │   ├── team-onboarding.md ..← Team (3)
 │   │   ├── infra-detect.md ...  ← Infrastructure (7)
 │   │   ├── diagram-generate.md..← Diagrams (4)
+│   │   ├── pipeline-status.md ..← Pipelines CI/CD (5)
+│   │   ├── repos-list.md ...   ← Azure Repos (6)
 │   │   ├── notify-slack.md ...  ← Connectors (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)
@@ -41,7 +43,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 11 reusable skills
+│   ├── skills/                  ← 12 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -54,8 +56,10 @@
 │   │   │   └── references/      ← Templates, matrices, team patterns
 │   │   ├── diagram-generation/  ← Diagram generation (Draw.io, Miro, Mermaid)
 │   │   │   └── references/      ← Mermaid templates, shapes, boards
-│   │   └── diagram-import/      ← Diagram import → Features/PBIs/Tasks
-│   │       └── references/      ← Mapping, PBI templates, business rules validation
+│   │   ├── diagram-import/      ← Diagram import → Features/PBIs/Tasks
+│   │   │   └── references/      ← Mapping, PBI templates, business rules validation
+│   │   └── azure-pipelines/     ← CI/CD with Azure Pipelines (YAML templates, stages)
+│   │       └── references/      ← YAML templates, multi-environment stage patterns
 │   │
 │   └── rules/                   ← Modular rules
 │       ├── pm-config.md         ← Azure DevOps constants
@@ -70,6 +74,7 @@
 │       ├── readme-update.md     ← Rule 12: update READMEs
 │       ├── connectors-config.md ← Claude connectors config (Slack, GitHub, Sentry...)
 │       ├── diagram-config.md    ← Draw.io/Miro configuration
+│       ├── azure-repos-config.md ← Azure Repos configuration (dual Git provider)
 │       ├── agents-catalog.md    ← 24 agents table
 │       └── languages/           ← Per-language conventions (excluded from auto-loading)
 │           ├── csharp-rules.md


### PR DESCRIPTION
## Summary
- Update command counts: **46 → 57** (+5 pipeline + 6 repos)
- Update skill counts: **11 → 12** (+azure-pipelines)
- Add **Pipelines (5)** and **Azure Repos (6)** categories to `help.md` and `pm-workflow.md`
- Expand PAT scopes: add `Code R/W`, `Build R/W`, `Release R` for pipeline execution and repo management
- Add Azure Repos config section to `pm-config.md` (dual Git provider per project)
- Update README structures (ES/EN) with new commands, skill, and rule entries

**Note:** This PR should be merged AFTER PR #35 (Pipelines) and PR #36 (Azure Repos) are merged.

## Test plan
- [ ] Verify `/help` shows "Pipelines (5)" and "Azure Repos (6)" categories
- [ ] Verify `pm-workflow.md` lists all 57 commands
- [ ] Verify CLAUDE.md shows 57 commands and 12 skills
- [ ] Verify READMEs (ES/EN) reflect new entries
- [ ] Run `scripts/validate-commands.sh` with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)