### PR TITLE
fix(commands): mandatory subagent delegation for heavy commands

### DIFF
--- a/.claude/commands/evaluate-repo.md
+++ b/.claude/commands/evaluate-repo.md
@@ -44,21 +44,15 @@ Si la URL es inválida o no se puede clonar → error claro:
    (o que tienes acceso configurado).
 ```
 
-## 3. Ejecución con progreso
+## 3. Delegar análisis a subagente
 
-```
-📋 Paso 1/5 — Analizando estructura del repositorio...
-📋 Paso 2/5 — Evaluando calidad de código...
-📋 Paso 3/5 — Escaneando seguridad...
-📋 Paso 4/5 — Verificando documentación...
-📋 Paso 5/5 — Calculando puntuaciones...
-```
+**OBLIGATORIO**: Delegar el análisis a un subagente (`Task`) para proteger el contexto.
 
-### Instrucciones internas
+Mostrar: `📋 Paso 1/1 — Análisis delegado a subagente (puede tardar ~2 min)...`
 
-1. **NO ejecutar código** — solo inspección estática
-2. Clonar a `/tmp/eval-repo-$(date +%s) --depth 1`
-3. Leer: README, CLAUDE.md, package.json, *.csproj, hooks, commands, scripts, configs
+El subagente debe: clonar (--depth 1) a `/tmp/eval-repo-*`, inspeccionar estáticamente (NO ejecutar código), evaluar las 6 categorías del §4, generar scoring y veredicto, y limpiar `/tmp/eval-repo-*`.
+
+Ficheros a leer: README, CLAUDE.md, package.json, *.csproj, hooks, commands, scripts, configs.
 
 ## 4. Criterios (1-10 cada uno)
 
@@ -105,3 +99,4 @@ Limpiar: `rm -rf /tmp/eval-repo-*`
 - NUNCA instalar dependencias ni ejecutar código
 - NUNCA aprobar automáticamente — es recomendación al humano
 - Si duda entre 🟡 y 🔴 → elevar a 🔴
+- **NO ejecutar análisis en el contexto principal** — SIEMPRE subagente

--- a/.claude/commands/legacy-assess.md
+++ b/.claude/commands/legacy-assess.md
@@ -25,7 +25,13 @@ description: >
 2. `.claude/skills/azure-devops-queries/SKILL.md` — Queries si hay work items
 3. Acceso al repositorio del proyecto (Git clone o Azure Repos)
 
-## Pasos de ejecución
+## Delegación a subagente
+
+**OBLIGATORIO**: Todo el análisis (recopilar datos, calcular scores, generar roadmap) se ejecuta en un subagente (`Task`) para proteger el contexto. Mostrar: `📋 Paso 1/1 — Análisis delegado a subagente (puede tardar ~2 min)...`
+
+El subagente ejecuta los pasos 1-5 abajo y guarda el informe en `output/assessments/`. El contexto principal solo recibe el resumen (score global + hallazgos críticos).
+
+## Pasos de ejecución (dentro del subagente)
 
 ### 1. Recopilar datos
 - **Código fuente**: LOC, lenguajes, edad del repo, frecuencia de commits
@@ -105,3 +111,4 @@ Conocimiento:   ████░░░░░░ 4/10
 - No modifica código ni crea branches — solo analiza y reporta
 - El score es orientativo, no sustituye el juicio del equipo
 - Acceso al repo necesario para análisis profundo (`--deep`)
+- **NO ejecutar análisis en el contexto principal** — SIEMPRE subagente

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.13.2] — 2026-02-27
+
+Fix silent failures: heavy commands (project-audit, evaluate-repo, legacy-assess) now explicitly delegate analysis to subagents. Added stack detection to project-audit prerequisite checks.
+
+### Fixed
+
+**`/project:audit` silent failure** — At 100% context, the command produced zero output. Root cause: anti-improvisation rule prevented Claude from using subagents (not defined in command spec). Now explicitly delegates to `Task` subagent.
+
+### Changed
+
+**`/project:audit`** — Rewritten: mandatory subagent delegation (§4), stack-aware prereqs (GitHub-only vs Azure DevOps), output-first summary.
+**`/evaluate:repo`** — Added mandatory subagent delegation for analysis.
+**`/legacy:assess`** — Added mandatory subagent delegation for analysis.
+
+---
+
 ## [0.13.1] — 2026-02-27
 
 Anti-improvisation: commands now strictly execute only what their `.md` file defines. `/help --setup` rewritten with explicit stack detection (GitHub-only vs Azure DevOps) and conditional checks.
@@ -412,7 +428,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.11.1...v0.12.0


### PR DESCRIPTION
## Summary

- **`/project:audit`** rewritten with mandatory `Task` subagent delegation — fixes silent failure at 100% context
- **`/evaluate:repo`** and **`/legacy:assess`** also updated with subagent delegation
- Stack-aware prerequisite checks in `/project:audit` (GitHub-only skips Azure DevOps APIs)

## Root cause

The anti-improvisation rule (v0.13.1) correctly prevents Claude from inventing behavior. But `context-health.md` says "use subagents for heavy commands" while the commands themselves didn't specify this. At 100% context, Claude couldn't process the command AND the anti-improvisation rule prevented it from delegating to a subagent on its own. Result: zero output.

## Test plan

- [ ] Run `/project:audit --project pm-workspace` at high context — should delegate to subagent and show summary
- [ ] Run `/evaluate:repo` — should delegate analysis to subagent
- [ ] Verify subagent saves full report to `output/audits/`
- [ ] Verify main conversation only shows summary (not full report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)