### PR TITLE
fix(changelog): add v0.13.0 link reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,7 +400,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
Adds missing `[0.13.0]` link definition and updates `[Unreleased]` to point to `v0.13.0...HEAD`.