### PR TITLE
v0.9.0 — Messaging & Voice Inbox

### DIFF
--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -31,9 +31,10 @@ Muestra la ayuda de PM-Workspace. Pasos:
    **Legacy & Capture (3):** legacy:assess --project {p}, backlog:capture --project {p} --source {tipo}, sprint:release-notes --project {p}
    **Project Onboarding (5):** project:audit --project {p}, project:release-plan --project {p}, project:assign --project {p}, project:roadmap --project {p}, project:kickoff --project {p}
    **DevOps Extended (5):** wiki:publish {file} --project {p}, wiki:sync --project {p}, testplan:status --project {p}, testplan:results --project {p} --run {id}, security:alerts --project {p}
+   **Mensajería e Inbox (6):** notify:whatsapp {contacto} {msg}, whatsapp:search {query}, notify:nctalk {sala} {msg}, nctalk:search {query}, inbox:check, inbox:start --interval {min}
    **Conectores (12):** notify:slack {canal} {msg}, slack:search {query}, github:activity {repo}, github:issues {repo}, sentry:health --project {p}, sentry:bugs --project {p}, gdrive:upload {file} --project {p}, linear:sync --project {p}, jira:sync --project {p}, confluence:publish {file} --project {p}, notion:sync --project {p}, figma:extract {url} --project {p}
    **Utilidades (2):** context:load, help [filtro]
 
-   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, onboarding, audit, roadmap, kickoff, wiki, testplan, security, devops, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
+   Si $ARGUMENTS filtra (sprint, pbi, sdd, pr, team, infra, diagram, pipeline, repos, governance, debt, dora, risk, dependency, retro, legacy, capture, backlog, release-notes, onboarding, audit, roadmap, kickoff, wiki, testplan, security, devops, whatsapp, nctalk, nextcloud, inbox, messaging, voice, slack, github, sentry, gdrive, linear, jira, confluence, atlassian, notion, figma, connectors, --setup), mostrar solo esa sección.
 
 3. **Solo lectura** — no modificar ficheros. No mostrar secrets.

--- a/.claude/commands/inbox-check.md
+++ b/.claude/commands/inbox-check.md
@@ -1,0 +1,104 @@
+---
+name: inbox-check
+description: >
+  Revisar mensajes nuevos en todos los canales de mensajería.
+  Transcribir audios, interpretar peticiones y proponer acciones.
+---
+
+# Inbox Check
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/inbox:check` o `/inbox:check --channels wa` o `/inbox:check --since {fecha}`
+
+## Parámetros
+
+- `--channels {wa|nctalk|all}` — Canales a revisar (defecto: todos los activos)
+- `--since {fecha|last}` — Desde cuándo (defecto: último check, o 24h si es primera vez)
+- `--audio-only` — Solo procesar mensajes de audio
+- `--no-transcribe` — No transcribir audios (solo listar)
+- `--project {nombre}` — Filtrar mensajes relacionados con un proyecto
+
+## Contexto requerido
+
+1. @.claude/rules/messaging-config.md — Config canales activos
+2. `.claude/skills/voice-inbox/SKILL.md` — Transcripción de audio
+3. MCP de WhatsApp y/o API de Nextcloud Talk según canales activos
+
+## Pasos de ejecución
+
+### 1. Determinar ventana temporal
+- Leer `inbox/last-check.txt` → timestamp del último check
+- Si no existe → usar últimas 24 horas
+- Si `--since {fecha}` → usar esa fecha
+
+### 2. Recopilar mensajes nuevos
+
+**WhatsApp (si habilitado):**
+- MCP: `list_chats` → chats con mensajes nuevos
+- MCP: `list_messages` con filtro desde último check
+- Separar: textos, audios, imágenes, documentos
+
+**Nextcloud Talk (si habilitado):**
+- API: `GET /chat/{token}?lookIntoFuture=0&lastKnownMessageId={id}`
+- Separar: textos, audios, ficheros compartidos
+
+**Inbox local (Modo 3):**
+- Leer `inbox/pending.json` si existe (mensajes del listener)
+
+### 3. Procesar audios
+
+Para cada mensaje de audio:
+1. Descargar: MCP `download_media` (WhatsApp) o API share (NCTalk)
+2. Convertir si necesario: `ffmpeg -i input.ogg -ar 16000 -ac 1 output.wav`
+3. Transcribir: Faster-Whisper con modelo configurado
+4. Interpretar: mapear texto a comando de pm-workspace
+5. Clasificar confianza: alta / media / baja
+
+### 4. Presentar resumen
+
+```
+## 📬 Inbox Check — 2026-02-27 11:00
+Último check: 2026-02-27 09:00 (hace 2h)
+
+### WhatsApp — 5 mensajes nuevos (1 audio)
+Grupo "Equipo Sala Reservas":
+  [09:15] Ana García: "¿Podemos adelantar la review a jueves?"
+  [09:22] Pedro López: "Por mí bien, si el PM confirma"
+  [10:30] Ana García: 🎤 Audio (12s):
+    📝 "Ponme el estado del sprint de sala reservas, porfa"
+    → /sprint:status --project sala-reservas [confianza: alta]
+    → ¿Ejecutar? (s/n)
+
+Chat "Carlos Sanz":
+  [10:45] Carlos: "Los tests de integración ya pasan todos"
+  [10:46] Carlos: 📎 test-results.png
+
+### Nextcloud Talk — 2 mensajes nuevos
+Sala "equipo-sala-reservas":
+  [09:30] María Ruiz: "He subido los mockups al Drive"
+  [10:00] Pedro López: "Revisado, falta el flujo de error"
+
+### Resumen de acciones pendientes
+1. 🎤 Ejecutar /sprint:status --project sala-reservas (Ana, WhatsApp)
+2. 💬 Ana pregunta adelantar review → requiere decisión del PM
+3. ℹ️ Carlos confirma tests OK → informativo
+```
+
+### 5. Actualizar timestamp
+- Guardar timestamp actual en `inbox/last-check.txt`
+- Guardar transcripciones en `inbox/transcriptions/` (si configurado)
+
+## Integración
+
+- `/inbox:start` → lanza inbox:check en background cada N minutos
+- `/context:load` → puede invocar inbox:check al inicio de sesión
+- `/notify:whatsapp` y `/notify:nctalk` → responder a mensajes encontrados
+- Skill `voice-inbox` → lógica de transcripción y mapeo voz→comando
+
+## Restricciones
+
+- Comandos detectados en audio SIEMPRE requieren confirmación del PM
+  (salvo `VOICE_AUTO_EXECUTE = true` con confianza alta)
+- No responde automáticamente a mensajes — solo informa al PM
+- Audio se procesa local (Faster-Whisper), nunca en APIs externas

--- a/.claude/commands/inbox-start.md
+++ b/.claude/commands/inbox-start.md
@@ -1,0 +1,135 @@
+---
+name: inbox-start
+description: >
+  Iniciar monitor de inbox en background. Revisa canales cada N minutos
+  mientras la sesión de Claude Code esté abierta.
+---
+
+# Inbox Start
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/inbox:start` o `/inbox:start --interval 2 --channels wa`
+
+## Parámetros
+
+- `--interval {minutos}` — Frecuencia de polling en minutos (defecto: 5)
+- `--channels {wa|nctalk|all}` — Canales a monitorizar (defecto: todos activos)
+- `--quiet` — No mostrar mensajes informativos (solo audios y acciones)
+- `--stop` — Detener el monitor en background
+
+## Contexto requerido
+
+1. @.claude/rules/messaging-config.md — Config canales activos
+2. `.claude/skills/voice-inbox/SKILL.md` — Transcripción de audio
+
+## Pasos de ejecución
+
+### 1. Verificar canales
+- Leer `messaging-config.md` → canales habilitados
+- Verificar conexión de cada canal activo
+- Si ningún canal activo → error con instrucciones de configuración
+
+### 2. Lanzar proceso en background
+
+Crear script de polling y ejecutar como tarea en background:
+
+```bash
+#!/bin/bash
+# inbox-monitor.sh — se ejecuta como background task
+INTERVAL=${1:-300}  # segundos (5 min por defecto)
+INBOX_DIR="inbox"
+mkdir -p "$INBOX_DIR/transcriptions"
+
+while true; do
+  TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # Marcar que el monitor está activo
+  echo "$TIMESTAMP" > "$INBOX_DIR/monitor-heartbeat.txt"
+
+  # Invocar inbox:check internamente
+  # (la lógica real la ejecuta Claude al leer los resultados)
+  echo "CHECK_REQUESTED:$TIMESTAMP" >> "$INBOX_DIR/check-queue.txt"
+
+  sleep $INTERVAL
+done
+```
+
+El proceso se lanza con `&` y Claude registra el task ID.
+
+### 3. Confirmar inicio
+
+```
+✅ Inbox monitor iniciado
+Intervalo: cada 5 minutos
+Canales: WhatsApp ✅, Nextcloud Talk ✅
+Task ID: bg-inbox-7a3f
+Detener: /inbox:start --stop
+
+Próximo check: 11:05 (en 5 min)
+```
+
+### 4. Ciclo de monitorización
+
+Cada N minutos, Claude recibe la señal del background task y ejecuta:
+1. `/inbox:check` silencioso
+2. Si hay mensajes nuevos → notificar al PM en la conversación
+3. Si hay audios → transcribir y proponer acciones
+4. Si no hay nada nuevo → silencio (no interrumpir)
+
+### Modo `--stop`
+- Localizar task en background por ID
+- Detener el proceso
+- Mostrar resumen de la sesión de monitorización:
+
+```
+⏹️ Inbox monitor detenido
+Duración: 2h 15min | Checks realizados: 27
+Mensajes procesados: 12 | Audios transcritos: 3
+Comandos ejecutados: 2
+```
+
+## Ejemplos de uso
+
+```bash
+# Inicio estándar (5 min, todos los canales)
+/inbox:start
+
+# Polling cada 2 minutos, solo WhatsApp
+/inbox:start --interval 2 --channels wa
+
+# Sin mensajes informativos (solo alertas y audios)
+/inbox:start --quiet
+
+# Detener
+/inbox:start --stop
+```
+
+## Flujo típico de una sesión
+
+```
+PM: /context:load                   ← carga contexto del proyecto
+PM: /inbox:start                    ← activa monitor de mensajes
+PM: /sprint:status --project x      ← trabaja normalmente
+
+  ... 10 minutos después ...
+
+→ 📩 Nuevo audio de Ana García (WhatsApp):
+→   "¿Puedes generar el informe ejecutivo para la reunión de las 12?"
+→   → /report:executive --project sala-reservas
+→   → ¿Ejecutar? (s/n)
+
+PM: s                               ← confirma
+→ ✅ Informe generado: output/reports/20260227-executive-sala-reservas.md
+→ ¿Enviar a Ana por WhatsApp? (s/n)
+
+PM: s
+→ ✅ Informe enviado a Ana García por WhatsApp
+```
+
+## Restricciones
+
+- El monitor se detiene automáticamente al cerrar la sesión
+- Solo un monitor activo a la vez (si ya hay uno corriendo, avisa)
+- El intervalo mínimo es 1 minuto (evitar spam a las APIs)
+- Requiere al menos un canal configurado y operativo

--- a/.claude/commands/nctalk-search.md
+++ b/.claude/commands/nctalk-search.md
@@ -1,0 +1,73 @@
+---
+name: nctalk-search
+description: >
+  Buscar mensajes en Nextcloud Talk como contexto.
+  Decisiones, acuerdos y conversaciones del equipo.
+---
+
+# Nextcloud Talk Search
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/nctalk:search {query}` o `/nctalk:search --room {sala} {query}`
+
+## Parámetros
+
+- `{query}` — Texto a buscar en los mensajes
+- `--room {sala}` — Buscar solo en una sala específica
+- `--since {fecha}` — Desde cuándo buscar (YYYY-MM-DD, defecto: 30 días)
+- `--limit {n}` — Máximo de resultados (defecto: 20)
+- `--participant {nombre}` — Filtrar por participante
+- `--context {n}` — Mensajes de contexto antes/después (defecto: 2)
+
+## Contexto requerido
+
+1. @.claude/rules/messaging-config.md — Config Nextcloud Talk
+2. Acceso a la API REST de Nextcloud Talk
+
+## Pasos de ejecución
+
+### 1. Verificar conexión
+- Comprobar `NCTALK_ENABLED = true` y acceso a la API
+
+### 2. Buscar mensajes
+- `GET /ocs/v2.php/apps/spreed/api/v4/room` → listar salas
+- Si `--room` → filtrar por sala
+- `GET /ocs/v2.php/apps/spreed/api/v4/chat/{token}?lookIntoFuture=0`
+- Paginar y filtrar por query + fecha + participante
+
+### 3. Presentar resultados
+
+```
+## Nextcloud Talk Search — "{query}"
+Resultados: 3 mensajes en 1 sala (últimos 30 días)
+
+### Sala "Equipo Sala Reservas"
+[2026-02-25 11:00] Ana García:
+  "La arquitectura del nuevo módulo será hexagonal, lo confirmamos"
+  → contexto: discusión técnica post-sprint review
+
+[2026-02-26 16:00] Carlos Sanz:
+  "Los tests de integración del módulo de pagos están fallando
+   por el cambio en la API del banco"
+  → contexto: reporte de bug
+
+[2026-02-27 09:30] Pedro López:
+  "He subido el diagrama de la nueva arquitectura a /docs/"
+  → adjunto: arquitectura-v2.drawio
+```
+
+## Ejemplos
+
+```bash
+/nctalk:search "arquitectura"
+/nctalk:search --room "equipo-sala-reservas" "decisión"
+/nctalk:search --participant "Ana García" --since 2026-02-01
+```
+
+## Restricciones
+
+- Solo lectura — no modifica ni borra mensajes
+- La API de Nextcloud Talk no tiene búsqueda full-text nativa;
+  se descarga historial y se filtra localmente
+- Rendimiento depende del volumen del historial de la sala

--- a/.claude/commands/notify-nctalk.md
+++ b/.claude/commands/notify-nctalk.md
@@ -1,0 +1,72 @@
+---
+name: notify-nctalk
+description: >
+  Enviar notificaciones e informes a una sala de Nextcloud Talk.
+  Funciona con cualquier instancia Nextcloud (self-hosted o cloud).
+---
+
+# Notify Nextcloud Talk
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/notify:nctalk {sala} {mensaje}` o `/notify:nctalk --team {msg}`
+
+## Parámetros
+
+- `{sala}` — Nombre o token de la sala de Nextcloud Talk
+- `{mensaje}` — Texto a enviar
+- `--team` — Enviar a la sala del equipo configurada en `messaging-config.md`
+- `--pm` — Enviar a la sala privada del PM
+- `--file {ruta}` — Adjuntar fichero (compartir via Nextcloud Files)
+- `--project {nombre}` — Contexto de proyecto
+- `--silent` — Enviar sin notificación push a los participantes
+
+## Contexto requerido
+
+1. @.claude/rules/messaging-config.md — Config Nextcloud Talk (URL, token, salas)
+2. Acceso a la API REST de Nextcloud Talk
+
+## Pasos de ejecución
+
+### 1. Verificar conexión
+- Comprobar `NCTALK_ENABLED = true`
+- Verificar acceso: `GET /ocs/v2.php/apps/spreed/api/v4/room` con token de app
+- Si falla → indicar al PM cómo generar token de app
+
+### 2. Resolver sala
+- Si `--team` → usar `NCTALK_ROOM_TEAM` de config
+- Si `--pm` → usar `NCTALK_ROOM_PM` de config
+- Si nombre → buscar sala por displayName en lista de rooms
+
+### 3. Preparar mensaje
+- Formatear para Nextcloud Talk (soporta markdown completo)
+- Si `--file` → subir a Nextcloud Files primero, luego compartir enlace
+
+### 4. Enviar
+- `POST /ocs/v2.php/apps/spreed/api/v4/chat/{token}`
+- Body: `{ "message": "{texto}", "silent": false }`
+- **Confirmar con PM antes de enviar**
+
+### 5. Confirmar envío
+
+```
+✅ Mensaje enviado a Nextcloud Talk
+Sala: "Equipo Sala Reservas" (5 participantes)
+Contenido: Resumen sprint 2026-04 (512 chars)
+Adjunto: sprint-report.pdf (compartido via Nextcloud Files)
+```
+
+## Ejemplos
+
+```bash
+/notify:nctalk --team "Sprint review mañana a las 10:00"
+/notify:nctalk "pm-notifications" "Alerta: 2 CVEs críticos detectados"
+/notify:nctalk --team --file output/reports/sprint-report.pdf
+/notify:nctalk --team --silent  # envía último informe sin notificar
+```
+
+## Restricciones
+
+- NUNCA enviar sin confirmación del PM
+- Requiere Nextcloud Talk v17+ (API v4) con capability `spreed`
+- Ficheros adjuntos requieren acceso a Nextcloud Files (misma cuenta)

--- a/.claude/commands/notify-whatsapp.md
+++ b/.claude/commands/notify-whatsapp.md
@@ -1,0 +1,75 @@
+---
+name: notify-whatsapp
+description: >
+  Enviar notificaciones e informes por WhatsApp al PM o al grupo del equipo.
+  Funciona con cuenta personal de WhatsApp (no requiere Business).
+---
+
+# Notify WhatsApp
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/notify:whatsapp {contacto|grupo} {mensaje}` o `/notify:whatsapp --team {msg}`
+
+## Parámetros
+
+- `{contacto}` — Nombre de contacto o número de teléfono
+- `{grupo}` — Nombre del grupo de WhatsApp
+- `{mensaje}` — Texto a enviar (se puede omitir para enviar último informe generado)
+- `--team` — Enviar al grupo del equipo configurado en `messaging-config.md`
+- `--pm` — Enviar al contacto del PM (auto-notificación)
+- `--file {ruta}` — Adjuntar fichero (PDF, imagen, etc.)
+- `--project {nombre}` — Contexto de proyecto (para mensajes automáticos)
+
+## Contexto requerido
+
+1. @.claude/rules/messaging-config.md — Config WhatsApp (WHATSAPP_ENABLED, contactos)
+2. MCP WhatsApp configurado y sesión activa
+
+## Pasos de ejecución
+
+### 1. Verificar conexión
+- Comprobar que `WHATSAPP_ENABLED = true`
+- Verificar sesión activa del bridge WhatsApp
+- Si no hay sesión → indicar al PM cómo reconectar (QR code)
+
+### 2. Resolver destinatario
+- Si `--team` → usar `WHATSAPP_TEAM_GROUP` de config
+- Si `--pm` → usar `WHATSAPP_PM_CONTACT` de config
+- Si nombre → MCP: `search_contacts` para resolver número
+
+### 3. Preparar mensaje
+- Si se proporciona texto → usar directamente
+- Si no → usar último informe generado en `output/`
+- Formatear para WhatsApp (markdown simplificado: *bold*, _italic_)
+- Truncar si excede 4096 caracteres (límite WhatsApp)
+
+### 4. Enviar
+- MCP: `send_message` con contacto/grupo y texto
+- Si `--file` → MCP: `send_file` con el adjunto
+- **Confirmar con PM antes de enviar** (regla 7)
+
+### 5. Confirmar envío
+
+```
+✅ Mensaje enviado por WhatsApp
+Destinatario: Grupo "Equipo Sala Reservas" (5 miembros)
+Contenido: Resumen sprint 2026-04 (324 chars)
+Adjunto: sprint-report.pdf
+```
+
+## Ejemplos
+
+```bash
+/notify:whatsapp --team "Sprint review mañana a las 10:00"
+/notify:whatsapp "Ana García" "El PR #42 necesita tu revisión"
+/notify:whatsapp --pm --file output/reports/sprint-report.pdf
+/notify:whatsapp --team   # envía último informe generado
+```
+
+## Restricciones
+
+- NUNCA enviar sin confirmación del PM
+- No enviar datos sensibles (passwords, tokens, secrets)
+- Respetar horario laboral configurable (no enviar de noche)
+- Requiere bridge WhatsApp con sesión activa

--- a/.claude/commands/whatsapp-search.md
+++ b/.claude/commands/whatsapp-search.md
@@ -1,0 +1,76 @@
+---
+name: whatsapp-search
+description: >
+  Buscar mensajes en WhatsApp como contexto para decisiones.
+  Acuerdos, conversaciones, decisiones del equipo.
+---
+
+# WhatsApp Search
+
+**Argumentos:** $ARGUMENTS
+
+> Uso: `/whatsapp:search {query}` o `/whatsapp:search --chat {nombre} {query}`
+
+## Parámetros
+
+- `{query}` — Texto a buscar en los mensajes
+- `--chat {nombre}` — Buscar solo en un chat específico (contacto o grupo)
+- `--since {fecha}` — Desde cuándo buscar (YYYY-MM-DD, defecto: 30 días)
+- `--limit {n}` — Máximo de resultados (defecto: 20)
+- `--media` — Incluir mensajes con media (audios, imágenes)
+- `--context {n}` — Mensajes de contexto antes/después (defecto: 2)
+
+## Contexto requerido
+
+1. @.claude/rules/messaging-config.md — Config WhatsApp
+2. MCP WhatsApp configurado y sesión activa
+
+## Pasos de ejecución
+
+### 1. Verificar conexión
+- Comprobar `WHATSAPP_ENABLED = true` y sesión activa
+
+### 2. Buscar mensajes
+- MCP: `list_chats` → obtener chats disponibles
+- Si `--chat` → filtrar por nombre de chat
+- MCP: `list_messages` con filtros temporales
+- Filtrar por query en contenido del mensaje
+
+### 3. Presentar resultados
+
+```
+## WhatsApp Search — "{query}"
+Resultados: 5 mensajes en 2 chats (últimos 30 días)
+
+### Grupo "Equipo Sala Reservas"
+[2026-02-25 10:15] Ana García:
+  "Hemos decidido usar Redis para la caché del dashboard"
+  → contexto: discusión sobre performance del sprint review
+
+[2026-02-26 14:30] Pedro López:
+  "El cliente confirmó que la fecha límite es el 15 de marzo"
+  → contexto: reunión con stakeholder
+
+### Chat "Ana García"
+[2026-02-27 09:00] Ana García:
+  "Te reenvío el email del cliente con los nuevos requisitos"
+  → adjunto: requisitos-v2.pdf
+```
+
+### 4. Ofrecer acciones
+- "¿Quieres que cree un PBI a partir de esta decisión?"
+- "¿Quieres que añada esto como nota al sprint?"
+
+## Ejemplos
+
+```bash
+/whatsapp:search "fecha límite"
+/whatsapp:search --chat "Equipo Sala Reservas" "decisión"
+/whatsapp:search --since 2026-02-01 "requisitos" --media
+```
+
+## Restricciones
+
+- Solo lectura — no modifica ni borra mensajes
+- Los datos están en SQLite local (nunca se envían a terceros)
+- Mensajes de otros chats no relacionados con el proyecto → excluir

--- a/.claude/rules/messaging-config.md
+++ b/.claude/rules/messaging-config.md
@@ -1,0 +1,238 @@
+# Configuración de Mensajería — WhatsApp, Nextcloud Talk e Inbox
+
+Configuración centralizada para todos los canales de mensajería de pm-workspace.
+El PM puede activar uno, varios o todos los canales según su entorno.
+
+---
+
+## Canales disponibles
+
+```yaml
+# Activar/desactivar canales
+WHATSAPP_ENABLED: true          # WhatsApp personal (no requiere Business)
+NCTALK_ENABLED: false           # Nextcloud Talk
+```
+
+---
+
+## WhatsApp — Configuración
+
+Usa la cuenta personal de WhatsApp del PM (sin necesidad de WhatsApp Business).
+Conexión vía API web multidevice (librería whatsmeow). Datos almacenados en SQLite local.
+
+```yaml
+# Autenticación
+WHATSAPP_AUTH: "qr"             # Método: "qr" (escanear QR desde el móvil)
+WHATSAPP_SESSION_PATH: "~/.whatsapp-mcp/session"  # Sesión persistente (~20 días)
+
+# Contactos/grupos del proyecto
+WHATSAPP_PM_CONTACT: "+34612345678"        # Teléfono del PM (para notificaciones personales)
+WHATSAPP_TEAM_GROUP: "Equipo Sala Reservas" # Nombre del grupo del equipo (para notificaciones de equipo)
+
+# Comportamiento
+WHATSAPP_NOTIFY_DEFAULT: "pm"   # A quién notificar por defecto: "pm", "team", "both"
+WHATSAPP_LISTEN_GROUP: true     # Escuchar mensajes del grupo del equipo
+WHATSAPP_LISTEN_DM: true        # Escuchar mensajes directos al PM
+```
+
+### Primer uso
+
+```bash
+# 1. Instalar el MCP server de WhatsApp
+git clone https://github.com/lharries/whatsapp-mcp
+cd whatsapp-mcp && go build -o whatsapp-bridge ./cmd/bridge
+
+# 2. Ejecutar el bridge (muestra QR para escanear)
+./whatsapp-bridge
+
+# 3. Escanear el QR con WhatsApp en el móvil
+#    (Ajustes → Dispositivos vinculados → Vincular dispositivo)
+
+# 4. La sesión se almacena localmente y persiste ~20 días
+```
+
+---
+
+## Nextcloud Talk — Configuración
+
+Integración con Nextcloud Talk vía API REST + sistema de bots webhook.
+Funciona con cualquier instancia de Nextcloud (self-hosted o cloud).
+
+```yaml
+# Conexión
+NCTALK_URL: "https://mi-nextcloud.empresa.com"  # URL de la instancia Nextcloud
+NCTALK_USER: "pm-bot"                            # Usuario del bot (o del PM)
+NCTALK_TOKEN: ""                                 # Token de app (Ajustes → Seguridad → Tokens de app)
+
+# Salas del proyecto
+NCTALK_ROOM_TEAM: "equipo-sala-reservas"   # Token/nombre de la sala del equipo
+NCTALK_ROOM_PM: "pm-notifications"         # Sala privada para notificaciones al PM
+
+# Webhook (para Modo 3 — listener persistente)
+NCTALK_WEBHOOK_SECRET: ""       # Secret HMAC-SHA256 para verificar webhooks
+NCTALK_WEBHOOK_PORT: 8085       # Puerto local del listener
+```
+
+### Primer uso
+
+```bash
+# 1. Crear un token de app en Nextcloud
+#    Ajustes → Seguridad → Dispositivos y sesiones → Crear nuevo token
+#    Copiar el token generado → NCTALK_TOKEN
+
+# 2. Obtener el token de la sala
+#    Abrir la sala en Nextcloud Talk → la URL contiene el token:
+#    https://mi-nextcloud.com/call/abc123def → token = "abc123def"
+
+# 3. (Opcional) Registrar bot webhook para Modo 3
+#    Solo necesario si se quiere listener persistente (ver Modo 3 abajo)
+```
+
+---
+
+## Voice Inbox — Transcripción de audio
+
+Transcripción local de mensajes de voz con Faster-Whisper.
+El audio NUNCA se envía a servicios externos — todo se procesa en local.
+
+```yaml
+# Transcripción
+WHISPER_MODEL: "small"          # Modelo: tiny, base, small, medium, large-v3
+WHISPER_LANGUAGE: "auto"        # Idioma: "auto" (detectar), "es", "en", etc.
+WHISPER_DEVICE: "cpu"           # Dispositivo: "cpu" o "cuda" (si hay GPU)
+
+# Comportamiento
+VOICE_AUTO_EXECUTE: false       # true = ejecutar comando sin confirmar (solo si confianza alta)
+VOICE_SAVE_TRANSCRIPTIONS: true # Guardar transcripciones en inbox/transcriptions/
+```
+
+### Instalación
+
+```bash
+# Transcriptor
+pip install faster-whisper --break-system-packages
+
+# Conversor de audio (necesario para algunos formatos)
+sudo apt install ffmpeg    # Linux
+brew install ffmpeg         # macOS
+```
+
+---
+
+## Modos de operación del Inbox
+
+### Modo 1 — Manual (sin infraestructura)
+
+El PM ejecuta `/inbox:check` cuando quiere ver si hay mensajes nuevos.
+
+```
+PM: /inbox:check
+→ Revisando WhatsApp... 3 mensajes nuevos (1 audio)
+→ Revisando Nextcloud Talk... 0 mensajes nuevos
+→
+→ 📩 WhatsApp — Grupo "Equipo Sala Reservas":
+→   [10:15] Ana García: "¿Podemos adelantar la review a jueves?"
+→   [10:22] Pedro López: "Por mí bien, pero falta revisar el PR #42"
+→   [10:30] Ana García: 🎤 Audio (12s) → Transcripción:
+→     "Oye, ¿puedes ponerme el estado del sprint? Que no me da tiempo a mirarlo"
+→     → Comando sugerido: /sprint:status --project sala-reservas
+→     → ¿Ejecutar? (s/n)
+```
+
+**Cuándo usar**: PMs que abren Claude Code puntualmente. Cero configuración extra.
+
+### Modo 2 — Background polling (sesión activa)
+
+Al iniciar sesión, el PM lanza `/inbox:start` y un proceso en background
+revisa los canales cada N minutos mientras la sesión esté abierta.
+
+```
+PM: /inbox:start --interval 5
+→ ✅ Inbox monitor iniciado (cada 5 min)
+→ Canales activos: WhatsApp ✅, Nextcloud Talk ✅
+→ Task ID: bg-inbox-7a3f (ver con /tasks)
+→
+→ ... el PM trabaja normalmente ...
+→
+→ 📩 [11:45] Nuevo mensaje de voz en WhatsApp:
+→   Ana García: 🎤 Audio (8s) → "Descompón el PBI 1234 en tareas"
+→   → Comando sugerido: /pbi:decompose 1234
+→   → ¿Ejecutar? (s/n)
+```
+
+**Cuándo usar**: PMs que mantienen Claude Code abierto durante la jornada.
+El proceso se detiene automáticamente al cerrar la sesión.
+
+```
+PM: /inbox:start                    # Iniciar con intervalo por defecto (5 min)
+PM: /inbox:start --interval 2      # Revisar cada 2 minutos
+PM: /inbox:start --channels wa      # Solo WhatsApp
+PM: /inbox:start --channels nctalk  # Solo Nextcloud Talk
+```
+
+### Modo 3 — Listener persistente (24/7)
+
+Un microservicio que corre como daemon, escuchando webhooks y polling.
+Encola mensajes en `inbox/pending.json` para que `/inbox:check` los lea.
+
+```bash
+# Opción A: Script Python como servicio systemd
+sudo cp scripts/inbox-listener.py /opt/pm-workspace/
+sudo cp scripts/inbox-listener.service /etc/systemd/system/
+sudo systemctl enable --now inbox-listener
+
+# Opción B: Docker
+docker run -d --name pm-inbox \
+  -v ~/.whatsapp-mcp:/data/whatsapp \
+  -v ./inbox:/data/inbox \
+  -e NCTALK_WEBHOOK_PORT=8085 \
+  pm-workspace/inbox-listener
+```
+
+**Cuándo usar**: Empresas que quieren captura de mensajes 24/7,
+incluso cuando el PM no tiene Claude Code abierto.
+Los mensajes se acumulan y se procesan en la siguiente sesión.
+
+```
+PM: /inbox:check
+→ 📬 12 mensajes acumulados desde 2026-02-27 18:00
+→   WhatsApp: 8 mensajes (2 audios)
+→   Nextcloud Talk: 4 mensajes (0 audios)
+→
+→ 🎤 Audio 1 (Ana, 10:15): "El cliente quiere cambiar el alcance del sprint"
+→   → No mapea a comando → archivado como nota informativa
+→
+→ 🎤 Audio 2 (Pedro, 14:30): "Hazme un report de horas del proyecto"
+→   → Comando sugerido: /report:hours --project sala-reservas
+→   → ¿Ejecutar? (s/n)
+```
+
+---
+
+## Seguridad y privacidad
+
+- **Audio**: se procesa LOCAL con Faster-Whisper, nunca se envía a APIs externas
+- **Mensajes**: almacenados en SQLite local (WhatsApp) o ficheros locales (inbox)
+- **Credenciales**: tokens y secrets en este fichero, que está en `.claude/rules/` (git-tracked).
+  Para datos sensibles, usar variables de entorno o `config.local/` (git-ignored)
+- **Confirmación**: por defecto, SIEMPRE se pide confirmación antes de ejecutar un comando
+  detectado en un mensaje de voz (configurable con `VOICE_AUTO_EXECUTE`)
+
+---
+
+## Referencia MCP
+
+### WhatsApp (whatsapp-mcp — lharries)
+- `search_contacts` — buscar contactos por nombre
+- `list_chats` — listar conversaciones recientes
+- `list_messages` — mensajes de un chat (con filtro temporal)
+- `send_message` — enviar texto a contacto o grupo
+- `send_file` — enviar fichero adjunto
+- `download_media` — descargar audio, imagen, documento recibido
+
+### Nextcloud Talk (API REST v4)
+- `GET /ocs/v2.php/apps/spreed/api/v4/room` — listar salas
+- `GET /ocs/v2.php/apps/spreed/api/v4/chat/{token}` — mensajes de una sala
+- `POST /ocs/v2.php/apps/spreed/api/v4/chat/{token}` — enviar mensaje
+- `GET /ocs/v2.php/apps/spreed/api/v4/chat/{token}/{messageId}/share` — descargar adjunto
+- Webhooks bot: `POST /bot/{token}/message` (requiere bots-v1 capability)

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -91,6 +91,12 @@
 | `/testplan:status {--project p}` | Estado de Test Plans: suites, casos, ejecución, cobertura |
 | `/testplan:results {--project p} {--run id}` | Resultados detallados de test runs: fallos, tendencias, recomendaciones |
 | `/security:alerts {--project p}` | Alertas de seguridad: CVEs, secrets, vulnerabilidades (Azure DevOps Advanced Security) |
+| `/notify:whatsapp {contacto} {msg}` | Enviar notificación/informe por WhatsApp (cuenta personal, no requiere Business) |
+| `/whatsapp:search {query}` | Buscar mensajes en WhatsApp como contexto (decisiones, acuerdos) |
+| `/notify:nctalk {sala} {msg}` | Enviar notificación/informe a sala de Nextcloud Talk |
+| `/nctalk:search {query}` | Buscar mensajes en Nextcloud Talk como contexto |
+| `/inbox:check` | Revisar mensajes nuevos en todos los canales, transcribir audios, proponer acciones |
+| `/inbox:start {--interval min}` | Iniciar monitor de inbox en background (polling cada N min mientras la sesión esté abierta) |
 | `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
 | `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
 | `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |
@@ -127,4 +133,6 @@
 - Diagram Config: `.claude/rules/diagram-config.md`
 - Azure Pipelines: `.claude/skills/azure-pipelines/SKILL.md`
 - Azure Repos Config: `.claude/rules/azure-repos-config.md`
+- Mensajería: `.claude/rules/messaging-config.md`
+- Voice Inbox: `.claude/skills/voice-inbox/SKILL.md`
 - Azure DevOps API v7.1: https://learn.microsoft.com/en-us/rest/api/azure/devops/

--- a/.claude/skills/voice-inbox/SKILL.md
+++ b/.claude/skills/voice-inbox/SKILL.md
@@ -1,0 +1,97 @@
+# Voice Inbox — Transcripción y procesamiento de mensajes de voz
+
+Skill para transcribir mensajes de audio recibidos por WhatsApp o Nextcloud Talk,
+interpretar la intención del PM y ejecutar el comando correspondiente en pm-workspace.
+
+## Flujo principal
+
+```
+Audio (.ogg/.opus/.m4a) → Faster-Whisper → Texto → Claude interpreta → Comando
+```
+
+1. **Descargar audio** — MCP WhatsApp `download_media` o Nextcloud Talk API
+2. **Convertir formato** — ffmpeg si necesario (ogg/opus → wav 16kHz mono)
+3. **Transcribir** — Faster-Whisper (local, sin enviar audio a terceros)
+4. **Interpretar** — Claude analiza el texto y mapea a un comando de pm-workspace
+5. **Confirmar** — Mostrar al PM la transcripción + comando propuesto antes de ejecutar
+6. **Ejecutar** — Lanzar el comando tras confirmación
+
+## Configuración de Faster-Whisper
+
+### Instalación
+
+```bash
+pip install faster-whisper --break-system-packages
+```
+
+### Modelos recomendados
+
+| Modelo | RAM | Velocidad | Calidad | Uso recomendado |
+|---|---|---|---|---|
+| `tiny` | ~1 GB | Muy rápida | Básica | Test rápido, mensajes cortos claros |
+| `base` | ~1 GB | Rápida | Buena | Mensajes cortos en entorno silencioso |
+| `small` | ~2 GB | Media | Muy buena | **Recomendado para uso diario** |
+| `medium` | ~5 GB | Lenta | Excelente | Audio con ruido o acentos fuertes |
+| `large-v3` | ~10 GB | Muy lenta | Máxima | Cuando la precisión es crítica |
+
+El modelo se configura en `messaging-config.md` → `WHISPER_MODEL`.
+Por defecto: `small` (buen equilibrio calidad/velocidad).
+
+### Idiomas
+
+Faster-Whisper detecta idioma automáticamente, pero se puede forzar:
+- `WHISPER_LANGUAGE = "es"` → español
+- `WHISPER_LANGUAGE = "auto"` → detección automática (defecto)
+
+## Interpretación de intención
+
+Una vez transcrito el audio, Claude recibe el texto con este prompt interno:
+
+```
+El PM ha enviado un mensaje de voz. Transcripción:
+"{texto_transcrito}"
+
+Analiza la intención y responde con:
+1. Comando de pm-workspace más adecuado (con parámetros)
+2. Confianza: alta/media/baja
+3. Si confianza < alta → pedir confirmación al PM
+
+Contexto: proyecto activo = {proyecto_actual}
+Comandos disponibles: @.claude/rules/pm-workflow.md
+```
+
+### Ejemplos de mapeo voz → comando
+
+| El PM dice... | Comando mapeado |
+|---|---|
+| "Ponme el estado del sprint de sala-reservas" | `/sprint:status --project sala-reservas` |
+| "¿Cómo va la deuda técnica?" | `/debt:track --project {activo}` |
+| "Descompón el PBI 1234 en tareas" | `/pbi:decompose 1234` |
+| "Genera el informe ejecutivo del sprint" | `/report:executive --project {activo}` |
+| "Hazme un audit del proyecto nuevo" | `/project:audit --project {activo}` |
+| "Manda el resumen del sprint al equipo por Slack" | `/notify:slack #equipo {resumen}` |
+| "¿Qué alertas de seguridad hay?" | `/security:alerts --project {activo}` |
+
+### Casos ambiguos
+
+Si la transcripción no mapea claramente a un comando:
+- Confianza baja → mostrar transcripción + "¿Qué quieres que haga con esto?"
+- Múltiples comandos posibles → listar opciones para que el PM elija
+- No es un comando → tratar como mensaje informativo y archivar
+
+## Formatos de audio soportados
+
+| Formato | Origen típico | Conversión necesaria |
+|---|---|---|
+| `.ogg` (Opus) | WhatsApp | No (Faster-Whisper lo soporta) |
+| `.m4a` (AAC) | iOS WhatsApp | `ffmpeg -i input.m4a output.wav` |
+| `.webm` (Opus) | Nextcloud Talk web | No |
+| `.wav` | General | No |
+
+## Restricciones
+
+- **Privacidad**: el audio se procesa LOCAL, nunca se envía a APIs externas
+- **Confirmación**: SIEMPRE mostrar transcripción y comando antes de ejecutar
+- **Errores de transcripción**: si el PM corrige, aprender del contexto
+- Requiere `ffmpeg` instalado para conversiones de formato
+- Requiere `faster-whisper` instalado (`pip install faster-whisper`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,41 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.9.0] — 2026-02-27
+
+Messaging & Voice Inbox: WhatsApp (personal, no requiere Business) y Nextcloud Talk como canales de comunicación bidireccional. El PM puede enviar mensajes de voz por WhatsApp y pm-workspace los transcribe con Faster-Whisper (local, sin APIs externas), interpreta la intención y propone el comando correspondiente. Tres modos de operación: manual, background polling y listener persistente. Adds 6 new commands, 1 skill, 1 config rule. Total: 81 slash commands, 13 skills.
+
+### Added
+
+**Messaging & Inbox commands (6)** — PR #44
+- `/notify:whatsapp {contacto} {msg}` — enviar notificaciones e informes por WhatsApp al PM o grupo del equipo. Funciona con cuenta personal (no requiere Business). Soporta adjuntos (PDF, imágenes)
+- `/whatsapp:search {query}` — buscar mensajes en WhatsApp como contexto: decisiones, acuerdos, conversaciones del equipo. Datos en SQLite local (nunca se envían a terceros)
+- `/notify:nctalk {sala} {msg}` — enviar notificaciones a sala de Nextcloud Talk. Funciona con cualquier instancia Nextcloud (self-hosted o cloud). Soporta ficheros adjuntos via Nextcloud Files
+- `/nctalk:search {query}` — buscar mensajes en Nextcloud Talk: decisiones y contexto del equipo
+- `/inbox:check` — revisar mensajes nuevos en todos los canales configurados. Transcribe audios con Faster-Whisper (local), interpreta peticiones del PM y propone el comando de pm-workspace correspondiente
+- `/inbox:start --interval {min}` — iniciar monitor de inbox en background. Polling cada N minutos mientras la sesión esté abierta. Se detiene automáticamente al cerrar sesión
+
+**Voice Inbox skill** — transcripción de audio y flujo audio→texto→acción
+- Faster-Whisper local (modelos: tiny, base, small, medium, large-v3)
+- Detección automática de idioma
+- Mapeo de intención: voz del PM → comando de pm-workspace con nivel de confianza
+- Confirmación obligatoria antes de ejecutar (configurable)
+
+**Messaging config rule** — `messaging-config.md`
+- Configuración centralizada: WhatsApp (personal vía whatsmeow) + Nextcloud Talk (API REST v4)
+- 3 modos de operación documentados con ejemplos: manual, background polling, listener persistente
+- Documentación completa de primer uso, instalación y configuración de cada canal
+- Referencia MCP tools (WhatsApp) y API endpoints (Nextcloud Talk)
+
+### Changed
+- Command count: 75 → 81 (+6 messaging & inbox)
+- Skills count: 12 → 13 (+voice-inbox)
+- Help command updated with Mensajería e Inbox (6) category
+- `pm-workflow.md` updated with 6 new commands + 2 new references (messaging-config, voice-inbox)
+- READMEs (ES/EN) updated with messaging & inbox commands
+
+---
+
 ## [0.8.0] — 2026-02-27
 
 DevOps Extended: Azure DevOps Wiki management, Test Plans visibility, and security alerts. Leverages remaining MCP tool domains. Adds 5 new commands. Total: 75 slash commands.
@@ -264,7 +299,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.5.0...v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 75 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 81 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
-│   └── skills/                    ← 12 skills reutilizables
+│   └── skills/                    ← 13 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README
 ├── projects/                      ← Proyectos reales (git-ignorados)
 └── scripts/                       ← Scripts auxiliares Azure DevOps

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 75 slash commands
+│   ├── commands/                ← 81 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -28,6 +28,7 @@
 │   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
 │   │   ├── project-audit.md ... ← Project Onboarding (5: audit, release-plan, assign, roadmap, kickoff)
 │   │   ├── wiki-publish.md ...  ← DevOps Extended (5: wiki, testplan, security alerts)
+│   │   ├── inbox-check.md ...   ← Mensajería e Inbox (6: WhatsApp, Nextcloud Talk, voice inbox)
 │   │   ├── notify-slack.md ...  ← Conectores (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilidades
 │   │   └── references/          ← Ficheros de referencia (no se cargan como commands)

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 75 slash commands
+│   ├── commands/                ← 81 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -28,6 +28,7 @@
 │   │   ├── legacy-assess.md ... ← Legacy & Capture (3: legacy assess, backlog capture, release notes)
 │   │   ├── project-audit.md ... ← Project Onboarding (5: audit, release-plan, assign, roadmap, kickoff)
 │   │   ├── wiki-publish.md ...  ← DevOps Extended (5: wiki, testplan, security alerts)
+│   │   ├── inbox-check.md ...   ← Messaging & Inbox (6: WhatsApp, Nextcloud Talk, voice inbox)
 │   │   ├── notify-slack.md ...  ← Connectors (12: Slack, GitHub, Sentry, GDrive, Linear, Atlassian, Notion, Figma)
 │   │   ├── context-load.md      ← Utilities
 │   │   └── references/          ← Reference files (not loaded as commands)


### PR DESCRIPTION
## Summary
WhatsApp (personal) + Nextcloud Talk + Voice Inbox with audio transcription.

**6 new commands:**
- `notify:whatsapp` / `whatsapp:search` — WhatsApp messaging (personal account, no Business required)
- `notify:nctalk` / `nctalk:search` — Nextcloud Talk messaging (any instance)
- `inbox:check` — Review all channels, transcribe audios, propose actions
- `inbox:start` — Background polling every N minutes while session is open

**1 new skill:** `voice-inbox` — Faster-Whisper local transcription → intent mapping → command execution

**1 new config rule:** `messaging-config.md` — Centralized config with 3 operation modes documented with examples:
- Mode 1: Manual (`/inbox:check` on demand)
- Mode 2: Background polling (`/inbox:start` during session)
- Mode 3: Persistent listener (24/7 systemd/Docker service)

**Totals:** 81 slash commands, 13 skills

## Test plan
- [ ] `bash scripts/validate-commands.sh` passes (0 errors)
- [ ] `/help whatsapp` shows WhatsApp commands
- [ ] `/help inbox` shows inbox commands
- [ ] messaging-config.md has clear setup instructions for both channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)