### PR TITLE
feat(sessions): session persistence with save/load rituals

### DIFF
--- a/.claude/commands/context-load.md
+++ b/.claude/commands/context-load.md
@@ -1,16 +1,15 @@
 ---
 name: context-load
 description: >
-  Carga de contexto al inicio de una sesión de Claude Code. Lee el estado actual
-  del workspace, el proyecto activo, el sprint en curso y la actividad reciente
-  para arrancar la sesión con información completa.
+  Carga de contexto al inicio de sesión. Lee estado del workspace, decisiones
+  recientes, último session save y actividad Git para arrancar con el big picture.
 ---
 
 # Carga de Contexto — Inicio de Sesión
 
 Aplica siempre @.claude/rules/command-ux-feedback.md
 
-> Ejecuta este comando al empezar una sesión nueva para tener contexto completo.
+> Ejecuta al empezar una sesión nueva para tener contexto completo.
 
 ## 1. Banner de inicio
 
@@ -20,55 +19,54 @@ Aplica siempre @.claude/rules/command-ux-feedback.md
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## 2. Protocolo de carga (con progreso)
+## 2. Detección de stack
+
+Leer `CLAUDE.local.md` → campo `AZURE_DEVOPS_ENABLED`.
+Mostrar: `📦 Stack: {GitHub-only|Azure DevOps}`
+
+## 3. Protocolo de carga (con progreso)
 
 ```
-📋 Paso 1/5 — Identificando workspace y rama...
+📋 Paso 1/5 — Workspace y rama...
 ```
 ```bash
-pwd
-git branch --show-current
+pwd && git branch --show-current
 ```
-Verificar que estamos en la raíz (`~/claude/`).
+Verificar raíz (`~/claude/`).
 
 ```
-📋 Paso 2/5 — Leyendo configuración global...
+📋 Paso 2/5 — Decisiones y sesión anterior...
 ```
-Leer `CLAUDE.md` (raíz) — Proyectos Activos y Config Esencial.
-Leer `CLAUDE.local.md` si existe — proyectos privados.
+**Decision log** (`decision-log.md` en raíz):
+- Si existe → leer las últimas 10 entradas y mostrar resumen (3-5 decisiones más recientes)
+- Si no existe → `ℹ️ Sin decision log — se creará con /session:save`
+
+**Último session save** (`output/sessions/` → fichero más reciente):
+- Si existe → leer y mostrar: objetivo, pendientes, contexto para esta sesión
+- Si no existe → `ℹ️ Sin sesiones anteriores guardadas`
 
 ```
-📋 Paso 3/5 — Analizando actividad Git reciente...
+📋 Paso 3/5 — Estado de proyectos...
+```
+Leer `CLAUDE.local.md` → tabla de proyectos activos.
+Para cada proyecto, comprobar si existe y mostrar 1 línea de estado:
+- Último audit: `output/audits/*-{proyecto}.md` → score si existe
+- Deuda: `projects/{p}/debt-register.md` → items abiertos si existe
+- Riesgos: `projects/{p}/risk-register.md` → riesgos críticos si existe
+
+```
+📋 Paso 4/5 — Actividad Git reciente...
 ```
 ```bash
-git log --oneline -10 --all --decorate
-git branch -a | grep -v "remotes/origin/HEAD"
+git log --oneline -5 --decorate
 ```
-Resumir: últimos 5 commits, ramas activas no mergeadas.
+Ramas activas no mergeadas (si hay).
 
 ```
-📋 Paso 4/5 — Consultando estado del sprint...
+📋 Paso 5/5 — Herramientas disponibles...
 ```
-Solo si PAT configurado:
-- Ejecutar `/sprint:status` en modo resumido (solo burndown y alertas)
-- Si no hay PAT → "⚠️ Azure DevOps no conectado — sprint no disponible"
-
-```
-📋 Paso 5/5 — Verificando herramientas disponibles...
-```
-```bash
-claude --version 2>/dev/null || echo "no disponible"
-az --version 2>/dev/null | head -1 || echo "no disponible"
-dotnet --version 2>/dev/null || echo "no disponible"
-jq --version 2>/dev/null || echo "no disponible"
-```
-
-## 3. Proyecto activo (detección automática)
-
-Si la rama sigue `feature/`, `fix/`, etc.:
-- Detectar proyecto por path o nombre de rama
-- Leer su CLAUDE.md específico
-- Resumir tarea en curso
+Solo si stack = Azure DevOps: verificar `az`, PAT.
+Siempre: `claude --version`, `git --version`.
 
 ## 4. Mostrar resultado
 
@@ -77,27 +75,31 @@ Si la rama sigue `feature/`, `fix/`, etc.:
   PM-WORKSPACE · Sesión iniciada
 ══════════════════════════════════════════════════
 
-  📁 Workspace: ~/claude/ (rama: main)
-  🔧 Herramientas: Claude X.X ✅ | az CLI ✅ | .NET X ✅ | jq ✅
+  📦 Stack: {GitHub-only|Azure DevOps}
+  📁 Workspace: ~/claude/ (rama: {branch})
 
-  📋 Proyectos activos: N
-     • ProyectoAlpha — Sprint 2026-05 (día 4/10)
-     • ProyectoBeta  — Sprint 2026-05 (día 4/10)
+  📋 Decisiones recientes:
+     • {decisión más reciente}
+     • {decisión 2}
+     • {decisión 3}
 
-  📊 Sprint actual: [resumen 1 línea del burndown]
-     [alerta más importante si hay]
+  ⏳ Pendiente (de última sesión):
+     • {tarea pendiente 1}
+     • {tarea pendiente 2}
 
-  🌿 Ramas activas: N
-     • feature/nueva-funcionalidad (3 commits adelante)
-     • fix/capacity-edge-case (1 commit)
+  📁 Proyectos activos: N
+     • {proyecto1} — audit: X/10 | deuda: N items | riesgos: N
+     • {proyecto2} — sin audit previo
 
   📝 Últimos cambios:
-     • feat(agents): add pr-review command
-     • docs(readme): update command reference
-     • fix(rules): correct PAT reference
+     • {commit 1}
+     • {commit 2}
 
 ══════════════════════════════════════════════════
 ```
+
+Si no hay decisiones ni sesiones previas, mostrar solo proyectos + git.
+Si no hay proyectos → sugerir `/help --setup`.
 
 ## 5. Banner de fin
 
@@ -105,13 +107,14 @@ Si la rama sigue `feature/`, `fix/`, etc.:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ✅ /context:load — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📁 {N} proyectos | 🌿 {N} ramas | 🔧 {N}/{M} herramientas OK
+📁 {N} proyectos | 📋 {N} decisiones recientes | ⏳ {N} pendientes
 💡 ¿Por dónde empezamos?
 ```
 
 ## Restricciones
 
 - **Solo lectura** — no modifica nada
-- **Rápido** — no queries pesadas a Azure DevOps; datos locales primero
-- **Conciso** — output legible en 30 segundos o menos
-- Si PAT no configurado → no error, solo aviso
+- **Conciso** — output legible en 30 segundos, NO cargar ficheros completos
+- Si no hay PAT / Azure DevOps → no error, solo omitir esos datos
+- Leer solo las primeras líneas de cada fichero de estado (no cargar completos)
+- **NO ejecutar otros comandos** como dependencia (/sprint:status, etc.)

--- a/.claude/commands/references/command-catalog.md
+++ b/.claude/commands/references/command-catalog.md
@@ -1,4 +1,4 @@
-# Catálogo de Comandos PM-Workspace (81)
+# Catálogo de Comandos PM-Workspace (83)
 
 > Este fichero se carga bajo demanda (desde `/help` o consultas de catálogo).
 > NO se auto-carga en el contexto.
@@ -48,5 +48,5 @@
 ## Conectores (12)
 `/notify:slack {canal} {msg}` · `/slack:search {query}` · `/github:activity {repo}` · `/github:issues {repo}` · `/sentry:health --project {p}` · `/sentry:bugs --project {p}` · `/gdrive:upload {file} --project {p}` · `/linear:sync --project {p}` · `/jira:sync --project {p}` · `/confluence:publish {file} --project {p}` · `/notion:sync --project {p}` · `/figma:extract {url} --project {p}`
 
-## Utilidades (2)
-`/context:load` · `/help [filtro]`
+## Utilidades (4)
+`/context:load` · `/session:save` · `/help [filtro]` · `/help --setup`

--- a/.claude/commands/session-save.md
+++ b/.claude/commands/session-save.md
@@ -1,0 +1,134 @@
+---
+name: session-save
+description: >
+  Guarda decisiones, resultados y pendientes de la sesión actual antes de /clear.
+  Persiste el conocimiento entre sesiones para que /context:load lo recupere.
+---
+
+# Session Save — Persistencia entre sesiones
+
+**Argumentos:** $ARGUMENTS
+
+Aplica siempre @.claude/rules/command-ux-feedback.md
+
+> Ejecuta ANTES de `/clear` o al terminar una sesión para no perder contexto.
+
+## 1. Banner de inicio
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🚀 /session:save — Guardando estado de sesión
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## 2. Recopilar información de la sesión
+
+Revisar la conversación actual y extraer:
+
+### 2a. Decisiones tomadas
+Cualquier cosa que el PM haya decidido, aprobado o rechazado:
+- Cambios de arquitectura, tecnología, priorización
+- Aprobaciones de PRs, specs, planes
+- Rechazos o postponements con motivo
+- Criterios definidos para futuras decisiones
+
+### 2b. Resultados de comandos
+Scores, hallazgos y métricas producidos en la sesión:
+- Audit scores y hallazgos críticos
+- Evaluaciones de repos
+- Métricas DORA / KPIs
+- Deuda técnica detectada
+
+### 2c. Ficheros modificados
+Lista de ficheros creados o editados en la sesión (del git status/log).
+
+### 2d. Tareas pendientes
+Lo que quedó sin hacer o se identificó como siguiente paso.
+
+### 2e. Contexto relevante
+Cualquier información que la próxima sesión necesite para no empezar de cero.
+
+## 3. Guardar en dos destinos
+
+### 3a. Session log (historial)
+
+Guardar en: `output/sessions/YYYYMMDD-HHMM-session.md`
+
+Formato:
+```markdown
+# Sesión YYYY-MM-DD HH:MM
+
+## Objetivo
+{qué se hizo en esta sesión — 1 línea}
+
+## Decisiones
+- {decisión 1}
+- {decisión 2}
+
+## Resultados
+- {resultado 1: score, métrica, hallazgo}
+
+## Ficheros modificados
+- {fichero 1}
+- {fichero 2}
+
+## Pendiente
+- {tarea 1}
+- {tarea 2}
+
+## Contexto para próxima sesión
+{lo que necesita saber quien continúe}
+```
+
+### 3b. Decision log (acumulativo, privado)
+
+Fichero: `decision-log.md` (raíz del workspace, git-ignorado)
+
+**Si no existe** → crearlo con cabecera:
+```markdown
+# Decision Log — PM-Workspace
+# ── FICHERO PRIVADO — git-ignorado ──────────────────────────────
+
+> Registro acumulativo de decisiones del PM. Cargado por /context:load.
+> Mantener máximo 50 entradas. Al superar → archivar antiguas al final.
+
+---
+```
+
+**Añadir al inicio** (después de la cabecera, antes de entradas anteriores):
+```markdown
+### YYYY-MM-DD — {objetivo de la sesión}
+- {decisión 1}
+- {decisión 2}
+```
+
+Solo decisiones — no resultados ni ficheros (eso está en el session log).
+
+## 4. Mostrar resumen en chat
+
+```
+📋 Sesión guardada:
+   📝 Decisiones: N
+   📊 Resultados: N
+   📁 Ficheros modificados: N
+   ⏳ Pendientes: N
+```
+
+## 5. Banner de fin
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ /session:save — Completado
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📄 Log: output/sessions/YYYYMMDD-HHMM-session.md
+📋 Decision log actualizado: decision-log.md
+💡 Ahora puedes ejecutar /clear con tranquilidad
+```
+
+## Restricciones
+
+- Solo lectura de la conversación + escritura en los 2 ficheros indicados
+- **NO modificar** ningún otro fichero
+- **NO ejecutar** ningún otro comando
+- Si no hay decisiones → guardar igualmente con "Sin decisiones en esta sesión"
+- El decision-log.md es PRIVADO — nunca subirlo al repo

--- a/.claude/rules/pm-workflow.md
+++ b/.claude/rules/pm-workflow.md
@@ -18,12 +18,12 @@
 - **Sprints:** `Sprint YYYY-NN` (ej: `Sprint 2026-04`)
 - **Informes:** `YYYYMMDD-tipo-proyecto.ext`
 
-## 📟 Comandos Disponibles (81)
+## 📟 Comandos Disponibles (83)
 
 > Tabla completa: `.claude/commands/references/command-catalog.md`
 > Catálogo interactivo: `/help [filtro]`
 
-**Categorías:** Sprint y Reporting (10), PBI y Discovery (6), SDD (5), Calidad y PRs (4), Equipo (3), Infra (7), Diagramas (4), Pipelines (5), Azure Repos (6), Governance (5), Legacy & Capture (3), Project Onboarding (5), DevOps Extended (5), Mensajería e Inbox (6), Conectores (12), Utilidades (2).
+**Categorías:** Sprint y Reporting (10), PBI y Discovery (6), SDD (5), Calidad y PRs (4), Equipo (3), Infra (7), Diagramas (4), Pipelines (5), Azure Repos (6), Governance (5), Legacy & Capture (3), Project Onboarding (5), DevOps Extended (5), Mensajería e Inbox (6), Conectores (12), Utilidades (4).
 
 ## 🔗 Referencias
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Thumbs.db
 
 # ── Claude Code — preferencias personales (no compartir) ─────────────────────
 CLAUDE.local.md
+
+# ── Decision log — privado del PM ─────────────────────────────────────────────
+decision-log.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.14.0] — 2026-02-27
+
+Session persistence: knowledge no longer lost between sessions. Inspired by Obsidian vault pattern — pm-workspace now has save/load rituals that build a persistent "second brain" for the PM.
+
+### Added
+
+**`/session:save` command** — Captures decisions, results, modified files, and pending tasks before `/clear`. Saves to two destinations: session log (`output/sessions/`) and cumulative decision log (`decision-log.md`).
+**`decision-log.md`** — Private (git-ignored) cumulative register of PM decisions. Max 50 entries. Loaded by `/context:load` at session start.
+**`output/sessions/`** — Session history with full context for continuity.
+
+### Changed
+
+**`/context:load` rewritten** — Now loads the "big picture": recent decisions from decision-log, last session's pending tasks, project health (last audit score, open debt, risks), plus git activity. Stack-aware (GitHub-only vs Azure DevOps).
+**Command count** — 81 → 83 commands (added session:save, help --setup as separate entry).
+
+---
+
 ## [0.13.2] — 2026-02-27
 
 Fix silent failures: heavy commands (project-audit, evaluate-repo, legacy-assess) now explicitly delegate analysis to subagents. Added stack detection to project-audit prerequisite checks.
@@ -428,7 +445,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.2...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.12.0...v0.13.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/agents-catalog.md
-│   ├── commands/                  ← 81 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
+│   ├── commands/                  ← 83 slash commands (+7 infra en skill) → @.claude/rules/pm-workflow.md
 │   ├── rules/                     ← Reglas core + languages/ (16 Language Packs, excluido de carga auto)
 │   └── skills/                    ← 13 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 81 slash commands
+│   ├── commands/                ← 83 slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -40,7 +40,8 @@
 ## Calidad y Operaciones
 ```
 /pr:review [PR]                  Revisión multi-perspectiva de PR (BA, Dev, QA, Sec, DevOps)
-/context:load                    Carga de contexto al iniciar sesión
+/context:load                    Carga de contexto al iniciar sesión (big picture)
+/session:save                    Guarda decisiones y pendientes antes de /clear
 /changelog:update                Actualizar CHANGELOG.md desde commits convencionales
 /evaluate:repo [URL]             Auditoría de seguridad y calidad de repo externo
 ```

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 81 slash commands
+│   ├── commands/                ← 83 slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -40,7 +40,8 @@
 ## Quality and Operations
 ```
 /pr:review [PR]                  Multi-perspective PR review (BA, Dev, QA, Sec, DevOps)
-/context:load                    Load session context on startup
+/context:load                    Load session context on startup (big picture)
+/session:save                    Save decisions and pending tasks before /clear
 /changelog:update                Update CHANGELOG.md from conventional commits
 /evaluate:repo [URL]             Security and quality audit of external repo
 ```


### PR DESCRIPTION
## Summary

- **New `/session:save` command** — Captures decisions, results, modified files, and pending tasks before `/clear`. Saves to `output/sessions/` (history) and `decision-log.md` (cumulative, private).
- **`/context:load` rewritten** — Loads "big picture" at session start: recent decisions, last session's pending tasks, project health (audit scores, debt, risks), git activity. Stack-aware.
- **`decision-log.md`** — Private (git-ignored) cumulative register of PM decisions, max 50 entries.
- **83 commands** (was 81)

## Motivation

Inspired by Nicolas Maldonado's Obsidian vault pattern for Claude Code. The key insight: "The solution is not a better LLM or larger context window — it's improving the information infrastructure." pm-workspace now has persistent memory between sessions without requiring external tools.

## Test plan

- [ ] Run `/session:save` — should create `output/sessions/YYYYMMDD-HHMM-session.md` and `decision-log.md`
- [ ] Verify `decision-log.md` is git-ignored
- [ ] Run `/context:load` in fresh session — should show decisions and pending tasks from previous session
- [ ] Run `/context:load` with no prior sessions — should show "Sin sesiones anteriores" gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)