### PR TITLE
v0.6.0 — Legacy & Capture

### DIFF
--- a/.claude/commands/backlog-capture.md
+++ b/.claude/commands/backlog-capture.md
@@ -1,0 +1,96 @@
+---
+name: backlog-capture
+description: >
+  Crear PBIs desde input desestructurado: emails, notas de reunión,
+  tickets de soporte, conversaciones de Slack.
+---
+
+# Backlog Capture
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/backlog:capture --project {p} --source {tipo}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--source {tipo}` — Origen: `text`, `email`, `slack`, `file`, `support`
+- `--input {contenido}` — Texto directo o ruta a fichero
+- `--channel {canal}` — Canal de Slack (con `--source slack`)
+- `--since {fecha}` — Desde cuándo buscar (formato YYYY-MM-DD)
+- `--dry-run` — Solo mostrar PBIs propuestos, no crear en Azure DevOps
+- `--priority {auto|must|should|could}` — Priorización (auto = inferida)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `.claude/skills/azure-devops-queries/SKILL.md` — Para crear work items
+3. `.claude/skills/pbi-decomposition/SKILL.md` — Formato PBI estándar
+
+## Pasos de ejecución
+
+### 1. Obtener input
+- **text**: el PM pega texto directamente en el prompt
+- **file**: leer fichero indicado (`.md`, `.txt`, `.eml`, `.csv`)
+- **slack**: usar `/slack:search` con filtros de canal y fecha
+- **email**: leer fichero `.eml` o texto pegado del email
+- **support**: leer CSV/JSON de tickets de soporte
+
+### 2. Analizar y extraer
+Usar agente `business-analyst` para:
+1. Identificar necesidades/problemas/solicitudes en el texto
+2. Eliminar duplicados con backlog existente (WIQL query)
+3. Clasificar cada item: Feature, Bug, Improvement, Spike
+4. Extraer: título, descripción, criterios de aceptación (si infiere)
+5. Asignar prioridad (si `--priority auto`, inferir del contexto)
+
+### 3. Formatear como PBIs
+
+Para cada item detectado:
+```
+### PBI candidato #{n}
+Tipo: User Story | Bug | Spike
+Título: {título inferido}
+Descripción: Como {persona}, quiero {acción}, para {beneficio}
+Criterios de aceptación:
+- [ ] {criterio 1}
+- [ ] {criterio 2}
+Prioridad: {Must|Should|Could}
+Fuente: {email de X / Slack #canal / reunión de Y}
+Duplicado de: — (o #ID si existe similar)
+```
+
+### 4. Presentar resumen
+
+```
+## Backlog Capture — {proyecto}
+Fuente: {tipo} | Items analizados: {n} | PBIs propuestos: {m}
+
+| # | Tipo | Título | Prioridad | Duplicado |
+|---|---|---|---|---|
+| 1 | Story | Login con SSO | Must | — |
+| 2 | Bug | Error 500 en /api/users | Must | ~#1234 |
+| 3 | Improvement | Mejorar UX de búsqueda | Should | — |
+
+Descartados: 2 (duplicados exactos de #1230, #1245)
+```
+
+### 5. Crear en Azure DevOps
+- Si `--dry-run` → solo mostrar, no crear
+- Si no → **confirmar con PM** antes de crear cada PBI
+- Crear work items con link a fuente original si posible
+- Asignar al backlog del proyecto, sin sprint (para refinement)
+
+## Integración
+
+- `/pbi:decompose` → descomponer los PBIs creados en tasks
+- `/sprint:plan` → incluir PBIs capturados en planning
+- `/slack:search` → fuente de input para captura desde Slack
+- `/project:audit` → puede generar input para backlog:capture
+
+## Restricciones
+
+- NUNCA crear PBIs sin confirmación del PM (regla 7)
+- Duplicados detectados se marcan, no se eliminan del backlog
+- Priorización automática es sugerencia, PM decide final
+- Textos muy ambiguos → crear como Spike para refinement

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -28,9 +28,10 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Pipelines (5):** pipeline:status --project {p}, pipeline:run --project {p} {pipeline}, pipeline:logs --project {p} --build {id}, pipeline:create --project {p} --name {n} --repo {r}, pipeline:artifacts --project {p} --build {id}
    **Azure Repos (6):** repos:list --project {p}, repos:branches --project {p} --repo {r}, repos:pr-create --project {p} --repo {r}, repos:pr-list --project {p}, repos:pr-review --project {p} --pr {id}, repos:search --project {p} {query}
    **Governance (5):** debt:track --project {p}, kpi:dora --project {p}, dependency:map --project {p}, retro:actions --project {p}, risk:log --project {p}
+   **Legacy & Capture (3):** legacy:assess --project {p}, backlog:capture --project {p} --source {tipo}, sprint:release-notes --project {p}
    **Conectores (12):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}, jira:sync --project {p}, confluence:publish {file} --project {p}, notion:sync --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/legacy-assess.md
+++ b/.claude/commands/legacy-assess.md
@@ -1,0 +1,107 @@
+---
+name: legacy-assess
+description: >
+  Evaluación de aplicaciones legacy: complejidad, coste de mantenimiento,
+  rating de riesgo y roadmap de modernización (strangler fig pattern).
+---
+
+# Legacy Assess
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/legacy:assess --project {p}` o `/legacy:assess --project {p} --deep`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--repo {url}` — URL del repositorio a analizar (si no está en el proyecto)
+- `--deep` — Análisis profundo: incluye métricas de código y dependencias
+- `--compare` — Comparar con assessment anterior (evolución)
+- `--output {format}` — Formato de salida: `md` (defecto), `xlsx`, `pptx`
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `.claude/skills/azure-devops-queries/SKILL.md` — Queries si hay work items
+3. Acceso al repositorio del proyecto (Git clone o Azure Repos)
+
+## Pasos de ejecución
+
+### 1. Recopilar datos
+- **Código fuente**: LOC, lenguajes, edad del repo, frecuencia de commits
+- **Dependencias**: paquetes obsoletos, CVEs conocidos, frameworks EOL
+- **Tests**: cobertura, tests rotos, ratio test/código
+- **CI/CD**: pipelines existentes (`/pipeline:status`), frecuencia de deploy
+- **Deuda técnica**: si existe `debt-register.md`, incorporar datos
+- **Errores**: si Sentry configurado (`/sentry:health`), crash rate
+
+### 2. Calcular scores (1-10)
+
+| Dimensión | Peso | Fuente |
+|---|---|---|
+| Complejidad del código | 20% | LOC, ciclomática, acoplamiento |
+| Coste de mantenimiento | 20% | Bugs/mes, tiempo medio de fix |
+| Riesgo técnico | 20% | Dependencias EOL, CVEs, sin tests |
+| Calidad de documentación | 15% | README, ADRs, comments ratio |
+| Madurez CI/CD | 15% | Pipelines, envs, deploy frequency |
+| Conocimiento del equipo | 10% | Bus factor, contributors activos |
+
+**Score global** = media ponderada → clasificación:
+- 8-10: Saludable — mantenimiento normal
+- 5-7: Atención requerida — plan de mejora recomendado
+- 1-4: Crítico — modernización urgente
+
+### 3. Generar roadmap de modernización
+
+Si score < 7, proponer **strangler fig pattern**:
+1. Identificar módulos más críticos (alto riesgo + alto acoplamiento)
+2. Proponer orden de migración: módulos independientes primero
+3. Para cada módulo: estrategia (rewrite, refactor, wrap, retire)
+4. Estimar esfuerzo por módulo (T-shirt sizing: S/M/L/XL)
+5. Generar timeline con dependencias entre módulos
+
+### 4. Presentar informe
+
+```
+## Legacy Assessment — {proyecto}
+Fecha: YYYY-MM-DD | Score global: 4.2/10 (Crítico)
+
+### Scores por dimensión
+Complejidad:    ██████░░░░ 6/10
+Mantenimiento:  ███░░░░░░░ 3/10
+Riesgo técnico: ████░░░░░░ 4/10
+Documentación:  ██░░░░░░░░ 2/10
+CI/CD:          █████░░░░░ 5/10
+Conocimiento:   ████░░░░░░ 4/10
+
+### Hallazgos críticos
+- 23 dependencias obsoletas (4 con CVEs conocidos)
+- 0% test coverage en módulo de pagos
+- No hay pipeline de deploy a PRO (manual)
+- Bus factor = 1 (solo un contributor activo en 6 meses)
+
+### Roadmap de modernización (strangler fig)
+| Fase | Módulos | Estrategia | Esfuerzo | Sprints |
+|---|---|---|---|---|
+| 1 | Auth, Config | Refactor + tests | M | 2 |
+| 2 | Pagos | Rewrite (nuevo servicio) | XL | 4 |
+| 3 | Reporting | Wrap (API facade) | L | 3 |
+| 4 | Core | Refactor incremental | XL | 6 |
+```
+
+### 5. Guardar informe
+- `output/assessments/YYYYMMDD-legacy-{proyecto}.md`
+- Si `--output xlsx` → generar Excel con detalle
+
+## Integración
+
+- `/project:audit` → usa legacy:assess como fuente para proyectos legacy
+- `/project:release-plan` → incorpora roadmap de modernización como input
+- `/debt:track` → importa hallazgos como items de deuda técnica
+- `/evaluate:repo` → complementario (evaluate:repo = seguridad, legacy:assess = salud global)
+
+## Restricciones
+
+- No modifica código ni crea branches — solo analiza y reporta
+- El score es orientativo, no sustituye el juicio del equipo
+- Acceso al repo necesario para análisis profundo (`--deep`)

--- a/.claude/commands/sprint-release-notes.md
+++ b/.claude/commands/sprint-release-notes.md
@@ -1,0 +1,100 @@
+---
+name: sprint-release-notes
+description: >
+  Generar release notes automáticas combinando work items completados,
+  commits convencionales y PRs mergeados del sprint.
+---
+
+# Sprint Release Notes
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/sprint:release-notes --project {p}` o `/sprint:release-notes --project {p} --sprint {s}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--sprint {nombre}` — Sprint específico (defecto: sprint actual/último cerrado)
+- `--format {md|html|slack}` — Formato de salida (defecto: md)
+- `--audience {tech|stakeholder|public}` — Nivel de detalle
+- `--include-breaking` — Destacar breaking changes
+- `--include-metrics` — Añadir métricas del sprint (velocity, etc.)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `.claude/skills/azure-devops-queries/SKILL.md` — Work items completados
+3. Acceso al repositorio (GitHub o Azure Repos)
+
+## Pasos de ejecución
+
+### 1. Recopilar datos
+
+**Desde Azure DevOps:**
+- PBIs completados (Done) en el sprint → WIQL query
+- Bugs resueltos en el sprint
+- Tasks completadas (para detalle técnico)
+
+**Desde repositorio:**
+- Commits del periodo del sprint (por fecha o tag-to-tag)
+- PRs mergeados al main/develop durante el sprint
+- Conventional commits parsing: `feat:`, `fix:`, `docs:`, `perf:`, `breaking:`
+
+### 2. Categorizar cambios
+
+| Categoría | Fuente | Icono |
+|---|---|---|
+| New Features | PBIs tipo Story + commits `feat:` | ✨ |
+| Bug Fixes | PBIs tipo Bug + commits `fix:` | 🐛 |
+| Improvements | commits `perf:`, `refactor:` | ⚡ |
+| Documentation | commits `docs:` | 📚 |
+| Breaking Changes | commits `breaking:` + flag manual | ⚠️ |
+
+### 3. Adaptar por audiencia
+
+- **tech**: todos los detalles, PRs, commits, IDs de work items
+- **stakeholder**: features y bugs en lenguaje de negocio, sin IDs técnicos
+- **public**: solo features visibles al usuario, lenguaje marketing
+
+### 4. Generar documento
+
+```
+## Release Notes — {proyecto} — Sprint {n}
+Fecha: {fecha fin sprint} | Version: {tag si existe}
+
+### ✨ Nuevas funcionalidades
+- **Login con SSO** — Los usuarios pueden iniciar sesión con su cuenta corporativa (#1234)
+- **Dashboard de métricas** — Nuevo panel con KPIs en tiempo real (#1240)
+
+### 🐛 Correcciones
+- Corregido error 500 al exportar informes en PDF (#1238)
+- Solucionado timeout en búsqueda con filtros complejos (#1235)
+
+### ⚡ Mejoras
+- Tiempo de carga del dashboard reducido un 40%
+- Actualizada librería de componentes UI a v3.2
+
+### ⚠️ Breaking Changes
+- API v1 deprecada — migrar a v2 antes del próximo sprint
+
+### 📊 Métricas del sprint (si --include-metrics)
+Velocity: 34 SP | Items completados: 8/10 | Bugs resueltos: 3
+```
+
+### 5. Guardar y distribuir
+- Guardar en `output/release-notes/YYYYMMDD-release-{proyecto}.{ext}`
+- Si `--format slack` → enviar via `/notify:slack`
+- Si `--format html` → generar HTML con estilos para email
+
+## Integración
+
+- `/sprint:review` → puede invocar release-notes como parte del review
+- `/changelog:update` → complementario (changelog = técnico, release notes = negocio)
+- `/notify:slack` → distribuir release notes al equipo/stakeholders
+- `/confluence:publish` → publicar en Confluence como página de release
+
+## Restricciones
+
+- No publica sin confirmación del PM
+- Audiencia `public` omite detalles internos y IDs de Azure DevOps
+- Si no hay conventional commits, se basa solo en work items

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -78,6 +78,9 @@
 | `/dependency:map {--project p}` | Mapa de dependencias entre PBIs/Features/equipos con alertas de bloqueo |
 | `/retro:actions {--project p}` | Seguimiento de action items de retrospectivas entre sprints |
 | `/risk:log {--project p}` | Registro de riesgos: probabilidad, impacto, mitigación, risk burndown |
+| `/legacy:assess {--project p}` | Evaluación de aplicación legacy: complejidad, riesgo, roadmap de modernización (strangler fig) |
+| `/backlog:capture {--project p} {--source tipo}` | Crear PBIs desde input desestructurado: emails, reuniones, Slack, tickets de soporte |
+| `/sprint:release-notes {--project p}` | Generar release notes automáticas combinando work items + commits + PRs |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,7 @@ Full automated workflow for onboarding new projects and planning their execution
 - `project:roadmap` — (Phase 4: Roadmap) Generate a visual roadmap from the release plan: timeline with milestones, releases, sprints, and dependencies. Uses `/diagram:generate` to produce Mermaid gantt/flow → Draw.io or Miro. Also generates an executive-friendly summary via `/report:executive`. Output: diagram + `output/roadmaps/YYYYMMDD-roadmap-{project}.md`
 - `project:kickoff` — (Phase 5: Notification) Summarize and notify. Compiles audit + release plan + assignments + roadmap into a kickoff report. Sends to PM and stakeholders via configured channel (`/notify:slack`, email, or Teams). Creates the Sprint 1 backlog in Azure DevOps with the first release scope already decomposed and assigned
 
-**High priority — industry consensus, clear gap in pm-workspace**
-- `legacy:assess` — legacy application assessment: complexity score, maintenance cost, risk rating, modernization roadmap (strangler fig pattern). Feeds into `project:audit` and `project:release-plan` for legacy onboarding
-
 **Medium priority — valuable additions aligned with current architecture**
-- `backlog:capture` — create PBIs from unstructured input (emails, meeting notes, support tickets)
-- `sprint:release-notes` — auto-generate release notes combining work items + commits
 - `wiki:publish` / `wiki:sync` — publish and sync documentation with Azure DevOps Wiki (MCP has 6 wiki tools)
 - `testplan:status` / `testplan:results` — manage Azure DevOps Test Plans and view test results (MCP has 9 test plan tools)
 - `security:alerts` — surface security alerts from Azure DevOps Advanced Security (MCP has 2 security tools)
@@ -34,6 +29,25 @@ Full automated workflow for onboarding new projects and planning their execution
 **Lower priority — infrastructure and tooling**
 - GitHub Actions: auto-label PRs by branch prefix (`feature/`, `fix/`, `docs/`)
 - Migrate work item CRUD from REST/CLI (`azdevops-queries.sh`) to MCP tools where equivalent
+
+---
+
+## [0.6.0] — 2026-02-27
+
+Legacy assessment, backlog capture from unstructured sources, and automated release notes generation. Adds 3 new commands. Total: 65 slash commands.
+
+### Added
+
+**Legacy & Capture commands (3)** — PR #41
+- `/legacy:assess --project {p}` — legacy application assessment: complexity score (6 dimensions), maintenance cost, risk rating, modernization roadmap using strangler fig pattern. Output: `output/assessments/YYYYMMDD-legacy-{project}.md`
+- `/backlog:capture --project {p} --source {tipo}` — create PBIs from unstructured input: emails, meeting notes, Slack messages, support tickets. Deduplicates against existing backlog, classifies by type and priority
+- `/sprint:release-notes --project {p}` — auto-generate release notes combining Azure DevOps work items + conventional commits + merged PRs. Three audience levels: tech, stakeholder, public
+
+### Changed
+- Command count: 62 → 65 (+3 legacy & capture)
+- Help command updated with Legacy & Capture (3) category
+- `pm-workflow.md` updated with 3 new command entries
+- READMEs (ES/EN) updated with legacy & capture commands
 
 ---
 
@@ -223,7 +237,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 62 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 65 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 12 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 62 slash commands
+│   ├── commands/                ← 65 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -25,6 +25,7 @@
 │   │   ├── pipeline-status.md ..← Pipelines CI/CD (5)
 │   │   ├── repos-list.md ...   ← Azure Repos (6)
 │   │   ├── debt-track.md ...    ← Governance (5: deuda técnica, DORA, dependencias, retro actions, riesgos)
+│   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
 │   │   ├── notify-slack.md ...  ← Conectores (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 62 slash commands
+│   ├── commands/                ← 65 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -25,6 +25,7 @@
 │   │   ├── pipeline-status.md ..← Pipelines CI/CD (5)
 │   │   ├── repos-list.md ...   ← Azure Repos (6)
 │   │   ├── debt-track.md ...    ← Governance (5: tech debt, DORA, dependencies, retro actions, risks)
+│   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
 │   │   ├── notify-slack.md ...  ← Connectors (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)


### PR DESCRIPTION
## Summary
- 3 new commands: `legacy:assess`, `backlog:capture`, `sprint:release-notes`
- Help command updated with Legacy & Capture (3) category
- pm-workflow.md, CLAUDE.md, READMEs (ES/EN) updated
- CHANGELOG updated with [0.6.0] section
- Total: 65 slash commands

## Test plan
- [ ] `bash scripts/validate-commands.sh` passes (0 errors)
- [ ] `/help legacy` shows 3 commands
- [ ] Each command has correct parameters and context references

🤖 Generated with [Claude Code](https://claude.com/claude-code)