### PR TITLE
v0.8.0 — DevOps Extended

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -30,9 +30,10 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Governance (5):** debt:track --project {p}, kpi:dora --project {p}, dependency:map --project {p}, retro:actions --project {p}, risk:log --project {p}
    **Legacy & Capture (3):** legacy:assess --project {p}, backlog:capture --project {p} --source {tipo}, sprint:release-notes --project {p}
    **Project Onboarding (5):** project:audit --project {p}, project:release-plan --project {p}, project:assign --project {p}, project:roadmap --project {p}, project:kickoff --project {p}
+   **DevOps Extended (5):** wiki:publish {file} --project {p}, wiki:sync --project {p}, testplan:status --project {p}, testplan:results --project {p} --run {id}, security:alerts --project {p}
    **Conectores (12):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}, jira:sync --project {p}, confluence:publish {file} --project {p}, notion:sync --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, onboarding, audit, roadmap, kickoff, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, onboarding, audit, roadmap, kickoff, wiki, testplan, security, devops, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/security-alerts.md
+++ b/.claude/commands/security-alerts.md
@@ -1,0 +1,98 @@
+---
+name: security-alerts
+description: >
+  Alertas de seguridad desde Azure DevOps Advanced Security.
+  CVEs, dependencias vulnerables, secrets expuestos.
+---
+
+# Security Alerts
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/security:alerts --project {p}` o `/security:alerts --project {p} --severity {level}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--repo {nombre}` — Repositorio específico (defecto: todos)
+- `--severity {critical|high|medium|low}` — Filtrar por severidad
+- `--type {dependency|secret|code}` — Filtrar por tipo de alerta
+- `--status {active|dismissed|fixed}` — Filtrar por estado
+- `--create-pbi` — Crear PBIs para alertas críticas/high
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. Azure DevOps Advanced Security habilitado en el proyecto
+
+## Pasos de ejecución
+
+### 1. Obtener alertas
+- MCP: `get_alerts` → listar alertas de seguridad del proyecto
+- Filtrar por parámetros proporcionados
+- Para cada alerta: MCP: `get_alert_details` → detalle completo
+
+### 2. Clasificar y priorizar
+
+| Tipo | Descripción | Severidad típica |
+|---|---|---|
+| Dependency | CVE en dependencia (NuGet, npm, pip...) | Variable |
+| Secret | Token, key, password en código | Critical |
+| Code | Vulnerability pattern en código fuente | Variable |
+
+Priorización: Critical → High → Medium → Low × edad de la alerta
+
+### 3. Presentar dashboard
+
+```
+## Security Alerts — {proyecto}
+Fecha: YYYY-MM-DD | Repos analizados: 3
+
+### Resumen
+| Severidad | Activas | Dismissed | Fixed |
+|---|---|---|---|
+| 🔴 Critical | 2 | 0 | 3 |
+| 🟠 High | 5 | 1 | 8 |
+| 🟡 Medium | 12 | 3 | 15 |
+| ⚪ Low | 8 | 5 | 20 |
+
+### Alertas críticas activas
+| # | Tipo | Descripción | Repo | Edad |
+|---|---|---|---|---|
+| 1 | Secret | GitHub token en appsettings.json | backend | 5 días |
+| 2 | Dependency | CVE-2026-1234 en auth-lib v2.1 (RCE) | backend | 12 días |
+
+### Alertas high activas
+| # | Tipo | Descripción | Repo | Edad |
+|---|---|---|---|---|
+| 1 | Dependency | CVE-2026-5678 en lodash v4.17 (XSS) | frontend | 3 días |
+| 2 | Code | SQL injection pattern en UserController | backend | 8 días |
+...
+
+### Recomendaciones
+1. 🚨 Rotar GitHub token expuesto INMEDIATAMENTE
+2. Actualizar auth-lib v2.1 → v3.0 (fix CVE-2026-1234)
+3. Actualizar lodash v4.17 → v4.18 (fix CVE-2026-5678)
+
+### Tendencia (últimos 30 días)
+Nuevas: 8 | Resueltas: 11 | Netas: -3 (mejorando 📉)
+```
+
+### 4. Crear PBIs (si `--create-pbi`)
+- Para cada alerta Critical/High activa → proponer PBI tipo Bug
+- **Confirmar con PM** antes de crear
+- Incluir: CVE ID, severidad, fix recomendado, repo afectado
+
+## Integración
+
+- `/project:audit` → incluye security alerts en evaluación
+- `/evaluate:repo` → complementario (evaluate:repo = estático, security:alerts = dinámico)
+- `/debt:track` → alertas no resueltas como deuda de seguridad
+- `/risk:log` → alertas critical alimentan registro de riesgos
+
+## Restricciones
+
+- Requiere Azure DevOps Advanced Security habilitado
+- MCP tools: `get_alerts`, `get_alert_details`
+- No remedia automáticamente — solo reporta y propone PBIs
+- Crear PBIs requiere confirmación del PM

--- a/.claude/commands/testplan-results.md
+++ b/.claude/commands/testplan-results.md
@@ -1,0 +1,88 @@
+---
+name: testplan-results
+description: >
+  Resultados detallados de ejecución de tests en Azure DevOps.
+  Análisis de fallos, tendencias y recomendaciones.
+---
+
+# TestPlan Results
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/testplan:results --project {p} --run {id}` o `--plan {id}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--run {id}` — ID del test run específico
+- `--plan {id}` — Resultados del último run de un plan
+- `--suite {id}` — Resultados de una suite específica
+- `--status {passed|failed|blocked}` — Filtrar por resultado
+- `--last {n}` — Últimos n runs (para análisis de tendencia)
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. Azure DevOps Test Plans con runs ejecutados
+
+## Pasos de ejecución
+
+### 1. Obtener resultados
+- MCP: `get_test_results` → resultados del run/plan indicado
+- Si `--last {n}` → obtener últimos n runs para tendencia
+
+### 2. Analizar fallos
+
+Para cada test fallido:
+- Nombre del test case y suite
+- Mensaje de error / stack trace (si disponible)
+- Historial: ¿es un flaky test? ¿fallo nuevo o recurrente?
+- PBI asociado (si linked)
+
+### 3. Presentar resultados
+
+```
+## Test Results — {proyecto} — Run #{id}
+Fecha: YYYY-MM-DD | Duración: 12m 34s | Ejecutor: Pedro López
+
+### Resumen
+Total: 47 | ✅ 30 (64%) | ❌ 7 (15%) | ⏸️ 3 (6%) | ⬜ 7 (15%)
+
+### Fallos detallados
+| # | Test Case | Suite | Error | Recurrente |
+|---|---|---|---|---|
+| 1 | TC-045 Payment validation | Payments | AssertionError: expected 200, got 500 | 🔴 3 runs |
+| 2 | TC-048 Refund flow | Payments | Timeout after 30s | 🟡 Nuevo |
+| 3 | TC-012 Token refresh | Auth | NullReferenceException | 🔴 5 runs |
+
+### Tests bloqueados
+| Test Case | Razón | Dependencia |
+|---|---|---|
+| TC-050 Payment report | Entorno PRE caído | Infra |
+
+### Tendencia (últimos 5 runs)
+Run #105: 64% passed
+Run #104: 68% passed
+Run #103: 55% passed ← regresión
+Run #102: 72% passed
+Run #101: 70% passed
+Tendencia: 📉 bajando (-6% vs media)
+
+### Recomendaciones
+1. TC-012 Token refresh: fallo recurrente (5 runs) → crear Bug PBI
+2. TC-045 Payment validation: fallo recurrente (3 runs) → investigar
+3. Suite Payments: 5/22 fallan → bloquea release de PBI #1235
+```
+
+## Integración
+
+- `/testplan:status` → vista general de planes y suites
+- `/sentry:bugs` → correlacionar fallos de tests con errores en producción
+- `/sprint:review` → incluir resultados en sprint review
+- `/debt:track` → tests flaky como deuda técnica
+
+## Restricciones
+
+- Solo lectura — no ejecuta ni modifica test runs
+- Stack traces pueden no estar disponibles para tests manuales
+- Tendencia requiere al menos 3 runs anteriores

--- a/.claude/commands/testplan-status.md
+++ b/.claude/commands/testplan-status.md
@@ -1,0 +1,79 @@
+---
+name: testplan-status
+description: >
+  Estado de Test Plans en Azure DevOps: planes activos,
+  suites, casos de test, ejecución y cobertura.
+---
+
+# TestPlan Status
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/testplan:status --project {p}` o `/testplan:status --project {p} --plan {id}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--plan {id|nombre}` — Test Plan específico (defecto: todos los activos)
+- `--suite {id}` — Suite específica dentro del plan
+- `--sprint {nombre}` — Filtrar por sprint asociado
+- `--assigned {persona}` — Filtrar por tester asignado
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. Azure DevOps Test Plans configurados en el proyecto
+
+## Pasos de ejecución
+
+### 1. Obtener datos
+- MCP: `get_test_plans` → listar planes de test del proyecto
+- Para cada plan activo: MCP: `get_test_suites` → suites
+- Para cada suite: obtener test cases y estados
+
+### 2. Calcular métricas
+
+- **Total test cases** por plan/suite
+- **Ejecución**: % passed, failed, blocked, not run
+- **Cobertura**: PBIs con tests asociados vs PBIs sin tests
+- **Tendencia**: comparar con sprint anterior si hay datos
+
+### 3. Presentar dashboard
+
+```
+## Test Plans — {proyecto}
+
+### Plan activo: "Sprint 2026-04 Tests"
+| Suite | Total | ✅ Passed | ❌ Failed | ⏸️ Blocked | ⬜ Not Run |
+|---|---|---|---|---|---|
+| Auth Module | 15 | 12 | 2 | 0 | 1 |
+| Payments | 22 | 8 | 5 | 3 | 6 |
+| Dashboard | 10 | 10 | 0 | 0 | 0 |
+| **Total** | **47** | **30 (64%)** | **7 (15%)** | **3 (6%)** | **7 (15%)** |
+
+### Cobertura por PBI
+| PBI | Tests | Ejecución | Estado |
+|---|---|---|---|
+| #1234 Auth SSO | 8 | 6/8 passed | 🟡 Parcial |
+| #1235 Payments | 12 | 3/12 passed | 🔴 Crítico |
+| #1236 Dashboard | 10 | 10/10 passed | 🟢 Completo |
+| #1237 Reports | 0 | — | ⚠️ Sin tests |
+
+### Alertas
+- ⚠️ PBI #1237 sin tests asociados
+- 🔴 Suite Payments: 5 failures en último run
+- ℹ️ 7 tests pendientes de ejecutar
+```
+
+## Integración
+
+- `/testplan:results` → detalle de resultados de ejecución
+- `/kpi:dashboard` → incluye cobertura de tests como KPI
+- `/sprint:review` → resumen de test status para review
+- `/project:audit` → evalúa madurez de testing
+
+## Restricciones
+
+- Solo lectura — no crea ni modifica test plans
+- Requiere Azure DevOps Test Plans habilitado en el proyecto
+- MCP tools: `get_test_plans`, `get_test_suites`, `get_test_results`

--- a/.claude/commands/wiki-publish.md
+++ b/.claude/commands/wiki-publish.md
@@ -1,0 +1,70 @@
+---
+name: wiki-publish
+description: >
+  Publicar documentación y páginas en Azure DevOps Wiki.
+  Soporta markdown, imágenes y estructura de páginas.
+---
+
+# Wiki Publish
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/wiki:publish {file} --project {p}` o `/wiki:publish --project {p} --page {path}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `{file}` — Fichero local a publicar (.md)
+- `--page {path}` — Ruta de la página en la wiki (ej: `/Architecture/Overview`)
+- `--wiki {nombre}` — Nombre de la wiki (defecto: wiki del proyecto)
+- `--update` — Actualizar página existente (en lugar de crear nueva)
+- `--dry-run` — Solo preview, no publicar
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. Azure DevOps Wiki configurada en el proyecto
+
+## Pasos de ejecución
+
+### 1. Preparar contenido
+- Leer fichero local (.md) o generar contenido desde prompt
+- Validar markdown: links, imágenes, formato
+- Adaptar paths de imágenes si hay (relative → wiki attachments)
+
+### 2. Verificar wiki destino
+- MCP: `get_wikis` → listar wikis disponibles del proyecto
+- Si no hay wiki → avisar al PM y sugerir crearla
+- Verificar si la página ya existe (`get_wiki_page`)
+
+### 3. Publicar
+
+Si página nueva:
+- MCP: `create_wiki_page` con path y contenido
+- Confirmar ruta y título con el PM antes de crear
+
+Si actualización (`--update`):
+- MCP: `update_wiki_page` con nueva versión del contenido
+- Mostrar diff si es posible
+
+### 4. Presentar resultado
+
+```
+## Wiki Publish — {proyecto}
+Página: /Architecture/Overview
+Estado: ✅ Publicada
+URL: https://dev.azure.com/{org}/{project}/_wiki/wikis/{wiki}/...
+Tamaño: 2.4 KB | Líneas: 85
+```
+
+## Integración
+
+- `/wiki:sync` → sincronización bidireccional wiki ↔ local
+- `/report:executive` → publicar informes en wiki
+- `/confluence:publish` → alternativa para equipos con Confluence
+
+## Restricciones
+
+- NUNCA publicar sin confirmación del PM
+- No soporta wikis de tipo "Code Wiki" (solo Project Wiki)
+- Imágenes deben subirse como attachments separadamente

--- a/.claude/commands/wiki-sync.md
+++ b/.claude/commands/wiki-sync.md
@@ -1,0 +1,70 @@
+---
+name: wiki-sync
+description: >
+  Sincronizar documentación entre ficheros locales y Azure DevOps Wiki.
+  Bidireccional: local→wiki y wiki→local.
+---
+
+# Wiki Sync
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/wiki:sync --project {p}` o `/wiki:sync --project {p} --direction {dir}`
+
+## Parámetros
+
+- `--project {nombre}` — Proyecto de PM-Workspace (obligatorio)
+- `--direction {push|pull|status}` — Dirección de sync (defecto: status)
+- `--path {ruta}` — Sincronizar solo una ruta específica de la wiki
+- `--wiki {nombre}` — Nombre de la wiki (defecto: wiki del proyecto)
+- `--dry-run` — Solo mostrar cambios, no sincronizar
+
+## Contexto requerido
+
+1. `projects/{proyecto}/CLAUDE.md` — Config del proyecto
+2. `projects/{proyecto}/docs/` — Documentación local del proyecto
+3. Azure DevOps Wiki configurada en el proyecto
+
+## Pasos de ejecución
+
+### Modo `status` (por defecto)
+1. MCP: `get_wikis` → obtener wiki del proyecto
+2. MCP: `get_wiki_page` → listar páginas existentes
+3. Comparar con ficheros locales en `projects/{proyecto}/docs/`
+4. Mostrar estado de sincronización:
+
+```
+## Wiki Sync Status — {proyecto}
+
+| Página | Local | Wiki | Estado |
+|---|---|---|---|
+| /Architecture/Overview | ✅ | ✅ | 🟢 Sincronizado |
+| /API/Endpoints | ✅ | ❌ | 🔵 Solo local |
+| /Setup/Installation | ❌ | ✅ | 🟡 Solo wiki |
+| /Architecture/Decisions | ✅ | ✅ | 🔴 Conflicto (ambos modificados) |
+
+Sincronizados: 5 | Solo local: 2 | Solo wiki: 1 | Conflictos: 1
+```
+
+### Modo `push` (local → wiki)
+1. Detectar ficheros locales nuevos o modificados
+2. Para cada fichero → MCP: `create_wiki_page` o `update_wiki_page`
+3. **Confirmar con PM** antes de cada cambio
+4. Reportar resultado
+
+### Modo `pull` (wiki → local)
+1. Detectar páginas wiki nuevas o modificadas
+2. Para cada página → descargar y guardar en `projects/{proyecto}/docs/`
+3. Reportar resultado
+
+## Integración
+
+- `/wiki:publish` → publicar páginas individuales
+- `/notion:sync` → patrón similar para Notion
+- `/confluence:publish` → patrón similar para Confluence
+
+## Restricciones
+
+- Conflictos requieren resolución manual por el PM
+- No soporta sync de imágenes (solo markdown)
+- Push requiere confirmación del PM para cada página

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -86,6 +86,11 @@
 | `/project:assign {--project p}` | (Phase 3) Asignar trabajo del plan al equipo según skills, seniority y capacity |
 | `/project:roadmap {--project p}` | (Phase 4) Roadmap visual: timeline, milestones, diagrama Gantt → Draw.io/Miro |
 | `/project:kickoff {--project p}` | (Phase 5) Compilar fases 1-4, notificar PM, crear Sprint 1 en Azure DevOps |
+| `/wiki:publish {file} {--project p}` | Publicar documentación en Azure DevOps Wiki |
+| `/wiki:sync {--project p}` | Sincronizar documentación local ↔ Azure DevOps Wiki (bidireccional) |
+| `/testplan:status {--project p}` | Estado de Test Plans: suites, casos, ejecución, cobertura |
+| `/testplan:results {--project p} {--run id}` | Resultados detallados de test runs: fallos, tendencias, recomendaciones |
+| `/security:alerts {--project p}` | Alertas de seguridad: CVEs, secrets, vulnerabilidades (Azure DevOps Advanced Security) |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Planned
 
-**Medium priority — valuable additions aligned with current architecture**
-- `wiki:publish` / `wiki:sync` — publish and sync documentation with Azure DevOps Wiki (MCP has 6 wiki tools)
-- `testplan:status` / `testplan:results` — manage Azure DevOps Test Plans and view test results (MCP has 9 test plan tools)
-- `security:alerts` — surface security alerts from Azure DevOps Advanced Security (MCP has 2 security tools)
-
 **Lower priority — infrastructure and tooling**
 - GitHub Actions: auto-label PRs by branch prefix (`feature/`, `fix/`, `docs/`)
 - Migrate work item CRUD from REST/CLI (`azdevops-queries.sh`) to MCP tools where equivalent
+
+---
+
+## [0.8.0] — 2026-02-27
+
+DevOps Extended: Azure DevOps Wiki management, Test Plans visibility, and security alerts. Leverages remaining MCP tool domains. Adds 5 new commands. Total: 75 slash commands.
+
+### Added
+
+**DevOps Extended commands (5)** — PR #43
+- `/wiki:publish {file} --project {p}` — publish markdown documentation to Azure DevOps Wiki. Supports create and update operations via MCP wiki tools
+- `/wiki:sync --project {p}` — bidirectional sync between local docs and Azure DevOps Wiki. Three modes: status (compare), push (local→wiki), pull (wiki→local). Conflict detection
+- `/testplan:status --project {p}` — Test Plans dashboard: active plans, suites, test cases, execution rates (passed/failed/blocked/not run), PBI test coverage, alerts for untested PBIs
+- `/testplan:results --project {p} --run {id}` — detailed test run results: failure analysis, stack traces, flaky test detection, trend over last N runs, recommendations for Bug PBI creation
+- `/security:alerts --project {p}` — security alerts from Azure DevOps Advanced Security: CVEs, exposed secrets, code vulnerabilities. Severity filtering, trend analysis, optional PBI creation for critical/high alerts
+
+### Changed
+- Command count: 70 → 75 (+5 DevOps Extended)
+- Help command updated with DevOps Extended (5) category
+- `pm-workflow.md` updated with 5 new command entries
+- READMEs (ES/EN) updated with DevOps Extended commands
 
 ---
 
@@ -248,7 +264,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.4.0...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 70 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 75 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 12 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 70 slash commands
+│   ├── commands/                ← 75 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -27,6 +27,7 @@
 │   │   ├── debt-track.md ...    ← Governance (5: deuda técnica, DORA, dependencias, retro actions, riesgos)
 │   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
 │   │   ├── project-audit.md ... ← Project Onboarding (5: audit, release-plan, assign, roadmap, kickoff)
+│   │   ├── wiki-publish.md ...  ← DevOps Extended (5: wiki, testplan, security alerts)
 │   │   ├── notify-slack.md ...  ← Conectores (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 70 slash commands
+│   ├── commands/                ← 75 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -27,6 +27,7 @@
 │   │   ├── debt-track.md ...    ← Governance (5: tech debt, DORA, dependencies, retro actions, risks)
 │   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
 │   │   ├── project-audit.md ... ← Project Onboarding (5: audit, release-plan, assign, roadmap, kickoff)
+│   │   ├── wiki-publish.md ...  ← DevOps Extended (5: wiki, testplan, security alerts)
 │   │   ├── notify-slack.md ...  ← Connectors (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)


### PR DESCRIPTION
## Summary
- 5 new commands leveraging remaining Azure DevOps MCP tool domains:
  - `wiki:publish` — Publish docs to Azure DevOps Wiki
  - `wiki:sync` — Bidirectional sync local docs ↔ Wiki
  - `testplan:status` — Test Plans dashboard with coverage metrics
  - `testplan:results` — Detailed test run analysis with flaky detection
  - `security:alerts` — Security alerts: CVEs, secrets, vulnerabilities
- Help command updated with DevOps Extended (5) category
- pm-workflow.md, CLAUDE.md, READMEs (ES/EN) updated
- CHANGELOG: all Planned items now implemented, only infra/tooling items remain
- Total: 75 slash commands

## Test plan
- [ ] `bash scripts/validate-commands.sh` passes (0 errors)
- [ ] `/help wiki` shows wiki commands
- [ ] `/help security` shows security:alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)