### PR TITLE
v0.10.0 — GitHub Actions auto-label + MCP migration

### DIFF
--- a/.claude/rules/mcp-migration.md
+++ b/.claude/rules/mcp-migration.md
@@ -1,0 +1,72 @@
+# Migración REST/CLI → MCP — Guía de equivalencias
+
+Mapeo entre las funciones de `scripts/azdevops-queries.sh` (REST API + az CLI)
+y los MCP tools equivalentes de `@azure-devops/mcp`.
+
+## Estado de migración
+
+| Función script | MCP tool equivalente | Estado | Notas |
+|---|---|---|---|
+| `get_current_sprint` | `get_team_iterations` | ✅ Migrado | MCP devuelve iteraciones del equipo con fechas |
+| `get_sprint_items` | `run_wiql_query` + `get_work_item` | ✅ Migrado | WIQL idéntico, get details por ID |
+| `get_board_status` | `run_wiql_query` + `get_work_item` | ✅ Migrado | Misma WIQL, agrupar por estado en Claude |
+| `update_workitem` | `update_work_item` | ✅ Migrado | MCP soporta update de campos |
+| `batch_get_workitems` | `get_work_item` (por ID) | ✅ Migrado | Llamar por cada ID (MCP no tiene batch nativo) |
+| `get_burndown_data` | ❌ No hay equivalente MCP | 🟡 Mantener script | Requiere Analytics OData, MCP no lo cubre |
+| `get_team_capacities` | ❌ No hay equivalente MCP | 🟡 Mantener script | Requiere Work API (capacities), MCP no lo cubre |
+| `get_velocity_history` | `get_team_iterations` (parcial) | 🟡 Híbrido | MCP da iteraciones, velocity requiere cálculo con SP completados por sprint |
+
+## Regla de decisión
+
+```
+¿La operación es CRUD de work items?
+  → Sí → Usar MCP tool (run_wiql_query, get_work_item, create_work_item, update_work_item)
+  → No → ¿Es Analytics / OData / Capacities?
+    → Sí → Mantener scripts/azdevops-queries.sh
+    → No → Evaluar caso por caso
+```
+
+## MCP tools para CRUD de work items
+
+### Lectura
+- `run_wiql_query` — Ejecutar cualquier WIQL query (equivale a todas las queries del script)
+- `get_work_item` — Obtener detalle de un work item por ID
+- `search_work_items` — Búsqueda full-text en work items
+
+### Escritura
+- `create_work_item` — Crear PBI, Bug, Task, etc.
+- `update_work_item` — Actualizar campos de un work item
+- `add_work_item_comment` — Añadir comentario a un work item
+
+### Relaciones
+- `manage_work_item_link` — Crear/eliminar links entre work items (parent, related, etc.)
+
+## Funciones que DEBEN mantenerse en el script
+
+1. **`get_burndown_data`** — Usa Analytics OData endpoint (`_odata/v4.0-preview/WorkItemSnapshot`)
+   que no está cubierto por ningún MCP tool. Necesario para dashboards de burndown.
+
+2. **`get_team_capacities`** — Usa Work API (`teamsettings/iterations/{id}/capacities`)
+   que no está cubierto por MCP. Necesario para `/report:capacity` y `/project:assign`.
+
+3. **`get_velocity_history`** (parcial) — MCP puede listar iteraciones (`get_team_iterations`)
+   pero el cálculo de SP completados por sprint requiere WIQL por cada iteración.
+
+## Cómo usar MCP en lugar del script
+
+### Antes (script):
+```bash
+./scripts/azdevops-queries.sh items ProyectoAlpha
+```
+
+### Ahora (MCP via Claude):
+```
+PM: /sprint:status --project sala-reservas
+→ Claude usa MCP: run_wiql_query con la WIQL del sprint actual
+→ Claude usa MCP: get_work_item para cada ID
+→ Claude formatea y presenta el dashboard
+```
+
+El PM ya no necesita ejecutar el script directamente. Los comandos de pm-workspace
+invocan los MCP tools internamente. El script se mantiene solo para funciones
+sin equivalente MCP (burndown, capacities) que los comandos invocan con `bash`.

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -135,4 +135,5 @@
 - Azure Repos Config: `.claude/rules/azure-repos-config.md`
 - Mensajería: `.claude/rules/messaging-config.md`
 - Voice Inbox: `.claude/skills/voice-inbox/SKILL.md`
+- MCP Migration: `.claude/rules/mcp-migration.md`
 - Azure DevOps API v7.1: https://learn.microsoft.com/en-us/rest/api/azure/devops/

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,89 @@
+name: Auto-label PRs by branch prefix
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR based on branch prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const labels = [];
+
+            // Map branch prefixes to labels
+            const prefixMap = {
+              'feature/': 'feature',
+              'fix/': 'fix',
+              'docs/': 'docs',
+              'refactor/': 'refactor',
+              'test/': 'test',
+              'release/': 'release',
+              'hotfix/': 'hotfix',
+              'chore/': 'chore'
+            };
+
+            for (const [prefix, label] of Object.entries(prefixMap)) {
+              if (branch.startsWith(prefix)) {
+                labels.push(label);
+                break;
+              }
+            }
+
+            // Add size label based on changed files
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const totalChanges = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+            if (totalChanges <= 10) labels.push('size/XS');
+            else if (totalChanges <= 50) labels.push('size/S');
+            else if (totalChanges <= 200) labels.push('size/M');
+            else if (totalChanges <= 500) labels.push('size/L');
+            else labels.push('size/XL');
+
+            if (labels.length > 0) {
+              // Ensure labels exist
+              for (const label of labels) {
+                try {
+                  await github.rest.issues.getLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label
+                  });
+                } catch {
+                  const colors = {
+                    'feature': '0E8A16', 'fix': 'D93F0B', 'docs': '0075CA',
+                    'refactor': 'FBCA04', 'test': '6F42C1', 'release': '006B75',
+                    'hotfix': 'B60205', 'chore': 'EDEDED',
+                    'size/XS': 'C2E0C6', 'size/S': '76D27D',
+                    'size/M': 'F9D0C4', 'size/L': 'E99695', 'size/XL': 'D93F0B'
+                  };
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label,
+                    color: colors[label] || 'EDEDED'
+                  });
+                }
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labels
+              });
+
+              console.log(`Added labels: ${labels.join(', ')}`);
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Planned
+*No planned items — all features from the original roadmap have been implemented.*
 
-**Lower priority — infrastructure and tooling**
-- GitHub Actions: auto-label PRs by branch prefix (`feature/`, `fix/`, `docs/`)
-- Migrate work item CRUD from REST/CLI (`azdevops-queries.sh`) to MCP tools where equivalent
+---
+
+## [0.10.0] — 2026-02-27
+
+Infrastructure and tooling: GitHub Actions workflow for auto-labeling PRs, and MCP migration guide documenting which `azdevops-queries.sh` functions are replaced by MCP tools and which must be kept.
+
+### Added
+
+**GitHub Actions** — PR #45
+- `auto-label-pr.yml` — automatically labels PRs based on branch prefix (`feature/` → feature, `fix/` → fix, `docs/` → docs, etc.) and adds size labels (XS/S/M/L/XL) based on total lines changed. Creates labels on first use with color coding
+
+**MCP migration guide** — `mcp-migration.md` config rule
+- Documents equivalence between `azdevops-queries.sh` functions and MCP tools
+- 5 functions fully migrated to MCP: `get_current_sprint`, `get_sprint_items`, `get_board_status`, `update_workitem`, `batch_get_workitems`
+- 3 functions kept in script (no MCP equivalent): `get_burndown_data` (Analytics OData), `get_team_capacities` (Work API), `get_velocity_history` (hybrid)
+- Decision rule: CRUD → MCP, Analytics/OData/Capacities → keep script
+
+### Changed
+- `azdevops-queries.sh` header updated with migration notes and reference to `mcp-migration.md`
+- `pm-workflow.md` updated with MCP migration reference
 
 ---
 
@@ -299,7 +316,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.6.0...v0.7.0

--- a/scripts/azdevops-queries.sh
+++ b/scripts/azdevops-queries.sh
@@ -4,6 +4,14 @@
 # =============================================================================
 # Uso: ./scripts/azdevops-queries.sh <comando> [opciones]
 # Requiere: az cli con extensión devops, jq
+#
+# NOTA: Las funciones CRUD (sprint, items, board, update, batch) tienen
+# equivalente MCP y los comandos de pm-workspace las usan via MCP tools.
+# Este script se mantiene para funciones sin equivalente MCP:
+#   - burndown    → Analytics OData (no cubierto por MCP)
+#   - capacities  → Work API capacities (no cubierto por MCP)
+#   - velocity    → Cálculo híbrido (MCP + OData)
+# Ver: .claude/rules/mcp-migration.md para detalle de la migración.
 # =============================================================================
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
- GitHub Actions workflow `auto-label-pr.yml`: auto-labels PRs by branch prefix + size labels
- MCP migration guide `mcp-migration.md`: documents REST/CLI → MCP equivalences
- Script header updated with migration notes
- **All originally planned CHANGELOG items are now implemented**

## Test plan
- [ ] Push a PR with `feature/` prefix → gets `feature` label
- [ ] Push a PR with <50 LOC → gets `size/S` label
- [ ] `mcp-migration.md` accurately reflects current MCP tool coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)