### PR TITLE
feat(context): context health management and output-first pattern

### DIFF
--- a/.claude/commands/references/command-catalog.md
+++ b/.claude/commands/references/command-catalog.md
@@ -1,84 +1,52 @@
-# Catálogo de Comandos PM-Workspace (37)
+# Catálogo de Comandos PM-Workspace (81)
 
-## 📅 Sprint y Reporting (10)
+> Este fichero se carga bajo demanda (desde `/help` o consultas de catálogo).
+> NO se auto-carga en el contexto.
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/sprint:status` | — | Burndown, progreso, alertas WIP, blockers |
-| `/sprint:plan` | — | Planning: capacity real + PBIs candidatos |
-| `/sprint:review` | — | Review: velocity, completados, demo |
-| `/sprint:retro` | — | Retro con datos cuantitativos del sprint |
-| `/report:hours` | — | Imputación de horas (Excel, 4 pestañas) |
-| `/report:executive` | — | Multi-proyecto (PPT + Word, semáforos) |
-| `/report:capacity` | — | Capacidades del equipo por persona |
-| `/team:workload` | — | Carga por persona + alertas sobrecarga |
-| `/board:flow` | — | Cycle time, WIP, cuellos de botella |
-| `/kpi:dashboard` | — | Velocity, cycle time, lead time, bug escape rate |
+## Sprint y Reporting (10)
+`/sprint:status` · `/sprint:plan` · `/sprint:review` · `/sprint:retro` · `/report:hours` · `/report:executive` · `/report:capacity` · `/team:workload` · `/board:flow` · `/kpi:dashboard`
 
-## 📦 PBI y Discovery (6)
+## PBI y Discovery (6)
+`/pbi:decompose {id}` · `/pbi:decompose-batch {ids}` · `/pbi:assign {pbi_id}` · `/pbi:plan-sprint` · `/pbi:jtbd {id}` · `/pbi:prd {id}`
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/pbi:decompose` | `{id}` | Descomponer PBI en tasks con estimación |
-| `/pbi:decompose-batch` | `{ids}` (coma) | Descomponer varios PBIs a la vez |
-| `/pbi:assign` | `{pbi_id}` | (Re)asignar tasks con scoring |
-| `/pbi:plan-sprint` | — | Planning completo: capacity → PBIs → tasks → asignación |
-| `/pbi:jtbd` | `{id}` | Jobs to be Done (discovery pre-técnico) |
-| `/pbi:prd` | `{id}` | Product Requirements Document |
+## SDD (5)
+`/spec:generate {task_id}` · `/spec:implement {spec}` · `/spec:review {spec}` · `/spec:status` · `/agent:run {spec}`
 
-## ⚙️ SDD — Spec-Driven Development (5)
+## Calidad y PRs (4)
+`/pr:review [PR]` · `/pr:pending [--project p]` · `/evaluate:repo [URL]` · `/changelog:update`
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/spec:generate` | `{task_id}` | Spec ejecutable desde Task de Azure DevOps |
-| `/spec:implement` | `{spec_file}` | Implementar Spec (agente Claude o humano) |
-| `/spec:review` | `{spec_file}` | Revisar calidad o validar implementación |
-| `/spec:status` | — | Dashboard de Specs del sprint |
-| `/agent:run` | `{spec_file}` | Lanzar agente Claude sobre Spec |
+## Equipo (3)
+`/team:privacy-notice {nombre} --project {p}` · `/team:onboarding {nombre} --project {p}` · `/team:evaluate {nombre} --project {p}`
 
-## 🔍 Calidad y PRs (4)
+## Infra (7)
+`/infra:detect {proy} {env}` · `/infra:plan {proy} {env}` · `/infra:estimate {proy}` · `/infra:scale {recurso}` · `/infra:status {proy}` · `/env:setup {proy}` · `/env:promote {proy} {orig} {dest}`
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/pr:review` | `[PR]` (opcional) | Revisión 5 perspectivas: BA, Dev, QA, Sec, DevOps |
-| `/pr:pending` | `--project {p}` (opc.) | PRs del PM pendientes: votos, comentarios, antigüedad |
-| `/evaluate:repo` | `[URL]` | Auditoría seguridad/calidad de repo externo |
-| `/changelog:update` | — | CHANGELOG.md desde commits convencionales |
+## Diagramas (4)
+`/diagram:generate {proy}` · `/diagram:import {source} --project {p}` · `/diagram:config --tool {t}` · `/diagram:status`
 
-## 👥 Equipo y Onboarding (3)
+## Pipelines (5)
+`/pipeline:status --project {p}` · `/pipeline:run --project {p} {pipeline}` · `/pipeline:logs --project {p} --build {id}` · `/pipeline:create --project {p} --name {n} --repo {r}` · `/pipeline:artifacts --project {p} --build {id}`
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/team:privacy-notice` | `{nombre}` `--project {p}` | Nota RGPD (obligatoria antes de evaluar) |
-| `/team:onboarding` | `{nombre}` `--project {p}` | Guía: contexto + tour del código (Fases 1-2) |
-| `/team:evaluate` | `{nombre}` `--project {p}` | Competencias → perfil expertise en equipo.md |
+## Azure Repos (6)
+`/repos:list --project {p}` · `/repos:branches --project {p} --repo {r}` · `/repos:pr-create --project {p} --repo {r}` · `/repos:pr-list --project {p}` · `/repos:pr-review --project {p} --pr {id}` · `/repos:search --project {p} {query}`
 
-## 🏗️ Infraestructura y Entornos (7)
+## Governance (5)
+`/debt:track --project {p}` · `/kpi:dora --project {p}` · `/dependency:map --project {p}` · `/retro:actions --project {p}` · `/risk:log --project {p}`
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/infra:detect` | `{proy}` `{env}` | Detectar infra existente en un entorno |
-| `/infra:plan` | `{proy}` `{env}` | Plan IaC (Terraform/CLI) para un entorno |
-| `/infra:estimate` | `{proy}` | Costes mensuales estimados por entorno |
-| `/infra:scale` | `{recurso}` | Proponer escalado (aprobación humana) |
-| `/infra:status` | `{proy}` | Estado actual de la infra del proyecto |
-| `/env:setup` | `{proy}` | Configurar entornos (DEV/PRE/PRO) |
-| `/env:promote` | `{proy}` `{orig}` `{dest}` | Promover deploy (PRE→PRO = aprobación) |
+## Legacy & Capture (3)
+`/legacy:assess --project {p}` · `/backlog:capture --project {p} --source {tipo}` · `/sprint:release-notes --project {p}`
 
-## 🔧 Utilidades (2)
+## Project Onboarding (5)
+`/project:audit --project {p}` · `/project:release-plan --project {p}` · `/project:assign --project {p}` · `/project:roadmap --project {p}` · `/project:kickoff --project {p}`
 
-| Comando | Params | Descripción |
-|---|---|---|
-| `/context:load` | — | Inicializar sesión: CLAUDE.md, git, commits, tools |
-| `/help` | `[filtro]` (opc.) | Esta ayuda. Filtros: sprint, pbi, sdd, pr, team, infra, --setup |
+## DevOps Extended (5)
+`/wiki:publish {file} --project {p}` · `/wiki:sync --project {p}` · `/testplan:status --project {p}` · `/testplan:results --project {p} --run {id}` · `/security:alerts --project {p}`
 
-## Ejemplos rápidos por escenario
+## Mensajería e Inbox (6)
+`/notify:whatsapp {contacto} {msg}` · `/whatsapp:search {query}` · `/notify:nctalk {sala} {msg}` · `/nctalk:search {query}` · `/inbox:check` · `/inbox:start --interval {min}`
 
-```
-Empezar el día:       /context:load → /sprint:status → /pr:pending
-Sprint Planning:      /sprint:plan → /pbi:plan-sprint
-Revisar un PR:        /pr:review 42
-Nuevo miembro:        /team:privacy-notice "Ana" --project Alpha → /team:onboarding "Ana" --project Alpha
-Crear infraestructura:/infra:detect Alpha DEV → /infra:plan Alpha DEV → /infra:estimate Alpha
-Generar informe:      /report:executive
-```
+## Conectores (12)
+`/notify:slack {canal} {msg}` · `/slack:search {query}` · `/github:activity {repo}` · `/github:issues {repo}` · `/sentry:health --project {p}` · `/sentry:bugs --project {p}` · `/gdrive:upload {file} --project {p}` · `/linear:sync --project {p}` · `/jira:sync --project {p}` · `/confluence:publish {file} --project {p}` · `/notion:sync --project {p}` · `/figma:extract {url} --project {p}`
+
+## Utilidades (2)
+`/context:load` · `/help [filtro]`

--- a/.claude/rules/command-ux-feedback.md
+++ b/.claude/rules/command-ux-feedback.md
@@ -124,28 +124,15 @@ Motivo: No se encontró el proyecto "alpha"
 Sugerencia: Ejecuta `/help --setup` para ver proyectos configurados
 ```
 
-## 6. Comandos sin output (solo lectura)
+## 6. Retry automático
 
-Incluso los comandos que solo muestran información (como `/help`):
-- Mostrar banner de inicio
-- Mostrar el contenido
-- Mostrar banner de fin: `✅ /help — Fin del catálogo`
+Fallo por config → Pedir dato → Guardar → Reintentar automáticamente.
 
-## 7. Regla de retry automático
+## 7. Output-first (protección de contexto)
 
-Cuando un comando falla por falta de configuración y el PM la proporciona
-de forma interactiva, el comando DEBE reintentarse automáticamente.
-No obligar al PM a volver a escribir el comando.
-
-Flujo: Fallo → Pedir dato → Guardar → Reintentar → Mostrar resultado
+Resultado > 30 líneas → guardar en fichero, mostrar resumen en chat.
+Ver @.claude/rules/context-health.md
 
 ## 8. Aplicación
 
-Esta regla se aplica a TODOS los comandos sin excepción:
-- Slash commands (`/comando:nombre`)
-- Skills invocados desde comandos
-- Agentes lanzados desde comandos
-
-Prioridad: Esta regla tiene prioridad sobre el contenido específico de cada
-comando en cuanto a formato de feedback. Si un comando no define feedback,
-aplicar estos estándares por defecto.
+TODOS los comandos sin excepción. Prioridad sobre contenido de cada comando.

--- a/.claude/rules/context-health.md
+++ b/.claude/rules/context-health.md
@@ -1,0 +1,109 @@
+# Regla: Context Health — Gestión proactiva del contexto
+# ── Prevenir saturación que inutiliza los comandos ───────────────────────────
+
+## Principio
+
+> El contexto es un recurso finito. Si se agota, pm-workspace deja de funcionar.
+> Cada decisión de diseño debe optimizar el uso de contexto.
+
+## 1. Patrón output-first (OBLIGATORIO en todos los comandos)
+
+Los comandos NUNCA deben volcar información extensa en la conversación.
+
+**Regla:** Si un resultado supera 30 líneas → guardar en fichero, mostrar resumen.
+
+```
+❌ MAL: Volcar 200 líneas de audit en la conversación
+✅ BIEN: Guardar en output/audits/..., mostrar 10 líneas de resumen + ruta
+```
+
+Formato obligatorio para resultados extensos:
+```
+📊 Resumen (5-10 líneas máximo en conversación)
+   Score global: 6.2/10 | 🔴 3 críticos | 🟡 5 mejorables | 🟢 4 correctos
+   Top crítico: SQL injection en AuthController (3 sprints sin resolver)
+
+📄 Detalle completo: output/audits/YYYYMMDD-audit-proyecto.md
+💡 Siguiente paso: /project:release-plan --project proyecto
+```
+
+## 2. Uso de subagentes para tareas pesadas
+
+Cuando un comando necesita análisis profundo (leer muchos ficheros, comparar
+datos, generar informes largos), DEBE usar `Task` (subagente).
+
+El subagente trabaja en contexto aislado y devuelve solo el resumen.
+Esto evita que el análisis intermedio contamine el contexto principal.
+
+**Comandos que DEBEN usar subagente:**
+- `/project:audit` → subagente analiza repo, devuelve scores + hallazgos
+- `/evaluate:repo` → subagente clona y analiza, devuelve puntuaciones
+- `/legacy:assess` → subagente evalúa 6 dimensiones, devuelve scoring
+- `/spec:generate` → subagente genera spec, guarda en fichero
+- Cualquier comando que lea más de 5 ficheros internamente
+
+## 3. Compactación proactiva
+
+### Cuándo sugerir `/compact`
+- Después de 10+ turnos de conversación
+- Después de ejecutar 3+ comandos en la misma sesión
+- Antes de ejecutar un comando pesado (audit, spec, evaluate)
+- Si el PM cambia de tema o proyecto
+
+### Mensaje de sugerencia
+```
+💡 Llevamos N turnos. Para mantener la precisión de los comandos,
+   te recomiendo ejecutar /compact antes de continuar.
+   (Preservará las decisiones y resultados de esta sesión)
+```
+
+### Instrucciones de compactación para CLAUDE.md
+Al compactar, SIEMPRE preservar:
+- Lista de ficheros modificados en la sesión
+- Resultados de audits/evaluaciones (scores, hallazgos críticos)
+- Decisiones tomadas por el PM
+- Estado del sprint/proyecto activo
+- Errores encontrados y cómo se resolvieron
+
+## 4. Sesiones enfocadas
+
+### Regla de una tarea por sesión
+Cada sesión debería tener UN objetivo claro:
+- "Auditar pm-workspace" → audit + actions
+- "Planificar Sprint 5" → planning + asignación
+- "Implementar feature X" → spec + implement + test
+
+Si el PM cambia de objetivo, sugerir `/clear` + nuevo `/context:load`.
+
+### Antipatrones a evitar
+- ❌ Mezclar auditoría + implementación + reporting en una sesión
+- ❌ Ejecutar 10+ comandos sin compactar
+- ❌ Pedir informes detallados en la conversación en vez de fichero
+
+## 5. Memoria persistente entre sesiones
+
+### Ficheros de estado del proyecto
+Cada proyecto mantiene estado en disco (no en contexto):
+- `projects/{p}/debt-register.md` — deuda técnica
+- `projects/{p}/risk-register.md` — riesgos
+- `projects/{p}/retro-actions.md` — acciones de retro
+- `output/audits/` — histórico de audits
+- `output/dora/` — histórico de métricas DORA
+
+Los comandos LEEN estos ficheros cuando los necesitan.
+No necesitan que la información esté en el contexto de conversación.
+
+### `/context:load` como punto de partida
+Al iniciar sesión, `/context:load` lee el estado de disco y muestra
+un resumen conciso. No carga todo — solo lo justo para orientar al PM.
+
+## 6. Límites de carga bajo demanda
+
+Cuando un comando referencia un fichero con `@`, Claude lo carga en contexto.
+Para evitar cargas excesivas:
+
+- Máximo 3 ficheros `@` por comando (los imprescindibles)
+- Skills: cargar solo el SKILL.md, no las references (cargar references
+  solo si el paso actual las necesita específicamente)
+- Si un comando necesita datos de otro comando anterior, leer del fichero
+  de output, no repetir la ejecución

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -1,5 +1,5 @@
 # Regla: Workflow PM — Convenciones, Cadencia y Comandos
-# ── Referencia operativa completa ────────────────────────────────────────────
+# ── Referencia operativa compacta ────────────────────────────────────────────
 
 ## 📅 Cadencia Scrum
 
@@ -13,103 +13,17 @@
 
 ## 📏 Convenciones
 
-- **Branches:** `feature/#XXXX-descripcion`, `fix/#XXXX-descripcion` (el `#ID` enlaza el commit con la tarea en DevOps)
+- **Branches:** `feature/#XXXX-descripcion`, `fix/#XXXX-descripcion`
 - **Commits:** `[AB#XXXX] Descripción corta en imperativo`
 - **Sprints:** `Sprint YYYY-NN` (ej: `Sprint 2026-04`)
-- **Informes:** `YYYYMMDD-tipo-proyecto.ext` (ej: `20260222-sprint-report-alpha.xlsx`)
+- **Informes:** `YYYYMMDD-tipo-proyecto.ext`
 
-## 📟 Comandos Disponibles
+## 📟 Comandos Disponibles (81)
 
-| Comando | Descripción |
-|---|---|
-| `/sprint:status` | Estado del sprint actual: progreso, burndown, alertas |
-| `/sprint:plan` | Asistente de Sprint Planning: capacity + PBIs candidatos |
-| `/sprint:review` | Resumen para Sprint Review: velocity, items completados |
-| `/sprint:retro` | Plantilla de retrospectiva con datos del sprint |
-| `/report:hours` | Informe de imputación de horas (Excel) |
-| `/report:executive` | Informe ejecutivo multi-proyecto (PPT/Word) |
-| `/report:capacity` | Estado de capacidades del equipo |
-| `/team:workload` | Carga de trabajo por persona |
-| `/board:flow` | Análisis del flujo: WIP, cuellos de botella, cycle time |
-| `/kpi:dashboard` | Dashboard completo de KPIs del equipo |
-| `/pbi:decompose {id}` | Descomponer un PBI en tasks con estimación y asignación |
-| `/pbi:decompose-batch {ids}` | Descomponer varios PBIs optimizando la carga global |
-| `/pbi:assign {pbi_id}` | (Re)asignar tasks existentes de un PBI |
-| `/pbi:plan-sprint` | Planning completo: capacity + PBIs + descomposición + asignación |
-| `/spec:generate {task_id}` | Generar Spec ejecutable desde una Task de Azure DevOps |
-| `/spec:implement {spec_file}` | Implementar una Spec (lanza agente Claude o asigna humano) |
-| `/spec:review {spec_file}` | Revisar calidad de Spec o validar implementación resultante |
-| `/spec:status` | Dashboard de estado de todas las Specs del sprint |
-| `/agent:run {spec_file}` | Lanzar agente Claude directamente sobre una Spec |
-| `/pbi:jtbd {id}` | Generar documento Jobs to be Done para un PBI (discovery) |
-| `/pbi:prd {id}` | Generar Product Requirements Document para un PBI (discovery) |
-| `/pr:review [PR]` | Revisión multi-perspectiva de PR (BA, Dev, QA, Security, DevOps) |
-| `/pr:pending` | PRs asignados al PM pendientes de revisión: estado, votos, comentarios, antigüedad |
-| `/context:load` | Carga de contexto al iniciar sesión (proyecto, sprint, actividad) |
-| `/changelog:update` | Actualizar CHANGELOG.md desde commits convencionales |
-| `/evaluate:repo [URL]` | Auditoría de seguridad y calidad de un repo externo |
-| `/team:onboarding {nombre}` | Guía de onboarding personalizada (Fases 1-2: contexto + código) |
-| `/team:evaluate {nombre}` | Cuestionario interactivo de competencias → perfil en equipo.md |
-| `/team:privacy-notice {nombre}` | Nota informativa RGPD obligatoria antes de evaluar competencias |
-| `/infra:detect {proyecto} {env}` | Detectar infraestructura existente del proyecto en un entorno |
-| `/infra:plan {proyecto} {env}` | Generar plan de infraestructura para un entorno |
-| `/infra:estimate {proyecto}` | Estimar costes de infraestructura por entorno |
-| `/infra:scale {recurso}` | Proponer escalado de un recurso (requiere aprobación humana) |
-| `/infra:status {proyecto}` | Estado de la infraestructura actual del proyecto |
-| `/env:setup {proyecto}` | Configurar entornos (DEV/PRE/PRO) para un proyecto |
-| `/env:promote {proyecto} {origen} {destino}` | Promover deploy entre entornos (PRE→PRO requiere aprobación) |
-| `/diagram:generate {proy}` | Generar diagrama de arquitectura/flujo → Draw.io, Miro o local |
-| `/diagram:import {source}` | Importar diagrama → validar reglas negocio → crear Features/PBIs/Tasks |
-| `/diagram:config` | Configurar credenciales Draw.io/Miro y verificar conexión |
-| `/diagram:status` | Listar diagramas por proyecto y estado de sincronización |
-| `/pipeline:status {--project p}` | Estado de pipelines: últimas builds, % éxito, duración, alertas |
-| `/pipeline:run {--project p} {pipeline}` | Ejecutar pipeline con preview y confirmación previa |
-| `/pipeline:logs {--project p} {--build id}` | Logs de una build: timeline, errores, warnings |
-| `/pipeline:create {--project p} {--name n}` | Crear pipeline YAML desde template con preview |
-| `/pipeline:artifacts {--project p} {--build id}` | Listar/descargar artefactos de una build |
-| `/repos:list {--project p}` | Listar repositorios del proyecto en Azure DevOps |
-| `/repos:branches {--project p} {--repo r}` | Gestión de branches: listar, crear, comparar |
-| `/repos:pr-create {--project p} {--repo r}` | Crear PR en Azure Repos con work item linking |
-| `/repos:pr-list {--project p}` | Listar PRs: pendientes, asignados al PM, por reviewer |
-| `/repos:pr-review {--project p} {--pr id}` | Review multi-perspectiva de PR en Azure Repos |
-| `/repos:search {--project p} {query}` | Buscar código en repositorios de Azure DevOps |
-| `/debt:track {--project p}` | Registro y seguimiento de deuda técnica: ratio, tendencia, SonarQube |
-| `/kpi:dora {--project p}` | Métricas DORA: deploy frequency, lead time, change failure rate, MTTR |
-| `/dependency:map {--project p}` | Mapa de dependencias entre PBIs/Features/equipos con alertas de bloqueo |
-| `/retro:actions {--project p}` | Seguimiento de action items de retrospectivas entre sprints |
-| `/risk:log {--project p}` | Registro de riesgos: probabilidad, impacto, mitigación, risk burndown |
-| `/legacy:assess {--project p}` | Evaluación de aplicación legacy: complejidad, riesgo, roadmap de modernización (strangler fig) |
-| `/backlog:capture {--project p} {--source tipo}` | Crear PBIs desde input desestructurado: emails, reuniones, Slack, tickets de soporte |
-| `/sprint:release-notes {--project p}` | Generar release notes automáticas combinando work items + commits + PRs |
-| `/project:audit {--project p}` | (Phase 1) Deep audit del proyecto: calidad, tests, deuda, seguridad, CI/CD → informe priorizado |
-| `/project:release-plan {--project p}` | (Phase 2) Plan de releases priorizado desde audit + backlog, respetando dependencias |
-| `/project:assign {--project p}` | (Phase 3) Asignar trabajo del plan al equipo según skills, seniority y capacity |
-| `/project:roadmap {--project p}` | (Phase 4) Roadmap visual: timeline, milestones, diagrama Gantt → Draw.io/Miro |
-| `/project:kickoff {--project p}` | (Phase 5) Compilar fases 1-4, notificar PM, crear Sprint 1 en Azure DevOps |
-| `/wiki:publish {file} {--project p}` | Publicar documentación en Azure DevOps Wiki |
-| `/wiki:sync {--project p}` | Sincronizar documentación local ↔ Azure DevOps Wiki (bidireccional) |
-| `/testplan:status {--project p}` | Estado de Test Plans: suites, casos, ejecución, cobertura |
-| `/testplan:results {--project p} {--run id}` | Resultados detallados de test runs: fallos, tendencias, recomendaciones |
-| `/security:alerts {--project p}` | Alertas de seguridad: CVEs, secrets, vulnerabilidades (Azure DevOps Advanced Security) |
-| `/notify:whatsapp {contacto} {msg}` | Enviar notificación/informe por WhatsApp (cuenta personal, no requiere Business) |
-| `/whatsapp:search {query}` | Buscar mensajes en WhatsApp como contexto (decisiones, acuerdos) |
-| `/notify:nctalk {sala} {msg}` | Enviar notificación/informe a sala de Nextcloud Talk |
-| `/nctalk:search {query}` | Buscar mensajes en Nextcloud Talk como contexto |
-| `/inbox:check` | Revisar mensajes nuevos en todos los canales, transcribir audios, proponer acciones |
-| `/inbox:start {--interval min}` | Iniciar monitor de inbox en background (polling cada N min mientras la sesión esté abierta) |
-| `/notify:slack {canal} {msg}` | Enviar notificación o informe al canal de Slack del proyecto |
-| `/slack:search {query}` | Buscar mensajes y decisiones en Slack como contexto |
-| `/github:activity {repo}` | Analizar actividad GitHub: PRs, commits, contributors |
-| `/github:issues {repo}` | Gestionar issues GitHub: buscar, crear, sincronizar con Azure DevOps |
-| `/sentry:health {--project p}` | Métricas de salud técnica desde Sentry: errores, crash rate, performance |
-| `/sentry:bugs {--project p}` | Crear PBIs (Bug) en Azure DevOps desde errores frecuentes en Sentry |
-| `/gdrive:upload {file}` | Subir informes y documentos generados a Google Drive |
-| `/linear:sync {--project p}` | Sincronizar issues Linear ↔ PBIs/Tasks Azure DevOps |
-| `/jira:sync {--project p}` | Sincronizar issues Jira ↔ PBIs Azure DevOps (bidireccional) |
-| `/confluence:publish {file}` | Publicar documentación/informes en Confluence |
-| `/notion:sync {--project p}` | Sincronizar documentación del proyecto con Notion (import/export) |
-| `/figma:extract {url}` | Extraer componentes UI, pantallas y design tokens desde Figma |
-| `/help [filtro]` | Ayuda: catálogo de comandos + detección de primeros pasos pendientes |
+> Tabla completa: `.claude/commands/references/command-catalog.md`
+> Catálogo interactivo: `/help [filtro]`
+
+**Categorías:** Sprint y Reporting (10), PBI y Discovery (6), SDD (5), Calidad y PRs (4), Equipo (3), Infra (7), Diagramas (4), Pipelines (5), Azure Repos (6), Governance (5), Legacy & Capture (3), Project Onboarding (5), DevOps Extended (5), Mensajería e Inbox (6), Conectores (12), Utilidades (2).
 
 ## 🔗 Referencias
 
@@ -119,22 +33,10 @@
 - Política estimación: `docs/politica-estimacion.md`
 - Queries WIQL: `.claude/skills/azure-devops-queries/references/wiql-patterns.md`
 - Product Discovery: `.claude/skills/product-discovery/SKILL.md`
-- Scoring asignación: `.claude/skills/pbi-decomposition/references/assignment-scoring.md`
-- SDD Template: `.claude/skills/spec-driven-development/references/spec-template.md`
-- SDD Layer Matrix: `.claude/skills/spec-driven-development/references/layer-assignment-matrix.md`
-- SDD Agent Patterns: `.claude/skills/spec-driven-development/references/agent-team-patterns.md`
+- SDD: `.claude/skills/spec-driven-development/SKILL.md`
 - Team Onboarding: `.claude/skills/team-onboarding/SKILL.md`
-- Multi-entorno: `.claude/rules/domain/environment-config.md`
-- Confidencialidad: `.claude/rules/domain/confidentiality-config.md`
-- Infrastructure as Code: `.claude/rules/domain/infrastructure-as-code.md`
-- Conectores Claude: `.claude/rules/domain/connectors-config.md`
-- Diagram Generation: `.claude/skills/diagram-generation/SKILL.md`
-- Diagram Import: `.claude/skills/diagram-import/SKILL.md`
-- Diagram Config: `.claude/rules/domain/diagram-config.md`
+- Diagramas: `.claude/skills/diagram-generation/SKILL.md`
 - Azure Pipelines: `.claude/skills/azure-pipelines/SKILL.md`
-- Azure Repos Config: `.claude/rules/domain/azure-repos-config.md`
-- Mensajería: `.claude/rules/domain/messaging-config.md`
-- Voice Inbox: `.claude/skills/voice-inbox/SKILL.md`
-- MCP Migration: `.claude/rules/domain/mcp-migration.md`
 - UX Feedback: `.claude/rules/command-ux-feedback.md`
+- Context Health: `.claude/rules/context-health.md`
 - Azure DevOps API v7.1: https://learn.microsoft.com/en-us/rest/api/azure/devops/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.13.0] — 2026-02-27
+
+Context health and operational resilience: proactive context management to prevent saturation. Output-first pattern, subagent delegation, compaction suggestions, session focus. pm-workflow.md slimmed from 140→42 lines. Auto-loaded context: 899 lines (was 2,109 pre-v0.12.0).
+
+### Added
+
+**Context health rule** — `context-health.md`
+- Output-first: results > 30 lines → file, summary in chat
+- Subagent delegation for heavy commands (audit, evaluate, legacy, spec)
+- Proactive compaction: suggest `/compact` after 10+ turns or 3+ commands
+- Session focus: one task per session, `/clear` between topics
+- Persistent state via project files (debt-register, risk-register, audits)
+
+**Critical rule #16** — Context management in CLAUDE.md
+**Compaction instructions** — Preserve files, scores, decisions on `/compact`
+
+### Changed
+
+- `pm-workflow.md`: 140→42 lines (-70%), command table to `references/command-catalog.md`
+- `command-ux-feedback.md`: added output-first section, compacted from 155→138 lines
+- `command-catalog.md`: updated from 37→81 commands, compact inline format
+
+---
+
 ## [0.12.0] — 2026-02-27
 
 Context optimization: 58% reduction in auto-loaded context. Domain-specific rules moved to on-demand loading, freeing ~1,200 lines of context window for actual PM work. Prevents context saturation that caused commands to fail silently at high usage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 13. **Git**: NUNCA commit directo en `main` — siempre rama + PR · ver `@.claude/rules/github-flow.md`
 14. **Comandos**: ANTES de commit que toque `commands/`, ejecutar `scripts/validate-commands.sh` · ver `@.claude/rules/command-validation.md`
 15. **UX Feedback OBLIGATORIO**: TODO slash command DEBE mostrar: (1) banner de inicio `🚀 /comando — Descripción`, (2) verificación de prerequisitos con ✅/❌, (3) progreso por pasos `📋 Paso N/M`, (4) resultado en pantalla, (5) banner de fin `✅ /comando — Completado` o `❌ /comando — Error`. Si falta configuración → preguntar interactivamente → guardar → reintentar. **El silencio es un bug.** · ver `@.claude/rules/command-ux-feedback.md`
+16. **Contexto**: Resultado > 30 líneas → guardar en fichero, mostrar solo resumen en chat. Usar `Task` (subagente) para análisis pesados. Sugerir `/compact` tras 10+ turnos o 3+ comandos. Una tarea por sesión. · ver `@.claude/rules/context-health.md`
 
 ---
 
@@ -117,8 +118,9 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 - **Pipelines** → `.claude/skills/azure-pipelines/SKILL.md`
 - **Azure Repos** → `@.claude/rules/domain/azure-repos-config.md`
 - **Comandos** → `@.claude/rules/pm-workflow.md`
-- Explorar → Planificar → Implementar → Commit · `/compact` al 50% · `/clear` entre tareas
+- Explorar → Planificar → Implementar → Commit
 - Arquitectura: **Command → Agent → Skills** — subagentes solo con `Task`
+- **Compactación**: Al hacer `/compact`, preservar: ficheros modificados, scores de audits, decisiones del PM, errores y cómo se resolvieron. Sugerir `/compact` tras 10 turnos o 3 comandos.
 
 ---
 

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -69,7 +69,7 @@
 │   │
 │   └── rules/                   ← Reglas modulares
 │       ├── pm-config.md         ← Constantes Azure DevOps (auto-cargado)
-│       ├── pm-workflow.md       ← Cadencia Scrum y tabla de comandos (auto-cargado)
+│       ├── pm-workflow.md       ← Cadencia Scrum e índice de categorías (auto-cargado)
 │       ├── github-flow.md       ← Branching, PRs, releases, tags (auto-cargado)
 │       ├── command-ux-feedback.md ← Estándares de feedback UX (auto-cargado)
 │       ├── command-validation.md← Pre-commit: validar commands (auto-cargado)
@@ -77,6 +77,7 @@
 │       ├── readme-update.md     ← Regla 12: actualizar READMEs (auto-cargado)
 │       ├── language-packs.md    ← Tabla de 16 lenguajes (auto-cargado)
 │       ├── agents-catalog.md    ← Tabla de 24 agentes (auto-cargado)
+│       ├── context-health.md   ← Gestión de contexto y output-first (auto-cargado)
 │       ├── domain/              ← Reglas por dominio (bajo demanda, excluidas de auto-carga)
 │       │   ├── infrastructure-as-code.md
 │       │   ├── confidentiality-config.md

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -68,7 +68,7 @@
 │   │
 │   └── rules/                   ← Modular rules
 │       ├── pm-config.md         ← Azure DevOps constants (auto-loaded)
-│       ├── pm-workflow.md       ← Scrum cadence and command table (auto-loaded)
+│       ├── pm-workflow.md       ← Scrum cadence and category index (auto-loaded)
 │       ├── github-flow.md       ← Branching, PRs, releases, tags (auto-loaded)
 │       ├── command-ux-feedback.md ← UX feedback standards (auto-loaded)
 │       ├── command-validation.md← Pre-commit: validate commands (auto-loaded)
@@ -76,6 +76,7 @@
 │       ├── readme-update.md     ← Rule 12: update READMEs (auto-loaded)
 │       ├── language-packs.md    ← 16 supported languages table (auto-loaded)
 │       ├── agents-catalog.md    ← 24 agents table (auto-loaded)
+│       ├── context-health.md   ← Context management and output-first (auto-loaded)
 │       ├── domain/              ← Domain-specific rules (on-demand, excluded from auto-loading)
 │       │   ├── infrastructure-as-code.md
 │       │   ├── confidentiality-config.md


### PR DESCRIPTION
## Summary

- **New rule `context-health.md`**: output-first pattern (results >30 lines → save to file, show summary), subagent delegation for heavy commands, proactive `/compact` suggestions after 10+ turns
- **Slimmed `pm-workflow.md`** from 140→42 lines by extracting 81-command table to `references/command-catalog.md`
- **Updated `command-ux-feedback.md`** with output-first section (155→138 lines)
- **CLAUDE.md rule #16**: context management + compaction instructions
- **Docs (ES/EN)**: structure trees updated with `context-health.md`

**Impact:** Auto-loaded context reduced from 2,109 to 899 lines (-57% from original baseline).

## Test plan

- [ ] Verify `context-health.md` loads automatically (not in `.claudeignore`)
- [ ] Run `/help` — confirms 81 commands from `command-catalog.md`
- [ ] Run a heavy command (e.g. `/project:audit`) — should delegate to subagent or use output-first
- [ ] Verify `pm-workflow.md` references command-catalog correctly
- [ ] Check CLAUDE.md rule #16 visible in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)