### PR TITLE
v0.7.0 — Project Onboarding Pipeline

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -29,9 +29,10 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Azure Repos (6):** repos:list --project {p}, repos:branches --project {p} --repo {r}, repos:pr-create --project {p} --repo {r}, repos:pr-list --project {p}, repos:pr-review --project {p} --pr {id}, repos:search --project {p} {query}
    **Governance (5):** debt:track --project {p}, kpi:dora --project {p}, dependency:map --project {p}, retro:actions --project {p}, risk:log --project {p}
    **Legacy & Capture (3):** legacy:assess --project {p}, backlog:capture --project {p} --source {tipo}, sprint:release-notes --project {p}
+   **Project Onboarding (5):** project:audit --project {p}, project:release-plan --project {p}, project:assign --project {p}, project:roadmap --project {p}, project:kickoff --project {p}
    **Conectores (12):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}, jira:sync --project {p}, confluence:publish {file} --project {p}, notion:sync --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, onboarding, audit, roadmap, kickoff, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/project-assign.md
+++ b/.claude/commands/project-assign.md
@@ -1,0 +1,103 @@
+---
+name: project-assign
+description: >
+  Phase 3 — Distribute release plan work across the team by profiles,
+  skills, seniority, and capacity. Generates assignment matrix.
+---
+
+# Project Assign
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/project:assign --project {p}` o con `--release-plan {file}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--release-plan {file}` — Fichero de release plan (defecto: último generado)
+- `--release {n}` — Asignar solo una release específica
+- `--sprint {nombre}` — Asignar solo para un sprint específico
+- `--rebalance` — Rebalancear asignaciones existentes
+- `--dry-run` — Solo mostrar propuesta, no asignar en Azure DevOps
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `projects/{proyecto}/equipo.md` — Perfiles del equipo
+3. `output/plans/` — Último release plan (o `--release-plan`)
+4. `.claude/skills/pbi-decomposition/SKILL.md` — Scoring de asignación
+
+## Pasos de ejecución
+
+### 1. Cargar datos del equipo
+- Leer `equipo.md` → nombre, rol, skills, seniority, disponibilidad
+- Obtener capacity actual → `/report:capacity`
+- Obtener carga actual → `/team:workload`
+- Calcular horas disponibles por persona y sprint
+
+### 2. Cargar trabajo a asignar
+- Leer release plan → PBIs agrupados por release y sprint
+- Para PBIs sin descomponer → invocar `/pbi:decompose` primero
+- Obtener tasks con estimaciones (SP u horas)
+
+### 3. Algoritmo de asignación
+
+Para cada task, calcular score por persona:
+```
+Score = (skill_match × 0.4) + (capacity_available × 0.3)
+      + (seniority_fit × 0.2) + (context_bonus × 0.1)
+```
+
+Donde:
+- **skill_match**: % de coincidencia entre skills de la task y del dev
+- **capacity_available**: horas libres / horas de la task
+- **seniority_fit**: match entre complejidad y nivel (no asignar L a junior)
+- **context_bonus**: ya trabajó en módulo relacionado
+
+Restricciones:
+- Ninguna persona supera 100% de su capacity
+- Tasks críticas (🔴) asignadas a senior/mid mínimo
+- Bus factor ≥ 2 por módulo (no todo a una persona)
+
+### 4. Presentar matriz de asignación
+
+```
+## Assignment Matrix — {proyecto} — Release {n}
+
+### Carga por persona
+| Persona | Rol | Capacity | Asignado | % Uso | Alerta |
+|---|---|---|---|---|---|
+| Ana García | Senior Dev | 64h | 58h | 91% | — |
+| Pedro López | Mid Dev | 64h | 52h | 81% | — |
+| María Ruiz | Junior Dev | 64h | 40h | 63% | — |
+| Carlos Sanz | QA | 64h | 68h | 106% | ⚠️ Sobrecarga |
+
+### Asignaciones por PBI
+| PBI | Task | Asignado | Score | Skill match |
+|---|---|---|---|---|
+| #1234 Fix Auth | T1: Update lib | Ana | 0.92 | 95% |
+| #1234 Fix Auth | T2: Tests | Pedro | 0.85 | 80% |
+| #1235 Tests Pagos | T1: Unit tests | María | 0.78 | 70% |
+
+### Alertas
+- ⚠️ Carlos Sanz sobrecargado en Sprint 3 → sugerir redistribuir
+- ℹ️ Módulo "Pagos" asignado solo a María → bus factor = 1
+```
+
+### 5. Aplicar asignaciones
+- Si `--dry-run` → solo mostrar propuesta
+- Si no → **confirmar con PM** → asignar tasks en Azure DevOps
+
+## Integración
+
+- `/project:release-plan` → (Phase 2) provee el trabajo a asignar
+- `/project:roadmap` → (Phase 4) visualiza asignaciones en timeline
+- `/pbi:decompose` → descompone PBIs antes de asignar tasks
+- `/team:workload` → datos de carga actual
+- `/report:capacity` → datos de capacity
+
+## Restricciones
+
+- NUNCA asignar sin confirmación del PM (regla 7)
+- `equipo.md` debe existir con perfiles del equipo
+- Si no hay release plan, trabaja sobre backlog del sprint actual

--- a/.claude/commands/project-audit.md
+++ b/.claude/commands/project-audit.md
@@ -1,0 +1,116 @@
+---
+name: project-audit
+description: >
+  Phase 1 — Deep audit of a newly onboarded project: code quality,
+  architecture, debt, security, CI/CD. Prioritized action report.
+---
+
+# Project Audit
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/project:audit --project {p}` o `/project:audit --project {p} --deep`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--deep` — Análisis profundo incluyendo código fuente y dependencias
+- `--focus {area}` — Foco en área específica: code, tests, cicd, debt, security, docs
+- `--compare {fecha}` — Comparar con audit anterior (evolución)
+- `--output {format}` — Formato: `md` (defecto), `xlsx`, `pptx`
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. Acceso al repositorio (GitHub o Azure Repos)
+3. Azure DevOps (backlog, pipelines) si está configurado
+
+## Pasos de ejecución
+
+### 1. Recopilar datos de todas las fuentes
+
+Ejecutar internamente (según disponibilidad):
+- `/pipeline:status` → madurez CI/CD, frecuencia de deploy, tasa de éxito
+- `/debt:track` → deuda técnica existente, ratio, tendencia
+- `/kpi:dora` → métricas DORA (si hay datos de pipeline)
+- `/sentry:health` → tasa de errores, crash rate (si Sentry configurado)
+- `/legacy:assess` → scores de complejidad (si es proyecto legacy)
+- Repo analysis → LOC, tests, cobertura, dependencias
+
+### 2. Evaluar 8 dimensiones
+
+| Dimensión | Peso | Indicadores clave |
+|---|---|---|
+| Calidad de código | 15% | Code smells, duplicación, complejidad |
+| Cobertura de tests | 15% | % cobertura, tests rotos, ratio test/code |
+| Arquitectura | 15% | Acoplamiento, cohesión, patrones |
+| Deuda técnica | 10% | Debt ratio, items críticos abiertos |
+| Seguridad | 15% | CVEs, dependencias EOL, secrets expuestos |
+| Documentación | 10% | README, ADRs, API docs, comments |
+| Madurez CI/CD | 10% | Pipelines, envs, deploy frequency |
+| Salud del equipo | 10% | Bus factor, contributors, workload |
+
+### 3. Clasificar hallazgos en 3 tiers
+
+**🔴 Crítico (must fix)** — Riesgo inmediato: CVEs, secrets, datos sin proteger, 0% tests en módulos críticos.
+
+**🟡 Mejorable (should fix)** — Calidad comprometida: baja cobertura, deuda técnica alta, documentación pobre, CI/CD incompleto.
+
+**🟢 Correcto (keep)** — Aspectos saludables que mantener o reforzar.
+
+### 4. Generar informe
+
+```
+## Project Audit — {proyecto}
+Fecha: YYYY-MM-DD | Score global: 6.2/10
+
+### Resumen ejecutivo
+{1-3 líneas con conclusión principal}
+
+### Scores por dimensión
+Código:      ██████░░░░ 6/10
+Tests:       ████░░░░░░ 4/10
+Arquitectura:███████░░░ 7/10
+Deuda:       █████░░░░░ 5/10
+Seguridad:   ████████░░ 8/10
+Docs:        ███░░░░░░░ 3/10
+CI/CD:       ██████░░░░ 6/10
+Equipo:      ████████░░ 8/10
+
+### 🔴 Crítico (3 items)
+1. [SEC] 2 CVEs críticos en dependencia auth-lib v2.1
+2. [TEST] 0% cobertura en módulo de pagos
+3. [SEC] API key hardcodeada en config.json
+
+### 🟡 Mejorable (5 items)
+1. [DEBT] 23% debt ratio (objetivo <20%)
+2. [DOCS] Sin documentación de API
+...
+
+### 🟢 Correcto (4 items)
+1. [ARCH] Clean Architecture bien implementada
+...
+
+### Plan de acción priorizado
+| # | Tier | Área | Acción | Esfuerzo | Sprint sugerido |
+|---|---|---|---|---|---|
+| 1 | 🔴 | SEC | Actualizar auth-lib a v3.0 | S | Sprint actual |
+| 2 | 🔴 | TEST | Añadir tests módulo pagos | L | Sprint actual |
+...
+```
+
+### 5. Guardar
+- `output/audits/YYYYMMDD-audit-{proyecto}.md`
+
+## Integración
+
+- `/project:release-plan` → (Phase 2) usa audit como input principal
+- `/legacy:assess` → fuente de datos para proyectos legacy
+- `/debt:track` → importa hallazgos de deuda del audit
+- `/risk:log` → alimenta registro de riesgos desde hallazgos críticos
+
+## Restricciones
+
+- Solo lectura — no modifica código ni Azure DevOps
+- Score es orientativo, no sustituye el juicio del equipo
+- Dimensiones sin datos se marcan "N/A" (no penalizan)

--- a/.claude/commands/project-kickoff.md
+++ b/.claude/commands/project-kickoff.md
@@ -1,0 +1,111 @@
+---
+name: project-kickoff
+description: >
+  Phase 5 — Compile audit + plan + assignments + roadmap into kickoff
+  report. Notify PM. Create Sprint 1 backlog in Azure DevOps.
+---
+
+# Project Kickoff
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/project:kickoff --project {p}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--notify {canal}` — Canal de notificación: slack, email (defecto: solo local)
+- `--create-sprint` — Crear Sprint 1 en Azure DevOps con scope de Release 1
+- `--dry-run` — Solo mostrar resumen, sin crear nada ni notificar
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `output/audits/` — Último audit (Phase 1)
+3. `output/plans/` — Último release plan (Phase 2)
+4. `output/roadmaps/` — Último roadmap (Phase 4)
+5. Resultados de `/project:assign` (Phase 3)
+
+## Pasos de ejecución
+
+### 1. Compilar resultados de las 4 fases
+
+Verificar que existen outputs de:
+- ✅ Phase 1: Audit → score global, hallazgos críticos
+- ✅ Phase 2: Release Plan → releases, timeline, dependencias
+- ✅ Phase 3: Assignments → matriz de asignación, alertas
+- ✅ Phase 4: Roadmap → diagrama, milestones
+
+Si falta alguna fase → avisar al PM y sugerir ejecutarla.
+
+### 2. Generar Kickoff Report
+
+```
+## Project Kickoff — {proyecto}
+Fecha: YYYY-MM-DD
+
+### 1. Estado del proyecto
+Score global: {n}/10 | Items críticos: {n} | Deuda técnica: {n}%
+{1-2 líneas de resumen del audit}
+
+### 2. Plan de releases
+| Release | Objetivo | Sprints | SP | Risk |
+|---|---|---|---|---|
+| R1: Stabilize | Fix críticos + tests | 1-2 | 34 | Alto |
+| R2: Core | Features principales | 3-5 | 55 | Medio |
+| R3: Launch | Polish + deploy | 6 | 18 | Bajo |
+
+### 3. Equipo y asignaciones
+| Persona | Rol | Sprint 1 | Sprint 2 |
+|---|---|---|---|
+| Ana | Senior Dev | Auth fix, CI/CD | API v2 |
+| Pedro | Mid Dev | Tests pagos | Dashboard |
+| María | Junior Dev | Docs API | Notificaciones |
+
+Alertas: {alertas de capacity o bus factor}
+
+### 4. Roadmap
+[Enlace o embed del diagrama Mermaid/Gantt]
+
+Milestones: MVP ({fecha}), Beta ({fecha}), Launch ({fecha})
+
+### 5. Próximos pasos
+1. Sprint Planning del Sprint 1: {fecha}
+2. Daily standup: cada día a las 09:15
+3. Sprint Review R1: {fecha}
+
+### 6. Riesgos top
+| Riesgo | Probabilidad | Impacto | Mitigación |
+|---|---|---|---|
+| {riesgo 1} | Alta | Alto | {acción} |
+```
+
+### 3. Crear Sprint 1 (si `--create-sprint`)
+- Crear iteration en Azure DevOps (nombre: Sprint YYYY-NN)
+- Mover PBIs de Release 1 al sprint
+- Asignar tasks según matriz de `/project:assign`
+- ⚠️ **Confirmar con PM antes de crear**
+
+### 4. Notificar (si `--notify`)
+- **slack**: enviar resumen al canal del proyecto via `/notify:slack`
+- **email**: generar email con kickoff report (no envía, solo genera)
+- Incluir: score, releases, roadmap, próximos pasos
+
+### 5. Guardar
+- `output/kickoffs/YYYYMMDD-kickoff-{proyecto}.md`
+
+## Integración
+
+- `/project:audit` → Phase 1 input
+- `/project:release-plan` → Phase 2 input
+- `/project:assign` → Phase 3 input
+- `/project:roadmap` → Phase 4 input
+- `/notify:slack` → distribución del kickoff
+- `/sprint:plan` → refinamiento del Sprint 1 post-kickoff
+
+## Restricciones
+
+- NUNCA crear sprint sin confirmación del PM
+- Si faltan fases previas, sugiere completarlas primero
+- Notificación requiere conector configurado
+- El kickoff report es de uso interno, no público

--- a/.claude/commands/project-release-plan.md
+++ b/.claude/commands/project-release-plan.md
@@ -1,0 +1,112 @@
+---
+name: project-release-plan
+description: >
+  Phase 2 — Generate prioritized release plan from audit + backlog.
+  Respects dependencies, risk, and business value.
+---
+
+# Project Release Plan
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/project:release-plan --project {p}` o con `--audit {file}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--audit {file}` — Fichero de audit previo (defecto: último generado)
+- `--sprints {n}` — Horizonte de planificación en sprints (defecto: 6)
+- `--strategy {greenfield|legacy|hybrid}` — Estrategia (auto-detecta si no se indica)
+- `--output {format}` — Formato: `md` (defecto), `xlsx`
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `output/audits/` — Último audit del proyecto (o `--audit`)
+3. `.claude/skills/azure-devops-queries/SKILL.md` — Backlog existente
+4. `.claude/skills/pbi-decomposition/SKILL.md` — Scoring de PBIs
+
+## Pasos de ejecución
+
+### 1. Recopilar inputs
+- **Audit report** → acciones priorizadas por tier (🔴🟡🟢)
+- **Backlog existente** → PBIs en Azure DevOps (New + Active)
+- **Dependencias** → `/dependency:map` si hay datos
+- **Riesgos** → `/risk:log` si hay registro
+- **Capacity del equipo** → `equipo.md` + `/report:capacity`
+
+### 2. Agrupar en releases lógicas
+
+Criterios de agrupación:
+1. **Dependencias**: items dependientes van en la misma release o en orden
+2. **Coherencia funcional**: features relacionadas juntas
+3. **Riesgo**: items 🔴 en releases tempranas
+4. **Business value**: items de mayor valor antes (MoSCoW si disponible)
+
+Para proyectos **legacy** → aplicar strangler fig:
+- Release 1: estabilizar (tests, CI/CD, security fixes)
+- Release 2-N: migrar módulo por módulo (de menor a mayor acoplamiento)
+- Release final: retirar código legacy
+
+### 3. Definir cada release
+
+Para cada release:
+```
+### Release {n}: {nombre descriptivo}
+Objetivo: {1 línea}
+Sprints estimados: {n}
+Entry criteria: {condiciones para empezar}
+Exit criteria: {definición de hecho}
+
+PBIs incluidos:
+| ID | Título | Tipo | SP | Dependencias |
+|---|---|---|---|---|
+| #1234 | Fix CVEs en auth | Bug | 5 | — |
+| #1235 | Tests módulo pagos | Tech | 13 | — |
+| #1236 | API v2 | Story | 21 | #1234 |
+
+Riesgos: {riesgos asociados}
+```
+
+### 4. Generar plan consolidado
+
+```
+## Release Plan — {proyecto}
+Fecha: YYYY-MM-DD | Horizonte: {n} sprints | Estrategia: {tipo}
+
+### Timeline
+Release 1 "Stabilize" — Sprint 1-2 (4 semanas)
+Release 2 "Core Features" — Sprint 3-5 (6 semanas)
+Release 3 "Polish & Launch" — Sprint 6 (2 semanas)
+
+### Resumen
+| Release | Sprints | PBIs | SP | Riesgo | Dependencias |
+|---|---|---|---|---|---|
+| R1: Stabilize | 1-2 | 8 | 34 | Alto | — |
+| R2: Core | 3-5 | 12 | 55 | Medio | R1 |
+| R3: Polish | 6 | 5 | 18 | Bajo | R2 |
+
+### Dependencias entre releases
+R1 → R2 → R3 (secuencial)
+R2.3 (#1240) → R2.5 (#1242) (intra-release)
+
+### Ruta crítica
+R1/#1234 → R2/#1236 → R3/#1250 (estimado: 10 sprints)
+```
+
+### 5. Guardar
+- `output/plans/YYYYMMDD-release-plan-{proyecto}.md`
+
+## Integración
+
+- `/project:audit` → (Phase 1) provee el input principal
+- `/project:assign` → (Phase 3) distribuye trabajo del plan
+- `/project:roadmap` → (Phase 4) visualiza el plan como timeline
+- `/dependency:map` → mapa de dependencias entre PBIs
+- `/pbi:decompose` → descomponer PBIs del plan en tasks
+
+## Restricciones
+
+- No crea work items — solo planifica y propone
+- El PM revisa y aprueba antes de ejecutar
+- Sin audit previo, genera plan solo desde backlog existente

--- a/.claude/commands/project-roadmap.md
+++ b/.claude/commands/project-roadmap.md
@@ -1,0 +1,119 @@
+---
+name: project-roadmap
+description: >
+  Phase 4 — Generate visual roadmap from release plan: timeline,
+  milestones, dependencies. Mermaid gantt → Draw.io/Miro.
+---
+
+# Project Roadmap
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/project:roadmap --project {p}` o con `--release-plan {file}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--release-plan {file}` — Fichero de release plan (defecto: último)
+- `--format {mermaid|drawio|miro}` — Formato de diagrama (defecto: mermaid)
+- `--audience {tech|executive}` — Nivel de detalle
+- `--include-assignments` — Incluir asignaciones por persona
+- `--output {format}` — Texto: `md` (defecto), `pptx`
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `output/plans/` — Último release plan
+3. `.claude/skills/diagram-generation/SKILL.md` — Generación de diagramas
+4. `.claude/rules/diagram-config.md` — Config Draw.io/Miro
+
+## Pasos de ejecución
+
+### 1. Cargar datos
+- Release plan → releases, sprints, PBIs, dependencias
+- Asignaciones → si `/project:assign` ya ejecutado
+- Calendario → fechas de sprints, festivos
+
+### 2. Generar diagrama Gantt (Mermaid)
+
+```mermaid
+gantt
+    title Roadmap — {proyecto}
+    dateFormat YYYY-MM-DD
+    axisFormat %d/%m
+
+    section Release 1: Stabilize
+    Fix CVEs auth      :crit, r1t1, 2026-03-02, 5d
+    Tests módulo pagos  :r1t2, 2026-03-02, 10d
+    CI/CD pipeline      :r1t3, after r1t1, 5d
+
+    section Release 2: Core Features
+    API v2              :r2t1, after r1t3, 15d
+    Dashboard métricas  :r2t2, after r1t2, 10d
+    Notificaciones      :r2t3, after r2t1, 8d
+
+    section Release 3: Polish
+    UX refinement       :r3t1, after r2t3, 5d
+    Performance tuning  :r3t2, after r2t2, 5d
+
+    section Milestones
+    MVP                 :milestone, m1, after r1t3, 0d
+    Beta                :milestone, m2, after r2t3, 0d
+    Launch              :milestone, m3, after r3t2, 0d
+```
+
+### 3. Adaptar por audiencia
+
+**tech**: incluye PBIs, tasks, dependencias, asignaciones por persona
+**executive**: solo releases, milestones, fechas clave, riesgos top
+
+### 4. Publicar diagrama
+
+- Si `--format mermaid` → incluir en markdown del roadmap
+- Si `--format drawio` → usar `/diagram:generate` → exportar XML
+- Si `--format miro` → usar `/diagram:generate` → publicar board
+
+### 5. Generar resumen ejecutivo
+
+```
+## Roadmap — {proyecto}
+Fecha: YYYY-MM-DD | Horizonte: {n} sprints ({m} semanas)
+
+### Timeline visual
+[Gantt diagram above]
+
+### Milestones
+| Milestone | Fecha | Releases | Estado |
+|---|---|---|---|
+| MVP | 2026-03-14 | R1 | 🔴 Pendiente |
+| Beta | 2026-04-11 | R1+R2 | — |
+| Launch | 2026-04-25 | R1+R2+R3 | — |
+
+### Riesgos para el timeline
+1. Dependencia de API Gateway (equipo Platform) → retraso +1 sprint
+2. Capacity reducida en Sprint 4 (vacaciones Ana)
+
+### Próximos pasos
+1. Aprobar release plan
+2. Iniciar Sprint 1 con scope de Release 1
+3. Review de progreso en Sprint Review
+```
+
+### 6. Guardar
+- Diagrama: `output/roadmaps/YYYYMMDD-roadmap-{proyecto}.mermaid`
+- Resumen: `output/roadmaps/YYYYMMDD-roadmap-{proyecto}.md`
+- Si `--output pptx` → usar `/report:executive` para presentación
+
+## Integración
+
+- `/project:release-plan` → (Phase 2) fuente de datos principal
+- `/project:assign` → (Phase 3) asignaciones para vista tech
+- `/project:kickoff` → (Phase 5) incluye roadmap en el kickoff
+- `/diagram:generate` → publicar en Draw.io o Miro
+- `/report:executive` → versión presentación del roadmap
+
+## Restricciones
+
+- Solo lectura — no crea work items ni modifica Azure DevOps
+- Diagrama Mermaid es local; Draw.io/Miro requieren config previa
+- Fechas son estimadas, basadas en velocity y capacity

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -81,6 +81,11 @@
 | `/legacy:assess {--project p}` | Evaluación de aplicación legacy: complejidad, riesgo, roadmap de modernización (strangler fig) |
 | `/backlog:capture {--project p} {--source tipo}` | Crear PBIs desde input desestructurado: emails, reuniones, Slack, tickets de soporte |
 | `/sprint:release-notes {--project p}` | Generar release notes automáticas combinando work items + commits + PRs |
+| `/project:audit {--project p}` | (Phase 1) Deep audit del proyecto: calidad, tests, deuda, seguridad, CI/CD → informe priorizado |
+| `/project:release-plan {--project p}` | (Phase 2) Plan de releases priorizado desde audit + backlog, respetando dependencias |
+| `/project:assign {--project p}` | (Phase 3) Asignar trabajo del plan al equipo según skills, seniority y capacity |
+| `/project:roadmap {--project p}` | (Phase 4) Roadmap visual: timeline, milestones, diagrama Gantt → Draw.io/Miro |
+| `/project:kickoff {--project p}` | (Phase 5) Compilar fases 1-4, notificar PM, crear Sprint 1 en Azure DevOps |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Planned
 
-**High priority — Project Onboarding & Release Planning pipeline**
-
-Full automated workflow for onboarding new projects and planning their execution. Five interconnected phases:
-
-- `project:audit` — (Phase 1: Analysis) Deep audit of a newly onboarded project: code quality, architecture, test coverage, technical debt, security, documentation, CI/CD maturity. Generates a prioritized action report with three tiers: critical (must fix), improvable (should fix), and good (keep). Leverages `/evaluate:repo`, `/sentry:health`, `/pipeline:status`, `/debt:track`, and `/kpi:dora` internally. Output: `output/audits/YYYYMMDD-audit-{project}.md`
-- `project:release-plan` — (Phase 2: Planning) Generate a prioritized release plan from the audit report + backlog. Groups PBIs into logical releases respecting dependencies (`/dependency:map`), risk (`/risk:log`), and business value. Each release has: scope, entry/exit criteria, estimated sprints, and dependency graph. Supports both greenfield and legacy projects (strangler fig phasing for legacy). Output: `output/plans/YYYYMMDD-release-plan-{project}.md`
-- `project:assign` — (Phase 3: Assignment) Distribute release plan work across the team. Reads `equipo.md` profiles (skills, seniority, capacity), applies `/team:workload` and `/report:capacity` to balance load, and assigns PBIs/Tasks per sprint using the scoring algorithm from `pbi-decomposition` skill. Generates assignment matrix with per-person load, skill-match %, and overload alerts
-- `project:roadmap` — (Phase 4: Roadmap) Generate a visual roadmap from the release plan: timeline with milestones, releases, sprints, and dependencies. Uses `/diagram:generate` to produce Mermaid gantt/flow → Draw.io or Miro. Also generates an executive-friendly summary via `/report:executive`. Output: diagram + `output/roadmaps/YYYYMMDD-roadmap-{project}.md`
-- `project:kickoff` — (Phase 5: Notification) Summarize and notify. Compiles audit + release plan + assignments + roadmap into a kickoff report. Sends to PM and stakeholders via configured channel (`/notify:slack`, email, or Teams). Creates the Sprint 1 backlog in Azure DevOps with the first release scope already decomposed and assigned
-
 **Medium priority — valuable additions aligned with current architecture**
 - `wiki:publish` / `wiki:sync` — publish and sync documentation with Azure DevOps Wiki (MCP has 6 wiki tools)
 - `testplan:status` / `testplan:results` — manage Azure DevOps Test Plans and view test results (MCP has 9 test plan tools)
@@ -29,6 +19,27 @@ Full automated workflow for onboarding new projects and planning their execution
 **Lower priority — infrastructure and tooling**
 - GitHub Actions: auto-label PRs by branch prefix (`feature/`, `fix/`, `docs/`)
 - Migrate work item CRUD from REST/CLI (`azdevops-queries.sh`) to MCP tools where equivalent
+
+---
+
+## [0.7.0] — 2026-02-27
+
+Project Onboarding Pipeline: 5-phase automated workflow for onboarding new projects. From audit to kickoff in one pipeline. Adds 5 new commands. Total: 70 slash commands.
+
+### Added
+
+**Project Onboarding commands (5)** — PR #42
+- `/project:audit --project {p}` — (Phase 1) Deep project audit: 8 dimensions (code quality, tests, architecture, debt, security, docs, CI/CD, team health). Generates prioritized action report with 3 tiers: critical, improvable, correct. Leverages `/debt:track`, `/kpi:dora`, `/pipeline:status`, `/sentry:health` internally
+- `/project:release-plan --project {p}` — (Phase 2) Prioritized release plan from audit + backlog. Groups PBIs into releases respecting dependencies, risk, and business value. Supports greenfield and legacy (strangler fig) strategies
+- `/project:assign --project {p}` — (Phase 3) Distribute work across team by skills, seniority, and capacity. Scoring algorithm: skill_match (40%) + capacity (30%) + seniority_fit (20%) + context_bonus (10%). Alerts for overload and bus factor
+- `/project:roadmap --project {p}` — (Phase 4) Visual roadmap: Mermaid Gantt with milestones, dependencies, releases. Exports to Draw.io/Miro. Two audiences: tech (detailed) and executive (summary)
+- `/project:kickoff --project {p}` — (Phase 5) Compile phases 1-4 into kickoff report. Notify PM via Slack/email. Optionally create Sprint 1 in Azure DevOps with Release 1 scope
+
+### Changed
+- Command count: 65 → 70 (+5 onboarding)
+- Help command updated with Project Onboarding (5) category
+- `pm-workflow.md` updated with 5 new onboarding command entries
+- READMEs (ES/EN) updated with project onboarding commands
 
 ---
 
@@ -237,7 +248,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 65 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 70 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 12 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 65 slash commands
+│   ├── commands/                ← 70 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -26,6 +26,7 @@
 │   │   ├── repos-list.md ...   ← Azure Repos (6)
 │   │   ├── debt-track.md ...    ← Governance (5: deuda técnica, DORA, dependencias, retro actions, riesgos)
 │   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
+│   │   ├── project-audit.md ... ← Project Onboarding (5: audit, release-plan, assign, roadmap, kickoff)
 │   │   ├── notify-slack.md ...  ← Conectores (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 65 slash commands
+│   ├── commands/                ← 70 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -26,6 +26,7 @@
 │   │   ├── repos-list.md ...   ← Azure Repos (6)
 │   │   ├── debt-track.md ...    ← Governance (5: tech debt, DORA, dependencies, retro actions, risks)
 │   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
+│   │   ├── project-audit.md ... ← Project Onboarding (5: audit, release-plan, assign, roadmap, kickoff)
 │   │   ├── notify-slack.md ...  ← Connectors (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)


### PR DESCRIPTION
## Summary
- 5 new commands implementing the 5-phase project onboarding pipeline:
  - `project:audit` (Phase 1) — Deep project audit with 8-dimension scoring
  - `project:release-plan` (Phase 2) — Prioritized release plan from audit + backlog
  - `project:assign` (Phase 3) — Team assignment by skills, seniority, capacity
  - `project:roadmap` (Phase 4) — Visual roadmap with Mermaid Gantt → Draw.io/Miro
  - `project:kickoff` (Phase 5) — Compile all phases, notify PM, create Sprint 1
- Help command updated with Project Onboarding (5) category
- pm-workflow.md, CLAUDE.md, READMEs (ES/EN) updated
- CHANGELOG updated: onboarding pipeline moved from Planned to [0.7.0]
- Total: 70 slash commands

## Test plan
- [ ] `bash scripts/validate-commands.sh` passes (0 errors)
- [ ] `/help onboarding` shows 5 commands
- [ ] Each phase references correct predecessor phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)