### PR TITLE
v0.5.0 — Governance foundations

### DIFF
--- a/.claude/commands/debt-track.md
+++ b/.claude/commands/debt-track.md
@@ -1,0 +1,75 @@
+---
+name: debt-track
+description: >
+  Registro y seguimiento de deuda técnica por proyecto.
+  Ratio de deuda, tendencia por sprint, integración con SonarQube.
+---
+
+# Debt Track
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/debt:track --project {p}` o `/debt:track --project {p} --add`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--add` — Registrar nuevo item de deuda técnica
+- `--resolve {id}` — Marcar item como resuelto
+- `--sprint-report` — Informe de deuda del sprint actual
+- `--sonarqube {url}` — Importar métricas desde SonarQube (opcional)
+- `--severity {critical|high|medium|low}` — Filtrar por severidad
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `projects/{proyecto}/debt-register.md` — Registro de deuda (se crea si no existe)
+
+## Pasos de ejecución
+
+### Modo vista (por defecto)
+1. **Leer registro** — `projects/{proyecto}/debt-register.md`
+2. **Calcular métricas:**
+   - Total items abiertos por severidad
+   - Debt ratio: items deuda / total PBIs del sprint
+   - Tendencia: comparar con últimos 5 sprints
+   - Edad media de items sin resolver
+3. **Si `--sonarqube`** → importar code smells, bugs, vulnerabilities
+4. **Presentar dashboard:**
+
+```
+## Deuda Técnica — {proyecto} — Sprint {n}
+
+Debt Ratio: 18% (objetivo < 20%) 🟢
+Items abiertos: 12 | Resueltos este sprint: 3 | Nuevos: 2
+Tendencia: 📉 mejorando (-2 vs sprint anterior)
+
+| ID | Severidad | Descripción | Edad | Asignado |
+|---|---|---|---|---|
+| DT-01 | critical | SQL injection en AuthController | 3 sprints | — |
+| DT-02 | high | Sin tests en módulo de pagos | 2 sprints | Ana |
+| ... | | | | |
+
+Recomendación: Incluir DT-01 en el próximo sprint (critical, 3 sprints sin resolver)
+```
+
+### Modo `--add`
+1. Solicitar: descripción, severidad, componente afectado, estimación
+2. Añadir al registro con ID auto-incrementable
+3. Sugerir sprint para resolución según capacity
+
+### Modo `--sprint-report`
+1. Generar informe de evolución de deuda en el sprint
+2. Guardar en `output/debt/YYYYMMDD-debt-{proyecto}.md`
+
+## Integración
+
+- `/kpi:dashboard` → incluye debt ratio como KPI
+- `/sprint:plan` → sugiere items de deuda para incluir en sprint
+- `/project:audit` → usa debt:track para evaluar salud del proyecto
+
+## Restricciones
+
+- El registro es un fichero markdown en el proyecto, no en Azure DevOps
+- Opcionalmente puede crear PBIs de tipo "Tech Debt" en DevOps con `--create-pbi`
+- SonarQube es opcional — funciona sin él con registro manual

--- a/.claude/commands/dependency-map.md
+++ b/.claude/commands/dependency-map.md
@@ -1,0 +1,85 @@
+---
+name: dependency-map
+description: >
+  Mapa de dependencias entre PBIs, Features y equipos.
+  Alertas de bloqueo y grafo visual para sprint planning.
+---
+
+# Dependency Map
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/dependency:map --project {p}` o `/dependency:map --project {p} --add`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--sprint` — Solo dependencias del sprint actual (defecto)
+- `--release {nombre}` — Dependencias de una release completa
+- `--add {from_id} --depends-on {to_id}` — Registrar dependencia
+- `--remove {from_id} --depends-on {to_id}` — Eliminar dependencia
+- `--cross-project` — Incluir dependencias con otros proyectos
+- `--diagram` — Generar diagrama visual (Mermaid → Draw.io/Miro)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `.claude/skills/azure-devops-queries/SKILL.md` — WIQL para work items
+
+## Pasos de ejecución
+
+### Modo vista
+1. **Obtener PBIs del sprint/release** — WIQL filtrado
+2. **Leer relaciones** — Azure DevOps link types:
+   - `System.LinkTypes.Dependency` (Predecessor/Successor)
+   - `System.LinkTypes.Related`
+   - Cross-project links
+3. **Detectar bloqueos:**
+   - Dependencia en estado New/Active → bloqueante
+   - Dependencia asignada a otro equipo → cross-team
+   - Dependencia circular → error crítico
+4. **Presentar mapa:**
+
+```
+## Dependencias — {proyecto} — Sprint {n}
+
+### Bloqueos activos (2)
+- PBI #1234 "OAuth login" BLOQUEADO POR #1230 "API Gateway" (equipo Platform)
+  → #1230 en estado Active, ETA: 3 días
+- PBI #1240 "Payment flow" BLOQUEADO POR #1238 "DB migration" (mismo equipo)
+  → #1238 en estado New, sin asignar ⚠️
+
+### Grafo de dependencias
+#1230 (Platform) → #1234 (Auth) → #1236 (Dashboard)
+#1238 (DB) → #1240 (Payments) → #1242 (Reports)
+#1235 (independiente)
+
+### Resumen
+Items con dependencias: 5/8 (62%)
+Bloqueos activos: 2
+Cross-team: 1
+Ruta crítica: #1230 → #1234 → #1236 (estimado: 8 días)
+```
+
+### Modo `--diagram`
+1. Generar Mermaid flowchart con dependencias
+2. Usar `/diagram:generate` para publicar en Draw.io/Miro
+3. Colorear: verde=resuelto, amarillo=en progreso, rojo=bloqueado
+
+### Modo `--add`
+1. Crear link de dependencia en Azure DevOps via MCP
+2. Verificar que no crea ciclo
+3. Confirmar con PM antes de crear
+
+## Integración
+
+- `/sprint:plan` → muestra dependencias al planificar
+- `/project:release-plan` → usa mapa para ordenar releases
+- `/board:flow` → detecta cuellos de botella por dependencias
+- `/project:roadmap` → incluye dependencias en timeline
+
+## Restricciones
+
+- Crear/eliminar dependencias requiere confirmación del PM
+- Dependencias circulares se reportan como error, no se crean
+- Cross-project requiere acceso a ambos proyectos en Azure DevOps

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -27,9 +27,10 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Diagramas (4):** diagram:generate {proy}, diagram:import {source} --project {p}, diagram:config --tool {t}, diagram:status
    **Pipelines (5):** pipeline:status --project {p}, pipeline:run --project {p} {pipeline}, pipeline:logs --project {p} --build {id}, pipeline:create --project {p} --name {n} --repo {r}, pipeline:artifacts --project {p} --build {id}
    **Azure Repos (6):** repos:list --project {p}, repos:branches --project {p} --repo {r}, repos:pr-create --project {p} --repo {r}, repos:pr-list --project {p}, repos:pr-review --project {p} --pr {id}, repos:search --project {p} {query}
+   **Governance (5):** debt:track --project {p}, kpi:dora --project {p}, dependency:map --project {p}, retro:actions --project {p}, risk:log --project {p}
    **Conectores (12):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}, jira:sync --project {p}, confluence:publish {file} --project {p}, notion:sync --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/kpi-dora.md
+++ b/.claude/commands/kpi-dora.md
@@ -1,0 +1,81 @@
+---
+name: kpi-dora
+description: >
+  Dashboard de métricas DORA: deployment frequency, lead time for changes,
+  change failure rate, MTTR y reliability.
+---
+
+# KPI DORA
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/kpi:dora --project {p}` o `/kpi:dora --project {p} --sprints 10`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--sprints {n}` — Período de análisis en sprints (defecto: 5)
+- `--pipeline {nombre}` — Pipeline específica (opcional)
+- `--compare {proyecto2}` — Comparar con otro proyecto
+- `--export` — Guardar informe en `output/dora/`
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `.claude/skills/azure-pipelines/SKILL.md` — MCP tools de pipelines
+
+## Métricas DORA calculadas
+
+| Métrica | Fuente | Cálculo |
+|---|---|---|
+| Deployment Frequency | MCP `get_builds` | Deploys a PRO por semana/mes |
+| Lead Time for Changes | MCP `get_builds` + repos | Tiempo primer commit → deploy PRO |
+| Change Failure Rate | MCP `get_builds` | Builds fallidas en PRO / total deploys PRO |
+| MTTR | MCP `get_builds` | Tiempo medio entre fallo y fix en PRO |
+| Reliability | Sentry + pipelines | Uptime estimado desde error rate y deploys |
+
+## Pasos de ejecución
+
+1. **Obtener datos de pipelines** — MCP `get_builds` del período
+2. **Filtrar deploys a producción** — builds con stage PRO/Production
+3. **Calcular cada métrica** según tabla anterior
+4. **Clasificar rendimiento** según benchmarks DORA 2025:
+
+| Métrica | Elite | High | Medium | Low |
+|---|---|---|---|---|
+| Deploy Frequency | On-demand (multi/día) | 1/semana-1/mes | 1/mes-6/mes | < 1/6m |
+| Lead Time | < 1 día | 1 día - 1 semana | 1 sem - 1 mes | > 1 mes |
+| Change Failure Rate | < 5% | 5-10% | 10-15% | > 15% |
+| MTTR | < 1 hora | < 1 día | < 1 semana | > 1 semana |
+
+5. **Presentar dashboard:**
+
+```
+## DORA Metrics — {proyecto} — Últimos {n} sprints
+
+| Métrica | Valor | Clasificación | Tendencia |
+|---|---|---|---|
+| Deploy Frequency | 3.2/semana | Elite | 📈 +15% |
+| Lead Time | 2.1 días | High | 📉 -0.5d |
+| Change Failure Rate | 8% | High | → estable |
+| MTTR | 45 min | Elite | 📉 -12min |
+
+Clasificación global: HIGH PERFORMER
+
+Recomendación: Reducir lead time automatizando merge → deploy
+```
+
+6. **Si `--export`** → guardar en `output/dora/YYYYMMDD-dora-{proyecto}.md`
+
+## Integración
+
+- `/kpi:dashboard` → incluye resumen DORA
+- `/pipeline:status` → datos fuente
+- `/project:audit` → usa DORA para evaluar madurez CI/CD
+- `/report:executive` → incluye DORA en informe directivo
+
+## Restricciones
+
+- Requiere historial de pipelines (mínimo 1 sprint con deploys)
+- Si no hay pipeline de PRO → informar y calcular solo sobre DEV/PRE
+- Benchmarks DORA 2025 como referencia, no como objetivo rígido

--- a/.claude/commands/retro-actions.md
+++ b/.claude/commands/retro-actions.md
@@ -1,0 +1,81 @@
+---
+name: retro-actions
+description: >
+  Seguimiento de action items de retrospectivas entre sprints.
+  Ownership, estado y % de implementación.
+---
+
+# Retro Actions
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/retro:actions --project {p}` o `/retro:actions --project {p} --add`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--add` — Registrar nuevos action items desde la última retro
+- `--update {id}` — Actualizar estado de un action item
+- `--sprint {nombre}` — Ver actions de un sprint específico
+- `--history` — Historial completo de actions y % implementación
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `projects/{proyecto}/retro-actions.md` — Registro de actions (se crea si no existe)
+
+## Pasos de ejecución
+
+### Modo vista (por defecto)
+1. **Leer registro** — `projects/{proyecto}/retro-actions.md`
+2. **Filtrar actions pendientes** del sprint actual y anteriores
+3. **Calcular métricas:**
+   - % implementación sprint anterior
+   - % implementación acumulado (últimos 5 sprints)
+   - Actions más antiguas sin resolver
+   - Actions recurrentes (mismo tema en múltiples retros)
+4. **Presentar:**
+
+```
+## Retro Actions — {proyecto}
+
+### Sprint actual: 3 pendientes, 2 completadas
+| ID | Sprint origen | Action | Owner | Estado |
+|---|---|---|---|---|
+| RA-12 | Sprint 2026-03 | Añadir smoke tests al deploy PRE | Pedro | done |
+| RA-13 | Sprint 2026-03 | Documentar API de pagos | Ana | done |
+| RA-14 | Sprint 2026-03 | Reducir flaky tests > 5% | Pedro | in progress |
+| RA-10 | Sprint 2026-02 | Mejorar onboarding de nuevos devs | María | pending |
+| RA-08 | Sprint 2026-01 | Definir política de code review | — | overdue ⚠️ |
+
+### Tendencia de implementación
+Sprint 2026-01: 60% (3/5)
+Sprint 2026-02: 75% (3/4)
+Sprint 2026-03: 40% (2/5) ← en curso
+Media: 58%
+
+### Temas recurrentes
+- "Testing" mencionado en 3 retros consecutivas → considerar initiative
+```
+
+### Modo `--add`
+1. Solicitar por cada action: descripción, owner, fecha límite
+2. Asignar ID auto-incremental (RA-XX)
+3. Añadir al registro
+
+### Modo `--history`
+1. Mostrar evolución por sprint: % implementación, temas
+2. Identificar patrones recurrentes
+3. Sugerir elevación a initiative si un tema aparece 3+ veces
+
+## Integración
+
+- `/sprint:retro` → al final de la retro, invoca `/retro:actions --add`
+- `/sprint:status` → muestra actions pendientes como recordatorio
+- `/project:audit` → usa % implementación como indicador de mejora continua
+
+## Restricciones
+
+- El registro es markdown local, no Azure DevOps
+- Con `--create-pbi` puede crear Tasks en DevOps para actions concretas
+- Nunca eliminar actions antiguas, solo marcar como done/cancelled

--- a/.claude/commands/risk-log.md
+++ b/.claude/commands/risk-log.md
@@ -1,0 +1,81 @@
+---
+name: risk-log
+description: >
+  Registro estructurado de riesgos del proyecto con probabilidad,
+  impacto, mitigación y risk burndown chart.
+---
+
+# Risk Log
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/risk:log --project {p}` o `/risk:log --project {p} --add`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--add` — Registrar nuevo riesgo
+- `--update {id}` — Actualizar estado/mitigación de un riesgo
+- `--close {id}` — Cerrar riesgo (mitigado o materializado)
+- `--matrix` — Mostrar matriz probabilidad × impacto
+- `--burndown` — Risk burndown chart (evolución por sprint)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `projects/{proyecto}/risk-register.md` — Registro de riesgos (se crea si no existe)
+
+## Pasos de ejecución
+
+### Modo vista (por defecto)
+1. **Leer registro** — `projects/{proyecto}/risk-register.md`
+2. **Calcular exposure** — probabilidad × impacto por riesgo
+3. **Ordenar** por exposure descendente
+4. **Presentar:**
+
+```
+## Risk Log — {proyecto} — Sprint {n}
+
+Riesgos abiertos: 6 | Exposure total: 24 | Tendencia: → estable
+
+| ID | Riesgo | Prob | Impacto | Exposure | Mitigación | Owner |
+|---|---|---|---|---|---|---|
+| R-01 | API proveedor inestable | Alta | Alto | 9 | Circuit breaker + cache | Pedro |
+| R-02 | Migración DB sin rollback | Media | Alto | 6 | Script rollback + backup | Ana |
+| R-03 | Dependencia de equipo Platform | Alta | Medio | 6 | Slack directo + escalado | PM |
+| R-04 | Scope creep en módulo pagos | Media | Medio | 4 | PBI congelados en sprint | PM |
+| ... | | | | | | |
+```
+
+### Modo `--matrix`
+```
+         | Bajo(1) | Medio(2) | Alto(3) |
+Alta(3)  |         | R-03     | R-01    |
+Media(2) |         | R-04     | R-02    |
+Baja(1)  | R-06    | R-05     |         |
+```
+
+### Modo `--burndown`
+1. Leer historial de exposure por sprint
+2. Mostrar evolución: riesgos abiertos y exposure total
+
+### Modo `--add`
+1. Solicitar: descripción, probabilidad (1-3), impacto (1-3)
+2. Solicitar: estrategia mitigación, owner, fecha revisión
+3. Añadir con ID auto-incremental (R-XX)
+
+## Integración
+
+- `/sprint:status` → muestra top 3 riesgos por exposure
+- `/sprint:plan` → revisa riesgos al planificar
+- `/project:release-plan` → riesgos por release
+- `/project:audit` → evalúa gestión de riesgos
+- `/dependency:map` → riesgos de dependencias cross-team
+
+## Restricciones
+
+- El registro es markdown local, no Azure DevOps
+- Con `--create-pbi` puede crear PBIs de mitigación en DevOps
+- Probabilidad e impacto: escala 1-3 (bajo/medio/alto)
+- Exposure = probabilidad × impacto (máximo 9)
+- Revisar riesgos en cada sprint planning (sugerencia automática)

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -73,6 +73,11 @@
 | `/repos:pr-list {--project p}` | Listar PRs: pendientes, asignados al PM, por reviewer |
 | `/repos:pr-review {--project p} {--pr id}` | Review multi-perspectiva de PR en Azure Repos |
 | `/repos:search {--project p} {query}` | Buscar código en repositorios de Azure DevOps |
+| `/debt:track {--project p}` | Registro y seguimiento de deuda técnica: ratio, tendencia, SonarQube |
+| `/kpi:dora {--project p}` | Métricas DORA: deploy frequency, lead time, change failure rate, MTTR |
+| `/dependency:map {--project p}` | Mapa de dependencias entre PBIs/Features/equipos con alertas de bloqueo |
+| `/retro:actions {--project p}` | Seguimiento de action items de retrospectivas entre sprints |
+| `/risk:log {--project p}` | Registro de riesgos: probabilidad, impacto, mitigación, risk burndown |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,10 @@ Full automated workflow for onboarding new projects and planning their execution
 - `project:kickoff` — (Phase 5: Notification) Summarize and notify. Compiles audit + release plan + assignments + roadmap into a kickoff report. Sends to PM and stakeholders via configured channel (`/notify:slack`, email, or Teams). Creates the Sprint 1 backlog in Azure DevOps with the first release scope already decomposed and assigned
 
 **High priority — industry consensus, clear gap in pm-workspace**
-- `debt:track` — technical debt register per project: debt ratio, trend per sprint, SonarQube integration if available. Debt reduction woven into sprints, not treated as a separate project
-- `kpi:dora` — DORA metrics dashboard: deployment frequency, lead time for changes, change failure rate, MTTR + reliability. Calculated from pipeline and repo data already available via MCP
-- `dependency:map` — cross-team/cross-PBI dependency mapping with blocking alerts. Visual graph for sprint planning. Critical for multi-project PM
-- `retro:actions` — track retrospective action items across sprints: ownership, status, % implemented. Retros without follow-up lose value
 - `legacy:assess` — legacy application assessment: complexity score, maintenance cost, risk rating, modernization roadmap (strangler fig pattern). Feeds into `project:audit` and `project:release-plan` for legacy onboarding
 
 **Medium priority — valuable additions aligned with current architecture**
 - `backlog:capture` — create PBIs from unstructured input (emails, meeting notes, support tickets)
-- `risk:log` — structured risk register updated automatically on each `/sprint:status`, with risk burndown chart
 - `sprint:release-notes` — auto-generate release notes combining work items + commits
 - `wiki:publish` / `wiki:sync` — publish and sync documentation with Azure DevOps Wiki (MCP has 6 wiki tools)
 - `testplan:status` / `testplan:results` — manage Azure DevOps Test Plans and view test results (MCP has 9 test plan tools)
@@ -39,6 +34,27 @@ Full automated workflow for onboarding new projects and planning their execution
 **Lower priority — infrastructure and tooling**
 - GitHub Actions: auto-label PRs by branch prefix (`feature/`, `fix/`, `docs/`)
 - Migrate work item CRUD from REST/CLI (`azdevops-queries.sh`) to MCP tools where equivalent
+
+---
+
+## [0.5.0] — 2026-02-27
+
+Governance foundations: technical debt tracking, DORA metrics, dependency mapping, retrospective action follow-up, and risk management. Adds 5 new governance commands. Total: 62 slash commands.
+
+### Added
+
+**Governance commands (5)** — PR #40
+- `/debt:track --project {p}` — technical debt register: debt ratio, trend per sprint, SonarQube integration. Stores data in `projects/{p}/debt-register.md`
+- `/kpi:dora --project {p}` — DORA metrics dashboard: deployment frequency, lead time, change failure rate, MTTR. Classifies as Elite/High/Medium/Low per DORA 2025 benchmarks
+- `/dependency:map --project {p}` — cross-team/cross-PBI dependency mapping with blocking alerts, circular dependency detection, critical path analysis. Visual graph via `/diagram:generate`
+- `/retro:actions --project {p}` — retrospective action items tracking: ownership, status, % implementation across sprints. Detects recurrent themes and suggests elevation to initiatives
+- `/risk:log --project {p}` — risk register: probability × impact matrix (1-3 scale), exposure scoring, risk burndown chart. Stores in `projects/{p}/risk-register.md`
+
+### Changed
+- Command count: 57 → 62 (+5 governance)
+- Help command updated with Governance (5) category
+- `pm-workflow.md` updated with 5 new governance command entries
+- READMEs (ES/EN) updated with governance commands
 
 ---
 
@@ -207,7 +223,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0...v0.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 57 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 62 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 12 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 57 slash commands
+│   ├── commands/                ← 62 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -24,6 +24,7 @@
 │   │   ├── diagram-generate.md..← Diagramas (4)
 │   │   ├── pipeline-status.md ..← Pipelines CI/CD (5)
 │   │   ├── repos-list.md ...   ← Azure Repos (6)
+│   │   ├── debt-track.md ...    ← Governance (5: deuda técnica, DORA, dependencias, retro actions, riesgos)
 │   │   ├── notify-slack.md ...  ← Conectores (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 57 slash commands
+│   ├── commands/                ← 62 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -24,6 +24,7 @@
 │   │   ├── diagram-generate.md..← Diagrams (4)
 │   │   ├── pipeline-status.md ..← Pipelines CI/CD (5)
 │   │   ├── repos-list.md ...   ← Azure Repos (6)
+│   │   ├── debt-track.md ...    ← Governance (5: tech debt, DORA, dependencies, retro actions, risks)
 │   │   ├── notify-slack.md ...  ← Connectors (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)


### PR DESCRIPTION
## Summary
- 5 new governance commands: `debt:track`, `kpi:dora`, `dependency:map`, `retro:actions`, `risk:log`
- Help command updated with Governance (5) category
- pm-workflow.md, CLAUDE.md, READMEs (ES/EN) updated
- CHANGELOG updated: items moved from Planned to new [0.5.0] section
- Total: 62 slash commands

## Test plan
- [ ] `bash scripts/validate-commands.sh` passes (0 errors)
- [ ] `/help governance` shows 5 commands
- [ ] Each command has correct parameters and context references

🤖 Generated with [Claude Code](https://claude.com/claude-code)