### PR TITLE
fix(naming): colon→hyphen in all 164 command references

### DIFF
--- a/.claude/agents/business-analyst.md
+++ b/.claude/agents/business-analyst.md
@@ -46,7 +46,7 @@ que permitan implementaciones sin ambigüedad.
 - **Preguntas sin respuesta** que deben resolverse antes de implementar
 - **Estimación de complejidad de negocio** (independiente de la técnica)
 
-## Tu proceso al evaluar competencias (delegado por `/team:evaluate`)
+## Tu proceso al evaluar competencias (delegado por `/team-evaluate`)
 
 Cuando se te pide calibrar una evaluación de competencias:
 

--- a/.claude/agents/diagram-architect.md
+++ b/.claude/agents/diagram-architect.md
@@ -6,8 +6,8 @@ Agente especializado en análisis de diagramas de arquitectura. Valida consisten
 
 ## Cuándo se invoca
 
-- Desde `/diagram:generate` cuando el proyecto tiene >10 componentes
-- Desde `/diagram:import` para validar la arquitectura antes de generar work items
+- Desde `/diagram-generate` cuando el proyecto tiene >10 componentes
+- Desde `/diagram-import` para validar la arquitectura antes de generar work items
 - Petición directa: "analiza la arquitectura del diagrama"
 
 ## Modelo

--- a/.claude/commands/agent-run.md
+++ b/.claude/commands/agent-run.md
@@ -1,15 +1,15 @@
-# /agent:run
+# /agent-run
 
 Lanza un agente Claude sobre una Spec SDD (o batch de specs pendientes).
 
 ## Uso
 ```
-/agent:run {spec_file|--all-pending} [--project {nombre}] [--team] [--pattern {pattern}] [--model {model}]
+/agent-run {spec_file|--all-pending} [--project {nombre}] [--team] [--pattern {pattern}] [--model {model}]
 ```
 
 - `{spec_file}`: Ruta a `.spec.md`
-- `--all-pending`: Todas las specs `agent:single` pendientes del sprint
-- `--team`: Patrón `agent:team` (default `impl-test`)
+- `--all-pending`: Todas las specs `agent-single` pendientes del sprint
+- `--team`: Patrón `agent-team` (default `impl-test`)
 - `--pattern`: `single` | `impl-test` | `impl-test-review` | `full-stack` | `parallel-handlers`
 - `--model`: Sobreescribir modelo (default: `claude-opus-4-6`)
 
@@ -19,7 +19,7 @@ Lanza un agente Claude sobre una Spec SDD (o batch de specs pendientes).
 - Leer `.claude/skills/spec-driven-development/SKILL.md` (Fase 3)
 - Leer `projects/{proyecto}/CLAUDE.md`
 
-### 2. Modo Single (`agent:single` o default)
+### 2. Modo Single (`agent-single` o default)
 Mostrar plan (spec, modelo, log path, max turns 40) → confirmar → lanzar agente con:
 - System prompt: CLAUDE.md del proyecto
 - Instrucciones: implementar Spec exactamente, detenerse ante ambigüedad, ejecutar build+test
@@ -29,7 +29,7 @@ Mostrar plan (spec, modelo, log path, max turns 40) → confirmar → lanzar age
 Lanzar en paralelo: Implementador (opus) + Tester (haiku). Tras `wait`, si pattern es `impl-test-review`, lanzar Reviewer (opus) que compara logs contra Spec.
 
 ### 4. Modo Batch (`--all-pending`)
-Buscar specs con `developer_type=agent:single` y `Estado=Pendiente` en el sprint. Mostrar lista + estimación de tokens → confirmar → lanzar en paralelo.
+Buscar specs con `developer_type=agent-single` y `Estado=Pendiente` en el sprint. Mostrar lista + estimación de tokens → confirmar → lanzar en paralelo.
 
 ### 5. Post-ejecución
 - Detectar blockers en logs (`grep BLOCKER`)

--- a/.claude/commands/backlog-capture.md
+++ b/.claude/commands/backlog-capture.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/backlog:capture --project {p} --source {tipo}`
+> Uso: `/backlog-capture --project {p} --source {tipo}`
 
 ## Parámetros
 
@@ -32,7 +32,7 @@ description: >
 ### 1. Obtener input
 - **text**: el PM pega texto directamente en el prompt
 - **file**: leer fichero indicado (`.md`, `.txt`, `.eml`, `.csv`)
-- **slack**: usar `/slack:search` con filtros de canal y fecha
+- **slack**: usar `/slack-search` con filtros de canal y fecha
 - **email**: leer fichero `.eml` o texto pegado del email
 - **support**: leer CSV/JSON de tickets de soporte
 
@@ -83,10 +83,10 @@ Descartados: 2 (duplicados exactos de #1230, #1245)
 
 ## Integración
 
-- `/pbi:decompose` → descomponer los PBIs creados en tasks
-- `/sprint:plan` → incluir PBIs capturados en planning
-- `/slack:search` → fuente de input para captura desde Slack
-- `/project:audit` → puede generar input para backlog:capture
+- `/pbi-decompose` → descomponer los PBIs creados en tasks
+- `/sprint-plan` → incluir PBIs capturados en planning
+- `/slack-search` → fuente de input para captura desde Slack
+- `/project-audit` → puede generar input para backlog-capture
 
 ## Restricciones
 

--- a/.claude/commands/board-flow.md
+++ b/.claude/commands/board-flow.md
@@ -1,10 +1,10 @@
-# /board:flow
+# /board-flow
 
 Analiza el flujo de trabajo del board: WIP actual, cuellos de botella y métricas de flujo.
 
 ## Uso
 ```
-/board:flow [proyecto]
+/board-flow [proyecto]
 ```
 
 ## Pasos de Ejecución

--- a/.claude/commands/confluence-publish.md
+++ b/.claude/commands/confluence-publish.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/confluence:publish {fichero} --project {p}` o `/confluence:publish --project {p} --type {tipo}`
+> Uso: `/confluence-publish {fichero} --project {p}` o `/confluence-publish --project {p} --type {tipo}`
 
 ## Parámetros
 
@@ -18,11 +18,11 @@ description: >
 - `--space {clave}` — Espacio Confluence (defecto: `CONFLUENCE_DEFAULT_SPACE` del proyecto)
 - `--parent {título}` — Página padre bajo la que crear la nueva página
 - `--type {tipo}` — Tipo de contenido predefinido:
-  - `sprint-report` → publica resultado de `/sprint:review`
+  - `sprint-report` → publica resultado de `/sprint-review`
   - `spec` → publica una SDD Spec
   - `architecture` → publica diagrama de arquitectura
   - `onboarding` → publica guía de onboarding
-  - `retro` → publica resultado de `/sprint:retro`
+  - `retro` → publica resultado de `/sprint-retro`
 - `--update` — Actualizar página existente en vez de crear nueva
 
 ## Contexto requerido
@@ -37,7 +37,7 @@ description: >
 2. **Resolver contenido**:
    - Si `{fichero}` → leer el markdown del fichero
    - Si `--type` → generar contenido desde el comando correspondiente
-   - Si `--type sprint-report` → ejecutar `/sprint:review` y usar su salida
+   - Si `--type sprint-report` → ejecutar `/sprint-review` y usar su salida
 
 3. **Convertir markdown → Confluence Storage Format**:
    - Tablas markdown → macro `{table}`
@@ -73,10 +73,10 @@ description: >
 
 ## Integración con otros comandos
 
-- `/sprint:review --publish-confluence` → publica automáticamente
-- `/sprint:retro --publish-confluence` → publica retrospectiva
-- `/spec:generate --publish-confluence` → publica la Spec en Confluence
-- `/report:executive --publish-confluence` → publica informe ejecutivo
+- `/sprint-review --publish-confluence` → publica automáticamente
+- `/sprint-retro --publish-confluence` → publica retrospectiva
+- `/spec-generate --publish-confluence` → publica la Spec en Confluence
+- `/report-executive --publish-confluence` → publica informe ejecutivo
 
 ## Restricciones
 

--- a/.claude/commands/context-load.md
+++ b/.claude/commands/context-load.md
@@ -15,7 +15,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /context:load — Cargando contexto de sesión
+🚀 /context-load — Cargando contexto de sesión
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -39,7 +39,7 @@ Verificar raíz (`~/claude/`).
 ```
 **Decision log** (`decision-log.md` en raíz):
 - Si existe → leer las últimas 10 entradas y mostrar resumen (3-5 decisiones más recientes)
-- Si no existe → `ℹ️ Sin decision log — se creará con /session:save`
+- Si no existe → `ℹ️ Sin decision log — se creará con /session-save`
 
 **Último session save** (`output/sessions/` → fichero más reciente):
 - Si existe → leer y mostrar: objetivo, pendientes, contexto para esta sesión
@@ -105,7 +105,7 @@ Si no hay proyectos → sugerir `/help --setup`.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /context:load — Completado
+✅ /context-load — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📁 {N} proyectos | 📋 {N} decisiones recientes | ⏳ {N} pendientes
 💡 ¿Por dónde empezamos?
@@ -117,4 +117,4 @@ Si no hay proyectos → sugerir `/help --setup`.
 - **Conciso** — output legible en 30 segundos, NO cargar ficheros completos
 - Si no hay PAT / Azure DevOps → no error, solo omitir esos datos
 - Leer solo las primeras líneas de cada fichero de estado (no cargar completos)
-- **NO ejecutar otros comandos** como dependencia (/sprint:status, etc.)
+- **NO ejecutar otros comandos** como dependencia (/sprint-status, etc.)

--- a/.claude/commands/debt-track.md
+++ b/.claude/commands/debt-track.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/debt:track --project {p}` o `/debt:track --project {p} --add`
+> Uso: `/debt-track --project {p}` o `/debt-track --project {p} --add`
 
 Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
@@ -17,7 +17,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /debt:track — Registro de deuda técnica
+🚀 /debt-track — Registro de deuda técnica
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -34,7 +34,7 @@ Si falta `--project`:
 ```
 ❌ Falta parámetro obligatorio: --project {nombre}
    Proyectos disponibles: [listar de projects/*/CLAUDE.md]
-   Uso: /debt:track --project nombre
+   Uso: /debt-track --project nombre
 ```
 
 ## 3. Verificar prerequisitos
@@ -95,16 +95,16 @@ Recomendación: Incluir DT-01 en el próximo sprint
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /debt:track — Completado
+✅ /debt-track — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📊 Debt ratio: X% | {N} abiertos | Tendencia: 📈/📉/→
 ```
 
 ## Integración
 
-- `/kpi:dashboard` → incluye debt ratio como KPI
-- `/sprint:plan` → sugiere items de deuda para sprint
-- `/project:audit` → usa debt:track para evaluar salud
+- `/kpi-dashboard` → incluye debt ratio como KPI
+- `/sprint-plan` → sugiere items de deuda para sprint
+- `/project-audit` → usa debt-track para evaluar salud
 
 ## Restricciones
 

--- a/.claude/commands/dependency-map.md
+++ b/.claude/commands/dependency-map.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/dependency:map --project {p}` o `/dependency:map --project {p} --add`
+> Uso: `/dependency-map --project {p}` o `/dependency-map --project {p} --add`
 
 ## Parámetros
 
@@ -63,7 +63,7 @@ Ruta crítica: #1230 → #1234 → #1236 (estimado: 8 días)
 
 ### Modo `--diagram`
 1. Generar Mermaid flowchart con dependencias
-2. Usar `/diagram:generate` para publicar en Draw.io/Miro
+2. Usar `/diagram-generate` para publicar en Draw.io/Miro
 3. Colorear: verde=resuelto, amarillo=en progreso, rojo=bloqueado
 
 ### Modo `--add`
@@ -73,10 +73,10 @@ Ruta crítica: #1230 → #1234 → #1236 (estimado: 8 días)
 
 ## Integración
 
-- `/sprint:plan` → muestra dependencias al planificar
-- `/project:release-plan` → usa mapa para ordenar releases
-- `/board:flow` → detecta cuellos de botella por dependencias
-- `/project:roadmap` → incluye dependencias en timeline
+- `/sprint-plan` → muestra dependencias al planificar
+- `/project-release-plan` → usa mapa para ordenar releases
+- `/board-flow` → detecta cuellos de botella por dependencias
+- `/project-roadmap` → incluye dependencias en timeline
 
 ## Restricciones
 

--- a/.claude/commands/diagram-config.md
+++ b/.claude/commands/diagram-config.md
@@ -9,7 +9,7 @@ description: >
 
 **Tool:** $ARGUMENTS
 
-> Uso: `/diagram:config --tool draw.io|miro [--test] [--list]`
+> Uso: `/diagram-config --tool draw.io|miro [--test] [--list]`
 
 ## Parámetros
 

--- a/.claude/commands/diagram-generate.md
+++ b/.claude/commands/diagram-generate.md
@@ -9,7 +9,7 @@ description: >
 
 **Proyecto:** $ARGUMENTS
 
-> Uso: `/diagram:generate {proyecto} [--tool draw.io|miro|local] [--type architecture|flow|sequence]`
+> Uso: `/diagram-generate {proyecto} [--tool draw.io|miro|local] [--type architecture|flow|sequence]`
 
 ## Parámetros
 
@@ -60,13 +60,13 @@ Leer en este orden (Progressive Disclosure):
    📁 Local: projects/{p}/diagrams/local/{tipo}.mermaid
 
    ¿Quieres importar este diagrama para generar Features/PBIs?
-   → /diagram:import {url_o_fichero} --project {proyecto}
+   → /diagram-import {url_o_fichero} --project {proyecto}
    ```
 
 ## Validaciones previas
 
 - Si `--tool draw.io` → verificar entrada `draw-io` en `mcp.json`
-- Si `--tool miro` → verificar token Miro existe (`/diagram:config --tool miro --test`)
+- Si `--tool miro` → verificar token Miro existe (`/diagram-config --tool miro --test`)
 - Si proyecto no tiene código ni infraestructura → advertir: "No se detectaron componentes. ¿Quieres crear un diagrama desde cero?"
 
 ## Invocar agente (opcional)

--- a/.claude/commands/diagram-import.md
+++ b/.claude/commands/diagram-import.md
@@ -9,7 +9,7 @@ description: >
 
 **Fuente:** $ARGUMENTS
 
-> Uso: `/diagram:import {source} --project {nombre} [--validate-only] [--dry-run]`
+> Uso: `/diagram-import {source} --project {nombre} [--validate-only] [--dry-run]`
 
 ## Parámetros
 
@@ -69,9 +69,9 @@ Leer en este orden (Progressive Disclosure):
 ## Ejemplo
 
 ```
-/diagram:import https://miro.com/app/board/uXjVN... --project ProyectoAlpha
-/diagram:import projects/alpha/diagrams/local/architecture.mermaid --project ProyectoAlpha
-/diagram:import --validate-only projects/alpha/diagrams/local/flow.mermaid --project ProyectoAlpha
+/diagram-import https://miro.com/app/board/uXjVN... --project ProyectoAlpha
+/diagram-import projects/alpha/diagrams/local/architecture.mermaid --project ProyectoAlpha
+/diagram-import --validate-only projects/alpha/diagrams/local/flow.mermaid --project ProyectoAlpha
 ```
 
 ## Restricciones

--- a/.claude/commands/diagram-status.md
+++ b/.claude/commands/diagram-status.md
@@ -9,7 +9,7 @@ description: >
 
 **Filtro:** $ARGUMENTS
 
-> Uso: `/diagram:status [--project {nombre}] [--tool draw.io|miro]`
+> Uso: `/diagram-status [--project {nombre}] [--tool draw.io|miro]`
 
 ## Parámetros
 
@@ -53,7 +53,7 @@ description: >
 5. **Si no hay diagramas**:
    ```
    📊 No hay diagramas registrados.
-   Usa /diagram:generate para crear uno, o /diagram:import para cargar uno existente.
+   Usa /diagram-generate para crear uno, o /diagram-import para cargar uno existente.
    ```
 
 ## Restricciones

--- a/.claude/commands/evaluate-repo.md
+++ b/.claude/commands/evaluate-repo.md
@@ -17,7 +17,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /evaluate:repo — Evaluación de repositorio
+🚀 /evaluate-repo — Evaluación de repositorio
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -87,7 +87,7 @@ Si RECHAZAR → indicar heurística.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /evaluate:repo — Completado
+✅ /evaluate-repo — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📊 Score: X.X/10 | Veredicto: ✅/🟡/🔍/🔴
 ```

--- a/.claude/commands/figma-extract.md
+++ b/.claude/commands/figma-extract.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/figma:extract {url} --project {p}` o `/figma:extract --project {p} --page {nombre}`
+> Uso: `/figma-extract {url} --project {p}` o `/figma-extract --project {p} --page {nombre}`
 
 ## Parámetros
 
@@ -84,9 +84,9 @@ description: >
 
 ## Integración con otros comandos
 
-- `/diagram:generate` puede usar la estructura de Figma como input
-- `/pbi:decompose` puede descomponer los PBIs generados en tasks
-- `/spec:generate` puede incluir specs de UI desde Figma
+- `/diagram-generate` puede usar la estructura de Figma como input
+- `/pbi-decompose` puede descomponer los PBIs generados en tasks
+- `/spec-generate` puede incluir specs de UI desde Figma
 - Soporta `--notify-slack` para publicar resumen
 
 ## Restricciones

--- a/.claude/commands/gdrive-upload.md
+++ b/.claude/commands/gdrive-upload.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/gdrive:upload {fichero} --project {p}` o `/gdrive:upload --project {p} --latest {tipo}`
+> Uso: `/gdrive-upload {fichero} --project {p}` o `/gdrive-upload --project {p} --latest {tipo}`
 
 ## Parámetros
 
@@ -69,10 +69,10 @@ description: >
 
 ## Integración con otros comandos
 
-- `/report:hours --upload-gdrive` → sube automáticamente tras generar
-- `/report:executive --upload-gdrive` → sube informe ejecutivo
-- `/report:capacity --upload-gdrive` → sube informe de capacidad
-- `/sprint:review --upload-gdrive` → sube resumen del sprint
+- `/report-hours --upload-gdrive` → sube automáticamente tras generar
+- `/report-executive --upload-gdrive` → sube informe ejecutivo
+- `/report-capacity --upload-gdrive` → sube informe de capacidad
+- `/sprint-review --upload-gdrive` → sube resumen del sprint
 
 ## Restricciones
 

--- a/.claude/commands/github-activity.md
+++ b/.claude/commands/github-activity.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/github:activity {repo} [--since {fecha}] [--author {usuario}]`
+> Uso: `/github-activity {repo} [--since {fecha}] [--author {usuario}]`
 
 ## Parámetros
 
@@ -64,10 +64,10 @@ description: >
 
 ## Integración con otros comandos
 
-- `/team:workload` puede invocar este comando para añadir métricas de código
-- `/team:evaluate` usa estos datos como input para evaluación técnica
-- `/sprint:status` puede incluir sección "Actividad de código" con estos datos
-- `/kpi:dashboard` puede mostrar métricas de PR lead time y review time
+- `/team-workload` puede invocar este comando para añadir métricas de código
+- `/team-evaluate` usa estos datos como input para evaluación técnica
+- `/sprint-status` puede incluir sección "Actividad de código" con estos datos
+- `/kpi-dashboard` puede mostrar métricas de PR lead time y review time
 
 ## Restricciones
 

--- a/.claude/commands/github-issues.md
+++ b/.claude/commands/github-issues.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/github:issues {repo} [--sync-from-azdo {ids}] [--search {query}] [--create {titulo}]`
+> Uso: `/github-issues {repo} [--sync-from-azdo {ids}] [--search {query}] [--create {titulo}]`
 
 ## Parámetros
 

--- a/.claude/commands/help.md
+++ b/.claude/commands/help.md
@@ -59,7 +59,7 @@ Terminar con:
   Pipelines (5), Repos (6), DevOps Extended (5)
 
 📄 Catálogo completo: output/help-catalog.md
-💡 Siguiente: /project:audit --project {nombre}
+💡 Siguiente: /project-audit --project {nombre}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 

--- a/.claude/commands/inbox-check.md
+++ b/.claude/commands/inbox-check.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/inbox:check` o `/inbox:check --channels wa` o `/inbox:check --since {fecha}`
+> Uso: `/inbox-check` o `/inbox-check --channels wa` o `/inbox-check --since {fecha}`
 
 ## Parámetros
 
@@ -67,7 +67,7 @@ Grupo "Equipo Sala Reservas":
   [09:22] Pedro López: "Por mí bien, si el PM confirma"
   [10:30] Ana García: 🎤 Audio (12s):
     📝 "Ponme el estado del sprint de sala reservas, porfa"
-    → /sprint:status --project sala-reservas [confianza: alta]
+    → /sprint-status --project sala-reservas [confianza: alta]
     → ¿Ejecutar? (s/n)
 
 Chat "Carlos Sanz":
@@ -80,7 +80,7 @@ Sala "equipo-sala-reservas":
   [10:00] Pedro López: "Revisado, falta el flujo de error"
 
 ### Resumen de acciones pendientes
-1. 🎤 Ejecutar /sprint:status --project sala-reservas (Ana, WhatsApp)
+1. 🎤 Ejecutar /sprint-status --project sala-reservas (Ana, WhatsApp)
 2. 💬 Ana pregunta adelantar review → requiere decisión del PM
 3. ℹ️ Carlos confirma tests OK → informativo
 ```
@@ -91,9 +91,9 @@ Sala "equipo-sala-reservas":
 
 ## Integración
 
-- `/inbox:start` → lanza inbox:check en background cada N minutos
-- `/context:load` → puede invocar inbox:check al inicio de sesión
-- `/notify:whatsapp` y `/notify:nctalk` → responder a mensajes encontrados
+- `/inbox-start` → lanza inbox-check en background cada N minutos
+- `/context-load` → puede invocar inbox-check al inicio de sesión
+- `/notify-whatsapp` y `/notify-nctalk` → responder a mensajes encontrados
 - Skill `voice-inbox` → lógica de transcripción y mapeo voz→comando
 
 ## Restricciones

--- a/.claude/commands/inbox-start.md
+++ b/.claude/commands/inbox-start.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/inbox:start` o `/inbox:start --interval 2 --channels wa`
+> Uso: `/inbox-start` o `/inbox-start --interval 2 --channels wa`
 
 ## Parámetros
 
@@ -47,7 +47,7 @@ while true; do
   # Marcar que el monitor está activo
   echo "$TIMESTAMP" > "$INBOX_DIR/monitor-heartbeat.txt"
 
-  # Invocar inbox:check internamente
+  # Invocar inbox-check internamente
   # (la lógica real la ejecuta Claude al leer los resultados)
   echo "CHECK_REQUESTED:$TIMESTAMP" >> "$INBOX_DIR/check-queue.txt"
 
@@ -64,7 +64,7 @@ El proceso se lanza con `&` y Claude registra el task ID.
 Intervalo: cada 5 minutos
 Canales: WhatsApp ✅, Nextcloud Talk ✅
 Task ID: bg-inbox-7a3f
-Detener: /inbox:start --stop
+Detener: /inbox-start --stop
 
 Próximo check: 11:05 (en 5 min)
 ```
@@ -72,7 +72,7 @@ Próximo check: 11:05 (en 5 min)
 ### 4. Ciclo de monitorización
 
 Cada N minutos, Claude recibe la señal del background task y ejecuta:
-1. `/inbox:check` silencioso
+1. `/inbox-check` silencioso
 2. Si hay mensajes nuevos → notificar al PM en la conversación
 3. Si hay audios → transcribir y proponer acciones
 4. Si no hay nada nuevo → silencio (no interrumpir)
@@ -93,30 +93,30 @@ Comandos ejecutados: 2
 
 ```bash
 # Inicio estándar (5 min, todos los canales)
-/inbox:start
+/inbox-start
 
 # Polling cada 2 minutos, solo WhatsApp
-/inbox:start --interval 2 --channels wa
+/inbox-start --interval 2 --channels wa
 
 # Sin mensajes informativos (solo alertas y audios)
-/inbox:start --quiet
+/inbox-start --quiet
 
 # Detener
-/inbox:start --stop
+/inbox-start --stop
 ```
 
 ## Flujo típico de una sesión
 
 ```
-PM: /context:load                   ← carga contexto del proyecto
-PM: /inbox:start                    ← activa monitor de mensajes
-PM: /sprint:status --project x      ← trabaja normalmente
+PM: /context-load                   ← carga contexto del proyecto
+PM: /inbox-start                    ← activa monitor de mensajes
+PM: /sprint-status --project x      ← trabaja normalmente
 
   ... 10 minutos después ...
 
 → 📩 Nuevo audio de Ana García (WhatsApp):
 →   "¿Puedes generar el informe ejecutivo para la reunión de las 12?"
-→   → /report:executive --project sala-reservas
+→   → /report-executive --project sala-reservas
 →   → ¿Ejecutar? (s/n)
 
 PM: s                               ← confirma

--- a/.claude/commands/jira-sync.md
+++ b/.claude/commands/jira-sync.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/jira:sync --project {p}` o `/jira:sync --project {p} --direction {dir}`
+> Uso: `/jira-sync --project {p}` o `/jira-sync --project {p} --direction {dir}`
 
 ## Parámetros
 

--- a/.claude/commands/kpi-dashboard.md
+++ b/.claude/commands/kpi-dashboard.md
@@ -1,10 +1,10 @@
-# /kpi:dashboard
+# /kpi-dashboard
 
 Muestra el dashboard completo con todos los KPIs definidos en docs/kpis-equipo.md.
 
 ## Uso
 ```
-/kpi:dashboard [proyecto] [--sprints N]
+/kpi-dashboard [proyecto] [--sprints N]
 ```
 `--sprints N`: número de sprints para análisis de tendencia (default: 5).
 

--- a/.claude/commands/kpi-dora.md
+++ b/.claude/commands/kpi-dora.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/kpi:dora --project {p}` o `/kpi:dora --project {p} --sprints 10`
+> Uso: `/kpi-dora --project {p}` o `/kpi-dora --project {p} --sprints 10`
 
 Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
@@ -17,7 +17,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /kpi:dora — Métricas DORA
+🚀 /kpi-dora — Métricas DORA
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -33,7 +33,7 @@ Si falta `--project`:
 ```
 ❌ Falta parámetro obligatorio: --project {nombre}
    Proyectos disponibles: [listar]
-   Uso: /kpi:dora --project nombre
+   Uso: /kpi-dora --project nombre
 ```
 
 ## 3. Verificar prerequisitos
@@ -98,17 +98,17 @@ Si `--export` → guardar en `output/dora/YYYYMMDD-dora-{proyecto}.md`
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /kpi:dora — Completado
+✅ /kpi-dora — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📊 Clasificación: {ELITE/HIGH/MEDIUM/LOW} PERFORMER
 ```
 
 ## Integración
 
-- `/kpi:dashboard` → incluye resumen DORA
-- `/pipeline:status` → datos fuente
-- `/project:audit` → usa DORA para evaluar madurez CI/CD
-- `/report:executive` → incluye DORA en informe directivo
+- `/kpi-dashboard` → incluye resumen DORA
+- `/pipeline-status` → datos fuente
+- `/project-audit` → usa DORA para evaluar madurez CI/CD
+- `/report-executive` → incluye DORA en informe directivo
 
 ## Restricciones
 

--- a/.claude/commands/legacy-assess.md
+++ b/.claude/commands/legacy-assess.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/legacy:assess --project {p}` o `/legacy:assess --project {p} --deep`
+> Uso: `/legacy-assess --project {p}` o `/legacy-assess --project {p} --deep`
 
 ## Parámetros
 
@@ -37,9 +37,9 @@ El subagente ejecuta los pasos 1-5 abajo y guarda el informe en `output/assessme
 - **Código fuente**: LOC, lenguajes, edad del repo, frecuencia de commits
 - **Dependencias**: paquetes obsoletos, CVEs conocidos, frameworks EOL
 - **Tests**: cobertura, tests rotos, ratio test/código
-- **CI/CD**: pipelines existentes (`/pipeline:status`), frecuencia de deploy
+- **CI/CD**: pipelines existentes (`/pipeline-status`), frecuencia de deploy
 - **Deuda técnica**: si existe `debt-register.md`, incorporar datos
-- **Errores**: si Sentry configurado (`/sentry:health`), crash rate
+- **Errores**: si Sentry configurado (`/sentry-health`), crash rate
 
 ### 2. Calcular scores (1-10)
 
@@ -101,10 +101,10 @@ Conocimiento:   ████░░░░░░ 4/10
 
 ## Integración
 
-- `/project:audit` → usa legacy:assess como fuente para proyectos legacy
-- `/project:release-plan` → incorpora roadmap de modernización como input
-- `/debt:track` → importa hallazgos como items de deuda técnica
-- `/evaluate:repo` → complementario (evaluate:repo = seguridad, legacy:assess = salud global)
+- `/project-audit` → usa legacy-assess como fuente para proyectos legacy
+- `/project-release-plan` → incorpora roadmap de modernización como input
+- `/debt-track` → importa hallazgos como items de deuda técnica
+- `/evaluate-repo` → complementario (evaluate-repo = seguridad, legacy-assess = salud global)
 
 ## Restricciones
 

--- a/.claude/commands/linear-sync.md
+++ b/.claude/commands/linear-sync.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/linear:sync --project {p}` o `/linear:sync --project {p} --cycle {nombre}`
+> Uso: `/linear-sync --project {p}` o `/linear-sync --project {p} --cycle {nombre}`
 
 ## Parámetros
 
@@ -77,9 +77,9 @@ description: >
 
 ## Integración con otros comandos
 
-- `/sprint:plan` puede considerar issues de Linear como candidatos
-- `/board:flow` puede incluir métricas de cycle time de Linear
-- `/kpi:dashboard` puede agregar métricas de ambos trackers
+- `/sprint-plan` puede considerar issues de Linear como candidatos
+- `/board-flow` puede incluir métricas de cycle time de Linear
+- `/kpi-dashboard` puede agregar métricas de ambos trackers
 - Soporta `--notify-slack` para publicar resumen del sync
 
 ## Restricciones

--- a/.claude/commands/nctalk-search.md
+++ b/.claude/commands/nctalk-search.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/nctalk:search {query}` o `/nctalk:search --room {sala} {query}`
+> Uso: `/nctalk-search {query}` o `/nctalk-search --room {sala} {query}`
 
 ## Parámetros
 
@@ -60,9 +60,9 @@ Resultados: 3 mensajes en 1 sala (últimos 30 días)
 ## Ejemplos
 
 ```bash
-/nctalk:search "arquitectura"
-/nctalk:search --room "equipo-sala-reservas" "decisión"
-/nctalk:search --participant "Ana García" --since 2026-02-01
+/nctalk-search "arquitectura"
+/nctalk-search --room "equipo-sala-reservas" "decisión"
+/nctalk-search --participant "Ana García" --since 2026-02-01
 ```
 
 ## Restricciones

--- a/.claude/commands/notify-nctalk.md
+++ b/.claude/commands/notify-nctalk.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/notify:nctalk {sala} {mensaje}` o `/notify:nctalk --team {msg}`
+> Uso: `/notify-nctalk {sala} {mensaje}` o `/notify-nctalk --team {msg}`
 
 ## Parámetros
 
@@ -59,10 +59,10 @@ Adjunto: sprint-report.pdf (compartido via Nextcloud Files)
 ## Ejemplos
 
 ```bash
-/notify:nctalk --team "Sprint review mañana a las 10:00"
-/notify:nctalk "pm-notifications" "Alerta: 2 CVEs críticos detectados"
-/notify:nctalk --team --file output/reports/sprint-report.pdf
-/notify:nctalk --team --silent  # envía último informe sin notificar
+/notify-nctalk --team "Sprint review mañana a las 10:00"
+/notify-nctalk "pm-notifications" "Alerta: 2 CVEs críticos detectados"
+/notify-nctalk --team --file output/reports/sprint-report.pdf
+/notify-nctalk --team --silent  # envía último informe sin notificar
 ```
 
 ## Restricciones

--- a/.claude/commands/notify-slack.md
+++ b/.claude/commands/notify-slack.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/notify:slack {canal} {mensaje}` o `/notify:slack --project {p} {mensaje}`
+> Uso: `/notify-slack {canal} {mensaje}` o `/notify-slack --project {p} {mensaje}`
 
 ## Parámetros
 
@@ -61,20 +61,20 @@ su resultado automáticamente. Cuando un comando incluye este flag:
 5. Mostrar confirmación
 
 Comandos que soportan `--notify-slack`:
-- `/sprint:status` → Publica resumen de estado del sprint
-- `/sprint:review` → Publica items completados y velocity
-- `/board:flow` → Publica alertas de WIP y cuellos de botella
-- `/team:workload` → Publica distribución de carga
-- `/kpi:dashboard` → Publica KPIs principales
-- `/pbi:decompose` → Notifica asignaciones de tasks
-- `/diagram:status` → Publica estado de diagramas
+- `/sprint-status` → Publica resumen de estado del sprint
+- `/sprint-review` → Publica items completados y velocity
+- `/board-flow` → Publica alertas de WIP y cuellos de botella
+- `/team-workload` → Publica distribución de carga
+- `/kpi-dashboard` → Publica KPIs principales
+- `/pbi-decompose` → Notifica asignaciones de tasks
+- `/diagram-status` → Publica estado de diagramas
 
 ## Ejemplos
 
 ```
-/notify:slack #dev-team Sprint 14 completado: 34 SP, velocity 32 📈
-/notify:slack --project ProyectoAlpha ⚠️ WIP limit superado en columna "In Progress"
-/notify:slack @maria.garcia Tu task #1234 ha sido asignada (4h estimadas)
+/notify-slack #dev-team Sprint 14 completado: 34 SP, velocity 32 📈
+/notify-slack --project ProyectoAlpha ⚠️ WIP limit superado en columna "In Progress"
+/notify-slack @maria.garcia Tu task #1234 ha sido asignada (4h estimadas)
 ```
 
 ## Restricciones

--- a/.claude/commands/notify-whatsapp.md
+++ b/.claude/commands/notify-whatsapp.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/notify:whatsapp {contacto|grupo} {mensaje}` o `/notify:whatsapp --team {msg}`
+> Uso: `/notify-whatsapp {contacto|grupo} {mensaje}` o `/notify-whatsapp --team {msg}`
 
 ## Parámetros
 
@@ -61,10 +61,10 @@ Adjunto: sprint-report.pdf
 ## Ejemplos
 
 ```bash
-/notify:whatsapp --team "Sprint review mañana a las 10:00"
-/notify:whatsapp "Ana García" "El PR #42 necesita tu revisión"
-/notify:whatsapp --pm --file output/reports/sprint-report.pdf
-/notify:whatsapp --team   # envía último informe generado
+/notify-whatsapp --team "Sprint review mañana a las 10:00"
+/notify-whatsapp "Ana García" "El PR #42 necesita tu revisión"
+/notify-whatsapp --pm --file output/reports/sprint-report.pdf
+/notify-whatsapp --team   # envía último informe generado
 ```
 
 ## Restricciones

--- a/.claude/commands/notion-sync.md
+++ b/.claude/commands/notion-sync.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/notion:sync --project {p} --direction {dir}` o `/notion:sync {page} --project {p}`
+> Uso: `/notion-sync --project {p} --direction {dir}` o `/notion-sync {page} --project {p}`
 
 ## Parámetros
 
@@ -68,10 +68,10 @@ description: >
 
 ## Integración con otros comandos
 
-- `/spec:generate --publish-notion` → publica Spec en Notion tras generarla
-- `/team:onboarding --publish-notion` → publica guía en Notion
-- `/sprint:retro --publish-notion` → publica retrospectiva en Notion
-- `/pbi:prd --publish-notion` → publica PRD en Notion
+- `/spec-generate --publish-notion` → publica Spec en Notion tras generarla
+- `/team-onboarding --publish-notion` → publica guía en Notion
+- `/sprint-retro --publish-notion` → publica retrospectiva en Notion
+- `/pbi-prd --publish-notion` → publica PRD en Notion
 
 ## Restricciones
 

--- a/.claude/commands/pbi-assign.md
+++ b/.claude/commands/pbi-assign.md
@@ -1,10 +1,10 @@
-# /pbi:assign
+# /pbi-assign
 
 Asigna (o reasigna) las Tasks existentes de un PBI según el algoritmo de asignación inteligente, sin recrear las tasks.
 
 ## Uso
 ```
-/pbi:assign {pbi_id} [--project {nombre}] [--rebalance]
+/pbi-assign {pbi_id} [--project {nombre}] [--rebalance]
 ```
 
 - `{pbi_id}`: ID del PBI padre cuyas tasks se quieren (re)asignar
@@ -15,12 +15,12 @@ Asigna (o reasigna) las Tasks existentes de un PBI según el algoritmo de asigna
 - Las tasks ya existen en Azure DevOps pero no están asignadas o están mal distribuidas
 - Alguien del equipo se ha ido de baja / vacaciones inesperadas y hay que redistribuir
 - Tras un cambio de capacity (ej: Pedro no puede trabajar esta semana) y quieres rebalancear
-- Como alternativa más rápida a `/pbi:decompose` cuando ya tienes las tasks
+- Como alternativa más rápida a `/pbi-decompose` cuando ya tienes las tasks
 
-## Diferencia con /pbi:decompose
+## Diferencia con /pbi-decompose
 
-`/pbi:decompose` → Crea tasks nuevas desde cero + asigna
-`/pbi:assign` → Solo reasigna tasks que ya existen
+`/pbi-decompose` → Crea tasks nuevas desde cero + asigna
+`/pbi-assign` → Solo reasigna tasks que ya existen
 
 ## Pasos de Ejecución
 

--- a/.claude/commands/pbi-decompose-batch.md
+++ b/.claude/commands/pbi-decompose-batch.md
@@ -1,16 +1,16 @@
-# /pbi:decompose-batch
+# /pbi-decompose-batch
 
 Descompone varios PBIs a la vez, optimizando las asignaciones en conjunto para equilibrar la carga global.
 
 ## Uso
 ```
-/pbi:decompose-batch {id1,id2,id3} [--project {nombre}]
+/pbi-decompose-batch {id1,id2,id3} [--project {nombre}]
 ```
 
 - `{id1,id2,id3}`: IDs separados por coma (ej: `1234,1235,1236`)
 - `--project`: Proyecto AzDO (default: el del CLAUDE.md raíz)
 
-## Diferencia con /pbi:decompose individual
+## Diferencia con /pbi-decompose individual
 
 En el modo batch, la asignación de tasks es **global y coordinada**:
 - El agente carga el estado de capacity del equipo una sola vez al inicio
@@ -20,7 +20,7 @@ En el modo batch, la asignación de tasks es **global y coordinada**:
 
 ## Pasos de Ejecución
 
-1. **Cargar contexto** (igual que `/pbi:decompose`)
+1. **Cargar contexto** (igual que `/pbi-decompose`)
 2. **Obtener todos los PBIs** en una sola pasada de la API
 3. **Obtener capacity del equipo** (una sola llamada, estado actual)
 4. Para cada PBI en orden de prioridad:

--- a/.claude/commands/pbi-decompose.md
+++ b/.claude/commands/pbi-decompose.md
@@ -1,10 +1,10 @@
-# /pbi:decompose
+# /pbi-decompose
 
 Descompone un PBI en Tasks técnicas con estimaciones y propuesta de asignación inteligente.
 
 ## Uso
 ```
-/pbi:decompose {id} [--project {nombre}] [--dry-run]
+/pbi-decompose {id} [--project {nombre}] [--dry-run]
 ```
 
 - `{id}`: ID del work item en Azure DevOps (ej: `1234`)
@@ -55,7 +55,7 @@ Descompone un PBI en Tasks técnicas con estimaciones y propuesta de asignación
    │ #  │ Task                                │ Horas    │ Act. │ Asignado a   │ Developer Type │
    ├────┼─────────────────────────────────────┼──────────┼──────┼──────────────┼────────────────┤
    │ B1 │ ...                                 │ 2h       │ Dev  │ ...          │ human          │
-   │ B3 │ ...                                 │ 4h       │ Dev  │ 🤖 agent     │ agent:single   │
+   │ B3 │ ...                                 │ 4h       │ Dev  │ 🤖 agent     │ agent-single   │
    └────┴─────────────────────────────────────┴──────────┴──────┴──────────────┴────────────────┘
 
    Total: Xh (rango esperado para Y SP: A-Bh)
@@ -70,7 +70,7 @@ Descompone un PBI en Tasks técnicas con estimaciones y propuesta de asignación
 
 ## Ejemplo
 ```
-/pbi:decompose 1234
-/pbi:decompose 1234 --project ProyectoAlpha
-/pbi:decompose 1234 --dry-run
+/pbi-decompose 1234
+/pbi-decompose 1234 --project ProyectoAlpha
+/pbi-decompose 1234 --dry-run
 ```

--- a/.claude/commands/pbi-jtbd.md
+++ b/.claude/commands/pbi-jtbd.md
@@ -10,7 +10,7 @@ description: >
 
 **PBI ID:** $ARGUMENTS
 
-> Uso: `/pbi:jtbd 302 --project GestiónClínica`
+> Uso: `/pbi-jtbd 302 --project GestiónClínica`
 > Solo para PBIs tipo feature o user story. No usar para bugs ni chores.
 
 ---
@@ -31,7 +31,7 @@ Extraer: título, descripción, criterios de aceptación, tipo, comentarios.
 
 ### 3. Verificar tipo de PBI
 
-- Si es `Bug` o `Task` → informar al usuario que JTBD no aplica y sugerir `/pbi:decompose` directamente
+- Si es `Bug` o `Task` → informar al usuario que JTBD no aplica y sugerir `/pbi-decompose` directamente
 - Si es `Feature` o `User Story` o `Product Backlog Item` → continuar
 
 ### 4. Leer contexto del proyecto
@@ -62,8 +62,8 @@ Guardar en: `projects/{proyecto}/discovery/PBI-{id}-jtbd.md`
 
 Mostrar el JTBD generado y preguntar:
 - ¿Algún ajuste?
-- ¿Procedo a generar el PRD? → sugerir `/pbi:prd {id}`
-- ¿O prefieres ir directo a descomponer? → sugerir `/pbi:decompose {id}`
+- ¿Procedo a generar el PRD? → sugerir `/pbi-prd {id}`
+- ¿O prefieres ir directo a descomponer? → sugerir `/pbi-decompose {id}`
 
 ---
 

--- a/.claude/commands/pbi-plan-sprint.md
+++ b/.claude/commands/pbi-plan-sprint.md
@@ -1,10 +1,10 @@
-# /pbi:plan-sprint
+# /pbi-plan-sprint
 
 Flujo completo de Sprint Planning asistido por IA: calcula capacity, propone qué PBIs caben, descompone en tasks y asigna todo de forma equilibrada.
 
 ## Uso
 ```
-/pbi:plan-sprint [--project {nombre}] [--sprint "Sprint 2026-XX"] [--max-sp N]
+/pbi-plan-sprint [--project {nombre}] [--sprint "Sprint 2026-XX"] [--max-sp N]
 ```
 
 - `--project`: Proyecto (default: el del CLAUDE.md raíz)
@@ -24,7 +24,7 @@ Flujo completo de Sprint Planning asistido por IA: calcula capacity, propone qu�
 
 ```bash
 # Capacity por persona para el sprint objetivo
-# (misma lógica que /report:capacity)
+# (misma lógica que /report-capacity)
 ./scripts/azdevops-queries.sh capacities {proyecto} "{equipo}"
 python3 scripts/capacity-calculator.py \
   --sprint-start {fecha_inicio} \
@@ -56,7 +56,7 @@ Si el último PBI que cabe tiene muchos SP, considerar si vale la pena incluir u
 
 ### Paso 4 — Descomponer y Asignar cada PBI
 
-Para cada PBI seleccionado, ejecutar las Fases 1-5 de `pbi-decomposition/SKILL.md` en modo batch (ver `/pbi:decompose-batch`), acumulando el estado de carga entre PBIs.
+Para cada PBI seleccionado, ejecutar las Fases 1-5 de `pbi-decomposition/SKILL.md` en modo batch (ver `/pbi-decompose-batch`), acumulando el estado de carga entre PBIs.
 
 ### Paso 5 — Presentar el Plan Completo
 

--- a/.claude/commands/pbi-prd.md
+++ b/.claude/commands/pbi-prd.md
@@ -3,15 +3,15 @@ name: pbi-prd
 description: >
   Genera un Product Requirements Document (PRD) para un PBI. Lee el JTBD previo
   (si existe) y formaliza los requisitos funcionales, no funcionales, dependencias,
-  riesgos y criterios de aceptación enriquecidos. Paso previo a /pbi:decompose.
+  riesgos y criterios de aceptación enriquecidos. Paso previo a /pbi-decompose.
 ---
 
 # Generar PRD para un PBI
 
 **PBI ID:** $ARGUMENTS
 
-> Uso: `/pbi:prd 302 --project GestiónClínica`
-> Idealmente ejecutar después de `/pbi:jtbd`. Si no hay JTBD, se genera igual
+> Uso: `/pbi-prd 302 --project GestiónClínica`
+> Idealmente ejecutar después de `/pbi-jtbd`. Si no hay JTBD, se genera igual
 > pero con menos contexto de usuario.
 
 ---
@@ -36,7 +36,7 @@ ls projects/{proyecto}/discovery/PBI-{id}-jtbd.md 2>/dev/null
 
 Si existe, leerlo y usarlo como base.
 Si no existe, informar al usuario que el PRD tendrá menos contexto de usuario
-y sugerir ejecutar `/pbi:jtbd {id}` primero.
+y sugerir ejecutar `/pbi-jtbd {id}` primero.
 
 ### 4. Leer contexto del proyecto
 
@@ -69,7 +69,7 @@ Guardar en: `projects/{proyecto}/discovery/PBI-{id}-prd.md`
 Mostrar el PRD y preguntar:
 - ¿Los requisitos son correctos?
 - ¿El scope está bien delimitado?
-- ¿Procedo a descomponer en tasks? → sugerir `/pbi:decompose {id}`
+- ¿Procedo a descomponer en tasks? → sugerir `/pbi-decompose {id}`
 
 ---
 
@@ -77,5 +77,5 @@ Mostrar el PRD y preguntar:
 
 - **No incluir estimaciones de tiempo** — eso es para decompose
 - **No proponer soluciones técnicas** — solo requisitos de producto
-- **No crear tasks en Azure DevOps** — eso es para `/pbi:decompose`
+- **No crear tasks en Azure DevOps** — eso es para `/pbi-decompose`
 - Si el humano ya validó el JTBD, no repetir preguntas ya respondidas

--- a/.claude/commands/pipeline-artifacts.md
+++ b/.claude/commands/pipeline-artifacts.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/pipeline:artifacts --project {p} --build {id}` o `/pipeline:artifacts --project {p} --pipeline {name}`
+> Uso: `/pipeline-artifacts --project {p} --build {id}` o `/pipeline-artifacts --project {p} --pipeline {name}`
 
 ## Parámetros
 
@@ -53,9 +53,9 @@ description: >
 
 ## Integración
 
-- `/pipeline:logs --build {id}` → ver logs de la build
-- `/pipeline:status` → contexto del pipeline
-- Artefactos de test → correlacionar con `/kpi:dashboard` (coverage)
+- `/pipeline-logs --build {id}` → ver logs de la build
+- `/pipeline-status` → contexto del pipeline
+- Artefactos de test → correlacionar con `/kpi-dashboard` (coverage)
 
 ## Restricciones
 

--- a/.claude/commands/pipeline-create.md
+++ b/.claude/commands/pipeline-create.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/pipeline:create --project {p} --name {n} --repo {r}`
+> Uso: `/pipeline-create --project {p} --name {n} --repo {r}`
 
 ## Parámetros
 
@@ -75,6 +75,6 @@ YAML path: azure-pipelines.yml
 
 ## Integración
 
-- `/pipeline:status` → verificar que la pipeline aparece
-- `/pipeline:run` → ejecutar primera build
-- `/env:setup` → configurar entornos si no existen
+- `/pipeline-status` → verificar que la pipeline aparece
+- `/pipeline-run` → ejecutar primera build
+- `/env-setup` → configurar entornos si no existen

--- a/.claude/commands/pipeline-logs.md
+++ b/.claude/commands/pipeline-logs.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/pipeline:logs --project {p} --build {id}` o `/pipeline:logs --project {p} --pipeline {name}`
+> Uso: `/pipeline-logs --project {p} --build {id}` o `/pipeline-logs --project {p} --pipeline {name}`
 
 ## Parámetros
 
@@ -66,9 +66,9 @@ Branch: main | Trigger: CI | Started: 2026-02-27 10:15
 
 ## Integración
 
-- `/pipeline:run` → re-ejecutar si el fallo es transitorio
-- `/pipeline:status` → contexto global del pipeline
-- `/sentry:health` → correlacionar errores de build con errores en runtime
+- `/pipeline-run` → re-ejecutar si el fallo es transitorio
+- `/pipeline-status` → contexto global del pipeline
+- `/sentry-health` → correlacionar errores de build con errores en runtime
 
 ## Restricciones
 

--- a/.claude/commands/pipeline-run.md
+++ b/.claude/commands/pipeline-run.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/pipeline:run --project {p} {pipeline}` o `/pipeline:run --project {p} {pipeline} --branch {b}`
+> Uso: `/pipeline-run --project {p} {pipeline}` o `/pipeline-run --project {p} {pipeline} --branch {b}`
 
 ## Parámetros
 
@@ -70,6 +70,6 @@ description: >
 
 ## Integración
 
-- `/pipeline:status` → ver resultado tras ejecución
-- `/pipeline:logs --build {id}` → si falla, ver logs
-- `/notify:slack` → notificar al canal del proyecto
+- `/pipeline-status` → ver resultado tras ejecución
+- `/pipeline-logs --build {id}` → si falla, ver logs
+- `/notify-slack` → notificar al canal del proyecto

--- a/.claude/commands/pipeline-status.md
+++ b/.claude/commands/pipeline-status.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/pipeline:status --project {p}` o `/pipeline:status --project {p} --pipeline {name}`
+> Uso: `/pipeline-status --project {p}` o `/pipeline-status --project {p} --pipeline {name}`
 
 ## Parámetros
 
@@ -52,18 +52,18 @@ description: >
 
 ### Alertas activas
 - backend-ci: Coverage 72% (< 80% mínimo)
-- frontend-ci: Build #89 fallida hace 1d — revisar con `/pipeline:logs --project {p} --build 89`
+- frontend-ci: Build #89 fallida hace 1d — revisar con `/pipeline-logs --project {p} --build 89`
 ```
 
 ## Integración con otros comandos
 
-- `/pipeline:logs --build {id}` → ver logs de build fallida
-- `/pipeline:run {pipeline}` → re-ejecutar pipeline
-- `/kpi:dashboard` → incluye métricas de pipelines
-- `/sprint:status` → muestra alertas de CI/CD si hay fallos
+- `/pipeline-logs --build {id}` → ver logs de build fallida
+- `/pipeline-run {pipeline}` → re-ejecutar pipeline
+- `/kpi-dashboard` → incluye métricas de pipelines
+- `/sprint-status` → muestra alertas de CI/CD si hay fallos
 
 ## Restricciones
 
 - Solo lectura — no modifica nada
-- Si no hay pipelines configuradas → informar y sugerir `/pipeline:create`
+- Si no hay pipelines configuradas → informar y sugerir `/pipeline-create`
 - Máximo 20 pipelines mostradas (ordenar por última actividad)

--- a/.claude/commands/pr-pending.md
+++ b/.claude/commands/pr-pending.md
@@ -9,7 +9,7 @@ description: >
 
 **Filtro:** $ARGUMENTS
 
-> Uso: `/pr:pending` (todos los proyectos) · `/pr:pending --project Alpha` (un proyecto)
+> Uso: `/pr-pending` (todos los proyectos) · `/pr-pending --project Alpha` (un proyecto)
 
 ---
 

--- a/.claude/commands/project-assign.md
+++ b/.claude/commands/project-assign.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/project:assign --project {p}` o con `--release-plan {file}`
+> Uso: `/project-assign --project {p}` o con `--release-plan {file}`
 
 ## Parámetros
 
@@ -31,13 +31,13 @@ description: >
 
 ### 1. Cargar datos del equipo
 - Leer `equipo.md` → nombre, rol, skills, seniority, disponibilidad
-- Obtener capacity actual → `/report:capacity`
-- Obtener carga actual → `/team:workload`
+- Obtener capacity actual → `/report-capacity`
+- Obtener carga actual → `/team-workload`
 - Calcular horas disponibles por persona y sprint
 
 ### 2. Cargar trabajo a asignar
 - Leer release plan → PBIs agrupados por release y sprint
-- Para PBIs sin descomponer → invocar `/pbi:decompose` primero
+- Para PBIs sin descomponer → invocar `/pbi-decompose` primero
 - Obtener tasks con estimaciones (SP u horas)
 
 ### 3. Algoritmo de asignación
@@ -90,11 +90,11 @@ Restricciones:
 
 ## Integración
 
-- `/project:release-plan` → (Phase 2) provee el trabajo a asignar
-- `/project:roadmap` → (Phase 4) visualiza asignaciones en timeline
-- `/pbi:decompose` → descompone PBIs antes de asignar tasks
-- `/team:workload` → datos de carga actual
-- `/report:capacity` → datos de capacity
+- `/project-release-plan` → (Phase 2) provee el trabajo a asignar
+- `/project-roadmap` → (Phase 4) visualiza asignaciones en timeline
+- `/pbi-decompose` → descompone PBIs antes de asignar tasks
+- `/team-workload` → datos de carga actual
+- `/report-capacity` → datos de capacity
 
 ## Restricciones
 

--- a/.claude/commands/project-audit.md
+++ b/.claude/commands/project-audit.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/project:audit --project {p}` o `/project:audit --project {p} --deep`
+> Uso: `/project-audit --project {p}` o `/project-audit --project {p} --deep`
 
 Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
@@ -17,7 +17,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /project:audit — Auditoría completa del proyecto
+🚀 /project-audit — Auditoría completa del proyecto
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -97,18 +97,18 @@ Cuando el subagente termine, mostrar en chat SOLO el resumen (NO el informe comp
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /project:audit — Completado
+✅ /project-audit — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📄 Informe: output/audits/YYYYMMDD-audit-{proyecto}.md
 📊 Score global: X.X/10 | 🔴 N | 🟡 N | 🟢 N
-💡 Siguiente: /project:release-plan --project {proyecto}
+💡 Siguiente: /project-release-plan --project {proyecto}
 ```
 
 ## Integración
 
-- `/project:release-plan` → Phase 2, usa audit como input
-- `/debt:track` → importa hallazgos de deuda
-- `/risk:log` → alimenta registro desde hallazgos críticos
+- `/project-release-plan` → Phase 2, usa audit como input
+- `/debt-track` → importa hallazgos de deuda
+- `/risk-log` → alimenta registro desde hallazgos críticos
 
 ## Restricciones
 

--- a/.claude/commands/project-kickoff.md
+++ b/.claude/commands/project-kickoff.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/project:kickoff --project {p}`
+> Uso: `/project-kickoff --project {p}`
 
 ## Parámetros
 
@@ -24,7 +24,7 @@ description: >
 2. `output/audits/` — Último audit (Phase 1)
 3. `output/plans/` — Último release plan (Phase 2)
 4. `output/roadmaps/` — Último roadmap (Phase 4)
-5. Resultados de `/project:assign` (Phase 3)
+5. Resultados de `/project-assign` (Phase 3)
 
 ## Pasos de ejecución
 
@@ -83,11 +83,11 @@ Milestones: MVP ({fecha}), Beta ({fecha}), Launch ({fecha})
 ### 3. Crear Sprint 1 (si `--create-sprint`)
 - Crear iteration en Azure DevOps (nombre: Sprint YYYY-NN)
 - Mover PBIs de Release 1 al sprint
-- Asignar tasks según matriz de `/project:assign`
+- Asignar tasks según matriz de `/project-assign`
 - ⚠️ **Confirmar con PM antes de crear**
 
 ### 4. Notificar (si `--notify`)
-- **slack**: enviar resumen al canal del proyecto via `/notify:slack`
+- **slack**: enviar resumen al canal del proyecto via `/notify-slack`
 - **email**: generar email con kickoff report (no envía, solo genera)
 - Incluir: score, releases, roadmap, próximos pasos
 
@@ -96,12 +96,12 @@ Milestones: MVP ({fecha}), Beta ({fecha}), Launch ({fecha})
 
 ## Integración
 
-- `/project:audit` → Phase 1 input
-- `/project:release-plan` → Phase 2 input
-- `/project:assign` → Phase 3 input
-- `/project:roadmap` → Phase 4 input
-- `/notify:slack` → distribución del kickoff
-- `/sprint:plan` → refinamiento del Sprint 1 post-kickoff
+- `/project-audit` → Phase 1 input
+- `/project-release-plan` → Phase 2 input
+- `/project-assign` → Phase 3 input
+- `/project-roadmap` → Phase 4 input
+- `/notify-slack` → distribución del kickoff
+- `/sprint-plan` → refinamiento del Sprint 1 post-kickoff
 
 ## Restricciones
 

--- a/.claude/commands/project-release-plan.md
+++ b/.claude/commands/project-release-plan.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/project:release-plan --project {p}` o con `--audit {file}`
+> Uso: `/project-release-plan --project {p}` o con `--audit {file}`
 
 ## Parámetros
 
@@ -31,9 +31,9 @@ description: >
 ### 1. Recopilar inputs
 - **Audit report** → acciones priorizadas por tier (🔴🟡🟢)
 - **Backlog existente** → PBIs en Azure DevOps (New + Active)
-- **Dependencias** → `/dependency:map` si hay datos
-- **Riesgos** → `/risk:log` si hay registro
-- **Capacity del equipo** → `equipo.md` + `/report:capacity`
+- **Dependencias** → `/dependency-map` si hay datos
+- **Riesgos** → `/risk-log` si hay registro
+- **Capacity del equipo** → `equipo.md` + `/report-capacity`
 
 ### 2. Agrupar en releases lógicas
 
@@ -99,11 +99,11 @@ R1/#1234 → R2/#1236 → R3/#1250 (estimado: 10 sprints)
 
 ## Integración
 
-- `/project:audit` → (Phase 1) provee el input principal
-- `/project:assign` → (Phase 3) distribuye trabajo del plan
-- `/project:roadmap` → (Phase 4) visualiza el plan como timeline
-- `/dependency:map` → mapa de dependencias entre PBIs
-- `/pbi:decompose` → descomponer PBIs del plan en tasks
+- `/project-audit` → (Phase 1) provee el input principal
+- `/project-assign` → (Phase 3) distribuye trabajo del plan
+- `/project-roadmap` → (Phase 4) visualiza el plan como timeline
+- `/dependency-map` → mapa de dependencias entre PBIs
+- `/pbi-decompose` → descomponer PBIs del plan en tasks
 
 ## Restricciones
 

--- a/.claude/commands/project-roadmap.md
+++ b/.claude/commands/project-roadmap.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/project:roadmap --project {p}` o con `--release-plan {file}`
+> Uso: `/project-roadmap --project {p}` o con `--release-plan {file}`
 
 ## Parámetros
 
@@ -31,7 +31,7 @@ description: >
 
 ### 1. Cargar datos
 - Release plan → releases, sprints, PBIs, dependencias
-- Asignaciones → si `/project:assign` ya ejecutado
+- Asignaciones → si `/project-assign` ya ejecutado
 - Calendario → fechas de sprints, festivos
 
 ### 2. Generar diagrama Gantt (Mermaid)
@@ -70,8 +70,8 @@ gantt
 ### 4. Publicar diagrama
 
 - Si `--format mermaid` → incluir en markdown del roadmap
-- Si `--format drawio` → usar `/diagram:generate` → exportar XML
-- Si `--format miro` → usar `/diagram:generate` → publicar board
+- Si `--format drawio` → usar `/diagram-generate` → exportar XML
+- Si `--format miro` → usar `/diagram-generate` → publicar board
 
 ### 5. Generar resumen ejecutivo
 
@@ -102,15 +102,15 @@ Fecha: YYYY-MM-DD | Horizonte: {n} sprints ({m} semanas)
 ### 6. Guardar
 - Diagrama: `output/roadmaps/YYYYMMDD-roadmap-{proyecto}.mermaid`
 - Resumen: `output/roadmaps/YYYYMMDD-roadmap-{proyecto}.md`
-- Si `--output pptx` → usar `/report:executive` para presentación
+- Si `--output pptx` → usar `/report-executive` para presentación
 
 ## Integración
 
-- `/project:release-plan` → (Phase 2) fuente de datos principal
-- `/project:assign` → (Phase 3) asignaciones para vista tech
-- `/project:kickoff` → (Phase 5) incluye roadmap en el kickoff
-- `/diagram:generate` → publicar en Draw.io o Miro
-- `/report:executive` → versión presentación del roadmap
+- `/project-release-plan` → (Phase 2) fuente de datos principal
+- `/project-assign` → (Phase 3) asignaciones para vista tech
+- `/project-kickoff` → (Phase 5) incluye roadmap en el kickoff
+- `/diagram-generate` → publicar en Draw.io o Miro
+- `/report-executive` → versión presentación del roadmap
 
 ## Restricciones
 

--- a/.claude/commands/references/command-catalog.md
+++ b/.claude/commands/references/command-catalog.md
@@ -4,49 +4,49 @@
 > NO se auto-carga en el contexto.
 
 ## Sprint y Reporting (10)
-`/sprint:status` · `/sprint:plan` · `/sprint:review` · `/sprint:retro` · `/report:hours` · `/report:executive` · `/report:capacity` · `/team:workload` · `/board:flow` · `/kpi:dashboard`
+`/sprint-status` · `/sprint-plan` · `/sprint-review` · `/sprint-retro` · `/report-hours` · `/report-executive` · `/report-capacity` · `/team-workload` · `/board-flow` · `/kpi-dashboard`
 
 ## PBI y Discovery (6)
-`/pbi:decompose {id}` · `/pbi:decompose-batch {ids}` · `/pbi:assign {pbi_id}` · `/pbi:plan-sprint` · `/pbi:jtbd {id}` · `/pbi:prd {id}`
+`/pbi-decompose {id}` · `/pbi-decompose-batch {ids}` · `/pbi-assign {pbi_id}` · `/pbi-plan-sprint` · `/pbi-jtbd {id}` · `/pbi-prd {id}`
 
 ## SDD (5)
-`/spec:generate {task_id}` · `/spec:implement {spec}` · `/spec:review {spec}` · `/spec:status` · `/agent:run {spec}`
+`/spec-generate {task_id}` · `/spec-implement {spec}` · `/spec-review {spec}` · `/spec-status` · `/agent-run {spec}`
 
 ## Calidad y PRs (4)
-`/pr:review [PR]` · `/pr:pending [--project p]` · `/evaluate:repo [URL]` · `/changelog:update`
+`/pr-review [PR]` · `/pr-pending [--project p]` · `/evaluate-repo [URL]` · `/changelog-update`
 
 ## Equipo (3)
-`/team:privacy-notice {nombre} --project {p}` · `/team:onboarding {nombre} --project {p}` · `/team:evaluate {nombre} --project {p}`
+`/team-privacy-notice {nombre} --project {p}` · `/team-onboarding {nombre} --project {p}` · `/team-evaluate {nombre} --project {p}`
 
 ## Infra (7)
-`/infra:detect {proy} {env}` · `/infra:plan {proy} {env}` · `/infra:estimate {proy}` · `/infra:scale {recurso}` · `/infra:status {proy}` · `/env:setup {proy}` · `/env:promote {proy} {orig} {dest}`
+`/infra-detect {proy} {env}` · `/infra-plan {proy} {env}` · `/infra-estimate {proy}` · `/infra-scale {recurso}` · `/infra-status {proy}` · `/env-setup {proy}` · `/env-promote {proy} {orig} {dest}`
 
 ## Diagramas (4)
-`/diagram:generate {proy}` · `/diagram:import {source} --project {p}` · `/diagram:config --tool {t}` · `/diagram:status`
+`/diagram-generate {proy}` · `/diagram-import {source} --project {p}` · `/diagram-config --tool {t}` · `/diagram-status`
 
 ## Pipelines (5)
-`/pipeline:status --project {p}` · `/pipeline:run --project {p} {pipeline}` · `/pipeline:logs --project {p} --build {id}` · `/pipeline:create --project {p} --name {n} --repo {r}` · `/pipeline:artifacts --project {p} --build {id}`
+`/pipeline-status --project {p}` · `/pipeline-run --project {p} {pipeline}` · `/pipeline-logs --project {p} --build {id}` · `/pipeline-create --project {p} --name {n} --repo {r}` · `/pipeline-artifacts --project {p} --build {id}`
 
 ## Azure Repos (6)
-`/repos:list --project {p}` · `/repos:branches --project {p} --repo {r}` · `/repos:pr-create --project {p} --repo {r}` · `/repos:pr-list --project {p}` · `/repos:pr-review --project {p} --pr {id}` · `/repos:search --project {p} {query}`
+`/repos-list --project {p}` · `/repos-branches --project {p} --repo {r}` · `/repos-pr-create --project {p} --repo {r}` · `/repos-pr-list --project {p}` · `/repos-pr-review --project {p} --pr {id}` · `/repos-search --project {p} {query}`
 
 ## Governance (5)
-`/debt:track --project {p}` · `/kpi:dora --project {p}` · `/dependency:map --project {p}` · `/retro:actions --project {p}` · `/risk:log --project {p}`
+`/debt-track --project {p}` · `/kpi-dora --project {p}` · `/dependency-map --project {p}` · `/retro-actions --project {p}` · `/risk-log --project {p}`
 
 ## Legacy & Capture (3)
-`/legacy:assess --project {p}` · `/backlog:capture --project {p} --source {tipo}` · `/sprint:release-notes --project {p}`
+`/legacy-assess --project {p}` · `/backlog-capture --project {p} --source {tipo}` · `/sprint-release-notes --project {p}`
 
 ## Project Onboarding (5)
-`/project:audit --project {p}` · `/project:release-plan --project {p}` · `/project:assign --project {p}` · `/project:roadmap --project {p}` · `/project:kickoff --project {p}`
+`/project-audit --project {p}` · `/project-release-plan --project {p}` · `/project-assign --project {p}` · `/project-roadmap --project {p}` · `/project-kickoff --project {p}`
 
 ## DevOps Extended (5)
-`/wiki:publish {file} --project {p}` · `/wiki:sync --project {p}` · `/testplan:status --project {p}` · `/testplan:results --project {p} --run {id}` · `/security:alerts --project {p}`
+`/wiki-publish {file} --project {p}` · `/wiki-sync --project {p}` · `/testplan-status --project {p}` · `/testplan-results --project {p} --run {id}` · `/security-alerts --project {p}`
 
 ## Mensajería e Inbox (6)
-`/notify:whatsapp {contacto} {msg}` · `/whatsapp:search {query}` · `/notify:nctalk {sala} {msg}` · `/nctalk:search {query}` · `/inbox:check` · `/inbox:start --interval {min}`
+`/notify-whatsapp {contacto} {msg}` · `/whatsapp-search {query}` · `/notify-nctalk {sala} {msg}` · `/nctalk-search {query}` · `/inbox-check` · `/inbox-start --interval {min}`
 
 ## Conectores (12)
-`/notify:slack {canal} {msg}` · `/slack:search {query}` · `/github:activity {repo}` · `/github:issues {repo}` · `/sentry:health --project {p}` · `/sentry:bugs --project {p}` · `/gdrive:upload {file} --project {p}` · `/linear:sync --project {p}` · `/jira:sync --project {p}` · `/confluence:publish {file} --project {p}` · `/notion:sync --project {p}` · `/figma:extract {url} --project {p}`
+`/notify-slack {canal} {msg}` · `/slack-search {query}` · `/github-activity {repo}` · `/github-issues {repo}` · `/sentry-health --project {p}` · `/sentry-bugs --project {p}` · `/gdrive-upload {file} --project {p}` · `/linear-sync --project {p}` · `/jira-sync --project {p}` · `/confluence-publish {file} --project {p}` · `/notion-sync --project {p}` · `/figma-extract {url} --project {p}`
 
 ## Utilidades (4)
-`/context:load` · `/session:save` · `/help [filtro]` · `/help --setup`
+`/context-load` · `/session-save` · `/help [filtro]` · `/help --setup`

--- a/.claude/commands/report-capacity.md
+++ b/.claude/commands/report-capacity.md
@@ -1,10 +1,10 @@
-# /report:capacity
+# /report-capacity
 
 Muestra el estado de capacidades del equipo: disponibilidad, asignación y alertas de sobre-carga.
 
 ## Uso
 ```
-/report:capacity [proyecto] [--sprint "Sprint 2026-XX"]
+/report-capacity [proyecto] [--sprint "Sprint 2026-XX"]
 ```
 
 ## Pasos de Ejecución

--- a/.claude/commands/report-executive.md
+++ b/.claude/commands/report-executive.md
@@ -1,10 +1,10 @@
-# /report:executive
+# /report-executive
 
 Genera el informe ejecutivo multi-proyecto para dirección en formato Word o PowerPoint.
 
 ## Uso
 ```
-/report:executive [--format pptx|docx] [--proyectos alpha,beta] [--semana YYYY-WW]
+/report-executive [--format pptx|docx] [--proyectos alpha,beta] [--semana YYYY-WW]
 ```
 Si no se indica formato, generar ambos. Si no se indica semana, usar la semana actual.
 

--- a/.claude/commands/report-hours.md
+++ b/.claude/commands/report-hours.md
@@ -1,10 +1,10 @@
-# /report:hours
+# /report-hours
 
 Genera el informe de imputación de horas del sprint actual o especificado.
 
 ## Uso
 ```
-/report:hours [proyecto] [--sprint "Sprint 2026-XX"] [--format xlsx|docx]
+/report-hours [proyecto] [--sprint "Sprint 2026-XX"] [--format xlsx|docx]
 ```
 Formato por defecto: `xlsx`.
 

--- a/.claude/commands/repos-branches.md
+++ b/.claude/commands/repos-branches.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/repos:branches --project {p} --repo {r}` o `/repos:branches --project {p} --repo {r} --create {name}`
+> Uso: `/repos-branches --project {p} --repo {r}` o `/repos-branches --project {p} --repo {r} --create {name}`
 
 ## Parámetros
 

--- a/.claude/commands/repos-list.md
+++ b/.claude/commands/repos-list.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/repos:list --project {p}`
+> Uso: `/repos-list --project {p}`
 
 ## Parámetros
 

--- a/.claude/commands/repos-pr-create.md
+++ b/.claude/commands/repos-pr-create.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/repos:pr-create --project {p} --repo {r}` o con todos los params
+> Uso: `/repos-pr-create --project {p} --repo {r}` o con todos los params
 
 ## Parámetros
 
@@ -68,9 +68,9 @@ description: >
 
 ## Integración
 
-- `/repos:pr-list` → ver PRs del repo
-- `/repos:pr-review` → review multi-perspectiva del PR
-- `/pipeline:status` → verificar que la build de validación pasa
+- `/repos-pr-list` → ver PRs del repo
+- `/repos-pr-review` → review multi-perspectiva del PR
+- `/pipeline-status` → verificar que la build de validación pasa
 
 ## Restricciones
 

--- a/.claude/commands/repos-pr-list.md
+++ b/.claude/commands/repos-pr-list.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/repos:pr-list --project {p}` o `/repos:pr-list --project {p} --repo {r} --status {s}`
+> Uso: `/repos-pr-list --project {p}` o `/repos-pr-list --project {p} --repo {r} --status {s}`
 
 ## Parámetros
 
@@ -49,15 +49,15 @@ description: >
 
 ### Resumen
 - 3 PRs activos, 1 listo para merge (#39)
-- 1 build fallida (#41) — revisar con `/repos:pr-review`
+- 1 build fallida (#41) — revisar con `/repos-pr-review`
 - Antigüedad media: 3.3 días
 ```
 
 ## Integración
 
-- `/repos:pr-review --pr {id}` → review detallado
-- `/pr:pending` → similar pero para GitHub (equivalente Azure Repos)
-- `/pipeline:logs` → si build fallida, ver logs
+- `/repos-pr-review --pr {id}` → review detallado
+- `/pr-pending` → similar pero para GitHub (equivalente Azure Repos)
+- `/pipeline-logs` → si build fallida, ver logs
 
 ## Restricciones
 

--- a/.claude/commands/repos-pr-review.md
+++ b/.claude/commands/repos-pr-review.md
@@ -2,14 +2,14 @@
 name: repos-pr-review
 description: >
   Review multi-perspectiva de un PR en Azure Repos. Analiza
-  desde BA, Dev, QA, Security y DevOps (reutiliza patrón pr:review).
+  desde BA, Dev, QA, Security y DevOps (reutiliza patrón pr-review).
 ---
 
 # Repos PR Review
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/repos:pr-review --project {p} --pr {id}` o `/repos:pr-review --project {p} --repo {r} --pr {id}`
+> Uso: `/repos-pr-review --project {p} --pr {id}` o `/repos-pr-review --project {p} --repo {r} --pr {id}`
 
 ## Parámetros
 
@@ -64,9 +64,9 @@ description: >
 
 ## Integración
 
-- `/repos:pr-list` → contexto de PRs activos
-- `/pipeline:logs` → si la build falla
-- `/pr:review` → equivalente para PRs de GitHub
+- `/repos-pr-list` → contexto de PRs activos
+- `/pipeline-logs` → si la build falla
+- `/pr-review` → equivalente para PRs de GitHub
 
 ## Restricciones
 

--- a/.claude/commands/repos-search.md
+++ b/.claude/commands/repos-search.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/repos:search --project {p} {query}` o con filtros
+> Uso: `/repos-search --project {p} {query}` o con filtros
 
 ## Parámetros
 
@@ -50,8 +50,8 @@ Total: 11 resultados en 2 repositorios
 
 ## Integración
 
-- `/repos:pr-create` → si buscas código para entender el impacto de un cambio
-- `/spec:generate` → buscar implementación existente antes de generar spec
+- `/repos-pr-create` → si buscas código para entender el impacto de un cambio
+- `/spec-generate` → buscar implementación existente antes de generar spec
 
 ## Restricciones
 

--- a/.claude/commands/retro-actions.md
+++ b/.claude/commands/retro-actions.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/retro:actions --project {p}` o `/retro:actions --project {p} --add`
+> Uso: `/retro-actions --project {p}` o `/retro-actions --project {p} --add`
 
 ## Parámetros
 
@@ -70,9 +70,9 @@ Media: 58%
 
 ## Integración
 
-- `/sprint:retro` → al final de la retro, invoca `/retro:actions --add`
-- `/sprint:status` → muestra actions pendientes como recordatorio
-- `/project:audit` → usa % implementación como indicador de mejora continua
+- `/sprint-retro` → al final de la retro, invoca `/retro-actions --add`
+- `/sprint-status` → muestra actions pendientes como recordatorio
+- `/project-audit` → usa % implementación como indicador de mejora continua
 
 ## Restricciones
 

--- a/.claude/commands/risk-log.md
+++ b/.claude/commands/risk-log.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/risk:log --project {p}` o `/risk:log --project {p} --add`
+> Uso: `/risk-log --project {p}` o `/risk-log --project {p} --add`
 
 ## Parámetros
 
@@ -66,11 +66,11 @@ Baja(1)  | R-06    | R-05     |         |
 
 ## Integración
 
-- `/sprint:status` → muestra top 3 riesgos por exposure
-- `/sprint:plan` → revisa riesgos al planificar
-- `/project:release-plan` → riesgos por release
-- `/project:audit` → evalúa gestión de riesgos
-- `/dependency:map` → riesgos de dependencias cross-team
+- `/sprint-status` → muestra top 3 riesgos por exposure
+- `/sprint-plan` → revisa riesgos al planificar
+- `/project-release-plan` → riesgos por release
+- `/project-audit` → evalúa gestión de riesgos
+- `/dependency-map` → riesgos de dependencias cross-team
 
 ## Restricciones
 

--- a/.claude/commands/security-alerts.md
+++ b/.claude/commands/security-alerts.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/security:alerts --project {p}` o `/security:alerts --project {p} --severity {level}`
+> Uso: `/security-alerts --project {p}` o `/security-alerts --project {p} --severity {level}`
 
 ## Parámetros
 
@@ -85,10 +85,10 @@ Nuevas: 8 | Resueltas: 11 | Netas: -3 (mejorando 📉)
 
 ## Integración
 
-- `/project:audit` → incluye security alerts en evaluación
-- `/evaluate:repo` → complementario (evaluate:repo = estático, security:alerts = dinámico)
-- `/debt:track` → alertas no resueltas como deuda de seguridad
-- `/risk:log` → alertas critical alimentan registro de riesgos
+- `/project-audit` → incluye security alerts en evaluación
+- `/evaluate-repo` → complementario (evaluate-repo = estático, security-alerts = dinámico)
+- `/debt-track` → alertas no resueltas como deuda de seguridad
+- `/risk-log` → alertas critical alimentan registro de riesgos
 
 ## Restricciones
 

--- a/.claude/commands/sentry-bugs.md
+++ b/.claude/commands/sentry-bugs.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/sentry:bugs --project {p}` o `/sentry:bugs --project {p} --min-events {N}`
+> Uso: `/sentry-bugs --project {p}` o `/sentry-bugs --project {p} --min-events {N}`
 
 ## Parámetros
 
@@ -85,10 +85,10 @@ description: >
 
 ## Integración con otros comandos
 
-- `/pbi:decompose` puede descomponer los bugs creados en tasks técnicas
-- `/sprint:plan` puede incluir bugs de Sentry como candidatos al sprint
-- `/notify:slack` puede publicar resumen de bugs detectados
-- `/sentry:health` complementa con visión general de salud
+- `/pbi-decompose` puede descomponer los bugs creados en tasks técnicas
+- `/sprint-plan` puede incluir bugs de Sentry como candidatos al sprint
+- `/notify-slack` puede publicar resumen de bugs detectados
+- `/sentry-health` complementa con visión general de salud
 
 ## Restricciones
 

--- a/.claude/commands/sentry-health.md
+++ b/.claude/commands/sentry-health.md
@@ -2,14 +2,14 @@
 name: sentry-health
 description: >
   Métricas de salud técnica del proyecto desde Sentry: errores, crash rate,
-  performance, alertas activas. Alimenta sprint:status y kpi:dashboard.
+  performance, alertas activas. Alimenta sprint-status y kpi-dashboard.
 ---
 
 # Salud Técnica — Sentry
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/sentry:health --project {p}` o `/sentry:health --project {p} --period {días}`
+> Uso: `/sentry-health --project {p}` o `/sentry-health --project {p} --period {días}`
 
 ## Parámetros
 
@@ -72,9 +72,9 @@ description: >
 
 ## Integración con otros comandos
 
-- `/sprint:status` puede invocar `sentry:health` para incluir métricas técnicas
-- `/kpi:dashboard` usa los datos de salud como KPIs técnicos
-- `/sprint:review` incluye tendencia de salud técnica en el resumen
+- `/sprint-status` puede invocar `sentry-health` para incluir métricas técnicas
+- `/kpi-dashboard` usa los datos de salud como KPIs técnicos
+- `/sprint-review` incluye tendencia de salud técnica en el resumen
 - Soporta `--notify-slack` para publicar el informe en el canal del proyecto
 
 ## Restricciones

--- a/.claude/commands/session-save.md
+++ b/.claude/commands/session-save.md
@@ -2,7 +2,7 @@
 name: session-save
 description: >
   Guarda decisiones, resultados y pendientes de la sesión actual antes de /clear.
-  Persiste el conocimiento entre sesiones para que /context:load lo recupere.
+  Persiste el conocimiento entre sesiones para que /context-load lo recupere.
 ---
 
 # Session Save — Persistencia entre sesiones
@@ -17,7 +17,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /session:save — Guardando estado de sesión
+🚀 /session-save — Guardando estado de sesión
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -89,7 +89,7 @@ Fichero: `decision-log.md` (raíz del workspace, git-ignorado)
 # Decision Log — PM-Workspace
 # ── FICHERO PRIVADO — git-ignorado ──────────────────────────────
 
-> Registro acumulativo de decisiones del PM. Cargado por /context:load.
+> Registro acumulativo de decisiones del PM. Cargado por /context-load.
 > Mantener máximo 50 entradas. Al superar → archivar antiguas al final.
 
 ---
@@ -118,7 +118,7 @@ Solo decisiones — no resultados ni ficheros (eso está en el session log).
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /session:save — Completado
+✅ /session-save — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📄 Log: output/sessions/YYYYMMDD-HHMM-session.md
 📋 Decision log actualizado: decision-log.md

--- a/.claude/commands/slack-search.md
+++ b/.claude/commands/slack-search.md
@@ -9,7 +9,7 @@ description: >
 
 **Búsqueda:** $ARGUMENTS
 
-> Uso: `/slack:search {query} [--channel {canal}] [--from {usuario}] [--since {fecha}]`
+> Uso: `/slack-search {query} [--channel {canal}] [--from {usuario}] [--since {fecha}]`
 
 ## Parámetros
 
@@ -58,9 +58,9 @@ description: >
 
 ## Casos de uso en PM-Workspace
 
-- **Input para `/diagram:import`**: Buscar decisiones arquitectónicas antes de importar
-- **Input para `/pbi:decompose`**: Buscar contexto funcional sobre un PBI
-- **Input para `/sprint:retro`**: Recopilar feedback del equipo durante el sprint
+- **Input para `/diagram-import`**: Buscar decisiones arquitectónicas antes de importar
+- **Input para `/pbi-decompose`**: Buscar contexto funcional sobre un PBI
+- **Input para `/sprint-retro`**: Recopilar feedback del equipo durante el sprint
 - **Auditoría**: Buscar quién aprobó qué y cuándo
 
 ## Restricciones

--- a/.claude/commands/spec-generate.md
+++ b/.claude/commands/spec-generate.md
@@ -1,10 +1,10 @@
-# /spec:generate
+# /spec-generate
 
 Genera una Spec ejecutable (`.spec.md`) a partir de una Task de Azure DevOps, lista para ser implementada por un humano o un agente Claude.
 
 ## Uso
 ```
-/spec:generate {task_id} [--project {nombre}] [--sprint {sprint}] [--force-type human|agent:single|agent:team]
+/spec-generate {task_id} [--project {nombre}] [--sprint {sprint}] [--force-type human|agent-single|agent-team]
 ```
 
 - `{task_id}`: ID de la Task en Azure DevOps (ej: `1234`)
@@ -93,7 +93,7 @@ Aplicar la matrix de `references/layer-assignment-matrix.md`:
 3. Si no hay override de proyecto, usar la matrix global
 4. Si `--force-type` está especificado, usar ese valor
 
-Mostrar al usuario: `Developer Type determinado: agent:single (Application / Command Handler)`
+Mostrar al usuario: `Developer Type determinado: agent-single (Application / Command Handler)`
 
 ### Paso 6 — Construir la Spec
 
@@ -124,7 +124,7 @@ SPEC_FILE="$SPEC_DIR/AB{task_id}-{tipo}-{descripcion-corta}.spec.md"
 📄 SPEC GENERADA — AB#{task_id}: {título}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Developer Type:  agent:single  (Application / Command Handler)
+Developer Type:  agent-single  (Application / Command Handler)
 Fichero:         {spec_file_path}
 Estimación:      {Xh}
 Asignado a:      {dev o "claude-agent"}
@@ -138,9 +138,9 @@ Checklist de calidad:
   ⚠️  {advertencia si algún campo quedó incompleto}
 
 ¿Está lista para implementar? Puedes:
-  - Ejecutar: /spec:implement {spec_file}  (si developer_type es agent)
+  - Ejecutar: /spec-implement {spec_file}  (si developer_type es agent)
   - Revisar el fichero manualmente antes de asignar
-  - Ejecutar: /spec:review {spec_file}     (para validación adicional)
+  - Ejecutar: /spec-review {spec_file}     (para validación adicional)
 ```
 
 > ⚠️ La Spec generada es un BORRADOR. Siempre revisarla antes de darla a un agente o a un desarrollador.

--- a/.claude/commands/spec-implement.md
+++ b/.claude/commands/spec-implement.md
@@ -1,10 +1,10 @@
-# /spec:implement
+# /spec-implement
 
 Implementa una Spec según su `developer_type`: lanza agente o asigna a humano.
 
 ## Uso
 ```
-/spec:implement {spec_file} [--dry-run] [--override-type human|agent:single|agent:team]
+/spec-implement {spec_file} [--dry-run] [--override-type human|agent-single|agent-team]
 ```
 
 ## Protocolo
@@ -20,15 +20,15 @@ Verificar criterios mínimos antes de implementar:
 - Sección 6: al menos un fichero de referencia
 - Estado: "Pendiente"
 
-Si falla → informar problemas y sugerir `/spec:review`.
+Si falla → informar problemas y sugerir `/spec-review`.
 
 ### 2. Ejecutar según developer_type
 
 **human** → Informar asignado + task ID. Ofrecer: notificar al dev o mover task a "Active".
 
-**agent:single** → Mostrar plan (spec, modelo opus, log, max turns 40) → confirmar → lanzar agente con system-prompt del proyecto, instrucciones de implementar Spec exactamente, detenerse ante ambigüedad, ejecutar build+test (máx 3 reintentos). Log en `output/agent-runs/`.
+**agent-single** → Mostrar plan (spec, modelo opus, log, max turns 40) → confirmar → lanzar agente con system-prompt del proyecto, instrucciones de implementar Spec exactamente, detenerse ante ambigüedad, ejecutar build+test (máx 3 reintentos). Log en `output/agent-runs/`.
 
-**agent:team** → Leer team pattern de la spec (default: `impl-test`) → confirmar → lanzar Implementador (opus) + Tester (haiku) en paralelo. Si pattern incluye review, lanzar Reviewer después.
+**agent-team** → Leer team pattern de la spec (default: `impl-test`) → confirmar → lanzar Implementador (opus) + Tester (haiku) en paralelo. Si pattern incluye review, lanzar Reviewer después.
 
 ### 3. Post-implementación (solo agentes)
 
@@ -39,4 +39,4 @@ Actualizar task en Azure DevOps: estado → "In Review", tags → "spec-driven;a
 ## Restricciones
 
 - Implementación por agente SIEMPRE requiere Code Review humano antes de merge
-- Usar `/spec:review {spec_file}` para pre-check automático antes del review humano
+- Usar `/spec-review {spec_file}` para pre-check automático antes del review humano

--- a/.claude/commands/spec-review.md
+++ b/.claude/commands/spec-review.md
@@ -1,10 +1,10 @@
-# /spec:review
+# /spec-review
 
 Valida una Spec y opcionalmente verifica que el código implementado la cumple.
 
 ## Uso
 ```
-/spec:review {spec_file} [--check-impl] [--project {nombre}]
+/spec-review {spec_file} [--check-impl] [--project {nombre}]
 ```
 
 ## Modo 1: Review de Spec (sin `--check-impl`)

--- a/.claude/commands/spec-status.md
+++ b/.claude/commands/spec-status.md
@@ -1,10 +1,10 @@
-# /spec:status
+# /spec-status
 
 Muestra el estado de todas las Specs del sprint activo: pendientes, en progreso, completadas, bloqueadas.
 
 ## Uso
 ```
-/spec:status [--project {nombre}] [--sprint {sprint}] [--filter pending|in-progress|blocked|all]
+/spec-status [--project {nombre}] [--sprint {sprint}] [--filter pending|in-progress|blocked|all]
 ```
 
 - `--project`: Proyecto AzDO (default: todos los proyectos con specs en el sprint activo)
@@ -59,12 +59,12 @@ grep "^\*\*Último update:\*\*" $SPEC_FILE | cut -d: -f2- | xargs
 ┌──────────┬──────────────────────────────────┬─────────┬──────────────┬───────┬─────────────────────┐
 │ Task     │ Spec                             │ Estado  │ Dev Type     │ Horas │ Asignado a          │
 ├──────────┼──────────────────────────────────┼─────────┼──────────────┼───────┼─────────────────────┤
-│ AB#1234  │ B3-create-patient-handler        │ ✅ Done │ agent:single │  4h   │ claude-agent        │
-│ AB#1235  │ D1-unit-tests-patient            │ ✅ Done │ agent:single │  3h   │ claude-agent        │
-│ AB#1236  │ B3-update-patient-command        │ 🔄 WIP  │ agent:single │  4h   │ claude-agent        │
+│ AB#1234  │ B3-create-patient-handler        │ ✅ Done │ agent-single │  4h   │ claude-agent        │
+│ AB#1235  │ D1-unit-tests-patient            │ ✅ Done │ agent-single │  3h   │ claude-agent        │
+│ AB#1236  │ B3-update-patient-command        │ 🔄 WIP  │ agent-single │  4h   │ claude-agent        │
 │ AB#1237  │ C1-patient-repository            │ ⏳ Pend │ human        │  5h   │ María García        │
 │ AB#1238  │ E1-code-review                   │ ⏳ Pend │ human        │  2h   │ Carlos Ruiz         │
-│ AB#1239  │ B3-create-appointment            │ 🚫 Bloq │ agent:single │  4h   │ -                   │
+│ AB#1239  │ B3-create-appointment            │ 🚫 Bloq │ agent-single │  4h   │ -                   │
 └──────────┴──────────────────────────────────┴─────────┴──────────────┴───────┴─────────────────────┘
 
 Leyenda: ✅ Completado | 🔄 En Progreso | ⏳ Pendiente | 🚫 Bloqueado
@@ -107,9 +107,9 @@ Leyenda: ✅ Completado | 🔄 En Progreso | ⏳ Pendiente | 🚫 Bloqueado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Comandos disponibles:
-  /spec:implement {spec_file}   — Iniciar implementación de una spec pendiente
-  /spec:review {spec_file}      — Revisar una spec antes de implementar
-  /agent:run {spec_file}        — Lanzar agente directamente
+  /spec-implement {spec_file}   — Iniciar implementación de una spec pendiente
+  /spec-review {spec_file}      — Revisar una spec antes de implementar
+  /agent-run {spec_file}        — Lanzar agente directamente
 ```
 
 ### Formato simplificado (si --filter)
@@ -129,8 +129,8 @@ Con `--filter pending`:
 
   AB#1237 — {título} (human / María García / 5h)
   AB#1238 — {título} (human / Carlos Ruiz / 2h)
-  AB#... — {título} (agent:single / claude-agent / Xh)
+  AB#... — {título} (agent-single / claude-agent / Xh)
 
   Para lanzar todos los agentes pendientes:
-  /agent:run --all-pending --project {proyecto}
+  /agent-run --all-pending --project {proyecto}
 ```

--- a/.claude/commands/sprint-plan.md
+++ b/.claude/commands/sprint-plan.md
@@ -1,10 +1,10 @@
-# /sprint:plan
+# /sprint-plan
 
 Asiste en el Sprint Planning calculando capacity disponible y proponiendo la carga de trabajo.
 
 ## Uso
 ```
-/sprint:plan [proyecto] [--sprint "Sprint 2026-XX"]
+/sprint-plan [proyecto] [--sprint "Sprint 2026-XX"]
 ```
 
 ## Pasos de Ejecución

--- a/.claude/commands/sprint-release-notes.md
+++ b/.claude/commands/sprint-release-notes.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/sprint:release-notes --project {p}` o `/sprint:release-notes --project {p} --sprint {s}`
+> Uso: `/sprint-release-notes --project {p}` o `/sprint-release-notes --project {p} --sprint {s}`
 
 ## Parámetros
 
@@ -83,15 +83,15 @@ Velocity: 34 SP | Items completados: 8/10 | Bugs resueltos: 3
 
 ### 5. Guardar y distribuir
 - Guardar en `output/release-notes/YYYYMMDD-release-{proyecto}.{ext}`
-- Si `--format slack` → enviar via `/notify:slack`
+- Si `--format slack` → enviar via `/notify-slack`
 - Si `--format html` → generar HTML con estilos para email
 
 ## Integración
 
-- `/sprint:review` → puede invocar release-notes como parte del review
-- `/changelog:update` → complementario (changelog = técnico, release notes = negocio)
-- `/notify:slack` → distribuir release notes al equipo/stakeholders
-- `/confluence:publish` → publicar en Confluence como página de release
+- `/sprint-review` → puede invocar release-notes como parte del review
+- `/changelog-update` → complementario (changelog = técnico, release notes = negocio)
+- `/notify-slack` → distribuir release notes al equipo/stakeholders
+- `/confluence-publish` → publicar en Confluence como página de release
 
 ## Restricciones
 

--- a/.claude/commands/sprint-retro.md
+++ b/.claude/commands/sprint-retro.md
@@ -1,15 +1,15 @@
-# /sprint:retro
+# /sprint-retro
 
 Genera la plantilla de retrospectiva con datos del sprint para facilitar la ceremonia.
 
 ## Uso
 ```
-/sprint:retro [proyecto] [--sprint "Sprint 2026-XX"]
+/sprint-retro [proyecto] [--sprint "Sprint 2026-XX"]
 ```
 
 ## Pasos de Ejecución
 
-1. Obtener datos del sprint cerrado (mismos que /sprint:review si ya se ejecutó)
+1. Obtener datos del sprint cerrado (mismos que /sprint-review si ya se ejecutó)
 2. Recuperar action items de la retro anterior desde `projects/<proyecto>/sprints/<sprint-anterior>/retro-actions.md`
 3. Verificar cuáles action items se han cumplido (revisar estado en Azure DevOps si generaron tasks)
 4. Calcular métricas de tendencia (velocity, cycle time, bug rate) vs sprint anterior

--- a/.claude/commands/sprint-review.md
+++ b/.claude/commands/sprint-review.md
@@ -1,10 +1,10 @@
-# /sprint:review
+# /sprint-review
 
 Genera el resumen para la Sprint Review con todos los datos del sprint cerrado.
 
 ## Uso
 ```
-/sprint:review [proyecto] [--sprint "Sprint 2026-XX"]
+/sprint-review [proyecto] [--sprint "Sprint 2026-XX"]
 ```
 Si no se indica sprint, usa el sprint actual (o el último cerrado).
 

--- a/.claude/commands/sprint-status.md
+++ b/.claude/commands/sprint-status.md
@@ -3,7 +3,7 @@ name: sprint-status
 description: Estado del sprint actual — progreso, burndown, alertas.
 ---
 
-# /sprint:status
+# /sprint-status
 
 **Argumentos:** $ARGUMENTS
 
@@ -13,7 +13,7 @@ Aplica siempre @.claude/rules/domain/command-ux-feedback.md
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-🚀 /sprint:status — Estado del sprint actual
+🚀 /sprint-status — Estado del sprint actual
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -86,7 +86,7 @@ Si falta el proyecto → preguntar cuál y cargar su CLAUDE.md.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ /sprint:status — Completado
+✅ /sprint-status — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📊 Sprint {nombre} | {X}% completado | {N} alertas
 ```

--- a/.claude/commands/team-evaluate.md
+++ b/.claude/commands/team-evaluate.md
@@ -9,7 +9,7 @@ description: >
 
 **Programador:** $ARGUMENTS
 
-> Uso: `/team:evaluate "Laura Sánchez" --project GestiónClínica`
+> Uso: `/team-evaluate "Laura Sánchez" --project GestiónClínica`
 > Prerequisito: nota informativa RGPD firmada.
 
 ## Protocolo
@@ -22,7 +22,7 @@ description: >
 
 ### 2. Verificar RGPD (BLOQUEO)
 Comprobar `projects/{proyecto}/privacy/{nombre}-nota-informativa-*.md`.
-Si no existe → DETENER → sugerir `/team:privacy-notice`.
+Si no existe → DETENER → sugerir `/team-privacy-notice`.
 
 ### 3. Personalizar sección C (dominio)
 Generar competencias de dominio a partir de los módulos reales del proyecto.

--- a/.claude/commands/team-onboarding.md
+++ b/.claude/commands/team-onboarding.md
@@ -10,10 +10,10 @@ description: >
 
 **Nuevo miembro:** $ARGUMENTS
 
-> Uso: `/team:onboarding "Laura Sánchez" --project GestiónClínica`
+> Uso: `/team-onboarding "Laura Sánchez" --project GestiónClínica`
 >
 > Prerequisito: la nota informativa RGPD debe estar firmada antes de registrar
-> datos del trabajador. Si no existe, sugerir `/team:privacy-notice` primero.
+> datos del trabajador. Si no existe, sugerir `/team-privacy-notice` primero.
 
 ---
 
@@ -37,13 +37,13 @@ Si el `--project` no se especifica, preguntar al usuario qué proyecto.
 Comprobar si existe `projects/{proyecto}/privacy/{nombre}-nota-informativa-*.md`.
 
 - Si existe → continuar
-- Si no existe → informar al usuario que debe ejecutar `/team:privacy-notice` primero.
+- Si no existe → informar al usuario que debe ejecutar `/team-privacy-notice` primero.
   No bloquear el onboarding (la nota es necesaria para Fase 4, no para Fases 1-2),
-  pero recordar que es **obligatoria antes de ejecutar `/team:evaluate`**.
+  pero recordar que es **obligatoria antes de ejecutar `/team-evaluate`**.
 
 ### 4. Fase 1 — Contexto inmediato
 
-Ejecutar el equivalente de `/context:load` pero orientado al nuevo miembro:
+Ejecutar el equivalente de `/context-load` pero orientado al nuevo miembro:
 
 **a) Arquitectura general:**
 - Leer la estructura de carpetas del source (`projects/{proyecto}/source/`)
@@ -99,7 +99,7 @@ Guardar en: `projects/{proyecto}/onboarding/{nombre}-guia.md`
 Mostrar la guía generada y preguntar:
 - ¿El mentor quiere ajustar algo?
 - ¿Está listo para la Fase 3 (primera task asistida)?
-- Recordar que tras la Fase 3, el siguiente paso es `/team:evaluate`
+- Recordar que tras la Fase 3, el siguiente paso es `/team-evaluate`
 
 ---
 
@@ -126,7 +126,7 @@ Mostrar la guía generada y preguntar:
   ═══ PRÓXIMOS PASOS ═══
 
   → Fase 3: Mentor asigna primera task (complejidad B/C)
-  → Fase 4: /team:evaluate "{nombre}" --project {proyecto}
+  → Fase 4: /team-evaluate "{nombre}" --project {proyecto}
 
   📄 Guía guardada en: projects/{proyecto}/onboarding/{nombre}-guia.md
 
@@ -138,7 +138,7 @@ Mostrar la guía generada y preguntar:
 ## Restricciones
 
 - **No asignar tasks** — eso es responsabilidad del mentor (Fase 3)
-- **No evaluar competencias** — eso es `/team:evaluate` (Fase 4)
+- **No evaluar competencias** — eso es `/team-evaluate` (Fase 4)
 - **No modificar equipo.md** — solo lectura en esta fase
 - **No mostrar datos de competencias de otros miembros** — privacidad (RGPD)
 - Si el source del proyecto no está clonado, informar y sugerir cómo clonarlo

--- a/.claude/commands/team-privacy-notice.md
+++ b/.claude/commands/team-privacy-notice.md
@@ -10,9 +10,9 @@ description: >
 
 **Trabajador:** $ARGUMENTS
 
-> Uso: `/team:privacy-notice "Laura Sánchez" --project GestiónClínica`
+> Uso: `/team-privacy-notice "Laura Sánchez" --project GestiónClínica`
 >
-> Este comando debe ejecutarse ANTES de `/team:evaluate`. La nota es obligatoria
+> Este comando debe ejecutarse ANTES de `/team-evaluate`. La nota es obligatoria
 > conforme al Art. 13 del RGPD.
 
 ---
@@ -73,7 +73,7 @@ Mostrar la nota generada y el checklist de entrega:
   [ ] El trabajador firma el acuse de recibo (sección 9 del documento)
   [ ] Archivar la copia firmada (física o digital con firma electrónica)
 
-  ⚠️  IMPORTANTE: No ejecutar /team:evaluate hasta que el acuse
+  ⚠️  IMPORTANTE: No ejecutar /team-evaluate hasta que el acuse
      de recibo esté firmado. Es un requisito legal (Art. 13 RGPD).
 
 ═══════════════════════════════════════
@@ -83,7 +83,7 @@ Mostrar la nota generada y el checklist de entrega:
 
 ## Restricciones
 
-- **Solo genera la nota** — no recoge datos de competencias (eso es `/team:evaluate`)
+- **Solo genera la nota** — no recoge datos de competencias (eso es `/team-evaluate`)
 - **No solicita consentimiento** — la base legal es interés legítimo, no consentimiento. La nota INFORMA, no pide permiso
 - **Si faltan datos de empresa**, preguntar al usuario antes de generar (no inventar)
 - **Un archivo por trabajador** — no reutilizar notas entre trabajadores

--- a/.claude/commands/team-workload.md
+++ b/.claude/commands/team-workload.md
@@ -1,10 +1,10 @@
-# /team:workload
+# /team-workload
 
 Muestra la carga de trabajo por persona: items asignados, horas remaining y balance de equipo.
 
 ## Uso
 ```
-/team:workload [proyecto]
+/team-workload [proyecto]
 ```
 
 ## Pasos de Ejecución

--- a/.claude/commands/testplan-results.md
+++ b/.claude/commands/testplan-results.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/testplan:results --project {p} --run {id}` o `--plan {id}`
+> Uso: `/testplan-results --project {p} --run {id}` o `--plan {id}`
 
 ## Parámetros
 
@@ -76,10 +76,10 @@ Tendencia: 📉 bajando (-6% vs media)
 
 ## Integración
 
-- `/testplan:status` → vista general de planes y suites
-- `/sentry:bugs` → correlacionar fallos de tests con errores en producción
-- `/sprint:review` → incluir resultados en sprint review
-- `/debt:track` → tests flaky como deuda técnica
+- `/testplan-status` → vista general de planes y suites
+- `/sentry-bugs` → correlacionar fallos de tests con errores en producción
+- `/sprint-review` → incluir resultados en sprint review
+- `/debt-track` → tests flaky como deuda técnica
 
 ## Restricciones
 

--- a/.claude/commands/testplan-status.md
+++ b/.claude/commands/testplan-status.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/testplan:status --project {p}` o `/testplan:status --project {p} --plan {id}`
+> Uso: `/testplan-status --project {p}` o `/testplan-status --project {p} --plan {id}`
 
 ## Parámetros
 
@@ -67,10 +67,10 @@ description: >
 
 ## Integración
 
-- `/testplan:results` → detalle de resultados de ejecución
-- `/kpi:dashboard` → incluye cobertura de tests como KPI
-- `/sprint:review` → resumen de test status para review
-- `/project:audit` → evalúa madurez de testing
+- `/testplan-results` → detalle de resultados de ejecución
+- `/kpi-dashboard` → incluye cobertura de tests como KPI
+- `/sprint-review` → resumen de test status para review
+- `/project-audit` → evalúa madurez de testing
 
 ## Restricciones
 

--- a/.claude/commands/whatsapp-search.md
+++ b/.claude/commands/whatsapp-search.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/whatsapp:search {query}` o `/whatsapp:search --chat {nombre} {query}`
+> Uso: `/whatsapp-search {query}` o `/whatsapp-search --chat {nombre} {query}`
 
 ## Parámetros
 
@@ -64,9 +64,9 @@ Resultados: 5 mensajes en 2 chats (últimos 30 días)
 ## Ejemplos
 
 ```bash
-/whatsapp:search "fecha límite"
-/whatsapp:search --chat "Equipo Sala Reservas" "decisión"
-/whatsapp:search --since 2026-02-01 "requisitos" --media
+/whatsapp-search "fecha límite"
+/whatsapp-search --chat "Equipo Sala Reservas" "decisión"
+/whatsapp-search --since 2026-02-01 "requisitos" --media
 ```
 
 ## Restricciones

--- a/.claude/commands/wiki-publish.md
+++ b/.claude/commands/wiki-publish.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/wiki:publish {file} --project {p}` o `/wiki:publish --project {p} --page {path}`
+> Uso: `/wiki-publish {file} --project {p}` o `/wiki-publish --project {p} --page {path}`
 
 ## Parámetros
 
@@ -59,9 +59,9 @@ Tamaño: 2.4 KB | Líneas: 85
 
 ## Integración
 
-- `/wiki:sync` → sincronización bidireccional wiki ↔ local
-- `/report:executive` → publicar informes en wiki
-- `/confluence:publish` → alternativa para equipos con Confluence
+- `/wiki-sync` → sincronización bidireccional wiki ↔ local
+- `/report-executive` → publicar informes en wiki
+- `/confluence-publish` → alternativa para equipos con Confluence
 
 ## Restricciones
 

--- a/.claude/commands/wiki-sync.md
+++ b/.claude/commands/wiki-sync.md
@@ -9,7 +9,7 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-> Uso: `/wiki:sync --project {p}` o `/wiki:sync --project {p} --direction {dir}`
+> Uso: `/wiki-sync --project {p}` o `/wiki-sync --project {p} --direction {dir}`
 
 ## Parámetros
 
@@ -59,9 +59,9 @@ Sincronizados: 5 | Solo local: 2 | Solo wiki: 1 | Conflictos: 1
 
 ## Integración
 
-- `/wiki:publish` → publicar páginas individuales
-- `/notion:sync` → patrón similar para Notion
-- `/confluence:publish` → patrón similar para Confluence
+- `/wiki-publish` → publicar páginas individuales
+- `/notion-sync` → patrón similar para Notion
+- `/confluence-publish` → patrón similar para Confluence
 
 ## Restricciones
 

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -21,7 +21,7 @@
       "headers": {
         "Authorization": "Bearer CARGAR_DESDE_FICHERO"
       },
-      "_note": "Miro MCP oficial (HTTP, OAuth 2.1). Sustituir CARGAR_DESDE_FICHERO por el token real, o configurar: export MIRO_TOKEN=$(cat $HOME/.azure/miro-token). Configurar con /diagram:config --tool miro"
+      "_note": "Miro MCP oficial (HTTP, OAuth 2.1). Sustituir CARGAR_DESDE_FICHERO por el token real, o configurar: export MIRO_TOKEN=$(cat $HOME/.azure/miro-token). Configurar con /diagram-config --tool miro"
     }
   }
 }

--- a/.claude/rules/domain/azure-repos-config.md
+++ b/.claude/rules/domain/azure-repos-config.md
@@ -1,7 +1,7 @@
 # Regla: Configuración Azure Repos
 
 > Configuración para gestión de repositorios Git en Azure DevOps.
-> Carga bajo demanda cuando se usan comandos `repos:*`.
+> Carga bajo demanda cuando se usan comandos `repos-*`.
 
 ## Proveedor Git por proyecto
 

--- a/.claude/rules/domain/context-health.md
+++ b/.claude/rules/domain/context-health.md
@@ -24,7 +24,7 @@ Formato obligatorio para resultados extensos:
    Top crítico: SQL injection en AuthController (3 sprints sin resolver)
 
 📄 Detalle completo: output/audits/YYYYMMDD-audit-proyecto.md
-💡 Siguiente paso: /project:release-plan --project proyecto
+💡 Siguiente paso: /project-release-plan --project proyecto
 ```
 
 ## 2. Uso de subagentes para tareas pesadas
@@ -36,10 +36,10 @@ El subagente trabaja en contexto aislado y devuelve solo el resumen.
 Esto evita que el análisis intermedio contamine el contexto principal.
 
 **Comandos que DEBEN usar subagente:**
-- `/project:audit` → subagente analiza repo, devuelve scores + hallazgos
-- `/evaluate:repo` → subagente clona y analiza, devuelve puntuaciones
-- `/legacy:assess` → subagente evalúa 6 dimensiones, devuelve scoring
-- `/spec:generate` → subagente genera spec, guarda en fichero
+- `/project-audit` → subagente analiza repo, devuelve scores + hallazgos
+- `/evaluate-repo` → subagente clona y analiza, devuelve puntuaciones
+- `/legacy-assess` → subagente evalúa 6 dimensiones, devuelve scoring
+- `/spec-generate` → subagente genera spec, guarda en fichero
 - Cualquier comando que lea más de 5 ficheros internamente
 
 ## 3. Compactación proactiva
@@ -73,7 +73,7 @@ Cada sesión debería tener UN objetivo claro:
 - "Planificar Sprint 5" → planning + asignación
 - "Implementar feature X" → spec + implement + test
 
-Si el PM cambia de objetivo, sugerir `/clear` + nuevo `/context:load`.
+Si el PM cambia de objetivo, sugerir `/clear` + nuevo `/context-load`.
 
 ### Antipatrones a evitar
 - ❌ Mezclar auditoría + implementación + reporting en una sesión
@@ -93,8 +93,8 @@ Cada proyecto mantiene estado en disco (no en contexto):
 Los comandos LEEN estos ficheros cuando los necesitan.
 No necesitan que la información esté en el contexto de conversación.
 
-### `/context:load` como punto de partida
-Al iniciar sesión, `/context:load` lee el estado de disco y muestra
+### `/context-load` como punto de partida
+Al iniciar sesión, `/context-load` lee el estado de disco y muestra
 un resumen conciso. No carga todo — solo lo justo para orientar al PM.
 
 ## 6. Límites de carga bajo demanda

--- a/.claude/rules/domain/diagram-config.md
+++ b/.claude/rules/domain/diagram-config.md
@@ -1,7 +1,7 @@
 # Regla: Configuración de Diagramas de Arquitectura
 # ── Constantes y configuración para generación e importación de diagramas ────
 
-> Esta regla se carga bajo demanda cuando se ejecutan comandos `diagram:*`.
+> Esta regla se carga bajo demanda cuando se ejecutan comandos `diagram-*`.
 
 ```
 # ── MCP Tools disponibles ────────────────────────────────────────────────────

--- a/.claude/rules/domain/environment-config.md
+++ b/.claude/rules/domain/environment-config.md
@@ -161,7 +161,7 @@ TELEMETRY_KEY=                # Application Insights / Datadog key
 
 ## Detección Automática de Entorno
 
-Al cargar un proyecto (`/context:load`), detectar entornos por:
+Al cargar un proyecto (`/context-load`), detectar entornos por:
 
 | Señal | Interpretación |
 |---|---|

--- a/.claude/rules/domain/infrastructure-as-code.md
+++ b/.claude/rules/domain/infrastructure-as-code.md
@@ -267,11 +267,11 @@ tags = {
 
 | Comando | Descripción |
 |---|---|
-| `/infra:detect {proyecto} {env}` | Detectar infraestructura existente del proyecto en un entorno |
-| `/infra:plan {proyecto} {env}` | Generar plan de infraestructura para un entorno |
-| `/infra:estimate {proyecto}` | Estimar costes de infraestructura por entorno |
-| `/infra:scale {recurso}` | Proponer escalado de un recurso (requiere aprobación) |
-| `/infra:status {proyecto}` | Estado de la infraestructura actual del proyecto |
+| `/infra-detect {proyecto} {env}` | Detectar infraestructura existente del proyecto en un entorno |
+| `/infra-plan {proyecto} {env}` | Generar plan de infraestructura para un entorno |
+| `/infra-estimate {proyecto}` | Estimar costes de infraestructura por entorno |
+| `/infra-scale {recurso}` | Proponer escalado de un recurso (requiere aprobación) |
+| `/infra-status {proyecto}` | Estado de la infraestructura actual del proyecto |
 
 ---
 

--- a/.claude/rules/domain/language-packs.md
+++ b/.claude/rules/domain/language-packs.md
@@ -24,7 +24,7 @@
 
 ## Detección automática
 
-Al cargar un proyecto (`/context:load`), detectar el Language Pack por archivos presentes:
+Al cargar un proyecto (`/context-load`), detectar el Language Pack por archivos presentes:
 
 | Archivo | Language Pack |
 |---|---|

--- a/.claude/rules/domain/mcp-migration.md
+++ b/.claude/rules/domain/mcp-migration.md
@@ -47,7 +47,7 @@ y los MCP tools equivalentes de `@azure-devops/mcp`.
    que no está cubierto por ningún MCP tool. Necesario para dashboards de burndown.
 
 2. **`get_team_capacities`** — Usa Work API (`teamsettings/iterations/{id}/capacities`)
-   que no está cubierto por MCP. Necesario para `/report:capacity` y `/project:assign`.
+   que no está cubierto por MCP. Necesario para `/report-capacity` y `/project-assign`.
 
 3. **`get_velocity_history`** (parcial) — MCP puede listar iteraciones (`get_team_iterations`)
    pero el cálculo de SP completados por sprint requiere WIQL por cada iteración.
@@ -61,7 +61,7 @@ y los MCP tools equivalentes de `@azure-devops/mcp`.
 
 ### Ahora (MCP via Claude):
 ```
-PM: /sprint:status --project sala-reservas
+PM: /sprint-status --project sala-reservas
 → Claude usa MCP: run_wiql_query con la WIQL del sprint actual
 → Claude usa MCP: get_work_item para cada ID
 → Claude formatea y presenta el dashboard

--- a/.claude/rules/domain/messaging-config.md
+++ b/.claude/rules/domain/messaging-config.md
@@ -123,10 +123,10 @@ brew install ffmpeg         # macOS
 
 ### Modo 1 — Manual (sin infraestructura)
 
-El PM ejecuta `/inbox:check` cuando quiere ver si hay mensajes nuevos.
+El PM ejecuta `/inbox-check` cuando quiere ver si hay mensajes nuevos.
 
 ```
-PM: /inbox:check
+PM: /inbox-check
 → Revisando WhatsApp... 3 mensajes nuevos (1 audio)
 → Revisando Nextcloud Talk... 0 mensajes nuevos
 →
@@ -135,7 +135,7 @@ PM: /inbox:check
 →   [10:22] Pedro López: "Por mí bien, pero falta revisar el PR #42"
 →   [10:30] Ana García: 🎤 Audio (12s) → Transcripción:
 →     "Oye, ¿puedes ponerme el estado del sprint? Que no me da tiempo a mirarlo"
-→     → Comando sugerido: /sprint:status --project sala-reservas
+→     → Comando sugerido: /sprint-status --project sala-reservas
 →     → ¿Ejecutar? (s/n)
 ```
 
@@ -143,11 +143,11 @@ PM: /inbox:check
 
 ### Modo 2 — Background polling (sesión activa)
 
-Al iniciar sesión, el PM lanza `/inbox:start` y un proceso en background
+Al iniciar sesión, el PM lanza `/inbox-start` y un proceso en background
 revisa los canales cada N minutos mientras la sesión esté abierta.
 
 ```
-PM: /inbox:start --interval 5
+PM: /inbox-start --interval 5
 → ✅ Inbox monitor iniciado (cada 5 min)
 → Canales activos: WhatsApp ✅, Nextcloud Talk ✅
 → Task ID: bg-inbox-7a3f (ver con /tasks)
@@ -156,7 +156,7 @@ PM: /inbox:start --interval 5
 →
 → 📩 [11:45] Nuevo mensaje de voz en WhatsApp:
 →   Ana García: 🎤 Audio (8s) → "Descompón el PBI 1234 en tareas"
-→   → Comando sugerido: /pbi:decompose 1234
+→   → Comando sugerido: /pbi-decompose 1234
 →   → ¿Ejecutar? (s/n)
 ```
 
@@ -164,16 +164,16 @@ PM: /inbox:start --interval 5
 El proceso se detiene automáticamente al cerrar la sesión.
 
 ```
-PM: /inbox:start                    # Iniciar con intervalo por defecto (5 min)
-PM: /inbox:start --interval 2      # Revisar cada 2 minutos
-PM: /inbox:start --channels wa      # Solo WhatsApp
-PM: /inbox:start --channels nctalk  # Solo Nextcloud Talk
+PM: /inbox-start                    # Iniciar con intervalo por defecto (5 min)
+PM: /inbox-start --interval 2      # Revisar cada 2 minutos
+PM: /inbox-start --channels wa      # Solo WhatsApp
+PM: /inbox-start --channels nctalk  # Solo Nextcloud Talk
 ```
 
 ### Modo 3 — Listener persistente (24/7)
 
 Un microservicio que corre como daemon, escuchando webhooks y polling.
-Encola mensajes en `inbox/pending.json` para que `/inbox:check` los lea.
+Encola mensajes en `inbox/pending.json` para que `/inbox-check` los lea.
 
 ```bash
 # Opción A: Script Python como servicio systemd
@@ -184,7 +184,7 @@ sudo systemctl enable --now inbox-listener
 # Opción B: Docker
 docker run -d --name pm-inbox \
   -v ~/.whatsapp-mcp:/data/whatsapp \
-  -v ./inbox:/data/inbox \
+  -v ./inbox-/data/inbox \
   -e NCTALK_WEBHOOK_PORT=8085 \
   pm-workspace/inbox-listener
 ```
@@ -194,7 +194,7 @@ incluso cuando el PM no tiene Claude Code abierto.
 Los mensajes se acumulan y se procesan en la siguiente sesión.
 
 ```
-PM: /inbox:check
+PM: /inbox-check
 → 📬 12 mensajes acumulados desde 2026-02-27 18:00
 →   WhatsApp: 8 mensajes (2 audios)
 →   Nextcloud Talk: 4 mensajes (0 audios)
@@ -203,7 +203,7 @@ PM: /inbox:check
 →   → No mapea a comando → archivado como nota informativa
 →
 → 🎤 Audio 2 (Pedro, 14:30): "Hazme un report de horas del proyecto"
-→   → Comando sugerido: /report:hours --project sala-reservas
+→   → Comando sugerido: /report-hours --project sala-reservas
 →   → ¿Ejecutar? (s/n)
 ```
 

--- a/.claude/rules/languages/java-conventions.md
+++ b/.claude/rules/languages/java-conventions.md
@@ -93,8 +93,8 @@ mvn test -pl {module}                          # tests de un módulo
 
 ```bash
 mvn versions:display-dependency-updates        # ver actualizaciones
-mvn dependency:analyze                         # dependencias no usadas
-mvn dependency:tree                            # árbol de dependencias
+mvn dependency-analyze                         # dependencias no usadas
+mvn dependency-tree                            # árbol de dependencias
 mvn org.owasp:dependency-check-maven:check     # vulnerabilidades (OWASP)
 ```
 

--- a/.claude/skills/azure-pipelines/references/stage-patterns.md
+++ b/.claude/skills/azure-pipelines/references/stage-patterns.md
@@ -96,8 +96,8 @@ variables:
 
 | Evento pipeline | Acción PM-Workspace |
 |---|---|
-| Build fallida | `/pipeline:logs` → investigar → crear Bug si recurrente |
+| Build fallida | `/pipeline-logs` → investigar → crear Bug si recurrente |
 | Deploy PRE OK | Notificar equipo → preparar Sprint Review demo |
 | Deploy PRO OK | Actualizar PBI state → Closed |
-| Approval pendiente | `/pipeline:status` muestra alerta |
-| Coverage < 80% | Alerta en `/kpi:dashboard` |
+| Approval pendiente | `/pipeline-status` muestra alerta |
+| Coverage < 80% | Alerta en `/kpi-dashboard` |

--- a/.claude/skills/capacity-planning/SKILL.md
+++ b/.claude/skills/capacity-planning/SKILL.md
@@ -176,5 +176,5 @@ curl -s -X PATCH \
 ## Referencias
 → Skill principal: `azure-devops-queries/SKILL.md`
 → Script de cálculo: `scripts/capacity-calculator.py`
-→ Comando: `/report:capacity`
+→ Comando: `/report-capacity`
 → Esta skill es prerequisito de `pbi-decomposition/SKILL.md` (Fase 4: perfil de disponibilidad del equipo)

--- a/.claude/skills/diagram-generation/SKILL.md
+++ b/.claude/skills/diagram-generation/SKILL.md
@@ -8,7 +8,7 @@ Generar diagramas de arquitectura, flujo de datos y secuencia a partir de la inf
 
 ## Triggers
 
-- Comando `/diagram:generate` — Genera diagrama completo
+- Comando `/diagram-generate` — Genera diagrama completo
 - Petición directa: "genera el diagrama de arquitectura del proyecto X"
 
 ---
@@ -176,7 +176,7 @@ Crear/actualizar `projects/{p}/diagrams/{tool}/{tipo}.meta.json`:
 📁 Metadata: projects/{p}/diagrams/{tool}/{tipo}.meta.json
 📝 Mermaid local: projects/{p}/diagrams/local/{tipo}.mermaid
 
-¿Quieres importar este diagrama para generar Features/PBIs? → /diagram:import
+¿Quieres importar este diagrama para generar Features/PBIs? → /diagram-import
 ```
 
 ---

--- a/.claude/skills/diagram-import/SKILL.md
+++ b/.claude/skills/diagram-import/SKILL.md
@@ -10,7 +10,7 @@ Importar diagramas de arquitectura (Draw.io, Miro, Mermaid local), extraer entid
 
 ## Triggers
 
-- Comando `/diagram:import` — Importación completa
+- Comando `/diagram-import` — Importación completa
 - Petición directa: "importa el diagrama y crea los PBIs"
 
 ---
@@ -258,8 +258,8 @@ SP total: ~{SP}
 📊 Metadata actualizada: projects/{p}/diagrams/{tool}/{tipo}.meta.json
 
 Siguiente paso recomendado:
-  → /pbi:decompose-batch {ids} para refinar estimaciones y asignaciones
-  → /sprint:plan para planificar el sprint con los nuevos PBIs
+  → /pbi-decompose-batch {ids} para refinar estimaciones y asignaciones
+  → /sprint-plan para planificar el sprint con los nuevos PBIs
 ```
 
 ---

--- a/.claude/skills/diagram-import/references/missing-info-request-template.md
+++ b/.claude/skills/diagram-import/references/missing-info-request-template.md
@@ -23,12 +23,12 @@ Para completar la importación, necesito que proporciones la información
 marcada como faltante. Puedes:
 
 1. **Actualizar `projects/{proyecto}/reglas-negocio.md`** con la información
-   y volver a ejecutar `/diagram:import`
+   y volver a ejecutar `/diagram-import`
 2. **Proporcionar la información aquí** y la añado al fichero
 3. **Generar solo las entidades completas** (parcial)
 
 ---
-Generado por PM-Workspace — /diagram:import
+Generado por PM-Workspace — /diagram-import
 ```
 
 ## Solicitud por entidad (para modo interactivo)

--- a/.claude/skills/executive-reporting/SKILL.md
+++ b/.claude/skills/executive-reporting/SKILL.md
@@ -183,4 +183,4 @@ Tablas:         Cabecera azul oscuro (#003865) texto blanco, filas alternas blan
 → KPIs calculados: `docs/kpis-equipo.md`
 → Plantillas: `docs/plantillas-informes.md`
 → Script generador: `scripts/report-generator.js`
-→ Comando: `/report:executive`
+→ Comando: `/report-executive`

--- a/.claude/skills/pbi-decomposition/SKILL.md
+++ b/.claude/skills/pbi-decomposition/SKILL.md
@@ -10,9 +10,9 @@ Esta skill combina análisis de código fuente, conocimiento del dominio del pro
 
 ## Triggers
 
-- Comando `/pbi:decompose` — Descompone uno o varios PBIs
-- Comando `/pbi:assign` — Solo asignación (si las Tasks ya existen)
-- Comando `/pbi:plan-sprint` — Descompone + estima + asigna todos los PBIs candidatos para un sprint
+- Comando `/pbi-decompose` — Descompone uno o varios PBIs
+- Comando `/pbi-assign` — Solo asignación (si las Tasks ya existen)
+- Comando `/pbi-plan-sprint` — Descompone + estima + asigna todos los PBIs candidatos para un sprint
 - Petición directa: "descompón el PBI #1234", "crea las tareas del PBI #1234", "asigna las tareas del sprint"
 
 ---
@@ -419,9 +419,9 @@ curl -s -u ":$PAT" \
    ├────┼─────────────────────────────────────────────┼──────────┼──────┼──────────────┼────────────────┤
    │ B1 │ Crear entidad Patient + value objects        │ 2h       │ Dev  │ María G.     │ human          │
    │ B2 │ Migration EF Core: tabla Patients            │ 1h       │ Dev  │ María G.     │ human          │
-   │ B3 │ Handler CreatePatientCommand + validación    │ 4h       │ Dev  │ 🤖 agent     │ agent:single   │
-   │ B4 │ Endpoint POST /api/patients + DTO            │ 2h       │ Dev  │ 🤖 agent     │ agent:single   │
-   │ D1 │ Unit tests CreatePatientCommandHandler       │ 3h       │ Dev  │ 🤖 agent     │ agent:single   │
+   │ B3 │ Handler CreatePatientCommand + validación    │ 4h       │ Dev  │ 🤖 agent     │ agent-single   │
+   │ B4 │ Endpoint POST /api/patients + DTO            │ 2h       │ Dev  │ 🤖 agent     │ agent-single   │
+   │ D1 │ Unit tests CreatePatientCommandHandler       │ 3h       │ Dev  │ 🤖 agent     │ agent-single   │
    │ D2 │ Integration test endpoint POST /patients     │ 2h       │ Dev  │ Carlos R.    │ human          │
    │ D3 │ Validación criterios aceptación              │ 2h       │ Test │ Ana L.       │ human          │
    │ E1 │ Code review                                  │ 1h       │ Dev  │ Pedro T. (TL)│ human          │
@@ -457,22 +457,22 @@ Tras crear las Tasks:
 
 ## Slash Commands
 
-### /pbi:decompose {id} [--project {nombre}] [--dry-run]
+### /pbi-decompose {id} [--project {nombre}] [--dry-run]
 
 Descompone un PBI en Tasks con estimaciones y propuesta de asignación.
 - `--dry-run`: Solo muestra la propuesta, no crea nada en Azure DevOps
 - Default: dry-run (siempre mostrar antes de crear)
 
-### /pbi:decompose-batch {id1,id2,id3} [--project {nombre}]
+### /pbi-decompose-batch {id1,id2,id3} [--project {nombre}]
 
 Descompone varios PBIs a la vez, optimizando las asignaciones en conjunto para equilibrar la carga global del equipo.
 
-### /pbi:assign {pbi_id} [--rebalance]
+### /pbi-assign {pbi_id} [--rebalance]
 
 Asigna (o reasigna) las Tasks existentes de un PBI según el algoritmo de asignación.
 - `--rebalance`: Redistribuye considerando la carga actual del sprint completo
 
-### /pbi:plan-sprint [--project {nombre}] [--sprint "Sprint N"]
+### /pbi-plan-sprint [--project {nombre}] [--sprint "Sprint N"]
 
 Flujo completo para Sprint Planning:
 1. Obtener PBIs candidatos (Approved, priorizados)

--- a/.claude/skills/product-discovery/SKILL.md
+++ b/.claude/skills/product-discovery/SKILL.md
@@ -20,11 +20,11 @@ Dos documentos que preceden la descomposición técnica:
 ```
 PBI en Azure DevOps
     ↓
-/pbi:jtbd {id}          ← business-analyst genera JTBD
+/pbi-jtbd {id}          ← business-analyst genera JTBD
     ↓
-/pbi:prd {id}           ← business-analyst genera PRD (lee JTBD)
+/pbi-prd {id}           ← business-analyst genera PRD (lee JTBD)
     ↓
-/pbi:decompose {id}     ← flujo existente (architect + spec-writer + ...)
+/pbi-decompose {id}     ← flujo existente (architect + spec-writer + ...)
 ```
 
 ## Cuándo NO usar

--- a/.claude/skills/product-discovery/references/prd-template.md
+++ b/.claude/skills/product-discovery/references/prd-template.md
@@ -95,7 +95,7 @@ Scenario: [Nombre del escenario]
 
 - [ ] Product Owner / Stakeholder confirma los requisitos
 - [ ] Business Analyst valida la coherencia con reglas de negocio
-- [ ] Listo para pasar a `architect` y `pbi:decompose`
+- [ ] Listo para pasar a `architect` y `pbi-decompose`
 
 ---
 

--- a/.claude/skills/spec-driven-development/SKILL.md
+++ b/.claude/skills/spec-driven-development/SKILL.md
@@ -21,8 +21,8 @@ Un **Developer** en este workspace puede ser:
 | Tipo | Descripción | Cuándo usar |
 |------|-------------|-------------|
 | `human` | Desarrollador humano del equipo | Lógica de dominio compleja, decisiones de arquitectura, código con alta ambigüedad |
-| `agent:single` | Un Claude Code agent ejecutando la Spec | Tasks bien definidas, patrones repetitivos, boilerplate, tests |
-| `agent:team` | Varios agentes Claude especializados en paralelo | Tasks grandes que se benefician de separación (implementer + tester + reviewer) |
+| `agent-single` | Un Claude Code agent ejecutando la Spec | Tasks bien definidas, patrones repetitivos, boilerplate, tests |
+| `agent-team` | Varios agentes Claude especializados en paralelo | Tasks grandes que se benefician de separación (implementer + tester + reviewer) |
 
 La Spec es el **contrato** que hace posible esta dualidad: debe ser suficientemente precisa para que un agente la implemente correctamente, y suficientemente expresiva para que un humano entienda el "por qué".
 
@@ -52,7 +52,7 @@ Cada proyecto define en su `CLAUDE.md` la sección `sdd_layer_assignment`. Si no
 
 ### 1.2 Factores de decisión
 
-**Favorecen `agent:single` o `agent:team`:**
+**Favorecen `agent-single` o `agent-team`:**
 - La task tiene un patrón claro y repetible en el proyecto
 - El output es determinístico dado el input (tests, DTOs, validators, mappers)
 - Existen ejemplos similares en el código fuente que el agente puede seguir
@@ -67,7 +67,7 @@ Cada proyecto define en su `CLAUDE.md` la sección `sdd_layer_assignment`. Si no
 - El PBI tiene criterios de aceptación incompletos o vagos
 - La Task es `E1: Code Review` → **siempre humano**
 
-**Favorecen `agent:team`:**
+**Favorecen `agent-team`:**
 - La Task es grande (> 6h) Y bien definida
 - Beneficia de separación de responsabilidades (un agente implementa, otro escribe tests)
 - La velocidad es crítica y hay budget de tokens disponible
@@ -145,7 +145,7 @@ El agente necesita acceso a:
 2. El código fuente del módulo — para seguir patrones existentes
 3. Los ficheros de reglas relevantes — `docs/reglas-negocio.md`, `projects/{proyecto}/reglas-negocio.md`
 
-### 3.2 Prompt de invocación para `agent:single`
+### 3.2 Prompt de invocación para `agent-single`
 
 ```bash
 # Invocar Claude Code como subagente
@@ -165,7 +165,7 @@ claude --model $CLAUDE_MODEL_AGENT \
    - Si detectas que la Spec es incompleta o ambigua, actualiza 'Blockers' en la Spec y detente"
 ```
 
-### 3.3 Patrón `agent:team` — Agentes especializados en paralelo
+### 3.3 Patrón `agent-team` — Agentes especializados en paralelo
 
 Para tasks grandes, se lanza un equipo de agentes con roles distintos:
 
@@ -260,8 +260,8 @@ Registrar en `projects/{proyecto}/specs/sdd-metrics.md`:
 ```markdown
 | Sprint | Task ID | Developer Type | Spec Quality | Impl OK? | Review Issues | Horas Estimadas | Horas Reales |
 |--------|---------|---------------|--------------|----------|---------------|----------------|--------------|
-| 2026-04 | AB#1234-B3 | agent:single | ✅ Completa | ✅ | 0 | 4h | 3.5h |
-| 2026-04 | AB#1234-D1 | agent:single | ✅ Completa | ✅ | 1 (naming) | 3h | 2h |
+| 2026-04 | AB#1234-B3 | agent-single | ✅ Completa | ✅ | 0 | 4h | 3.5h |
+| 2026-04 | AB#1234-D1 | agent-single | ✅ Completa | ✅ | 1 (naming) | 3h | 2h |
 | 2026-04 | AB#1235-B3 | human | ✅ Completa | ✅ | 0 | 6h | 7h |
 ```
 
@@ -281,4 +281,4 @@ Principio: **"Si el agente falla, la Spec no era suficientemente buena"**
 → Matrix de asignación por capa: `references/layer-assignment-matrix.md`
 → Patrones de agent team: `references/agent-team-patterns.md`
 → Skill base: `../pbi-decomposition/SKILL.md`
-→ Comandos: `/spec:generate`, `/spec:implement`, `/spec:review`, `/spec:status`, `/agent:run`
+→ Comandos: `/spec-generate`, `/spec-implement`, `/spec-review`, `/spec-status`, `/agent-run`

--- a/.claude/skills/spec-driven-development/references/agent-team-patterns.md
+++ b/.claude/skills/spec-driven-development/references/agent-team-patterns.md
@@ -261,7 +261,7 @@ N agentes en paralelo, cada uno implementando un handler diferente que sigue el 
 ### Cuándo usar
 - Sprint con múltiples Commands/Queries del mismo módulo
 - Todos siguen el mismo patrón (validar → consultar → crear → persistir)
-- Se han detectado las Specs de todos como `agent:single`
+- Se han detectado las Specs de todos como `agent-single`
 
 ### Invocación
 ```bash
@@ -273,9 +273,9 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 for SPEC_FILE in $SPRINT_DIR/*.spec.md; do
   SPEC_BASENAME=$(basename $SPEC_FILE .spec.md)
 
-  # Solo procesar specs marcadas como agent:single (no human)
+  # Solo procesar specs marcadas como agent-single (no human)
   DEVELOPER_TYPE=$(grep "^\*\*Developer Type:\*\*" $SPEC_FILE | awk '{print $NF}')
-  if [ "$DEVELOPER_TYPE" != "agent:single" ]; then
+  if [ "$DEVELOPER_TYPE" != "agent-single" ]; then
     echo "⏭️  Saltando $SPEC_BASENAME (Developer Type: $DEVELOPER_TYPE)"
     continue
   fi
@@ -388,8 +388,8 @@ Dos agentes modificando `DependencyInjection.cs` → pérdida de cambios de uno 
 ### ❌ Reviewer que modifica código
 El agente reviewer es read-only. Si modifica código → loop infinito de correcciones. Solo reporta.
 
-### ❌ `agent:team` para tasks < 4h
-El overhead de coordinación y el coste de tokens supera el ahorro. Usar `agent:single`.
+### ❌ `agent-team` para tasks < 4h
+El overhead de coordinación y el coste de tokens supera el ahorro. Usar `agent-single`.
 
 ### ❌ Agente para Code Review (E1)
 El Code Review siempre lo realiza un humano. Siempre. Sin excepción.

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-angular.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-angular.md
@@ -22,11 +22,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| Crear Guard funcional (autenticación simple) | `agent:single` | Patrón fijo: verificar token → retornar true/false/redirect |
+| Crear Guard funcional (autenticación simple) | `agent-single` | Patrón fijo: verificar token → retornar true/false/redirect |
 | Implementar Guard con lógica compleja | `human` | Decisiones de autorización multi-rol requieren revisión |
-| Crear Interceptor (logging, timing) | `agent:single` | Patrón predecible: wrap request → call next → return response |
+| Crear Interceptor (logging, timing) | `agent-single` | Patrón predecible: wrap request → call next → return response |
 | Implementar Interceptor de error global | `human` | Decisiones de manejo de errores afectan a toda la app |
-| Servicio singleton (Auth, Config) | `agent:single` si patrón existe / `human` si es nuevo | Verificar si existe servicio similar |
+| Servicio singleton (Auth, Config) | `agent-single` si patrón existe / `human` si es nuevo | Verificar si existe servicio similar |
 
 ---
 
@@ -34,10 +34,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| Componente presentacional (UI puro) | `agent:single` | Sin lógica de estado; entrada=@Input, salida=@Output |
-| Pipe simple (formato fecha, moneda) | `agent:single` | Transformación mecánica de datos |
-| Directiva de utilidad (highlight, autofocus) | `agent:single` | Patrón fijo: @Directive + @HostListener/Binding |
-| Componente con @Input/@Output clara | `agent:single` | Contrato definido: inputs/outputs especificados |
+| Componente presentacional (UI puro) | `agent-single` | Sin lógica de estado; entrada=@Input, salida=@Output |
+| Pipe simple (formato fecha, moneda) | `agent-single` | Transformación mecánica de datos |
+| Directiva de utilidad (highlight, autofocus) | `agent-single` | Patrón fijo: @Directive + @HostListener/Binding |
+| Componente con @Input/@Output clara | `agent-single` | Contrato definido: inputs/outputs especificados |
 | Componente con lógica de estado | `human` | Requiere entendimiento de flujos de datos |
 
 ---
@@ -46,12 +46,12 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Smart Component** (con Signal + consulta) | `agent:single` si spec clara / `human` si lógica compleja | Patrón: `signal()` + servicio + `computed()` |
-| **Dumb Component** (presentación) | `agent:single` | Recibe data por @Input, emite eventos por @Output |
-| **Servicio local del feature** (queries, mutations) | `agent:single` | Métodos CRUD delegados a backend |
+| **Smart Component** (con Signal + consulta) | `agent-single` si spec clara / `human` si lógica compleja | Patrón: `signal()` + servicio + `computed()` |
+| **Dumb Component** (presentación) | `agent-single` | Recibe data por @Input, emite eventos por @Output |
+| **Servicio local del feature** (queries, mutations) | `agent-single` | Métodos CRUD delegados a backend |
 | **RxJS observable con lógica de transformación** | `human` | `switchMap`, `mergeMap`, operadores requieren expertise |
 | **Manejo de estado con NgRx (feature store)** | `human` | Actions, reducers, effects requieren diseño arquitectónico |
-| **Formulario Reactive complejo** | `agent:single` si validadores simples / `human` si validators custom | Depende de reglas de negocio |
+| **Formulario Reactive complejo** | `agent-single` si validadores simples / `human` si validators custom | Depende de reglas de negocio |
 
 ---
 
@@ -59,10 +59,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **HTTP GET/POST básico** (HttpClient) | `agent:single` | Patrón fijo: `this.http.get<T>(url)` |
-| **Query con parámetros** | `agent:single` | Construcción de HttpParams mecánica |
+| **HTTP GET/POST básico** (HttpClient) | `agent-single` | Patrón fijo: `this.http.get<T>(url)` |
+| **Query con parámetros** | `agent-single` | Construcción de HttpParams mecánica |
 | **Error handling genérico** | `human` | Decisiones de retry, fallback, logging |
-| **Request/Response mapping** | `agent:single` | Transformación de DTOs mecánica |
+| **Request/Response mapping** | `agent-single` | Transformación de DTOs mecánica |
 
 ---
 
@@ -70,11 +70,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Pipe** | `agent:single` | Entrada/salida determinada |
-| **Unit Test — Directive** | `agent:single` | Comportamiento DOM predecible |
-| **Component Test — Presentacional** | `agent:single` | Sin dependencias complejas; inputs/outputs claros |
-| **Component Test — Smart component** | `agent:single` si spec clara / `human` si mocking complejo | Puede requerir MockService, fixture setup |
-| **Service Test** | `agent:single` | Métodos desacoplados, mocks de HTTP claros |
+| **Unit Test — Pipe** | `agent-single` | Entrada/salida determinada |
+| **Unit Test — Directive** | `agent-single` | Comportamiento DOM predecible |
+| **Component Test — Presentacional** | `agent-single` | Sin dependencias complejas; inputs/outputs claros |
+| **Component Test — Smart component** | `agent-single` si spec clara / `human` si mocking complejo | Puede requerir MockService, fixture setup |
+| **Service Test** | `agent-single` | Métodos desacoplados, mocks de HTTP claros |
 | **E2E Test** (Cypress) | `human` | Flujos completos de usuario; criterios de test |
 | **Visual Regression Test** | `human` | Decisiones sobre umbrales visuales |
 
@@ -85,7 +85,7 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** | `human` siempre | Por definición, requiere un humano |
-| **Documentación de componentes** (Storybook) | `agent:single` con revisión humana | Generar historias de componentes |
+| **Documentación de componentes** (Storybook) | `agent-single` con revisión humana | Generar historias de componentes |
 | **Actualización de Angular** (ng update) | `human` | Cambios de breaking, dependencias |
 | **Optimización de performance** (OnPush, lazy loading) | `human` | Decisiones de arquitectura |
 
@@ -93,7 +93,7 @@ El Tech Lead tiene siempre la última palabra.
 
 ## Heurísticas de Decisión Rápida
 
-### ✅ Task ideal para `agent:single`
+### ✅ Task ideal para `agent-single`
 
 Marca al menos 4 de estos:
 - [ ] Existe componente similar en el codebase
@@ -103,9 +103,9 @@ Marca al menos 4 de estos:
 - [ ] Sin lógica de validación custom
 - [ ] El Tech Lead puede verificar solo revisando el code
 
-### ✅ Task ideal para `agent:team`
+### ✅ Task ideal para `agent-team`
 
-Además de criterios de `agent:single`:
+Además de criterios de `agent-single`:
 - [ ] Feature completa con smart + dumb components + tests
 - [ ] ≥ 6h de trabajo
 - [ ] Roles separados: UI vs Logic vs Tests

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-go.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-go.md
@@ -23,9 +23,9 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear entidad de dominio (struct) | `human` | Decisiones de identidad y encapsulación |
-| Añadir Value Object immutable (struct + private fields) | `agent:single` | Patrón claro: constructor factory + equals |
-| Definir interfaz de repositorio | `agent:single` | Firma predecible, patrón idéntico |
-| Crear Domain Event (struct) | `agent:single` | Estructura fija con propiedades |
+| Añadir Value Object immutable (struct + private fields) | `agent-single` | Patrón claro: constructor factory + equals |
+| Definir interfaz de repositorio | `agent-single` | Firma predecible, patrón idéntico |
+| Crear Domain Event (struct) | `agent-single` | Estructura fija con propiedades |
 | Implementar regla de negocio compleja | `human` | Requiere entendimiento del negocio |
 
 ---
@@ -34,9 +34,9 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Use Case / Service CRUD** | `agent:single` | Patrón: validate → check rules → execute → return error |
-| **Query / Service para GetByID, List** | `agent:single` | Patrón: fetch → map → return data |
-| **DTO / Request structs** | `agent:single` | Modelos planos con validación tags |
+| **Use Case / Service CRUD** | `agent-single` | Patrón: validate → check rules → execute → return error |
+| **Query / Service para GetByID, List** | `agent-single` | Patrón: fetch → map → return data |
+| **DTO / Request structs** | `agent-single` | Modelos planos con validación tags |
 | **Use Case con lógica compleja** | `human` | El agente puede equivocarse en orquestación |
 | **Application Service (orquestación) complejo** | `human` | Alto riesgo si no está perfectamente especificado |
 
@@ -46,9 +46,9 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio (sqlc o sqlx)** | `agent:single` | Patrón: query → scan → return; derivable del schema |
+| **Implementación de Repositorio (sqlc o sqlx)** | `agent-single` | Patrón: query → scan → return; derivable del schema |
 | **HTTP Client** | `human` | Depende de documentación externa; alto riesgo |
-| **Email / Notification Service** | `agent:single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
+| **Email / Notification Service** | `agent-single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
 | **Caché Implementation** (Redis) | `human` | Decisiones de TTL, invalidación y coherencia |
 | **Background Job / Scheduled Task** | `human` | Ciclo de vida, concurrencia, context management |
 | **Mensaje Queue Consumer** | `human` | At-least-once, idempotencia, error handling |
@@ -60,10 +60,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **HTTP Handler CRUD** | `agent:single` | Patrón: decode request → call service → encode response |
-| **Handler con validación de entrada** | `agent:single` | Validación tags en structs |
-| **Router setup y structure** | `agent:single` | Organización mecánica de rutas |
-| **Middleware simple** (logging) | `agent:single` | Patrón predecible: wrap handler |
+| **HTTP Handler CRUD** | `agent-single` | Patrón: decode request → call service → encode response |
+| **Handler con validación de entrada** | `agent-single` | Validación tags en structs |
+| **Router setup y structure** | `agent-single` | Organización mecánica de rutas |
+| **Middleware simple** (logging) | `agent-single` | Patrón predecible: wrap handler |
 | **Authorization middleware complejo** | `human` | Decisiones de control de acceso |
 | **Global error handling** | `human` | Afecta toda la aplicación |
 
@@ -73,10 +73,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Use Case / Service** | `agent:single` | Los test scenarios están en la Spec |
-| **Unit Test — Domain** | `agent:single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
+| **Unit Test — Use Case / Service** | `agent-single` | Los test scenarios están en la Spec |
+| **Unit Test — Domain** | `agent-single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
 | **Integration Test** (sqlc + DB) | `human` | Require setup, TestContainers, fixtures |
-| **HTTP Handler Test** | `agent:single` si patrón existe | Verificar que hay tests similares |
+| **HTTP Handler Test** | `agent-single` si patrón existe | Verificar que hay tests similares |
 | **Performance / Load Tests** | `human` | Decisiones sobre umbrales |
 
 ---

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-java.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-java.md
@@ -23,9 +23,9 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear entidad de dominio (Sealed class, Record) | `human` | Decisiones de identidad y encapsulación |
-| Añadir Value Object (Record immutable) | `agent:single` | Patrón claro: Record con equals/hashCode automáticos |
-| Definir interfaz de repositorio | `agent:single` | Firma predecible, patrón idéntico |
-| Crear Domain Event (Record) | `agent:single` | Estructura fija: record con propiedades |
+| Añadir Value Object (Record immutable) | `agent-single` | Patrón claro: Record con equals/hashCode automáticos |
+| Definir interfaz de repositorio | `agent-single` | Firma predecible, patrón idéntico |
+| Crear Domain Event (Record) | `agent-single` | Estructura fija: record con propiedades |
 | Implementar regla de dominio compleja | `human` | Requiere entendimiento del negocio |
 
 ---
@@ -34,11 +34,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Command Handler (CRUD Create/Update/Delete)** | `agent:single` | Patrón fijo: validate → check rules → execute → persist → return Result |
-| **Query Handler (Get by ID, List con paginación)** | `agent:single` | Patrón fijo: fetch → map → return DTO |
-| **DTO / Request / Response** | `agent:single` | Modelos planos, sin lógica; Record o @Data |
-| **Validator con FluentValidation** | `agent:single` | Completamente derivable de la Spec |
-| **MapStruct Profile** (Entity ↔ DTO) | `agent:single` | Mapeo mecánico |
+| **Command Handler (CRUD Create/Update/Delete)** | `agent-single` | Patrón fijo: validate → check rules → execute → persist → return Result |
+| **Query Handler (Get by ID, List con paginación)** | `agent-single` | Patrón fijo: fetch → map → return DTO |
+| **DTO / Request / Response** | `agent-single` | Modelos planos, sin lógica; Record o @Data |
+| **Validator con FluentValidation** | `agent-single` | Completamente derivable de la Spec |
+| **MapStruct Profile** (Entity ↔ DTO) | `agent-single` | Mapeo mecánico |
 | **Command/Query con lógica de dominio compleja** | `human` | El agente puede equivocarse en la orquestación |
 | **Application Service (orquestación) complejo** | `human` | Alto riesgo si no está perfectamente especificado |
 
@@ -48,11 +48,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio (JPA)** | `agent:single` | Patrón fijo: operaciones CRUD derivables del schema |
-| **Entity Configuration (Fluent API JPA)** | `agent:single` | Completamente derivable del modelo de dominio |
+| **Implementación de Repositorio (JPA)** | `agent-single` | Patrón fijo: operaciones CRUD derivables del schema |
+| **Entity Configuration (Fluent API JPA)** | `agent-single` | Completamente derivable del modelo de dominio |
 | **Migration (Flyway)** | `human` ⚠️ | Las migraciones afectan BD de producción — siempre revisión |
 | **HTTP Client** (RestTemplate, WebClient) | `human` | Depende de documentación externa; alto riesgo |
-| **Email / Notification Service** | `agent:single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
+| **Email / Notification Service** | `agent-single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
 | **Caché Implementation** (Redis) | `human` | Decisiones de TTL, invalidación y coherencia |
 | **Background Service / Scheduler** | `human` | Ciclo de vida y concurrencia requieren expertise |
 | **Messaging Consumer** (Kafka, RabbitMQ) | `human` | At-least-once, idempotencia, DLQ handling |
@@ -63,11 +63,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Endpoint CRUD estándar** (REST) | `agent:single` | Patrón fijo: @Post/Get/Put/Delete → dispatch → return response |
-| **Endpoint con validación de entrada** | `agent:single` | @Valid + DTO con Bean Validation |
+| **Endpoint CRUD estándar** (REST) | `agent-single` | Patrón fijo: @Post/Get/Put/Delete → dispatch → return response |
+| **Endpoint con validación de entrada** | `agent-single` | @Valid + DTO con Bean Validation |
 | **Endpoint con autorización compleja** | `human` | Reglas de acceso: rol + tenant + ownership |
-| **DTO de API** (separado de Application) | `agent:single` | Modelos planos |
-| **Swagger / OpenAPI annotations** | `agent:single` | Decoradores mecánicos |
+| **DTO de API** (separado de Application) | `agent-single` | Modelos planos |
+| **Swagger / OpenAPI annotations** | `agent-single` | Decoradores mecánicos |
 | **Global Exception Handler** | `human` | Afecta toda la aplicación |
 | **Authentication/Authorization config** | `human` | Seguridad: siempre revisión humana |
 
@@ -77,10 +77,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Handler (Command/Query)** | `agent:single` | Los test scenarios están en la Spec |
-| **Unit Test — Domain** | `agent:single` si Spec incluye escenarios / `human` si no | Requiere definición clara de escenarios |
+| **Unit Test — Handler (Command/Query)** | `agent-single` | Los test scenarios están en la Spec |
+| **Unit Test — Domain** | `agent-single` si Spec incluye escenarios / `human` si no | Requiere definición clara de escenarios |
 | **Integration Test** (JpaRepository + DB) | `human` | Require setup de infraestructura, TestContainers |
-| **API Test** (WebMvcTest, MockMvc) | `agent:single` si patrón existe | Verificar que hay tests API similares |
+| **API Test** (WebMvcTest, MockMvc) | `agent-single` si patrón existe | Verificar que hay tests API similares |
 | **Performance / Load Tests** | `human` | Decisiones sobre umbrales aceptables |
 
 ---
@@ -90,7 +90,7 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** | `human` siempre | Por definición, requiere un humano |
-| **Documentación técnica** (README, ADRs) | `agent:single` con revisión humana | Agente genera borrador; humano valida |
+| **Documentación técnica** (README, ADRs) | `agent-single` con revisión humana | Agente genera borrador; humano valida |
 | **Actualización de dependencias** | `human` | Cambios de breaking, compatibilidad |
 | **Optimización de performance** | `human` | Decisiones de índices, caching, queries |
 
@@ -98,7 +98,7 @@ El Tech Lead tiene siempre la última palabra.
 
 ## Heurísticas de Decisión Rápida
 
-### ✅ Task ideal para `agent:single`
+### ✅ Task ideal para `agent-single`
 
 Marca al menos 4 de estos:
 - [ ] Existe al menos 1 ejemplo del mismo tipo en el codebase
@@ -109,9 +109,9 @@ Marca al menos 4 de estos:
 - [ ] No requiere conocimiento de sistemas externos sin documentar
 - [ ] El Tech Lead puede verificar sin ejecutar el código
 
-### ✅ Task ideal para `agent:team`
+### ✅ Task ideal para `agent-team`
 
-Además de criterios de `agent:single`:
+Además de criterios de `agent-single`:
 - [ ] La task es ≥ 6h de implementación
 - [ ] Los roles están claramente separados (código + tests)
 - [ ] No hay dependencias fuertes entre implementador y tester

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-php.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-php.md
@@ -23,11 +23,11 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear entidad de dominio (Entity, Aggregate) | `human` | Decisiones de identidad y encapsulación |
-| Añadir Value Object (immutable class) | `agent:single` | Patrón claro: constructor privado + factory + equals |
-| Definir interfaz de repositorio | `agent:single` | Firma predecible, patrón idéntico |
-| Crear Domain Event (class) | `agent:single` | Estructura fija con propiedades |
+| Añadir Value Object (immutable class) | `agent-single` | Patrón claro: constructor privado + factory + equals |
+| Definir interfaz de repositorio | `agent-single` | Firma predecible, patrón idéntico |
+| Crear Domain Event (class) | `agent-single` | Estructura fija con propiedades |
 | Implementar regla de dominio compleja | `human` | Requiere entendimiento del negocio |
-| Crear Specification (filtrado complejo) | `agent:single` si simple / `human` si complejo | Depende de lógica del criterio |
+| Crear Specification (filtrado complejo) | `agent-single` si simple / `human` si complejo | Depende de lógica del criterio |
 
 ---
 
@@ -35,10 +35,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Use Case / Action CRUD** | `agent:single` | Patrón: validate → check rules → execute → return |
-| **Query / Finder para GetByID, List** | `agent:single` | Patrón: fetch → map → return DTO |
-| **DTO / Data Transfer Object** | `agent:single` | Modelos con validación automática |
-| **Laravel Validator** | `agent:single` | Completamente derivable de la Spec |
+| **Use Case / Action CRUD** | `agent-single` | Patrón: validate → check rules → execute → return |
+| **Query / Finder para GetByID, List** | `agent-single` | Patrón: fetch → map → return DTO |
+| **DTO / Data Transfer Object** | `agent-single` | Modelos con validación automática |
+| **Laravel Validator** | `agent-single` | Completamente derivable de la Spec |
 | **Use Case con lógica de dominio compleja** | `human` | El agente puede equivocarse en orquestación |
 | **Service Orchestration** | `human` | Alto riesgo si no está perfectamente especificado |
 
@@ -48,12 +48,12 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio (Eloquent)** | `agent:single` | Patrón: query → map → return; derivable del modelo |
-| **Eloquent Model** (sin lógica de negocio) | `agent:single` | Mapeo mecánico de propiedades |
+| **Implementación de Repositorio (Eloquent)** | `agent-single` | Patrón: query → map → return; derivable del modelo |
+| **Eloquent Model** (sin lógica de negocio) | `agent-single` | Mapeo mecánico de propiedades |
 | **HTTP Client** (GuzzleHttp) | `human` | Depende de documentación externa; alto riesgo |
-| **Email / Notification Service** | `agent:single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
+| **Email / Notification Service** | `agent-single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
 | **Caché Implementation** (Redis, File) | `human` | Decisiones de TTL, invalidación y coherencia |
-| **Background Job / Queue** (Queued Mail) | `agent:single` si patrón existe / `human` si nuevo | Ciclo de vida y retry logic |
+| **Background Job / Queue** (Queued Mail) | `agent-single` si patrón existe / `human` si nuevo | Ciclo de vida y retry logic |
 | **Database Migration** | `human` ⚠️ | Las migraciones afectan BD de producción |
 
 ---
@@ -62,12 +62,12 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Controller CRUD estándar** (REST) | `agent:single` | Patrón: validate → dispatch action → return response |
-| **Request Validator** | `agent:single` | Laravel Form Request Rules derivables |
-| **Resource** (JSON serialization) | `agent:single` | Mapeo de model → JSON |
+| **Controller CRUD estándar** (REST) | `agent-single` | Patrón: validate → dispatch action → return response |
+| **Request Validator** | `agent-single` | Laravel Form Request Rules derivables |
+| **Resource** (JSON serialization) | `agent-single` | Mapeo de model → JSON |
 | **Controller con autorización compleja** | `human` | Decisiones de control de acceso y policies |
 | **Middleware transversal** | `human` | Afecta toda la aplicación |
-| **API versioning** | `agent:single` si estructura existe | Organización mecánica de rutas |
+| **API versioning** | `agent-single` si estructura existe | Organización mecánica de rutas |
 
 ---
 
@@ -75,11 +75,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Action / Service** | `agent:single` | Los test scenarios están en la Spec |
-| **Unit Test — Domain** | `agent:single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
-| **Feature Test** (Laravel tests) | `agent:single` | Integración controller + action con fixtures |
+| **Unit Test — Action / Service** | `agent-single` | Los test scenarios están en la Spec |
+| **Unit Test — Domain** | `agent-single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
+| **Feature Test** (Laravel tests) | `agent-single` | Integración controller + action con fixtures |
 | **Integration Test** (Eloquent + DB) | `human` | Require setup, factories, seeding |
-| **API Test** (HTTP assertions) | `agent:single` si patrón existe | Verificar que hay tests similares |
+| **API Test** (HTTP assertions) | `agent-single` si patrón existe | Verificar que hay tests similares |
 
 ---
 
@@ -88,7 +88,7 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** | `human` siempre | Por definición |
-| **Documentación técnica** (README, ADRs) | `agent:single` con revisión humana | Borrador automático |
+| **Documentación técnica** (README, ADRs) | `agent-single` con revisión humana | Borrador automático |
 | **Actualización de Laravel** (composer update) | `human` | Breaking changes, dependencias |
 | **Optimización de performance** (eager loading, indexing) | `human` | Decisiones arquitectónicas |
 
@@ -96,7 +96,7 @@ El Tech Lead tiene siempre la última palabra.
 
 ## Heurísticas de Decisión Rápida
 
-### ✅ Task ideal para `agent:single`
+### ✅ Task ideal para `agent-single`
 
 Marca al menos 4 de estos:
 - [ ] Existe al menos 1 ejemplo del mismo tipo en el codebase

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-python.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-python.md
@@ -23,9 +23,9 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear entidad de dominio (dataclass, Pydantic BaseModel) | `human` | Decisiones de identidad y encapsulación |
-| Añadir Value Object immutable (frozen dataclass, NamedTuple) | `agent:single` | Patrón claro: immutable + equals automáticos |
-| Definir interfaz de repositorio (Protocol) | `agent:single` | Firma predecible, patrón idéntico |
-| Crear Domain Event (dataclass) | `agent:single` | Estructura fija con propiedades |
+| Añadir Value Object immutable (frozen dataclass, NamedTuple) | `agent-single` | Patrón claro: immutable + equals automáticos |
+| Definir interfaz de repositorio (Protocol) | `agent-single` | Firma predecible, patrón idéntico |
+| Crear Domain Event (dataclass) | `agent-single` | Estructura fija con propiedades |
 | Implementar regla de dominio compleja | `human` | Requiere entendimiento del negocio |
 
 ---
@@ -34,10 +34,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Use Case / Service CRUD (Create/Update/Delete)** | `agent:single` | Patrón: validate → check rules → execute → return Result |
-| **Query / Service para Get by ID, List** | `agent:single` | Patrón: fetch → map → return DTO |
-| **DTO / Pydantic Schema** | `agent:single` | Modelos con validación automática |
-| **Validator con Pydantic** | `agent:single` | Completamente derivable de la Spec |
+| **Use Case / Service CRUD (Create/Update/Delete)** | `agent-single` | Patrón: validate → check rules → execute → return Result |
+| **Query / Service para Get by ID, List** | `agent-single` | Patrón: fetch → map → return DTO |
+| **DTO / Pydantic Schema** | `agent-single` | Modelos con validación automática |
+| **Validator con Pydantic** | `agent-single` | Completamente derivable de la Spec |
 | **Use Case con lógica de dominio compleja** | `human` | El agente puede equivocarse en orquestación |
 | **Application Service (orquestación) complejo** | `human` | Alto riesgo si no está perfectamente especificado |
 
@@ -47,9 +47,9 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio (SQLAlchemy)** | `agent:single` | Patrón: query → map → return; derivable del schema |
+| **Implementación de Repositorio (SQLAlchemy)** | `agent-single` | Patrón: query → map → return; derivable del schema |
 | **HTTP Client** (httpx async) | `human` | Depende de documentación externa; alto riesgo |
-| **Email / Notification Service** | `agent:single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
+| **Email / Notification Service** | `agent-single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
 | **Caché Implementation** (Redis) | `human` | Decisiones de TTL, invalidación y coherencia |
 | **Background Job / Scheduled Task** (Celery) | `human` | Ciclo de vida, concurrencia, retry logic |
 | **Mensaje Queue Consumer** (Kafka, RabbitMQ) | `human` | At-least-once, idempotencia, DLQ handling |
@@ -61,13 +61,13 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Endpoint CRUD estándar** (FastAPI router) | `agent:single` | Patrón: @post/@get/@put/@delete → dispatch → return |
-| **Endpoint con validación de entrada** | `agent:single` | Pydantic schema + path/query params |
-| **Router grouping y estructura** | `agent:single` | Organización mecánica de APIRouter |
-| **Dependency Injection setup** | `agent:single` | Patrón: Depends(get_db), Depends(get_service) |
+| **Endpoint CRUD estándar** (FastAPI router) | `agent-single` | Patrón: @post/@get/@put/@delete → dispatch → return |
+| **Endpoint con validación de entrada** | `agent-single` | Pydantic schema + path/query params |
+| **Router grouping y estructura** | `agent-single` | Organización mecánica de APIRouter |
+| **Dependency Injection setup** | `agent-single` | Patrón: Depends(get_db), Depends(get_service) |
 | **Authorization/Permission setup** | `human` | Decisiones de control de acceso |
 | **Global exception handler** | `human` | Afecta toda la aplicación |
-| **OpenAPI/Swagger documentation** | `agent:single` | Tags, descriptions mecánicos |
+| **OpenAPI/Swagger documentation** | `agent-single` | Tags, descriptions mecánicos |
 
 ---
 
@@ -75,10 +75,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Use Case / Service** | `agent:single` | Los test scenarios están en la Spec |
-| **Unit Test — Domain** | `agent:single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
+| **Unit Test — Use Case / Service** | `agent-single` | Los test scenarios están en la Spec |
+| **Unit Test — Domain** | `agent-single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
 | **Integration Test** (SQLAlchemy + DB) | `human` | Require setup, TestContainers, fixtures |
-| **API Test** (FastAPI TestClient) | `agent:single` si patrón existe | Verificar que hay tests similares |
+| **API Test** (FastAPI TestClient) | `agent-single` si patrón existe | Verificar que hay tests similares |
 | **Performance / Load Tests** | `human` | Decisiones sobre umbrales |
 
 ---
@@ -88,7 +88,7 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** | `human` siempre | Por definición |
-| **Documentación técnica** (README, ADRs) | `agent:single` con revisión humana | Borrador automático |
+| **Documentación técnica** (README, ADRs) | `agent-single` con revisión humana | Borrador automático |
 | **Actualización de dependencias** | `human` | Breaking changes, compatibilidad |
 | **Optimización de performance** | `human` | Decisiones de índices, queries |
 

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-react.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-react.md
@@ -22,11 +22,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Componente presentacional (UI puro)** | `agent:single` | Sin estado, sin efectos; solo props y JSX |
-| **Componente Container (Client)** | `agent:single` si patrón simple / `human` si lógica compleja | Integra hooks y pasa props a presentacionales |
-| **Server Component** (Next.js) | `agent:single` si data fetch simple / `human` si transformación compleja | Patrón: `async` component → `<Suspense>` |
-| **Componente con children polymórfico** | `agent:single` | Composición con `React.ReactNode` claro |
-| **Componente con estado local (`useState`)** | `agent:single` | State management simple dentro del componente |
+| **Componente presentacional (UI puro)** | `agent-single` | Sin estado, sin efectos; solo props y JSX |
+| **Componente Container (Client)** | `agent-single` si patrón simple / `human` si lógica compleja | Integra hooks y pasa props a presentacionales |
+| **Server Component** (Next.js) | `agent-single` si data fetch simple / `human` si transformación compleja | Patrón: `async` component → `<Suspense>` |
+| **Componente con children polymórfico** | `agent-single` | Composición con `React.ReactNode` claro |
+| **Componente con estado local (`useState`)** | `agent-single` | State management simple dentro del componente |
 
 ---
 
@@ -34,11 +34,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Custom hook simple** (wrapping single state) | `agent:single` | Patrón fijo: `useState` + lógica + return `[state, handler]` |
-| **Custom hook con efectos simples** | `agent:single` | `useEffect` directo sin dependencias complejas |
-| **Custom hook con TanStack Query** | `agent:single` | Patrón: `useQuery` wrapper tipado con QueryFn clara |
+| **Custom hook simple** (wrapping single state) | `agent-single` | Patrón fijo: `useState` + lógica + return `[state, handler]` |
+| **Custom hook con efectos simples** | `agent-single` | `useEffect` directo sin dependencias complejas |
+| **Custom hook con TanStack Query** | `agent-single` | Patrón: `useQuery` wrapper tipado con QueryFn clara |
 | **Custom hook con múltiples efectos** | `human` | Orquestación de efectos requiere expertise |
-| **Custom hook con reducer** | `agent:single` si reducer simple / `human` si acciones complejas | Depende de complejidad del estado |
+| **Custom hook con reducer** | `agent-single` si reducer simple / `human` si acciones complejas | Depende de complejidad del estado |
 
 ---
 
@@ -46,11 +46,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Zustand store simple** (un slice) | `agent:single` | Patrón mecánico: `create()` → state + actions |
+| **Zustand store simple** (un slice) | `agent-single` | Patrón mecánico: `create()` → state + actions |
 | **Zustand store con múltiples slices** | `human` | Arquitectura de estado global requiere decisión |
-| **TanStack Query mutation** (POST/PUT/DELETE) | `agent:single` | Patrón fijo: `useMutation` → `mutate` → invalidar |
-| **TanStack Query query** | `agent:single` | Patrón: `useQuery` con QueryKey + QueryFn tipadas |
-| **Computed/derived state** | `agent:single` | `useMemo` o Zustand selector claro |
+| **TanStack Query mutation** (POST/PUT/DELETE) | `agent-single` | Patrón fijo: `useMutation` → `mutate` → invalidar |
+| **TanStack Query query** | `agent-single` | Patrón: `useQuery` con QueryKey + QueryFn tipadas |
+| **Computed/derived state** | `agent-single` | `useMemo` o Zustand selector claro |
 
 ---
 
@@ -58,10 +58,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Route page (Next.js)** | `agent:single` | Composición de componentes en `page.tsx` |
-| **Layout (Next.js)** | `agent:single` si estructura simple / `human` si providers complejos | Puede requerir Context/Providers |
-| **Error boundary** | `agent:single` | Patrón predecible: `error.tsx` captura y display |
-| **Loading UI** (`loading.tsx`) | `agent:single` | Simple skeleton o spinner |
+| **Route page (Next.js)** | `agent-single` | Composición de componentes en `page.tsx` |
+| **Layout (Next.js)** | `agent-single` si estructura simple / `human` si providers complejos | Puede requerir Context/Providers |
+| **Error boundary** | `agent-single` | Patrón predecible: `error.tsx` captura y display |
+| **Loading UI** (`loading.tsx`) | `agent-single` | Simple skeleton o spinner |
 | **Route handler** (`route.ts` API) | `human` | Lógica de negocio en el borde servidor/cliente |
 
 ---
@@ -70,10 +70,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Presentational component** | `agent:single` | Render + snapshot + props variations claras |
-| **Unit Test — Hook** (`renderHook`) | `agent:single` | Entrada/salida determinada |
-| **Unit Test — Utility function** | `agent:single` | Sin dependencias externas |
-| **Component Test — Container component** | `agent:single` si mocks simples / `human` si complejos | Puede requerir MockedProvider, fixtures |
+| **Unit Test — Presentational component** | `agent-single` | Render + snapshot + props variations claras |
+| **Unit Test — Hook** (`renderHook`) | `agent-single` | Entrada/salida determinada |
+| **Unit Test — Utility function** | `agent-single` | Sin dependencias externas |
+| **Component Test — Container component** | `agent-single` si mocks simples / `human` si complejos | Puede requerir MockedProvider, fixtures |
 | **Integration Test — Feature** | `human` | Flujos completos, múltiples componentes |
 | **E2E Test** (Playwright, Cypress) | `human` | Flujos de usuario completos |
 
@@ -84,16 +84,16 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** | `human` siempre | Por definición, requiere un humano |
-| **Documentación de componentes** (Storybook) | `agent:single` con revisión humana | Generar historias automáticas |
-| **Migración de propTypes a TypeScript** | `agent:single` | Mapeo mecánico de tipos |
+| **Documentación de componentes** (Storybook) | `agent-single` con revisión humana | Generar historias automáticas |
+| **Migración de propTypes a TypeScript** | `agent-single` | Mapeo mecánico de tipos |
 | **Optimización de performance** (React.memo, lazy loading) | `human` | Decisiones de arquitectura |
-| **Type safety refactor** | `agent:single` | Añadir tipos a código existente |
+| **Type safety refactor** | `agent-single` | Añadir tipos a código existente |
 
 ---
 
 ## Heurísticas de Decisión Rápida
 
-### ✅ Task ideal para `agent:single`
+### ✅ Task ideal para `agent-single`
 
 Marca al menos 4 de estos:
 - [ ] Existe componente similar en el codebase
@@ -103,9 +103,9 @@ Marca al menos 4 de estos:
 - [ ] Sin dependencias circulares o contexto complicado
 - [ ] El Tech Lead puede verificar revisando el code
 
-### ✅ Task ideal para `agent:team`
+### ✅ Task ideal para `agent-team`
 
-Además de criterios de `agent:single`:
+Además de criterios de `agent-single`:
 - [ ] Feature completa con múltiples componentes + hook + tests
 - [ ] ≥ 6h de trabajo
 - [ ] Roles separados: UI vs Logic vs Tests

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-rust.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-rust.md
@@ -23,9 +23,9 @@ El Tech Lead tiene siempre la última palabra.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear entidad de dominio (struct, enum) | `human` | Decisiones de identidad, lifetimes, ownership |
-| Añadir Value Object (newtype pattern, struct) | `agent:single` | Patrón claro: tipo fuerte con derive |
-| Definir trait de repositorio | `agent:single` | Firma predecible, patrón idéntico |
-| Crear Domain Event (struct, derive Clone) | `agent:single` | Estructura fija con propiedades |
+| Añadir Value Object (newtype pattern, struct) | `agent-single` | Patrón claro: tipo fuerte con derive |
+| Definir trait de repositorio | `agent-single` | Firma predecible, patrón idéntico |
+| Crear Domain Event (struct, derive Clone) | `agent-single` | Estructura fija con propiedades |
 | Implementar regla de negocio compleja | `human` | Requiere entendimiento del negocio |
 
 ---
@@ -34,11 +34,11 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Use Case / Service CRUD** | `agent:single` | Patrón: validate → check rules → execute → Result |
-| **Query / Service para GetByID, List** | `agent:single` | Patrón: fetch → map → return Result |
-| **DTO / Request structs (serde)** | `agent:single` | Modelos con serde::Serialize/Deserialize |
+| **Use Case / Service CRUD** | `agent-single` | Patrón: validate → check rules → execute → Result |
+| **Query / Service para GetByID, List** | `agent-single` | Patrón: fetch → map → return Result |
+| **DTO / Request structs (serde)** | `agent-single` | Modelos con serde::Serialize/Deserialize |
 | **Use Case con lógica compleja** | `human` | El agente puede equivocarse en orquestación |
-| **Error handling con thiserror/anyhow** | `agent:single` | Patrón: custom error type con Display |
+| **Error handling con thiserror/anyhow** | `agent-single` | Patrón: custom error type con Display |
 
 ---
 
@@ -46,9 +46,9 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio (sqlx)** | `agent:single` | Patrón: query → map → return Result |
+| **Implementación de Repositorio (sqlx)** | `agent-single` | Patrón: query → map → return Result |
 | **HTTP Client (reqwest)** | `human` | Depende de documentación externa; alto riesgo |
-| **Email / Notification Service** | `agent:single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
+| **Email / Notification Service** | `agent-single` si patrón existe / `human` si nuevo | Verificar si existe servicio similar |
 | **Caché Implementation** (Redis) | `human` | Decisiones de TTL, invalidación y coherencia |
 | **Background Job / Task** | `human` | Ciclo de vida, spawn logic, error recovery |
 | **Mensaje Queue Consumer** | `human` | At-least-once, idempotencia, error handling |
@@ -60,12 +60,12 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **HTTP Handler CRUD** (Axum) | `agent:single` | Patrón: decode → call service → encode response |
-| **Handler con validación** | `agent:single` | Axum extractors tipados |
-| **Router setup y structure** | `agent:single` | Organización mecánica de rutas |
-| **Middleware simple** (logging) | `agent:single` | Patrón predecible: tower middleware |
+| **HTTP Handler CRUD** (Axum) | `agent-single` | Patrón: decode → call service → encode response |
+| **Handler con validación** | `agent-single` | Axum extractors tipados |
+| **Router setup y structure** | `agent-single` | Organización mecánica de rutas |
+| **Middleware simple** (logging) | `agent-single` | Patrón predecible: tower middleware |
 | **Authorization middleware complejo** | `human` | Decisiones de control de acceso |
-| **Error responder** | `agent:single` | Error → HTTP response mapping |
+| **Error responder** | `agent-single` | Error → HTTP response mapping |
 
 ---
 
@@ -73,10 +73,10 @@ El Tech Lead tiene siempre la última palabra.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Test — Use Case / Service** | `agent:single` | Los test scenarios están en la Spec |
-| **Unit Test — Domain** | `agent:single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
+| **Unit Test — Use Case / Service** | `agent-single` | Los test scenarios están en la Spec |
+| **Unit Test — Domain** | `agent-single` si Spec incluye escenarios / `human` si no | Requiere definición clara |
 | **Integration Test** (sqlx + DB) | `human` | Require setup, TestContainers |
-| **HTTP Handler Test** (Axum) | `agent:single` si patrón existe | Verificar que hay tests similares |
+| **HTTP Handler Test** (Axum) | `agent-single` si patrón existe | Verificar que hay tests similares |
 | **Property-based Tests** (proptest) | `human` | Decisiones de estrategias de testing |
 
 ---

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix-typescript.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix-typescript.md
@@ -23,9 +23,9 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear nueva entidad de dominio (clase o interface) | `human` | Decisiones de encapsulación e invariantes de dominio |
-| Añadir Value Object inmutable | `agent:single` | Patrón claro: constructor privado + factory + equals |
-| Definir interfaz de repositorio | `agent:single` | Firma predecible, patrón idéntico entre módulos |
-| Crear Domain Event | `agent:single` | Estructura fija: interfaz con propiedades del evento |
+| Añadir Value Object inmutable | `agent-single` | Patrón claro: constructor privado + factory + equals |
+| Definir interfaz de repositorio | `agent-single` | Firma predecible, patrón idéntico entre módulos |
+| Crear Domain Event | `agent-single` | Estructura fija: interfaz con propiedades del evento |
 | Implementar regla de negocio compleja | `human` | Requiere entendimiento profundo del dominio |
 | Crear servicio de dominio (lógica inter-agregado) | `human` | Alto riesgo de diseño incorrecto |
 
@@ -35,14 +35,14 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Use Case / Command Handler** (CRUD básico) | `agent:single` | Patrón fijo: validar → verificar reglas → ejecutar → retornar Result |
-| **Query Handler** (Get by ID, listar con paginación) | `agent:single` | Patrón fijo: buscar → mapear → retornar DTO |
-| **DTO / Request / Response** | `agent:single` | Modelos planos, sin lógica; completamente determinado por inputs |
-| **Validator con reglas de dominio simples** | `agent:single` | Implementable directamente desde la Spec |
+| **Use Case / Command Handler** (CRUD básico) | `agent-single` | Patrón fijo: validar → verificar reglas → ejecutar → retornar Result |
+| **Query Handler** (Get by ID, listar con paginación) | `agent-single` | Patrón fijo: buscar → mapear → retornar DTO |
+| **DTO / Request / Response** | `agent-single` | Modelos planos, sin lógica; completamente determinado por inputs |
+| **Validator con reglas de dominio simples** | `agent-single` | Implementable directamente desde la Spec |
 | **Use Case con lógica de dominio compleja** | `human` | El agente puede equivocarse orquestando reglas nuevas |
 | **Servicio de aplicación (orquestación) complejo** | `human` | Alto riesgo si la orquestación no está perfectamente especificada |
 | **Event handler de integración** | `human` | Requiere entender contratos de otros sistemas |
-| **Mapper manual entre capas** | `agent:single` | Mapeo mecánico; si es repetitivo, usar librería (MapStruct TypeScript) |
+| **Mapper manual entre capas** | `agent-single` | Mapeo mecánico; si es repetitivo, usar librería (MapStruct TypeScript) |
 
 ---
 
@@ -50,9 +50,9 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio** (Prisma) | `agent:single` | Patrón fijo: operaciones CRUD derivables del schema |
+| **Implementación de Repositorio** (Prisma) | `agent-single` | Patrón fijo: operaciones CRUD derivables del schema |
 | **HTTP Client** (integración con API externa) | `human` | Depende de documentación externa; alto riesgo de integración |
-| **Email / Notification Service** | `agent:single` si sigue patrón existente / `human` si es nuevo | Verificar si existe servicio similar implementado |
+| **Email / Notification Service** | `agent-single` si sigue patrón existente / `human` si es nuevo | Verificar si existe servicio similar implementado |
 | **Caché Implementation** (Redis) | `human` | Decisiones de TTL, invalidación y coherencia requieren juicio |
 | **Background Job / Scheduled Task** | `human` | Ciclo de vida, concurrencia y recuperación de fallos requieren expertise |
 | **Mensaje Queue Consumer** (Kafka, RabbitMQ) | `human` | At-least-once, idempotencia, dead-letter handling requieren expertise |
@@ -64,13 +64,13 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Endpoint CRUD estándar** (Express/NestJS) | `agent:single` | Patrón fijo: [POST/GET/PUT/DELETE] → dispatch use case → return response |
-| **Endpoint con validación de entrada** (DTO + Zod) | `agent:single` | Patrón completamente derivable del schema |
-| **Route grouping y estructura REST** | `agent:single` | Organización mecánica de routers |
+| **Endpoint CRUD estándar** (Express/NestJS) | `agent-single` | Patrón fijo: [POST/GET/PUT/DELETE] → dispatch use case → return response |
+| **Endpoint con validación de entrada** (DTO + Zod) | `agent-single` | Patrón completamente derivable del schema |
+| **Route grouping y estructura REST** | `agent-single` | Organización mecánica de routers |
 | **Middleware transversal** (logging, timing) | `human` | Afecta toda la pipeline HTTP |
 | **Autorización compleja** (roles + ownership) | `human` | Lógica de control de acceso: requiere revisión de seguridad |
 | **Error handler global** | `human` | Afecta a toda la app; decisiones sobre respuestas de error |
-| **OpenAPI/Swagger annotations** | `agent:single` | Decoradores mecánicos si la estructura ya existe |
+| **OpenAPI/Swagger annotations** | `agent-single` | Decoradores mecánicos si la estructura ya existe |
 
 ---
 
@@ -78,10 +78,10 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Tests — Application Layer** (use cases, validators) | `agent:single` | Los escenarios están en la Spec; implementación mecánica |
-| **Unit Tests — Domain Layer** | `agent:single` si la Spec incluye escenarios / `human` si no | Requiere que la Spec defina claramente los escenarios de test |
+| **Unit Tests — Application Layer** (use cases, validators) | `agent-single` | Los escenarios están en la Spec; implementación mecánica |
+| **Unit Tests — Domain Layer** | `agent-single` si la Spec incluye escenarios / `human` si no | Requiere que la Spec defina claramente los escenarios de test |
 | **Integration Tests** (Prisma + DB) | `human` | Require setup de infraestructura, datos de prueba, fixtures |
-| **API Tests** (supertest o similar) | `agent:single` si sigue patrón existente | Verificar que hay tests API similares en el proyecto |
+| **API Tests** (supertest o similar) | `agent-single` si sigue patrón existente | Verificar que hay tests API similares en el proyecto |
 | **End-to-End Tests** | `human` | Requieren flujos completos de usuario y decisiones de coverage |
 | **Performance / Load Tests** | `human` | Decisiones sobre umbrales aceptables |
 
@@ -92,7 +92,7 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** | `human` siempre | Por definición, requiere un humano |
-| **Documentación técnica** (README, ADRs) | `agent:single` con revisión humana | El agente genera borrador; humano valida |
+| **Documentación técnica** (README, ADRs) | `agent-single` con revisión humana | El agente genera borrador; humano valida |
 | **Configuración de seguridad** (JWT, CORS, HTTPS) | `human` | Decisiones de seguridad: siempre revisión humana |
 | **Migration script** | `human` ⚠️ | Afecta a datos de producción |
 
@@ -100,7 +100,7 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 ## Heurísticas de Decisión Rápida
 
-### ✅ Task ideal para `agent:single`
+### ✅ Task ideal para `agent-single`
 
 Marca al menos 4 de estos:
 - [ ] Existe al menos 1 ejemplo del mismo tipo en el codebase
@@ -111,13 +111,13 @@ Marca al menos 4 de estos:
 - [ ] No requiere conocimiento de sistemas externos sin documentar
 - [ ] El Tech Lead puede verificar la corrección sin ejecutar el código
 
-### ✅ Task ideal para `agent:team`
+### ✅ Task ideal para `agent-team`
 
-Además de los criterios de `agent:single`:
+Además de los criterios de `agent-single`:
 - [ ] La task es ≥ 6h de implementación
 - [ ] Los roles están claramente separados (código producción vs tests)
 - [ ] No hay dependencias fuertes entre implementador y tester al inicio
-- [ ] Hay presupuesto de tokens disponible (agent:team consume ~3x más que agent:single)
+- [ ] Hay presupuesto de tokens disponible (agent-team consume ~3x más que agent-single)
 
 ### ❌ Task que DEBE ser `human`
 

--- a/.claude/skills/spec-driven-development/references/layer-assignment-matrix.md
+++ b/.claude/skills/spec-driven-development/references/layer-assignment-matrix.md
@@ -23,13 +23,13 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | Crear nueva entidad raíz de agregado | `human` | Decisiones de identidad y encapsulación de dominio |
-| Añadir Value Object simple (con validación) | `agent:single` | Patrón claro: constructor privado + factory method + equals |
-| Añadir propiedad a entidad existente (sin lógica) | `agent:single` | Mecánico, sigue el patrón existente |
-| Definir Domain Event | `agent:single` | Estructura fija: record inmutable con propiedades |
+| Añadir Value Object simple (con validación) | `agent-single` | Patrón claro: constructor privado + factory method + equals |
+| Añadir propiedad a entidad existente (sin lógica) | `agent-single` | Mecánico, sigue el patrón existente |
+| Definir Domain Event | `agent-single` | Estructura fija: record inmutable con propiedades |
 | Implementar regla de dominio compleja | `human` | Requiere entendimiento del negocio |
 | Crear Domain Service (lógica inter-agregado) | `human` | Alto riesgo de diseño incorrecto |
-| Definir interfaz de repositorio (`IPatientRepository`) | `agent:single` | Firma predecible, patrón idéntico entre módulos |
-| Crear Specification (patrón Specification) | `agent:single` si spec simple / `human` si compleja | Depende de la lógica de filtrado |
+| Definir interfaz de repositorio (`IPatientRepository`) | `agent-single` | Firma predecible, patrón idéntico entre módulos |
+| Crear Specification (patrón Specification) | `agent-single` si spec simple / `human` si compleja | Depende de la lógica de filtrado |
 
 ---
 
@@ -37,12 +37,12 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Command Handler** (Create/Update/Delete) | `agent:single` | Patrón fijo: validate → check business rules → create/modify → persist → return Result |
-| **Query Handler** (Get by ID, List con paginación) | `agent:single` | Patrón fijo: fetch → map → return DTO |
+| **Command Handler** (Create/Update/Delete) | `agent-single` | Patrón fijo: validate → check business rules → create/modify → persist → return Result |
+| **Query Handler** (Get by ID, List con paginación) | `agent-single` | Patrón fijo: fetch → map → return DTO |
 | **Command con lógica de dominio compleja** | `human` | El agente puede equivocarse en la orquestación de reglas de negocio nuevas |
-| **FluentValidation Validator** | `agent:single` | Completamente derivable de la Spec (tipos, restricciones, reglas de negocio simples) |
-| **AutoMapper Profile** | `agent:single` | Mapeo mecánico entre entidades y DTOs |
-| **DTO / Request / Response** | `agent:single` | Modelos de datos planos, sin lógica |
+| **FluentValidation Validator** | `agent-single` | Completamente derivable de la Spec (tipos, restricciones, reglas de negocio simples) |
+| **AutoMapper Profile** | `agent-single` | Mapeo mecánico entre entidades y DTOs |
+| **DTO / Request / Response** | `agent-single` | Modelos de datos planos, sin lógica |
 | **Pipeline Behavior** (logging, performance) | `human` | Afecta transversalmente a toda la app |
 | **Integration Event Handler** | `human` | Requiere entender contratos de otros sistemas |
 | **Application Service** (orquestación compleja) | `human` | Alto riesgo si la orquestación no está perfectamente especificada |
@@ -53,11 +53,11 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Implementación de Repositorio** (EF Core) | `agent:single` | Patrón fijo: DbSet operations, AsNoTracking para queries, SaveChangesAsync |
-| **Entity Configuration** (Fluent API EF Core) | `agent:single` | Completamente derivable del modelo de dominio |
+| **Implementación de Repositorio** (EF Core) | `agent-single` | Patrón fijo: DbSet operations, AsNoTracking para queries, SaveChangesAsync |
+| **Entity Configuration** (Fluent API EF Core) | `agent-single` | Completamente derivable del modelo de dominio |
 | **Migration** EF Core | `human` ⚠️ | Las migraciones afectan a la BD de producción — siempre revisión humana |
 | **External Service Client** (HTTP/REST) | `human` | Depende de documentación externa; alto riesgo de integración |
-| **Email / Notification Service** | `agent:single` si sigue patrón existente / `human` si es nuevo | Verificar si hay un servicio similar ya implementado |
+| **Email / Notification Service** | `agent-single` si sigue patrón existente / `human` si es nuevo | Verificar si hay un servicio similar ya implementado |
 | **Caché Implementation** | `human` | Decisiones de TTL, invalidación y coherencia requieren juicio |
 | **Background Service / Hosted Service** | `human` | Ciclo de vida y concurrencia requieren expertise |
 | **Azure Service Bus / Event Grid Consumer** | `human` | Integración con mensajería: at-least-once, idempotencia |
@@ -68,10 +68,10 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Endpoint CRUD estándar** (Controller Action) | `agent:single` | Patrón fijo: [HttpPost/Get/Put/Delete] → dispatch command/query → return ActionResult |
+| **Endpoint CRUD estándar** (Controller Action) | `agent-single` | Patrón fijo: [HttpPost/Get/Put/Delete] → dispatch command/query → return ActionResult |
 | **Endpoint con lógica de autorización compleja** | `human` | Reglas de acceso: rol + tenant + ownership |
-| **DTO de API** (separado del Application DTO) | `agent:single` | Modelos planos |
-| **Swagger / OpenAPI annotations** | `agent:single` | Decoradores mecánicos |
+| **DTO de API** (separado del Application DTO) | `agent-single` | Modelos planos |
+| **Swagger / OpenAPI annotations** | `agent-single` | Decoradores mecánicos |
 | **Middleware** | `human` | Afecta toda la pipeline HTTP |
 | **Authentication/Authorization config** | `human` | Seguridad: siempre revisión humana |
 | **SignalR Hub** | `human` | Gestión de conexiones concurrentes |
@@ -82,10 +82,10 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
-| **Unit Tests — Application Layer** (handlers, validators) | `agent:single` | Los test scenarios están en la Spec; el agente los implementa mecánicamente |
-| **Unit Tests — Domain Layer** | `agent:single` si la Spec incluye escenarios / `human` si no | Requiere que la Spec defina los escenarios |
+| **Unit Tests — Application Layer** (handlers, validators) | `agent-single` | Los test scenarios están en la Spec; el agente los implementa mecánicamente |
+| **Unit Tests — Domain Layer** | `agent-single` si la Spec incluye escenarios / `human` si no | Requiere que la Spec defina los escenarios |
 | **Integration Tests** | `human` | Requieren setup de infraestructura, datos de prueba, puertos |
-| **API Tests (WebApplicationFactory)** | `agent:single` si sigue patrón existente | Verificar que hay tests API similares en el proyecto |
+| **API Tests (WebApplicationFactory)** | `agent-single` si sigue patrón existente | Verificar que hay tests API similares en el proyecto |
 | **Performance / Load Tests** | `human` | Requieren decisiones sobre umbrales aceptables |
 | **Mutation Tests** | `human` | Análisis de cobertura de mutaciones: requiere criterio |
 
@@ -96,9 +96,9 @@ El Tech Lead tiene siempre la última palabra. Ver §Override Manual.
 | Tipo de Tarea | Developer Type | Justificación |
 |--------------|---------------|---------------|
 | **Code Review** (`E1`) | `human` siempre | Por definición, el Code Review requiere un humano |
-| **Documentación técnica** (README, ADRs) | `agent:single` con revisión humana | El agente genera el borrador; el humano lo valida |
+| **Documentación técnica** (README, ADRs) | `agent-single` con revisión humana | El agente genera el borrador; el humano lo valida |
 | **Script SQL de migración de datos** | `human` ⚠️ | Afecta datos de producción |
-| **Pipeline CI/CD** (YAML) | `agent:single` si sigue patrón existente | Si hay un pipeline similar de referencia |
+| **Pipeline CI/CD** (YAML) | `agent-single` si sigue patrón existente | Si hay un pipeline similar de referencia |
 | **Análisis de Performance / Profiling** | `human` | Requiere interpretación y decisiones |
 
 ---
@@ -119,7 +119,7 @@ sdd_layer_assignment:
 
     # Ejemplo: sprint de alta presión, maximizar uso de agentes
     - task_category: "D1"  # Unit tests
-      force: "agent:single"
+      force: "agent-single"
       reason: "Sprint 2026-04: velocidad crítica, todos los tests por agente"
 
     # Ejemplo: módulo crítico de seguridad
@@ -133,7 +133,7 @@ sdd_layer_assignment:
 El PM o Tech Lead puede sobreescribir el developer_type en la Spec directamente:
 
 ```markdown
-**Developer Type:** human    ← cambiado manualmente de agent:single
+**Developer Type:** human    ← cambiado manualmente de agent-single
 **Razón del override:** El PBI tiene criterios de aceptación incompletos en el área de validación
 ```
 
@@ -143,7 +143,7 @@ O en el work item en Azure DevOps con tags: `dev:human`, `dev:agent`, `dev:agent
 
 ## Heurísticas de Decisión Rápida
 
-### ✅ Task ideal para `agent:single`
+### ✅ Task ideal para `agent-single`
 
 Marca al menos 4 de estos:
 - [ ] Existe al menos 1 ejemplo del mismo tipo en el codebase
@@ -154,13 +154,13 @@ Marca al menos 4 de estos:
 - [ ] No requiere conocimiento de sistemas externos sin documentar
 - [ ] El Tech Lead puede verificar la corrección del output sin ejecutar el código
 
-### ✅ Task ideal para `agent:team`
+### ✅ Task ideal para `agent-team`
 
-Además de los criterios de `agent:single`:
+Además de los criterios de `agent-single`:
 - [ ] La task es ≥ 6h de implementación
 - [ ] Los roles están claramente separados (código producción vs tests)
 - [ ] No hay dependencias fuerte entre implementador y tester al inicio
-- [ ] Hay presupuesto de tokens disponible (agent:team consume ~3x más que agent:single)
+- [ ] Hay presupuesto de tokens disponible (agent-team consume ~3x más que agent-single)
 
 ### ❌ Task que DEBE ser `human`
 

--- a/.claude/skills/spec-driven-development/references/spec-template.md
+++ b/.claude/skills/spec-driven-development/references/spec-template.md
@@ -16,7 +16,7 @@
 **Fecha creación:** {YYYY-MM-DD}
 **Creado por:**     {PM/Tech Lead}
 
-**Developer Type:** human | agent:single | agent:team
+**Developer Type:** human | agent-single | agent-team
 **Asignado a:**     {nombre_dev | claude-agent | claude-agent-team}
 **Estimación:**     {Xh}
 **Estado:**         Pendiente | En Progreso | Completado | Bloqueado
@@ -304,7 +304,7 @@ dotnet test $TEST_PROJECT --filter "Category=Unit" --no-build
 **Último update:** {YYYY-MM-DD HH:MM}
 **Actualizado por:** {dev/agent}
 
-### Log de implementación (si agent:single o agent:team)
+### Log de implementación (si agent-single o agent-team)
 - {timestamp} — [AGENT] Iniciando implementación
 - {timestamp} — [AGENT] Handler creado: CreatePatientCommandHandler.cs
 - {timestamp} — [AGENT] Validator creado: CreatePatientCommandValidator.cs

--- a/.claude/skills/sprint-management/SKILL.md
+++ b/.claude/skills/sprint-management/SKILL.md
@@ -164,5 +164,5 @@ cp /tmp/sprint-items.json "$SPRINT_DIR/snapshots/$DATE-items.json"
 
 ## Referencias
 → Patrones WIQL: `references/wiql-patterns.md`
-→ Comandos disponibles: `/sprint:status`, `/sprint:plan`, `/sprint:review`, `/sprint:retro`
-→ Para descomponer los PBIs del sprint en tasks: `../pbi-decomposition/SKILL.md` y `/pbi:plan-sprint`
+→ Comandos disponibles: `/sprint-status`, `/sprint-plan`, `/sprint-review`, `/sprint-retro`
+→ Para descomponer los PBIs del sprint en tasks: `../pbi-decomposition/SKILL.md` y `/pbi-plan-sprint`

--- a/.claude/skills/team-onboarding/SKILL.md
+++ b/.claude/skills/team-onboarding/SKILL.md
@@ -20,13 +20,13 @@ Tres outputs que cubren el ciclo completo de incorporación:
 ```
 Nuevo miembro se incorpora al proyecto
     ↓
-/team:privacy-notice {nombre}     ← PM genera nota informativa RGPD
+/team-privacy-notice {nombre}     ← PM genera nota informativa RGPD
     ↓                                (trabajador lee, firma, se archiva)
-/team:onboarding {nombre}         ← Fases 1-2: contexto + tour del código
+/team-onboarding {nombre}         ← Fases 1-2: contexto + tour del código
     ↓                                (mentor valida cada fase)
   [Fase 3: primera task asistida]  ← Mentor asigna task B/C, pair programming con Claude
     ↓                                (Code Review humano obligatorio)
-/team:evaluate {nombre}            ← Fase 4: cuestionario interactivo de competencias
+/team-evaluate {nombre}            ← Fase 4: cuestionario interactivo de competencias
     ↓                                (autoevaluación + calibración Tech Lead)
   [Fase 5: autonomía progresiva]   ← Semanas 1-3 con supervisión decreciente
 ```
@@ -36,9 +36,9 @@ Nuevo miembro se incorpora al proyecto
 ## Cuándo NO usar
 
 - El miembro ya lleva >2 semanas productivo en el proyecto (ya está onboarded)
-- Cambio de proyecto de un miembro existente (usar solo `/team:evaluate` para actualizar dominio)
+- Cambio de proyecto de un miembro existente (usar solo `/team-evaluate` para actualizar dominio)
 - Becarios o personal de soporte que no escriben código (el cuestionario es para programadores)
-- Si no se ha entregado la nota informativa RGPD — `/team:evaluate` verificará esto
+- Si no se ha entregado la nota informativa RGPD — `/team-evaluate` verificará esto
 
 ## Almacenamiento
 
@@ -70,7 +70,7 @@ Las plantillas están en `references/`:
 
 - **PM/Scrum Master** — orquesta el proceso completo y genera la nota informativa
 - **Mentor humano** — valida fases 1-3, aprueba checkpoints
-- **business-analyst** — ejecuta la calibración de competencias (Fase 4) vía `/team:evaluate`
+- **business-analyst** — ejecuta la calibración de competencias (Fase 4) vía `/team-evaluate`
 - **Tech Lead** — co-firma la evaluación final de competencias
 
 ## Métricas de éxito

--- a/.claude/skills/team-onboarding/references/onboarding-checklist.md
+++ b/.claude/skills/team-onboarding/references/onboarding-checklist.md
@@ -8,9 +8,9 @@ Checklist para el **mentor** y el **nuevo miembro**. Cada fase tiene un criterio
 
 **Responsable:** PM + Mentor
 
-- [ ] Nota informativa RGPD entregada y firmada (`/team:privacy-notice`)
+- [ ] Nota informativa RGPD entregada y firmada (`/team-privacy-notice`)
 - [ ] Accesos configurados: Azure DevOps, repositorio Git, CI/CD, canales de comunicación
-- [ ] `/context:load` ejecutado en presencia del nuevo miembro
+- [ ] `/context-load` ejecutado en presencia del nuevo miembro
 - [ ] Claude explica la arquitectura general del proyecto
 - [ ] Mentor complementa con contexto que Claude no tiene (decisiones históricas, deuda técnica conocida, relaciones con el cliente)
 
@@ -56,7 +56,7 @@ Checklist para el **mentor** y el **nuevo miembro**. Cada fase tiene un criterio
 **Responsable:** PM + Nuevo miembro + Tech Lead
 
 - [ ] Verificar que la nota informativa RGPD está firmada
-- [ ] Ejecutar `/team:evaluate {nombre} --project {proyecto}`
+- [ ] Ejecutar `/team-evaluate {nombre} --project {proyecto}`
 - [ ] Nuevo miembro responde las secciones A (técnico), B (transversal), C (dominio)
 - [ ] Tech Lead revisa y calibra las respuestas (ajustar si discrepancia > ±1 nivel)
 - [ ] Ambos confirman el perfil final

--- a/.claude/skills/team-onboarding/references/privacy-notice-template.md
+++ b/.claude/skills/team-onboarding/references/privacy-notice-template.md
@@ -121,5 +121,5 @@ He leído y comprendo esta nota informativa sobre el tratamiento de mis datos de
 
 ---
 
-*Documento generado por pm-workspace — `/team:privacy-notice`*
+*Documento generado por pm-workspace — `/team-privacy-notice`*
 *Este documento no constituye un contrato ni solicita consentimiento. Informa sobre un tratamiento basado en interés legítimo (Art. 6.1.f RGPD).*

--- a/.claude/skills/time-tracking-report/SKILL.md
+++ b/.claude/skills/time-tracking-report/SKILL.md
@@ -168,4 +168,4 @@ El Word incluye: portada, tabla resumen por persona, tabla detalle con todos los
 ## Referencias
 → Script generador: `scripts/report-generator.js`
 → Plantilla de informes: `docs/plantillas-informes.md`
-→ Comando: `/report:hours`
+→ Comando: `/report-hours`

--- a/.claude/skills/voice-inbox/SKILL.md
+++ b/.claude/skills/voice-inbox/SKILL.md
@@ -64,13 +64,13 @@ Comandos disponibles: @.claude/rules/domain/pm-workflow.md
 
 | El PM dice... | Comando mapeado |
 |---|---|
-| "Ponme el estado del sprint de sala-reservas" | `/sprint:status --project sala-reservas` |
-| "¿Cómo va la deuda técnica?" | `/debt:track --project {activo}` |
-| "Descompón el PBI 1234 en tareas" | `/pbi:decompose 1234` |
-| "Genera el informe ejecutivo del sprint" | `/report:executive --project {activo}` |
-| "Hazme un audit del proyecto nuevo" | `/project:audit --project {activo}` |
-| "Manda el resumen del sprint al equipo por Slack" | `/notify:slack #equipo {resumen}` |
-| "¿Qué alertas de seguridad hay?" | `/security:alerts --project {activo}` |
+| "Ponme el estado del sprint de sala-reservas" | `/sprint-status --project sala-reservas` |
+| "¿Cómo va la deuda técnica?" | `/debt-track --project {activo}` |
+| "Descompón el PBI 1234 en tareas" | `/pbi-decompose 1234` |
+| "Genera el informe ejecutivo del sprint" | `/report-executive --project {activo}` |
+| "Hazme un audit del proyecto nuevo" | `/project-audit --project {activo}` |
+| "Manda el resumen del sprint al equipo por Slack" | `/notify-slack #equipo {resumen}` |
+| "¿Qué alertas de seguridad hay?" | `/security-alerts --project {activo}` |
 
 ### Casos ambiguos
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,25 +25,25 @@ body:
       label: Command or skill involved
       description: Which command or skill is affected?
       options:
-        - /sprint:status
-        - /sprint:plan
-        - /sprint:review
-        - /sprint:retro
-        - /report:hours
-        - /report:executive
-        - /report:capacity
-        - /team:workload
-        - /board:flow
-        - /kpi:dashboard
-        - /pbi:decompose
-        - /pbi:decompose-batch
-        - /pbi:assign
-        - /pbi:plan-sprint
-        - /spec:generate
-        - /spec:implement
-        - /spec:review
-        - /spec:status
-        - /agent:run
+        - /sprint-status
+        - /sprint-plan
+        - /sprint-review
+        - /sprint-retro
+        - /report-hours
+        - /report-executive
+        - /report-capacity
+        - /team-workload
+        - /board-flow
+        - /kpi-dashboard
+        - /pbi-decompose
+        - /pbi-decompose-batch
+        - /pbi-assign
+        - /pbi-plan-sprint
+        - /spec-generate
+        - /spec-implement
+        - /spec-review
+        - /spec-status
+        - /agent-run
         - scripts/test-workspace.sh
         - scripts/azdevops-queries.sh
         - Other (describe below)
@@ -86,7 +86,7 @@ body:
       description: Step-by-step instructions to reproduce the bug.
       placeholder: |
         1. Open Claude Code from pm-workspace/
-        2. Run /sprint:status --project ...
+        2. Run /sprint-status --project ...
         3. See error
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -47,7 +47,7 @@ body:
         How would this work? If it's a new command, what would you type and what would Claude respond?
         Include a sample conversation if possible.
       placeholder: |
-        Command: /risk:log --project ProyectoAlpha
+        Command: /risk-log --project ProyectoAlpha
         Claude: [reads sprint status and current risks]
                 [updates projects/proyecto-alpha/risks.md]
                 "3 active risks, 1 escalated to critical. See risks.md."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.15.0] — 2026-02-27
+
+Command naming fix: Claude Code only supports hyphens in slash command names, not colons. All 106 unique command references across 164 files renamed from colon notation (`/project:audit`) to hyphen notation (`/project-audit`). This fix ensures all documented commands actually work as slash commands.
+
+### Fixed
+
+**All command references renamed** — Colon notation (`/project:audit`, `/sprint:status`, etc.) replaced with hyphen notation (`/project-audit`, `/sprint-status`, etc.) across all documentation, commands, rules, skills, READMEs, CHANGELOG, guides, templates, and scripts. 164 files, 1203 lines changed.
+
+### Why
+
+Claude Code command names only support lowercase letters, numbers, and hyphens (max 64 chars). Colons were never valid — commands like `/project:audit` were interpreted as free text, not as slash commands. The actual command files already used hyphens (`project-audit.md`, `name: project-audit`), but all documentation referenced them with colons.
+
+---
+
 ## [0.14.1] — 2026-02-27
 
 Context optimization: auto-loaded baseline reduced by 79% (929 → 193 lines). All 10 domain rules moved to `rules/domain/` (loaded on-demand via `@` references). `/help` rewritten to separate `--setup` from catalog display.
@@ -32,14 +46,14 @@ Session persistence: knowledge no longer lost between sessions. Inspired by Obsi
 
 ### Added
 
-**`/session:save` command** — Captures decisions, results, modified files, and pending tasks before `/clear`. Saves to two destinations: session log (`output/sessions/`) and cumulative decision log (`decision-log.md`).
-**`decision-log.md`** — Private (git-ignored) cumulative register of PM decisions. Max 50 entries. Loaded by `/context:load` at session start.
+**`/session-save` command** — Captures decisions, results, modified files, and pending tasks before `/clear`. Saves to two destinations: session log (`output/sessions/`) and cumulative decision log (`decision-log.md`).
+**`decision-log.md`** — Private (git-ignored) cumulative register of PM decisions. Max 50 entries. Loaded by `/context-load` at session start.
 **`output/sessions/`** — Session history with full context for continuity.
 
 ### Changed
 
-**`/context:load` rewritten** — Now loads the "big picture": recent decisions from decision-log, last session's pending tasks, project health (last audit score, open debt, risks), plus git activity. Stack-aware (GitHub-only vs Azure DevOps).
-**Command count** — 81 → 83 commands (added session:save, help --setup as separate entry).
+**`/context-load` rewritten** — Now loads the "big picture": recent decisions from decision-log, last session's pending tasks, project health (last audit score, open debt, risks), plus git activity. Stack-aware (GitHub-only vs Azure DevOps).
+**Command count** — 81 → 83 commands (added session-save, help --setup as separate entry).
 
 ---
 
@@ -49,13 +63,13 @@ Fix silent failures: heavy commands (project-audit, evaluate-repo, legacy-assess
 
 ### Fixed
 
-**`/project:audit` silent failure** — At 100% context, the command produced zero output. Root cause: anti-improvisation rule prevented Claude from using subagents (not defined in command spec). Now explicitly delegates to `Task` subagent.
+**`/project-audit` silent failure** — At 100% context, the command produced zero output. Root cause: anti-improvisation rule prevented Claude from using subagents (not defined in command spec). Now explicitly delegates to `Task` subagent.
 
 ### Changed
 
-**`/project:audit`** — Rewritten: mandatory subagent delegation (§4), stack-aware prereqs (GitHub-only vs Azure DevOps), output-first summary.
-**`/evaluate:repo`** — Added mandatory subagent delegation for analysis.
-**`/legacy:assess`** — Added mandatory subagent delegation for analysis.
+**`/project-audit`** — Rewritten: mandatory subagent delegation (§4), stack-aware prereqs (GitHub-only vs Azure DevOps), output-first summary.
+**`/evaluate-repo`** — Added mandatory subagent delegation for analysis.
+**`/legacy-assess`** — Added mandatory subagent delegation for analysis.
 
 ---
 
@@ -141,12 +155,12 @@ UX Feedback Standards: Every command now provides consistent visual feedback —
 - Retry flow: fail → ask → save → retry → show result
 
 **6 core commands updated with UX feedback pattern:**
-- `/sprint:status` — banners, prerequisite checks, progress steps, completion summary
-- `/project:audit` — banners, interactive project creation if missing, 5-step progress, detailed completion
-- `/evaluate:repo` — banners, clone verification, 5-step progress, score summary
-- `/debt:track` — banners, parameter validation, 3-step progress, debt ratio summary
-- `/kpi:dora` — banners, prerequisite checks, 4-step progress, performer classification
-- `/context:load` — banners, 5-step progress, session summary
+- `/sprint-status` — banners, prerequisite checks, progress steps, completion summary
+- `/project-audit` — banners, interactive project creation if missing, 5-step progress, detailed completion
+- `/evaluate-repo` — banners, clone verification, 5-step progress, score summary
+- `/debt-track` — banners, parameter validation, 3-step progress, debt ratio summary
+- `/kpi-dora` — banners, prerequisite checks, 4-step progress, performer classification
+- `/context-load` — banners, 5-step progress, session summary
 
 **Documentation updated:**
 - `pm-workflow.md` — added UX Feedback reference
@@ -183,12 +197,12 @@ Messaging & Voice Inbox: WhatsApp (personal, no requiere Business) y Nextcloud T
 ### Added
 
 **Messaging & Inbox commands (6)** — PR #44
-- `/notify:whatsapp {contacto} {msg}` — enviar notificaciones e informes por WhatsApp al PM o grupo del equipo. Funciona con cuenta personal (no requiere Business). Soporta adjuntos (PDF, imágenes)
-- `/whatsapp:search {query}` — buscar mensajes en WhatsApp como contexto: decisiones, acuerdos, conversaciones del equipo. Datos en SQLite local (nunca se envían a terceros)
-- `/notify:nctalk {sala} {msg}` — enviar notificaciones a sala de Nextcloud Talk. Funciona con cualquier instancia Nextcloud (self-hosted o cloud). Soporta ficheros adjuntos via Nextcloud Files
-- `/nctalk:search {query}` — buscar mensajes en Nextcloud Talk: decisiones y contexto del equipo
-- `/inbox:check` — revisar mensajes nuevos en todos los canales configurados. Transcribe audios con Faster-Whisper (local), interpreta peticiones del PM y propone el comando de pm-workspace correspondiente
-- `/inbox:start --interval {min}` — iniciar monitor de inbox en background. Polling cada N minutos mientras la sesión esté abierta. Se detiene automáticamente al cerrar sesión
+- `/notify-whatsapp {contacto} {msg}` — enviar notificaciones e informes por WhatsApp al PM o grupo del equipo. Funciona con cuenta personal (no requiere Business). Soporta adjuntos (PDF, imágenes)
+- `/whatsapp-search {query}` — buscar mensajes en WhatsApp como contexto: decisiones, acuerdos, conversaciones del equipo. Datos en SQLite local (nunca se envían a terceros)
+- `/notify-nctalk {sala} {msg}` — enviar notificaciones a sala de Nextcloud Talk. Funciona con cualquier instancia Nextcloud (self-hosted o cloud). Soporta ficheros adjuntos via Nextcloud Files
+- `/nctalk-search {query}` — buscar mensajes en Nextcloud Talk: decisiones y contexto del equipo
+- `/inbox-check` — revisar mensajes nuevos en todos los canales configurados. Transcribe audios con Faster-Whisper (local), interpreta peticiones del PM y propone el comando de pm-workspace correspondiente
+- `/inbox-start --interval {min}` — iniciar monitor de inbox en background. Polling cada N minutos mientras la sesión esté abierta. Se detiene automáticamente al cerrar sesión
 
 **Voice Inbox skill** — transcripción de audio y flujo audio→texto→acción
 - Faster-Whisper local (modelos: tiny, base, small, medium, large-v3)
@@ -218,11 +232,11 @@ DevOps Extended: Azure DevOps Wiki management, Test Plans visibility, and securi
 ### Added
 
 **DevOps Extended commands (5)** — PR #43
-- `/wiki:publish {file} --project {p}` — publish markdown documentation to Azure DevOps Wiki. Supports create and update operations via MCP wiki tools
-- `/wiki:sync --project {p}` — bidirectional sync between local docs and Azure DevOps Wiki. Three modes: status (compare), push (local→wiki), pull (wiki→local). Conflict detection
-- `/testplan:status --project {p}` — Test Plans dashboard: active plans, suites, test cases, execution rates (passed/failed/blocked/not run), PBI test coverage, alerts for untested PBIs
-- `/testplan:results --project {p} --run {id}` — detailed test run results: failure analysis, stack traces, flaky test detection, trend over last N runs, recommendations for Bug PBI creation
-- `/security:alerts --project {p}` — security alerts from Azure DevOps Advanced Security: CVEs, exposed secrets, code vulnerabilities. Severity filtering, trend analysis, optional PBI creation for critical/high alerts
+- `/wiki-publish {file} --project {p}` — publish markdown documentation to Azure DevOps Wiki. Supports create and update operations via MCP wiki tools
+- `/wiki-sync --project {p}` — bidirectional sync between local docs and Azure DevOps Wiki. Three modes: status (compare), push (local→wiki), pull (wiki→local). Conflict detection
+- `/testplan-status --project {p}` — Test Plans dashboard: active plans, suites, test cases, execution rates (passed/failed/blocked/not run), PBI test coverage, alerts for untested PBIs
+- `/testplan-results --project {p} --run {id}` — detailed test run results: failure analysis, stack traces, flaky test detection, trend over last N runs, recommendations for Bug PBI creation
+- `/security-alerts --project {p}` — security alerts from Azure DevOps Advanced Security: CVEs, exposed secrets, code vulnerabilities. Severity filtering, trend analysis, optional PBI creation for critical/high alerts
 
 ### Changed
 - Command count: 70 → 75 (+5 DevOps Extended)
@@ -239,11 +253,11 @@ Project Onboarding Pipeline: 5-phase automated workflow for onboarding new proje
 ### Added
 
 **Project Onboarding commands (5)** — PR #42
-- `/project:audit --project {p}` — (Phase 1) Deep project audit: 8 dimensions (code quality, tests, architecture, debt, security, docs, CI/CD, team health). Generates prioritized action report with 3 tiers: critical, improvable, correct. Leverages `/debt:track`, `/kpi:dora`, `/pipeline:status`, `/sentry:health` internally
-- `/project:release-plan --project {p}` — (Phase 2) Prioritized release plan from audit + backlog. Groups PBIs into releases respecting dependencies, risk, and business value. Supports greenfield and legacy (strangler fig) strategies
-- `/project:assign --project {p}` — (Phase 3) Distribute work across team by skills, seniority, and capacity. Scoring algorithm: skill_match (40%) + capacity (30%) + seniority_fit (20%) + context_bonus (10%). Alerts for overload and bus factor
-- `/project:roadmap --project {p}` — (Phase 4) Visual roadmap: Mermaid Gantt with milestones, dependencies, releases. Exports to Draw.io/Miro. Two audiences: tech (detailed) and executive (summary)
-- `/project:kickoff --project {p}` — (Phase 5) Compile phases 1-4 into kickoff report. Notify PM via Slack/email. Optionally create Sprint 1 in Azure DevOps with Release 1 scope
+- `/project-audit --project {p}` — (Phase 1) Deep project audit: 8 dimensions (code quality, tests, architecture, debt, security, docs, CI/CD, team health). Generates prioritized action report with 3 tiers: critical, improvable, correct. Leverages `/debt-track`, `/kpi-dora`, `/pipeline-status`, `/sentry-health` internally
+- `/project-release-plan --project {p}` — (Phase 2) Prioritized release plan from audit + backlog. Groups PBIs into releases respecting dependencies, risk, and business value. Supports greenfield and legacy (strangler fig) strategies
+- `/project-assign --project {p}` — (Phase 3) Distribute work across team by skills, seniority, and capacity. Scoring algorithm: skill_match (40%) + capacity (30%) + seniority_fit (20%) + context_bonus (10%). Alerts for overload and bus factor
+- `/project-roadmap --project {p}` — (Phase 4) Visual roadmap: Mermaid Gantt with milestones, dependencies, releases. Exports to Draw.io/Miro. Two audiences: tech (detailed) and executive (summary)
+- `/project-kickoff --project {p}` — (Phase 5) Compile phases 1-4 into kickoff report. Notify PM via Slack/email. Optionally create Sprint 1 in Azure DevOps with Release 1 scope
 
 ### Changed
 - Command count: 65 → 70 (+5 onboarding)
@@ -260,9 +274,9 @@ Legacy assessment, backlog capture from unstructured sources, and automated rele
 ### Added
 
 **Legacy & Capture commands (3)** — PR #41
-- `/legacy:assess --project {p}` — legacy application assessment: complexity score (6 dimensions), maintenance cost, risk rating, modernization roadmap using strangler fig pattern. Output: `output/assessments/YYYYMMDD-legacy-{project}.md`
-- `/backlog:capture --project {p} --source {tipo}` — create PBIs from unstructured input: emails, meeting notes, Slack messages, support tickets. Deduplicates against existing backlog, classifies by type and priority
-- `/sprint:release-notes --project {p}` — auto-generate release notes combining Azure DevOps work items + conventional commits + merged PRs. Three audience levels: tech, stakeholder, public
+- `/legacy-assess --project {p}` — legacy application assessment: complexity score (6 dimensions), maintenance cost, risk rating, modernization roadmap using strangler fig pattern. Output: `output/assessments/YYYYMMDD-legacy-{project}.md`
+- `/backlog-capture --project {p} --source {tipo}` — create PBIs from unstructured input: emails, meeting notes, Slack messages, support tickets. Deduplicates against existing backlog, classifies by type and priority
+- `/sprint-release-notes --project {p}` — auto-generate release notes combining Azure DevOps work items + conventional commits + merged PRs. Three audience levels: tech, stakeholder, public
 
 ### Changed
 - Command count: 62 → 65 (+3 legacy & capture)
@@ -279,11 +293,11 @@ Governance foundations: technical debt tracking, DORA metrics, dependency mappin
 ### Added
 
 **Governance commands (5)** — PR #40
-- `/debt:track --project {p}` — technical debt register: debt ratio, trend per sprint, SonarQube integration. Stores data in `projects/{p}/debt-register.md`
-- `/kpi:dora --project {p}` — DORA metrics dashboard: deployment frequency, lead time, change failure rate, MTTR. Classifies as Elite/High/Medium/Low per DORA 2025 benchmarks
-- `/dependency:map --project {p}` — cross-team/cross-PBI dependency mapping with blocking alerts, circular dependency detection, critical path analysis. Visual graph via `/diagram:generate`
-- `/retro:actions --project {p}` — retrospective action items tracking: ownership, status, % implementation across sprints. Detects recurrent themes and suggests elevation to initiatives
-- `/risk:log --project {p}` — risk register: probability × impact matrix (1-3 scale), exposure scoring, risk burndown chart. Stores in `projects/{p}/risk-register.md`
+- `/debt-track --project {p}` — technical debt register: debt ratio, trend per sprint, SonarQube integration. Stores data in `projects/{p}/debt-register.md`
+- `/kpi-dora --project {p}` — DORA metrics dashboard: deployment frequency, lead time, change failure rate, MTTR. Classifies as Elite/High/Medium/Low per DORA 2025 benchmarks
+- `/dependency-map --project {p}` — cross-team/cross-PBI dependency mapping with blocking alerts, circular dependency detection, critical path analysis. Visual graph via `/diagram-generate`
+- `/retro-actions --project {p}` — retrospective action items tracking: ownership, status, % implementation across sprints. Detects recurrent themes and suggests elevation to initiatives
+- `/risk-log --project {p}` — risk register: probability × impact matrix (1-3 scale), exposure scoring, risk burndown chart. Stores in `projects/{p}/risk-register.md`
 
 ### Changed
 - Command count: 57 → 62 (+5 governance)
@@ -300,35 +314,35 @@ Connectors ecosystem, Azure DevOps MCP optimization, CI/CD pipelines, and Azure 
 ### Added
 
 **Connector integrations (8 connectors, 12 commands)** — PRs #27–#34
-- `/notify:slack {canal} {msg}` — send notifications and reports to Slack channels
-- `/slack:search {query}` — search messages and decisions in Slack for context
-- `/github:activity {repo}` — analyze GitHub activity: PRs, commits, contributors
-- `/github:issues {repo}` — manage GitHub issues: search, create, sync with Azure DevOps
-- `/sentry:health --project {p}` — health metrics from Sentry: error rate, crash rate, p95 latency
-- `/sentry:bugs --project {p}` — create Bug PBIs in Azure DevOps from frequent Sentry errors
-- `/gdrive:upload {file} --project {p}` — upload generated reports and documents to Google Drive
-- `/linear:sync --project {p}` — bidirectional sync Linear issues ↔ Azure DevOps PBIs/Tasks
-- `/jira:sync --project {p}` — bidirectional sync Jira issues ↔ Azure DevOps PBIs
-- `/confluence:publish {file} --project {p}` — publish documentation and reports to Confluence
-- `/notion:sync --project {p}` — bidirectional document sync with Notion databases
-- `/figma:extract {url} --project {p}` — extract UI components, screens, and design tokens from Figma
+- `/notify-slack {canal} {msg}` — send notifications and reports to Slack channels
+- `/slack-search {query}` — search messages and decisions in Slack for context
+- `/github-activity {repo}` — analyze GitHub activity: PRs, commits, contributors
+- `/github-issues {repo}` — manage GitHub issues: search, create, sync with Azure DevOps
+- `/sentry-health --project {p}` — health metrics from Sentry: error rate, crash rate, p95 latency
+- `/sentry-bugs --project {p}` — create Bug PBIs in Azure DevOps from frequent Sentry errors
+- `/gdrive-upload {file} --project {p}` — upload generated reports and documents to Google Drive
+- `/linear-sync --project {p}` — bidirectional sync Linear issues ↔ Azure DevOps PBIs/Tasks
+- `/jira-sync --project {p}` — bidirectional sync Jira issues ↔ Azure DevOps PBIs
+- `/confluence-publish {file} --project {p}` — publish documentation and reports to Confluence
+- `/notion-sync --project {p}` — bidirectional document sync with Notion databases
+- `/figma-extract {url} --project {p}` — extract UI components, screens, and design tokens from Figma
 - `connectors-config.md` — centralized connector configuration with per-connector enable/disable
 
 **Azure Pipelines CI/CD (5 commands, 1 skill)** — PR #35
-- `/pipeline:status --project {p}` — pipeline health: last builds, success rate, duration, alerts
-- `/pipeline:run --project {p} {pipeline}` — execute pipeline with preview and PM confirmation
-- `/pipeline:logs --project {p} --build {id}` — build logs: timeline, errors, warnings
-- `/pipeline:create --project {p} --name {n}` — create pipeline from YAML templates with preview
-- `/pipeline:artifacts --project {p} --build {id}` — list/download build artifacts
+- `/pipeline-status --project {p}` — pipeline health: last builds, success rate, duration, alerts
+- `/pipeline-run --project {p} {pipeline}` — execute pipeline with preview and PM confirmation
+- `/pipeline-logs --project {p} --build {id}` — build logs: timeline, errors, warnings
+- `/pipeline-create --project {p} --name {n}` — create pipeline from YAML templates with preview
+- `/pipeline-artifacts --project {p} --build {id}` — list/download build artifacts
 - `azure-pipelines` skill with YAML templates (build+test, multi-env, PR validation, nightly) and stage patterns (DEV→PRE→PRO with approval gates)
 
 **Azure Repos management (6 commands, 1 config rule)** — PR #36
-- `/repos:list --project {p}` — list Azure DevOps repositories with stats
-- `/repos:branches --project {p} --repo {r}` — branch management: list, create, compare
-- `/repos:pr-create --project {p} --repo {r}` — create PR with work item linking, reviewers, auto-complete
-- `/repos:pr-list --project {p}` — list PRs: pending, assigned to PM, by reviewer
-- `/repos:pr-review --project {p} --pr {id}` — multi-perspective PR review (BA, Dev, QA, Security, DevOps)
-- `/repos:search --project {p} {query}` — search code across Azure Repos
+- `/repos-list --project {p}` — list Azure DevOps repositories with stats
+- `/repos-branches --project {p} --repo {r}` — branch management: list, create, compare
+- `/repos-pr-create --project {p} --repo {r}` — create PR with work item linking, reviewers, auto-complete
+- `/repos-pr-list --project {p}` — list PRs: pending, assigned to PM, by reviewer
+- `/repos-pr-review --project {p} --pr {id}` — multi-perspective PR review (BA, Dev, QA, Security, DevOps)
+- `/repos-search --project {p} {query}` — search code across Azure Repos
 - `azure-repos-config.md` — dual Git provider support (`GIT_PROVIDER = "github" | "azure-repos"` per project)
 
 **DevOps workflow improvements** — PR #26
@@ -365,13 +379,13 @@ Multi-language, multi-environment, infrastructure as code, documentation reorgan
 - `confidentiality-config.md` — secrets protection policy (Key Vault, SSM, Secret Manager, config.local/)
 - `infrastructure-as-code.md` — multi-cloud IaC support (Terraform, Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pulumi)
 - `infrastructure-agent` (Opus 4.6) — auto-detect existing resources, minimum viable tier, cost estimation, human approval for scaling
-- 7 new commands: `/infra:detect`, `/infra:plan`, `/infra:estimate`, `/infra:scale`, `/infra:status`, `/env:setup`, `/env:promote`
+- 7 new commands: `/infra-detect`, `/infra-plan`, `/infra-estimate`, `/infra-scale`, `/infra-status`, `/env-setup`, `/env-promote`
 
 **File size governance**
 - `file-size-limit.md` — max 150 lines per file (code, rules, docs, tests); legacy inherited code exempt unless PM requests refactor
 
 **Team evaluation and onboarding**
-- `/team:evaluate` — competency evaluation across 8 dimensions with radar charts
+- `/team-evaluate` — competency evaluation across 8 dimensions with radar charts
 - `business-analyst` agent extended with onboarding and GDPR-compliant evaluation capabilities
 - Onboarding proposal and evaluation framework in `docs/propuestas/`
 
@@ -392,15 +406,15 @@ Quality, discovery, and operations expansion. Adds 6 new slash commands, 1 new s
 ### Added
 
 **Product Discovery workflow**
-- `/pbi:jtbd {id}` — generate Jobs to be Done document for a PBI before technical decomposition
-- `/pbi:prd {id}` — generate Product Requirements Document (MoSCoW prioritisation, Gherkin acceptance criteria, risks)
+- `/pbi-jtbd {id}` — generate Jobs to be Done document for a PBI before technical decomposition
+- `/pbi-prd {id}` — generate Product Requirements Document (MoSCoW prioritisation, Gherkin acceptance criteria, risks)
 - `product-discovery` skill with JTBD and PRD reference templates
 
 **Quality and operations commands**
-- `/pr:review [PR]` — multi-perspective PR review from 5 angles
-- `/context:load` — session initialisation: loads CLAUDE.md, checks git, summarises commits, verifies tools
-- `/changelog:update` — automates CHANGELOG.md updates from conventional commits
-- `/evaluate:repo [URL]` — static security and quality evaluation of external repositories
+- `/pr-review [PR]` — multi-perspective PR review from 5 angles
+- `/context-load` — session initialisation: loads CLAUDE.md, checks git, summarises commits, verifies tools
+- `/changelog-update` — automates CHANGELOG.md updates from conventional commits
+- `/evaluate-repo [URL]` — static security and quality evaluation of external repositories
 
 **Agents and rules enhancements**
 - `security-guardian` — SEC-8: merge conflict markers detection
@@ -428,21 +442,21 @@ Initial public release of PM-Workspace.
 - `docs/SETUP.md` — step-by-step setup guide
 
 **Sprint management commands**
-- `/sprint:status`, `/sprint:plan`, `/sprint:review`, `/sprint:retro`
+- `/sprint-status`, `/sprint-plan`, `/sprint-review`, `/sprint-retro`
 
 **Reporting commands**
-- `/report:hours`, `/report:executive`, `/report:capacity`
-- `/team:workload`, `/board:flow`, `/kpi:dashboard`
+- `/report-hours`, `/report-executive`, `/report-capacity`
+- `/team-workload`, `/board-flow`, `/kpi-dashboard`
 
 **PBI decomposition commands**
-- `/pbi:decompose`, `/pbi:decompose-batch`, `/pbi:assign`, `/pbi:plan-sprint`
+- `/pbi-decompose`, `/pbi-decompose-batch`, `/pbi-assign`, `/pbi-plan-sprint`
 
 **Skills**
 - `azure-devops-queries`, `sprint-management`, `capacity-planning`
 - `time-tracking-report`, `executive-reporting`, `pbi-decomposition`
 
 **Spec-Driven Development (SDD)**
-- `/spec:generate`, `/spec:implement`, `/spec:review`, `/spec:status`, `/agent:run`
+- `/spec-generate`, `/spec-implement`, `/spec-review`, `/spec-status`, `/agent-run`
 - `spec-driven-development` skill with spec template, layer matrix, agent patterns
 
 **Test project** (`projects/sala-reservas/`)
@@ -458,7 +472,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.1...v0.13.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you start, please read this document and the [Code of Conduct](CODE_OF_CO
 
 The highest-impact contributions are:
 
-**New slash commands** (`.claude/commands/`) — if you've had a conversation with Claude that solved a PM problem not yet covered, package it as a reusable command. Commands currently in high demand: `risk:log`, `sprint:release-notes`, `backlog:capture`, `pr:status`, `tech-debt:review`. See [ROADMAP.md](docs/ROADMAP.md) for the full list.
+**New slash commands** (`.claude/commands/`) — if you've had a conversation with Claude that solved a PM problem not yet covered, package it as a reusable command. Commands currently in high demand: `risk-log`, `sprint-release-notes`, `backlog-capture`, `pr-status`, `tech-debt-review`. See [ROADMAP.md](docs/ROADMAP.md) for the full list.
 
 **New skills** (`.claude/skills/`) — skills that extend Claude's behaviour into new territory: Jira integration, Kanban / SAFe methodology support, non-.NET stacks (Java Spring, Node.js, Python FastAPI), or new reporting formats.
 
@@ -72,7 +72,7 @@ Every new command must include:
 4. At least one usage example, ideally showing both the user's input and Claude's response.
 5. A reference to any skills it depends on.
 
-Follow the naming convention of existing commands: `namespace:action` (e.g. `sprint:status`, `pbi:decompose`, `spec:generate`).
+Follow the naming convention of existing commands: `namespace:action` (e.g. `sprint-status`, `pbi-decompose`, `spec-generate`).
 
 ### Skills (`.claude/skills/nombre-skill/`)
 
@@ -124,7 +124,7 @@ Open a GitHub Issue using one of the provided templates. Choose **Bug report** o
 Use these title prefixes if you write the issue manually:
 
 ```
-[BUG]      /sprint:status does not show alerts when WIP = 0
+[BUG]      /sprint-status does not show alerts when WIP = 0
 [FEATURE]  Add support for Kanban methodology
 [DOCS]     SDD example in README does not match current behaviour
 [QUESTION] How to configure workspace for multi-repo projects?

--- a/README.en.md
+++ b/README.en.md
@@ -88,29 +88,29 @@ Full documentation is organized into sections for easy reference:
 
 ### Sprint and Reporting
 ```
-/sprint:status    /sprint:plan    /sprint:review    /sprint:retro
-/report:hours     /report:executive    /report:capacity
-/team:workload    /board:flow    /kpi:dashboard
+/sprint-status    /sprint-plan    /sprint-review    /sprint-retro
+/report-hours     /report-executive    /report-capacity
+/team-workload    /board-flow    /kpi-dashboard
 ```
 
 ### PBI and SDD
 ```
-/pbi:decompose {id}    /pbi:plan-sprint    /pbi:assign {id}
-/spec:generate {id}    /spec:review {file}    /agent:run {file}
-/spec:status    /pbi:jtbd {id}    /pbi:prd {id}
+/pbi-decompose {id}    /pbi-plan-sprint    /pbi-assign {id}
+/spec-generate {id}    /spec-review {file}    /agent-run {file}
+/spec-status    /pbi-jtbd {id}    /pbi-prd {id}
 ```
 
 ### Infrastructure and Environments
 ```
-/infra:detect {proj} {env}    /infra:plan {proj} {env}    /infra:estimate {proj}
-/infra:scale {resource}       /infra:status {proj}
-/env:setup {proj}             /env:promote {proj} {source} {dest}
+/infra-detect {proj} {env}    /infra-plan {proj} {env}    /infra-estimate {proj}
+/infra-scale {resource}       /infra-status {proj}
+/env-setup {proj}             /env-promote {proj} {source} {dest}
 ```
 
 ### Quality and Team
 ```
-/pr:review [PR]    /pr:pending    /context:load    /changelog:update    /evaluate:repo [URL]
-/team:onboarding {name}    /team:evaluate {name}    /team:privacy-notice {name}
+/pr-review [PR]    /pr-pending    /context-load    /changelog-update    /evaluate-repo [URL]
+/team-onboarding {name}    /team-evaluate {name}    /team-privacy-notice {name}
 /help [filter]
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,29 +88,29 @@ La documentación completa está organizada en secciones para facilitar la consu
 
 ### Sprint y Reporting
 ```
-/sprint:status    /sprint:plan    /sprint:review    /sprint:retro
-/report:hours     /report:executive    /report:capacity
-/team:workload    /board:flow    /kpi:dashboard
+/sprint-status    /sprint-plan    /sprint-review    /sprint-retro
+/report-hours     /report-executive    /report-capacity
+/team-workload    /board-flow    /kpi-dashboard
 ```
 
 ### PBI y SDD
 ```
-/pbi:decompose {id}    /pbi:plan-sprint    /pbi:assign {id}
-/spec:generate {id}    /spec:review {file}    /agent:run {file}
-/spec:status    /pbi:jtbd {id}    /pbi:prd {id}
+/pbi-decompose {id}    /pbi-plan-sprint    /pbi-assign {id}
+/spec-generate {id}    /spec-review {file}    /agent-run {file}
+/spec-status    /pbi-jtbd {id}    /pbi-prd {id}
 ```
 
 ### Infraestructura y Entornos
 ```
-/infra:detect {proy} {env}    /infra:plan {proy} {env}    /infra:estimate {proy}
-/infra:scale {recurso}        /infra:status {proy}
-/env:setup {proy}             /env:promote {proy} {origen} {destino}
+/infra-detect {proy} {env}    /infra-plan {proy} {env}    /infra-estimate {proy}
+/infra-scale {recurso}        /infra-status {proy}
+/env-setup {proy}             /env-promote {proy} {origen} {destino}
 ```
 
 ### Calidad y Equipo
 ```
-/pr:review [PR]    /pr:pending    /context:load    /changelog:update    /evaluate:repo [URL]
-/team:onboarding {nombre}    /team:evaluate {nombre}    /team:privacy-notice {nombre}
+/pr-review [PR]    /pr-pending    /context-load    /changelog-update    /evaluate-repo [URL]
+/team-onboarding {nombre}    /team-evaluate {nombre}    /team-privacy-notice {nombre}
 /help [filtro]
 ```
 

--- a/claude.sln
+++ b/claude.sln
@@ -1,0 +1,87 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "projects", "projects", "{17245595-230B-9055-A944-863F0DDDA8E8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet-microservices-home-lab", "dotnet-microservices-home-lab", "{038069AF-3A38-2BE1-1958-8B2CB9A82FF8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E0712063-50B8-CFCF-303A-7757F2C3B1F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Integration.Tests", "projects\dotnet-microservices-home-lab\tests\Project.Integration.Tests\Project.Integration.Tests.csproj", "{0987FF02-9495-EDEC-A53A-59D81BFEFC01}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Domain.Tests", "projects\dotnet-microservices-home-lab\tests\Project.Domain.Tests\Project.Domain.Tests.csproj", "{DC2C507E-A957-E7CE-7D51-DC4E5CD63C31}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Application.Tests", "projects\dotnet-microservices-home-lab\tests\Project.Application.Tests\Project.Application.Tests.csproj", "{37403718-18A9-138B-615C-0427988CDFC2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8FB95A11-AC6D-C3B6-9E78-AB611DC0A822}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Application", "projects\dotnet-microservices-home-lab\src\Project.Application\Project.Application.csproj", "{FAFA4F49-AECF-4187-FEA4-4F6B2136D1D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Domain", "projects\dotnet-microservices-home-lab\src\Project.Domain\Project.Domain.csproj", "{4AEBCE68-8D09-58F4-93A8-F30053960C81}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Worker", "projects\dotnet-microservices-home-lab\src\Project.Worker\Project.Worker.csproj", "{8166F84B-1ABA-AA23-C9FE-0247D3A9F91B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Api", "projects\dotnet-microservices-home-lab\src\Project.Api\Project.Api.csproj", "{15C0C66C-44D5-80EE-BE85-719E4E685D49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project.Infrastructure", "projects\dotnet-microservices-home-lab\src\Project.Infrastructure\Project.Infrastructure.csproj", "{52A42D66-63D0-7774-8F4E-1BEFE588162C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0987FF02-9495-EDEC-A53A-59D81BFEFC01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0987FF02-9495-EDEC-A53A-59D81BFEFC01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0987FF02-9495-EDEC-A53A-59D81BFEFC01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0987FF02-9495-EDEC-A53A-59D81BFEFC01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC2C507E-A957-E7CE-7D51-DC4E5CD63C31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC2C507E-A957-E7CE-7D51-DC4E5CD63C31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC2C507E-A957-E7CE-7D51-DC4E5CD63C31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC2C507E-A957-E7CE-7D51-DC4E5CD63C31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37403718-18A9-138B-615C-0427988CDFC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37403718-18A9-138B-615C-0427988CDFC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37403718-18A9-138B-615C-0427988CDFC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37403718-18A9-138B-615C-0427988CDFC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAFA4F49-AECF-4187-FEA4-4F6B2136D1D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAFA4F49-AECF-4187-FEA4-4F6B2136D1D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAFA4F49-AECF-4187-FEA4-4F6B2136D1D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAFA4F49-AECF-4187-FEA4-4F6B2136D1D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AEBCE68-8D09-58F4-93A8-F30053960C81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AEBCE68-8D09-58F4-93A8-F30053960C81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AEBCE68-8D09-58F4-93A8-F30053960C81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AEBCE68-8D09-58F4-93A8-F30053960C81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8166F84B-1ABA-AA23-C9FE-0247D3A9F91B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8166F84B-1ABA-AA23-C9FE-0247D3A9F91B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8166F84B-1ABA-AA23-C9FE-0247D3A9F91B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8166F84B-1ABA-AA23-C9FE-0247D3A9F91B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15C0C66C-44D5-80EE-BE85-719E4E685D49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15C0C66C-44D5-80EE-BE85-719E4E685D49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15C0C66C-44D5-80EE-BE85-719E4E685D49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15C0C66C-44D5-80EE-BE85-719E4E685D49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52A42D66-63D0-7774-8F4E-1BEFE588162C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52A42D66-63D0-7774-8F4E-1BEFE588162C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52A42D66-63D0-7774-8F4E-1BEFE588162C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52A42D66-63D0-7774-8F4E-1BEFE588162C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{038069AF-3A38-2BE1-1958-8B2CB9A82FF8} = {17245595-230B-9055-A944-863F0DDDA8E8}
+		{E0712063-50B8-CFCF-303A-7757F2C3B1F0} = {038069AF-3A38-2BE1-1958-8B2CB9A82FF8}
+		{0987FF02-9495-EDEC-A53A-59D81BFEFC01} = {E0712063-50B8-CFCF-303A-7757F2C3B1F0}
+		{DC2C507E-A957-E7CE-7D51-DC4E5CD63C31} = {E0712063-50B8-CFCF-303A-7757F2C3B1F0}
+		{37403718-18A9-138B-615C-0427988CDFC2} = {E0712063-50B8-CFCF-303A-7757F2C3B1F0}
+		{8FB95A11-AC6D-C3B6-9E78-AB611DC0A822} = {038069AF-3A38-2BE1-1958-8B2CB9A82FF8}
+		{FAFA4F49-AECF-4187-FEA4-4F6B2136D1D1} = {8FB95A11-AC6D-C3B6-9E78-AB611DC0A822}
+		{4AEBCE68-8D09-58F4-93A8-F30053960C81} = {8FB95A11-AC6D-C3B6-9E78-AB611DC0A822}
+		{8166F84B-1ABA-AA23-C9FE-0247D3A9F91B} = {8FB95A11-AC6D-C3B6-9E78-AB611DC0A822}
+		{15C0C66C-44D5-80EE-BE85-719E4E685D49} = {8FB95A11-AC6D-C3B6-9E78-AB611DC0A822}
+		{52A42D66-63D0-7774-8F4E-1BEFE588162C} = {8FB95A11-AC6D-C3B6-9E78-AB611DC0A822}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3CD32F37-D23D-4814-8494-9E83B633A39D}
+	EndGlobalSection
+EndGlobal

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -274,7 +274,7 @@ Claude will read `CLAUDE.md` and show you the active projects and available comm
 ### 7.2 Sprint status (your most-used command)
 
 ```
-/sprint:status --project YourProject
+/sprint-status --project YourProject
 ```
 
 Shows: sprint burndown, items in progress, WIP alerts, people at 100%, blocked items, and remaining capacity. Ideal for preparing the Daily standup every morning.
@@ -282,7 +282,7 @@ Shows: sprint burndown, items in progress, WIP alerts, people at 100%, blocked i
 ### 7.3 Team workload
 
 ```
-/team:workload --project YourProject
+/team-workload --project YourProject
 ```
 
 Shows a visual map of each team member's workload, with overload alerts and redistribution suggestions.
@@ -290,7 +290,7 @@ Shows a visual map of each team member's workload, with overload alerts and redi
 ### 7.4 Hours report
 
 ```
-/report:hours --project YourProject --sprint 2026-04
+/report-hours --project YourProject --sprint 2026-04
 ```
 
 Generates an Excel with 4 tabs (Summary, By person, By PBI, Agents) ready to deliver to the client or PMO.
@@ -298,12 +298,12 @@ Generates an Excel with 4 tabs (Summary, By person, By PBI, Agents) ready to del
 ### 7.5 KPI dashboard
 
 ```
-/kpi:dashboard --project YourProject
+/kpi-dashboard --project YourProject
 ```
 
 Velocity, cycle time, lead time, bug escape rate, and more — all calculated automatically from real Azure DevOps data.
 
-> **💡 Recommendation:** During the first 2 weeks, use only `/sprint:status`, `/team:workload`, and `/report:hours`. Get comfortable with these 3 commands before moving on to PBI decomposition and SDD.
+> **💡 Recommendation:** During the first 2 weeks, use only `/sprint-status`, `/team-workload`, and `/report-hours`. Get comfortable with these 3 commands before moving on to PBI decomposition and SDD.
 
 ---
 
@@ -359,7 +359,7 @@ cd ~/claude && claude
 ```
 
 ```
-/sprint:status --project MyProject
+/sprint-status --project MyProject
 ```
 
 If you see the sprint status with real data, the project is correctly incorporated.
@@ -386,7 +386,7 @@ Follow steps 8.1 through 8.6, adapting the constants to the new project.
 Create PBIs in Azure DevOps with clear acceptance criteria. Then use PM-Workspace to prepare the sprint:
 
 ```
-/pbi:plan-sprint --project NewProject
+/pbi-plan-sprint --project NewProject
 ```
 
 Claude will calculate team capacity, select PBIs that fit the sprint, break them into tasks, and propose assignments.
@@ -396,8 +396,8 @@ Claude will calculate team capacity, select PBIs that fit the sprint, break them
 Before breaking down a PBI, you can use the discovery commands:
 
 ```
-/pbi:jtbd {id}    ← Generate JTBD (Jobs to be Done)
-/pbi:prd {id}     ← Generate PRD (Product Requirements)
+/pbi-jtbd {id}    ← Generate JTBD (Jobs to be Done)
+/pbi-prd {id}     ← Generate PRD (Product Requirements)
 ```
 
 This ensures the PBI is well-defined before investing time in decomposition and development.
@@ -414,9 +414,9 @@ The process has 3 mandatory steps, always in this order:
 
 | Step | Command | What it does |
 |------|---------|-------------|
-| 1. GDPR privacy notice | `/team:privacy-notice {name}` | Generates the legal notice so the worker knows what data is collected, its purpose, and their ARCO-POL rights |
-| 2. Onboarding guide | `/team:onboarding {name}` | Generates a personalized guide: project context, code tour, conventions, first tasks |
-| 3. Competency assessment | `/team:evaluate {name}` | Interactive 26-competency questionnaire (12 .NET + 7 transversal + domain) that updates `equipo.md` |
+| 1. GDPR privacy notice | `/team-privacy-notice {name}` | Generates the legal notice so the worker knows what data is collected, its purpose, and their ARCO-POL rights |
+| 2. Onboarding guide | `/team-onboarding {name}` | Generates a personalized guide: project context, code tour, conventions, first tasks |
+| 3. Competency assessment | `/team-evaluate {name}` | Interactive 26-competency questionnaire (12 .NET + 7 transversal + domain) that updates `equipo.md` |
 
 ### 10.2 Practical example: onboarding a new developer
 
@@ -425,7 +425,7 @@ The process has 3 mandatory steps, always in this order:
 **Step 1 — Generate the GDPR privacy notice**
 
 ```
-/team:privacy-notice "Laura García" --project ClinicManagement
+/team-privacy-notice "Laura García" --project ClinicManagement
 ```
 
 Claude generates the document in `projects/clinic-management/privacy/` with company data already filled in. The PM prints the document, Laura reads it and signs the receipt acknowledgment.
@@ -433,7 +433,7 @@ Claude generates the document in `projects/clinic-management/privacy/` with comp
 **Step 2 — Generate the onboarding guide**
 
 ```
-/team:onboarding "Laura García" --project ClinicManagement
+/team-onboarding "Laura García" --project ClinicManagement
 ```
 
 Claude reads the project's `CLAUDE.md`, `equipo.md`, `reglas-negocio.md`, and the source code, then generates a personalized guide with: project summary, architecture, main modules, code conventions, and suggested first tasks to build momentum.
@@ -441,7 +441,7 @@ Claude reads the project's `CLAUDE.md`, `equipo.md`, `reglas-negocio.md`, and th
 **Step 3 — Assess competencies**
 
 ```
-/team:evaluate "Laura García" --project ClinicManagement
+/team-evaluate "Laura García" --project ClinicManagement
 ```
 
 Claude conducts an interactive questionnaire in groups of 3 questions. It assesses 12 .NET/C# competencies, 7 transversal ones, and the project's domain competencies. Each is rated 1-5 (Shu-Ha-Ri scale: Apprentice → Reference) with verifiable evidence. The result is saved to `equipo.md` to improve future assignments.
@@ -456,16 +456,16 @@ The recommended adoption is incremental. Don't try to use all features from day 
 
 | Weeks | Phase | Goal | Key commands |
 |-------|-------|------|-------------|
-| 1-2 | Connection | Configure PAT, verify connectivity, first `/sprint:status` | `/sprint:status` |
-| 3-4 | Basic management | Use `/sprint:status` every morning, `/team:workload`, adjust constants | `/team:workload`, `/report:capacity` |
-| 5-6 | Reporting | Generate client reports with real data | `/report:hours`, `/report:executive` |
-| 7-8 | SDD pilot | Generate 2-3 specs, test agent with 1 Application Layer task | `/spec:generate`, `/agent:run` |
-| 9-10 | Onboarding + scale | Onboard new members, scale SDD to 40%+ | `/team:onboarding`, `/team:evaluate` |
+| 1-2 | Connection | Configure PAT, verify connectivity, first `/sprint-status` | `/sprint-status` |
+| 3-4 | Basic management | Use `/sprint-status` every morning, `/team-workload`, adjust constants | `/team-workload`, `/report-capacity` |
+| 5-6 | Reporting | Generate client reports with real data | `/report-hours`, `/report-executive` |
+| 7-8 | SDD pilot | Generate 2-3 specs, test agent with 1 Application Layer task | `/spec-generate`, `/agent-run` |
+| 9-10 | Onboarding + scale | Onboard new members, scale SDD to 40%+ | `/team-onboarding`, `/team-evaluate` |
 
 ### Success indicators by phase
 
 - **Phase 1-2:** The PM can see the real sprint status without opening Azure DevOps.
-- **Phase 3-4:** The PM prepares the Daily in <5 minutes with `/sprint:status`.
+- **Phase 3-4:** The PM prepares the Daily in <5 minutes with `/sprint-status`.
 - **Phase 5-6:** The hours report is generated in <2 minutes (previously: 30-60 min manual).
 - **Phase 7-8:** At least 1 repetitive task implemented by agent without errors.
 - **Phase 9-10:** New members onboarded with personalized guide and competency assessment.
@@ -481,9 +481,9 @@ The recommended adoption is incremental. Don't try to use all features from day 
 | `az: command not found` | Azure CLI not installed | Install from https://aka.ms/installazurecliwindows |
 | Empty sprint results | Sprint not active or wrong name | Verify in AzDO > Project Settings > Iterations that the sprint is active |
 | Claude doesn't recognize the project | `CLAUDE.md` not updated | Add project to the "Active Projects" table in `CLAUDE.md` |
-| `/sprint:status` shows no data | Incorrect IterationPath in `CLAUDE.md` | Verify `CURRENT_SPRINT_PATH` matches the exact AzDO name (with `\\`) |
+| `/sprint-status` shows no data | Incorrect IterationPath in `CLAUDE.md` | Verify `CURRENT_SPRINT_PATH` matches the exact AzDO name (with `\\`) |
 | Long context error | Conversation too long | Use `/compact` or `/clear` and reformulate |
-| SDD agent fails immediately | Incomplete spec or placeholders | Review with `/spec:review` before `/agent:run` |
+| SDD agent fails immediately | Incomplete spec or placeholders | Review with `/spec-review` before `/agent-run` |
 | `npm: command not found` | Node.js not installed | Install Node.js ≥ 18 from [nodejs.org](https://nodejs.org) |
 
 ---

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -274,7 +274,7 @@ Claude leerá `CLAUDE.md` y te mostrará los proyectos activos y los comandos di
 ### 7.2 Estado del sprint (tu comando más usado)
 
 ```
-/sprint:status --project TuProyecto
+/sprint-status --project TuProyecto
 ```
 
 Muestra: burndown del sprint, items en progreso, alertas de WIP, personas al 100%, items bloqueados y capacidad restante. Ideal para preparar la Daily cada mañana.
@@ -282,7 +282,7 @@ Muestra: burndown del sprint, items en progreso, alertas de WIP, personas al 100
 ### 7.3 Carga del equipo
 
 ```
-/team:workload --project TuProyecto
+/team-workload --project TuProyecto
 ```
 
 Muestra un mapa visual de la carga de cada miembro del equipo, con alertas de sobrecarga y sugerencias de redistribución.
@@ -290,7 +290,7 @@ Muestra un mapa visual de la carga de cada miembro del equipo, con alertas de so
 ### 7.4 Informe de horas
 
 ```
-/report:hours --project TuProyecto --sprint 2026-04
+/report-hours --project TuProyecto --sprint 2026-04
 ```
 
 Genera un Excel con 4 pestañas (Resumen, Detalle por persona, Detalle por PBI, Agentes) listo para entregar al cliente o al PMO.
@@ -298,12 +298,12 @@ Genera un Excel con 4 pestañas (Resumen, Detalle por persona, Detalle por PBI, 
 ### 7.5 Dashboard de KPIs
 
 ```
-/kpi:dashboard --project TuProyecto
+/kpi-dashboard --project TuProyecto
 ```
 
 Velocity, cycle time, lead time, bug escape rate y más, calculados automáticamente desde los datos reales de Azure DevOps.
 
-> **💡 Recomendación:** Durante las primeras 2 semanas, usa solo `/sprint:status`, `/team:workload` y `/report:hours`. Familiarízate con estos 3 comandos antes de avanzar a descomposición de PBIs y SDD.
+> **💡 Recomendación:** Durante las primeras 2 semanas, usa solo `/sprint-status`, `/team-workload` y `/report-hours`. Familiarízate con estos 3 comandos antes de avanzar a descomposición de PBIs y SDD.
 
 ---
 
@@ -359,7 +359,7 @@ cd ~/claude && claude
 ```
 
 ```
-/sprint:status --project MiProyecto
+/sprint-status --project MiProyecto
 ```
 
 Si ves el estado del sprint con datos reales, el proyecto está correctamente incorporado.
@@ -386,7 +386,7 @@ Sigue los pasos 8.1 a 8.6 adaptando las constantes al nuevo proyecto.
 Crea los PBIs en Azure DevOps con criterios de aceptación claros. Luego usa PM-Workspace para preparar el sprint:
 
 ```
-/pbi:plan-sprint --project NuevoProyecto
+/pbi-plan-sprint --project NuevoProyecto
 ```
 
 Claude calculará la capacity del equipo, seleccionará los PBIs que caben en el sprint, los descompondrá en tasks y propondrá asignaciones.
@@ -396,8 +396,8 @@ Claude calculará la capacity del equipo, seleccionará los PBIs que caben en el
 Antes de descomponer un PBI, puedes usar los comandos de discovery:
 
 ```
-/pbi:jtbd {id}    ← Genera el JTBD (Jobs to be Done)
-/pbi:prd {id}     ← Genera el PRD (Product Requirements)
+/pbi-jtbd {id}    ← Genera el JTBD (Jobs to be Done)
+/pbi-prd {id}     ← Genera el PRD (Product Requirements)
 ```
 
 Esto asegura que el PBI está bien definido antes de invertir tiempo en descomposición y desarrollo.
@@ -414,9 +414,9 @@ El proceso tiene 3 pasos obligatorios, siempre en este orden:
 
 | Paso | Comando | Qué hace |
 |------|---------|----------|
-| 1. Nota informativa RGPD | `/team:privacy-notice {nombre}` | Genera la nota informativa legal para que el trabajador sepa qué datos se recogen, con qué finalidad y sus derechos ARCO-POL |
-| 2. Guía de onboarding | `/team:onboarding {nombre}` | Genera una guía personalizada: contexto del proyecto, tour por el código, convenciones, primeras tasks |
-| 3. Evaluación de competencias | `/team:evaluate {nombre}` | Cuestionario interactivo de 26 competencias (12 .NET + 7 transversales + dominio) que actualiza `equipo.md` |
+| 1. Nota informativa RGPD | `/team-privacy-notice {nombre}` | Genera la nota informativa legal para que el trabajador sepa qué datos se recogen, con qué finalidad y sus derechos ARCO-POL |
+| 2. Guía de onboarding | `/team-onboarding {nombre}` | Genera una guía personalizada: contexto del proyecto, tour por el código, convenciones, primeras tasks |
+| 3. Evaluación de competencias | `/team-evaluate {nombre}` | Cuestionario interactivo de 26 competencias (12 .NET + 7 transversales + dominio) que actualiza `equipo.md` |
 
 ### 10.2 Ejemplo práctico: incorporar a un nuevo programador
 
@@ -425,7 +425,7 @@ El proceso tiene 3 pasos obligatorios, siempre en este orden:
 **Paso 1 — Generar la nota informativa RGPD**
 
 ```
-/team:privacy-notice "Laura García" --project GestionClinica
+/team-privacy-notice "Laura García" --project GestionClinica
 ```
 
 Claude genera el documento en `projects/gestion-clinica/privacy/` con los datos de la empresa ya rellenados. El PM imprime el documento, Laura lo lee y firma el acuse de recibo.
@@ -433,7 +433,7 @@ Claude genera el documento en `projects/gestion-clinica/privacy/` con los datos 
 **Paso 2 — Generar la guía de onboarding**
 
 ```
-/team:onboarding "Laura García" --project GestionClinica
+/team-onboarding "Laura García" --project GestionClinica
 ```
 
 Claude lee el `CLAUDE.md` del proyecto, `equipo.md`, `reglas-negocio.md` y el código fuente, y genera una guía personalizada con: resumen del proyecto, arquitectura, módulos principales, convenciones de código, y las primeras tasks sugeridas para ir cogiendo ritmo.
@@ -441,7 +441,7 @@ Claude lee el `CLAUDE.md` del proyecto, `equipo.md`, `reglas-negocio.md` y el c�
 **Paso 3 — Evaluar competencias**
 
 ```
-/team:evaluate "Laura García" --project GestionClinica
+/team-evaluate "Laura García" --project GestionClinica
 ```
 
 Claude conduce un cuestionario interactivo en grupos de 3 preguntas. Evalúa 12 competencias .NET/C#, 7 transversales y las del dominio del proyecto. Cada competencia se valora de 1 a 5 (escala Shu-Ha-Ri: Aprendiz → Referente) con evidencias verificables. El resultado se guarda en `equipo.md` para mejorar las asignaciones futuras.
@@ -456,16 +456,16 @@ La adopción recomendada es incremental. No intentes usar todas las funcionalida
 
 | Semanas | Fase | Objetivo | Comandos clave |
 |---------|------|----------|----------------|
-| 1-2 | Conexión | Configurar PAT, verificar conectividad, primer `/sprint:status` | `/sprint:status` |
-| 3-4 | Gestión básica | Usar `/sprint:status` cada mañana, `/team:workload`, ajustar constantes | `/team:workload`, `/report:capacity` |
-| 5-6 | Reporting | Generar informes para el cliente con datos reales | `/report:hours`, `/report:executive` |
-| 7-8 | SDD piloto | Generar 2-3 specs, probar agente con 1 task de Application Layer | `/spec:generate`, `/agent:run` |
-| 9-10 | Onboarding + escala | Incorporar nuevos miembros, escalar SDD a 40%+ | `/team:onboarding`, `/team:evaluate` |
+| 1-2 | Conexión | Configurar PAT, verificar conectividad, primer `/sprint-status` | `/sprint-status` |
+| 3-4 | Gestión básica | Usar `/sprint-status` cada mañana, `/team-workload`, ajustar constantes | `/team-workload`, `/report-capacity` |
+| 5-6 | Reporting | Generar informes para el cliente con datos reales | `/report-hours`, `/report-executive` |
+| 7-8 | SDD piloto | Generar 2-3 specs, probar agente con 1 task de Application Layer | `/spec-generate`, `/agent-run` |
+| 9-10 | Onboarding + escala | Incorporar nuevos miembros, escalar SDD a 40%+ | `/team-onboarding`, `/team-evaluate` |
 
 ### Indicadores de éxito por fase
 
 - **Fase 1-2:** El PM puede ver el estado real del sprint sin abrir Azure DevOps.
-- **Fase 3-4:** El PM prepara la Daily en <5 minutos con `/sprint:status`.
+- **Fase 3-4:** El PM prepara la Daily en <5 minutos con `/sprint-status`.
 - **Fase 5-6:** El informe de horas se genera en <2 minutos (antes: 30-60 min manual).
 - **Fase 7-8:** Al menos 1 task repetitiva implementada por agente sin errores.
 - **Fase 9-10:** Nuevos miembros incorporados con guía personalizada y evaluación de competencias.
@@ -481,9 +481,9 @@ La adopción recomendada es incremental. No intentes usar todas las funcionalida
 | `az: command not found` | Azure CLI no instalado | Instalar desde https://aka.ms/installazurecliwindows |
 | Resultados vacíos del sprint | Sprint no activo o nombre incorrecto | Verificar en AzDO > Project Settings > Iterations que el sprint esté activo |
 | Claude no reconoce el proyecto | `CLAUDE.md` no actualizado | Añadir proyecto a la tabla «Proyectos Activos» de `CLAUDE.md` |
-| `/sprint:status` sin datos | IterationPath incorrecto en `CLAUDE.md` | Verificar `CURRENT_SPRINT_PATH` con el nombre exacto de AzDO (con `\\`) |
+| `/sprint-status` sin datos | IterationPath incorrecto en `CLAUDE.md` | Verificar `CURRENT_SPRINT_PATH` con el nombre exacto de AzDO (con `\\`) |
 | Error de contexto largo | Conversación demasiado larga | Usar `/compact` o `/clear` y reformular |
-| Agente SDD falla inmediatamente | Spec incompleta o con placeholders | Revisar con `/spec:review` antes de `/agent:run` |
+| Agente SDD falla inmediatamente | Spec incompleta o con placeholders | Revisar con `/spec-review` antes de `/agent-run` |
 | `npm: command not found` | Node.js no instalado | Instalar Node.js ≥ 18 desde [nodejs.org](https://nodejs.org) |
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,12 +28,12 @@ Extends the workspace with features that close the loop between external inputs 
 
 | Feature | Issue | Status |
 |---------|-------|--------|
-| `backlog:capture` — create PBIs from unstructured input (emails, meeting notes, Slack threads) | [#1] | 🔴 |
-| `backlog:estimate` — AI-assisted Story Point estimation based on historical PBI similarity | [#2] | 🔴 |
-| `tech-debt:review` — scan backlog for tech-debt items and propose a maintenance sprint slot | [#3] | 🔴 |
-| `sprint:release-notes` — auto-generate release notes combining work items + commits (builds on `/changelog:update`) | [#4] | 🔴 |
-| `risk:log` — structured risk register (probability × impact) updated on each `/sprint:status` | [#5] | 🔴 |
-| `risk:escalate` — automatic escalation of critical risks to PM via daily digest | [#6] | 🔴 |
+| `backlog-capture` — create PBIs from unstructured input (emails, meeting notes, Slack threads) | [#1] | 🔴 |
+| `backlog-estimate` — AI-assisted Story Point estimation based on historical PBI similarity | [#2] | 🔴 |
+| `tech-debt-review` — scan backlog for tech-debt items and propose a maintenance sprint slot | [#3] | 🔴 |
+| `sprint-release-notes` — auto-generate release notes combining work items + commits (builds on `/changelog-update`) | [#4] | 🔴 |
+| `risk-log` — structured risk register (probability × impact) updated on each `/sprint-status` | [#5] | 🔴 |
+| `risk-escalate` — automatic escalation of critical risks to PM via daily digest | [#6] | 🔴 |
 
 ---
 
@@ -45,8 +45,8 @@ Adds PR lifecycle tracking and team onboarding automation.
 
 | Feature | Issue | Status |
 |---------|-------|--------|
-| `pr:status` — track PR state in AzDO (reviewers, pending comments, review time) — extends `/pr:review` | [#7] | 🔴 |
-| `team:onboarding` — generate personalised onboarding guide for new team members | [#8] | 🔴 |
+| `pr-status` — track PR state in AzDO (reviewers, pending comments, review time) — extends `/pr-review` | [#7] | 🔴 |
+| `team-onboarding` — generate personalised onboarding guide for new team members | [#8] | 🔴 |
 
 ---
 
@@ -72,7 +72,7 @@ Ideas from the community that are not yet committed to a version. Open an issue 
 
 - GitHub Actions integration: track CI/CD pipeline status per sprint item
 - Multi-language documentation (EN, DE, FR)
-- `report:client` — client-facing progress report (lighter than executive report, no internal metrics)
+- `report-client` — client-facing progress report (lighter than executive report, no internal metrics)
 - Budget tracking per project (burned vs. estimated cost)
 - VS Code extension for running workspace commands from the editor sidebar
 - MCP server exposing workspace tools to other Claude Code projects

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -87,7 +87,7 @@ Para usar Spec-Driven Development con agentes Claude, necesitas la CLI de Claude
 # Verificar que claude CLI está instalado
 claude --version
 
-# Verificar que puedes invocar claude como subproceso (necesario para agent:run)
+# Verificar que puedes invocar claude como subproceso (necesario para agent-run)
 echo "Test de invocación de agente:"
 claude --model claude-haiku-4-5-20251001 --max-turns 1 "Di 'Hola' en una sola palabra"
 
@@ -123,35 +123,35 @@ Una vez dentro de Claude Code:
 
 | Comando | Descripción |
 |---------|-------------|
-| `/sprint:status` | Estado del sprint actual |
-| `/sprint:plan` | Asistente de sprint planning |
-| `/sprint:review` | Generar resumen de sprint review |
-| `/sprint:retro` | Plantilla de retrospectiva con datos |
-| `/report:hours` | Informe de imputación de horas (Excel) |
-| `/report:executive` | Informe ejecutivo multi-proyecto (PPT/Word) |
-| `/report:capacity` | Estado de capacidades del equipo |
-| `/team:workload` | Carga de trabajo por persona |
-| `/board:flow` | Análisis del flujo y cuellos de botella |
-| `/kpi:dashboard` | Dashboard completo de KPIs |
+| `/sprint-status` | Estado del sprint actual |
+| `/sprint-plan` | Asistente de sprint planning |
+| `/sprint-review` | Generar resumen de sprint review |
+| `/sprint-retro` | Plantilla de retrospectiva con datos |
+| `/report-hours` | Informe de imputación de horas (Excel) |
+| `/report-executive` | Informe ejecutivo multi-proyecto (PPT/Word) |
+| `/report-capacity` | Estado de capacidades del equipo |
+| `/team-workload` | Carga de trabajo por persona |
+| `/board-flow` | Análisis del flujo y cuellos de botella |
+| `/kpi-dashboard` | Dashboard completo de KPIs |
 
 ### Descomposición de PBIs
 
 | Comando | Descripción |
 |---------|-------------|
-| `/pbi:decompose {id}` | Descomponer un PBI en tasks con estimación y asignación |
-| `/pbi:decompose-batch {ids}` | Descomponer varios PBIs optimizando la carga global |
-| `/pbi:assign {pbi_id}` | (Re)asignar tasks existentes de un PBI |
-| `/pbi:plan-sprint` | Planning completo: capacity + PBIs + descomposición |
+| `/pbi-decompose {id}` | Descomponer un PBI en tasks con estimación y asignación |
+| `/pbi-decompose-batch {ids}` | Descomponer varios PBIs optimizando la carga global |
+| `/pbi-assign {pbi_id}` | (Re)asignar tasks existentes de un PBI |
+| `/pbi-plan-sprint` | Planning completo: capacity + PBIs + descomposición |
 
 ### Spec-Driven Development (SDD) — Agentes Claude
 
 | Comando | Descripción |
 |---------|-------------|
-| `/spec:generate {task_id}` | Generar Spec ejecutable desde una Task de Azure DevOps |
-| `/spec:implement {spec_file}` | Implementar Spec (lanza agente o asigna humano) |
-| `/spec:review {spec_file}` | Revisar calidad de Spec o validar implementación |
-| `/spec:status` | Dashboard de estado de todas las Specs del sprint |
-| `/agent:run {spec_file}` | Lanzar agente Claude directamente sobre una Spec |
+| `/spec-generate {task_id}` | Generar Spec ejecutable desde una Task de Azure DevOps |
+| `/spec-implement {spec_file}` | Implementar Spec (lanza agente o asigna humano) |
+| `/spec-review {spec_file}` | Revisar calidad de Spec o validar implementación |
+| `/spec-status` | Dashboard de estado de todas las Specs del sprint |
+| `/agent-run {spec_file}` | Lanzar agente Claude directamente sobre una Spec |
 
 ---
 
@@ -214,7 +214,7 @@ output/agent-runs/                           ← Logs de ejecuciones de agentes
 ## Roadmap de Implementación (según propuesta)
 
 - **Semanas 1-2 (Fase 1):** ✅ Estructura creada — Configurar PAT y probar conectividad
-- **Semanas 3-4 (Fase 2):** Iterar con `/sprint:status` y `/team:workload` — documentar ajustes
-- **Semanas 5-6 (Fase 3):** Activar `/report:hours` y `/report:executive` con datos reales
-- **Semanas 7-8 (Fase 4):** Activar SDD — generar primeras specs con `/spec:generate` y probar agente con una task piloto
+- **Semanas 3-4 (Fase 2):** Iterar con `/sprint-status` y `/team-workload` — documentar ajustes
+- **Semanas 5-6 (Fase 3):** Activar `/report-hours` y `/report-executive` con datos reales
+- **Semanas 7-8 (Fase 4):** Activar SDD — generar primeras specs con `/spec-generate` y probar agente con una task piloto
 - **Semana 9+ (Fase 5):** Escalar SDD — objetivo 60% de tasks técnicas repetitivas por agente

--- a/docs/flujo-trabajo.md
+++ b/docs/flujo-trabajo.md
@@ -240,11 +240,11 @@ Un item se marca como **Blocked** (tag `blocked` en Azure DevOps) cuando:
 ```
 PBI en Backlog
     ↓
-/pbi:decompose {id}        → Tasks creadas con campo "Developer Type" (human | agent:single | agent:team)
+/pbi-decompose {id}        → Tasks creadas con campo "Developer Type" (human | agent-single | agent-team)
     ↓
-/spec:generate {task_id}   → Spec generada para cada task (fichero .spec.md)
+/spec-generate {task_id}   → Spec generada para cada task (fichero .spec.md)
     ↓
-/spec:review {spec_file}   → PM/Tech Lead valida la Spec (calidad, completitud)
+/spec-review {spec_file}   → PM/Tech Lead valida la Spec (calidad, completitud)
     ↓
          ┌──────────────────────────────────────────────┐
          │  ¿Developer Type?                            │
@@ -253,17 +253,17 @@ PBI en Backlog
          │                   Task: Active               │
          │                   Dev implementa normalmente │
          │                                              │
-         │  agent:single   → /agent:run {spec_file}     │
+         │  agent-single   → /agent-run {spec_file}     │
          │                   Agente implementa la Spec  │
          │                   Task: Active → In Review   │
          │                                              │
-         │  agent:team     → /agent:run {spec_file}     │
+         │  agent-team     → /agent-run {spec_file}     │
          │                        --team                │
          │                   Implementador + Tester     │
          │                   en paralelo                │
          └──────────────────────────────────────────────┘
     ↓
-/spec:review {spec_file}   → Pre-check de implementación (--check-impl)
+/spec-review {spec_file}   → Pre-check de implementación (--check-impl)
     ↓
 Code Review (E1)           → SIEMPRE humano (Tech Lead)
     ↓
@@ -318,11 +318,11 @@ Tiempo adicional estimado por SDD en el Daily: +2 minutos
 
 | Comando | Propósito |
 |---------|-----------|
-| `/spec:generate {task_id}` | Generar Spec desde una Task de Azure DevOps |
-| `/spec:implement {spec_file}` | Implementar una Spec (lanza agente o asigna humano) |
-| `/spec:review {spec_file}` | Revisar calidad de Spec o validar implementación |
-| `/spec:status` | Dashboard de todas las Specs del sprint |
-| `/agent:run {spec_file}` | Lanzar agente directamente sobre una Spec |
+| `/spec-generate {task_id}` | Generar Spec desde una Task de Azure DevOps |
+| `/spec-implement {spec_file}` | Implementar una Spec (lanza agente o asigna humano) |
+| `/spec-review {spec_file}` | Revisar calidad de Spec o validar implementación |
+| `/spec-status` | Dashboard de todas las Specs del sprint |
+| `/agent-run {spec_file}` | Lanzar agente directamente sobre una Spec |
 
 ### 8.6 Cuándo NO usar SDD
 

--- a/docs/guia-incorporacion-lenguajes.md
+++ b/docs/guia-incorporacion-lenguajes.md
@@ -408,7 +408,7 @@ Añadir el lenguaje a la sección "Lenguajes Soportados" en `README.md` y `READM
 
 ## Referencia Rápida: Detección Automática de Lenguaje
 
-Para el comando `/context:load`, detectar el Language Pack automáticamente:
+Para el comando `/context-load`, detectar el Language Pack automáticamente:
 
 | Archivo(s) en el proyecto | Language Pack |
 |---|---|

--- a/docs/kpis-equipo.md
+++ b/docs/kpis-equipo.md
@@ -209,7 +209,7 @@ throughput_semanal = items_done / semanas_del_período
 
 ## Dashboard Completo — Tabla de KPIs
 
-Formato para el comando `/kpi:dashboard`:
+Formato para el comando `/kpi-dashboard`:
 
 | KPI | Valor actual | Referencia | Semáforo | Tendencia |
 |-----|-------------|------------|----------|-----------|

--- a/docs/plantillas-informes.md
+++ b/docs/plantillas-informes.md
@@ -22,7 +22,7 @@ EMAIL_DESTINATARIOS   = ["pm@empresa.com"]                 # ← configurar dest
 **Cuándo:** Al finalizar cada Sprint Review
 **Formato:** Word (.docx) + resumen en Markdown
 **Destino:** `output/sprints/YYYYMMDD-sprint-review-[proyecto]-[sprint].docx`
-**Comando:** `/sprint:review`
+**Comando:** `/sprint-review`
 
 ### Estructura
 
@@ -76,7 +76,7 @@ EMAIL_DESTINATARIOS   = ["pm@empresa.com"]                 # ← configurar dest
 **Cuándo:** Cada viernes antes de las 18:00
 **Formato:** PowerPoint (.pptx) — máximo 8 diapositivas
 **Destino:** `output/executive/YYYYMMDD-weekly-report.pptx`
-**Comando:** `/report:executive`
+**Comando:** `/report-executive`
 
 ### Estructura de diapositivas
 
@@ -115,7 +115,7 @@ Diapositiva N+3 — PRÓXIMOS PASOS
 **Cuándo:** Al finalizar cada sprint o bajo demanda
 **Formato:** Excel (.xlsx) — 4 pestañas
 **Destino:** `output/reports/YYYYMMDD-hours-[proyecto]-[sprint].xlsx`
-**Comando:** `/report:hours`
+**Comando:** `/report-hours`
 
 ### Estructura
 
@@ -151,7 +151,7 @@ Pestaña 4 — COMPARATIVA SPRINTS
 **Cuándo:** Bajo demanda o como adjunto al informe semanal
 **Formato:** HTML interactivo o Excel
 **Destino:** `output/reports/YYYYMMDD-dashboard-[proyecto].html`
-**Comando:** `/kpi:dashboard`
+**Comando:** `/kpi-dashboard`
 
 ### Widgets del dashboard
 
@@ -182,7 +182,7 @@ Widget 6 — Carga del equipo
 **Cuándo:** Al inicio de cada sprint (para el planning) y bajo demanda
 **Formato:** Markdown o tabla en terminal
 **Destino:** `output/reports/YYYYMMDD-capacity-[proyecto]-[sprint].md`
-**Comando:** `/report:capacity`
+**Comando:** `/report-capacity`
 
 ### Estructura
 

--- a/docs/propuestas/propuesta-incorporacion-awesome-claude-code.md
+++ b/docs/propuestas/propuesta-incorporacion-awesome-claude-code.md
@@ -73,7 +73,7 @@ Tras un análisis exhaustivo del repositorio awesome-claude-code (209 recursos c
 
 **Qué hace:** Antes de descomponer un PBI en tareas técnicas, documenta el *por qué* del usuario (Jobs to be Done) y el *qué* del producto (Product Requirements Document). Esto enriquece la cadena: JTBD → PRD → PBI → Tasks.
 
-**Por qué tiene sentido:** Actualmente, `/pbi:decompose` toma un PBI de Azure DevOps y lo descompone directamente en tareas técnicas. Pero los PBIs a veces llegan sin contexto suficiente sobre la necesidad del usuario. Agregar una fase de discovery formaliza lo que el `business-analyst` debería hacer antes de que el `architect` diseñe la solución.
+**Por qué tiene sentido:** Actualmente, `/pbi-decompose` toma un PBI de Azure DevOps y lo descompone directamente en tareas técnicas. Pero los PBIs a veces llegan sin contexto suficiente sobre la necesidad del usuario. Agregar una fase de discovery formaliza lo que el `business-analyst` debería hacer antes de que el `architect` diseñe la solución.
 
 **Adaptación necesaria:**
 
@@ -105,7 +105,7 @@ Tras un análisis exhaustivo del repositorio awesome-claude-code (209 recursos c
 **Adaptación necesaria:**
 
 - Leer `CLAUDE.md` raíz + `CLAUDE.md` del proyecto activo
-- Ejecutar `/sprint:status` para obtener el estado actual del sprint
+- Ejecutar `/sprint-status` para obtener el estado actual del sprint
 - Listar las ramas activas (`git branch -a | grep -v main`)
 - Resumir los últimos 5 commits para entender en qué se estuvo trabajando
 - Verificar si hay PBIs asignados sin empezar en el sprint actual

--- a/docs/propuestas/propuesta-onboarding-y-evaluacion.md
+++ b/docs/propuestas/propuesta-onboarding-y-evaluacion.md
@@ -16,7 +16,7 @@ El proceso se dise&ntilde;a para que un nuevo miembro del equipo llegue a su pri
 
 #### Fase 1 &mdash; Contexto inmediato (D&iacute;a 1, ma&ntilde;ana)
 
-**Qu&eacute; hace la persona nueva:** ejecuta `/context:load` y despu&eacute;s pregunta a Claude:
+**Qu&eacute; hace la persona nueva:** ejecuta `/context-load` y despu&eacute;s pregunta a Claude:
 
 ```
 Soy nuevo en este proyecto. Expl&iacute;came la arquitectura general,
@@ -37,7 +37,7 @@ Mu&eacute;strame el flujo completo de un POST /salas desde el Controller
 hasta la base de datos, explicando cada capa que atraviesa.
 ```
 
-**Herramientas complementarias:** Claude Code con `/evaluate:repo` sobre el propio proyecto para que el nuevo miembro entienda la calidad actual y las &aacute;reas de mejora.
+**Herramientas complementarias:** Claude Code con `/evaluate-repo` sobre el propio proyecto para que el nuevo miembro entienda la calidad actual y las &aacute;reas de mejora.
 
 **Tiempo:** 2-3 horas. **Verificable:** la persona puede explicar el flujo de un endpoint al mentor.
 

--- a/docs/readme/01-introduccion.md
+++ b/docs/readme/01-introduccion.md
@@ -44,18 +44,18 @@ Tengo configurados 2 proyectos activos:
   • ProyectoBeta   — equipo de 4 personas, precio fijo, sprint 2026-04 activo
 
 Puedo ayudarte con:
-  Sprint      → /sprint:status, /sprint:plan, /sprint:review, /sprint:retro
-  Informes    → /report:hours, /report:executive, /report:capacity
-  Backlog     → /pbi:decompose, /pbi:plan-sprint, /pbi:assign
-  SDD (agentes) → /spec:generate, /agent:run, /spec:status
+  Sprint      → /sprint-status, /sprint-plan, /sprint-review, /sprint-retro
+  Informes    → /report-hours, /report-executive, /report-capacity
+  Backlog     → /pbi-decompose, /pbi-plan-sprint, /pbi-assign
+  SDD (agentes) → /spec-generate, /agent-run, /spec-status
 
-¿Por dónde quieres empezar? Si es lunes, te recomiendo /sprint:status
+¿Por dónde quieres empezar? Si es lunes, te recomiendo /sprint-status
 para ver el estado actual del sprint antes de la Daily.
 ```
 
 **Tú escribes:**
 ```
-/sprint:status --project ProyectoAlpha
+/sprint-status --project ProyectoAlpha
 ```
 
 **Claude responde:**

--- a/docs/readme/04-uso-sprint-informes.md
+++ b/docs/readme/04-uso-sprint-informes.md
@@ -6,10 +6,10 @@ Ejecuta estos comandos dentro de Claude Code:
 
 | Comando | Descripción |
 |---------|-------------|
-| `/sprint:status` | Estado del sprint: burndown, items activos, alertas de WIP |
-| `/sprint:plan` | Asistente de Sprint Planning: capacity + PBIs candidatos del backlog |
-| `/sprint:review` | Resumen para Sprint Review: velocity, items completados, demostración |
-| `/sprint:retro` | Plantilla de retrospectiva con datos del sprint |
+| `/sprint-status` | Estado del sprint: burndown, items activos, alertas de WIP |
+| `/sprint-plan` | Asistente de Sprint Planning: capacity + PBIs candidatos del backlog |
+| `/sprint-review` | Resumen para Sprint Review: velocity, items completados, demostración |
+| `/sprint-retro` | Plantilla de retrospectiva con datos del sprint |
 
 ---
 
@@ -19,7 +19,7 @@ _Escenario: Sprint en curso, día 4 de 10. Quieres saber si el equipo va bien an
 
 **Tú escribes:**
 ```
-/sprint:status --project GestiónClínica
+/sprint-status --project GestiónClínica
 ```
 
 **Claude responde:**
@@ -82,7 +82,7 @@ _Escenario: Es el viernes antes del nuevo sprint. Quieres preparar el planning._
 
 **Tú escribes:**
 ```
-/sprint:plan --project GestiónClínica
+/sprint-plan --project GestiónClínica
 ```
 
 **Claude responde:**
@@ -132,10 +132,10 @@ Descomponiendo los 4 PBIs... [consulta Azure DevOps]
 PBI #301 — Notificaciones de cita por email (8 SP)
   B1  Entidad NotificacionEmail + reglas de dominio   4h  Carlos TL   human
   B2  IEmailNotificationService interface             2h  Carlos TL   human
-  B3  SendCitaConfirmationCommandHandler              4h  🤖 agente   agent:single
-  B4  EmailTemplateService (Infrastructure)          3h  🤖 agente   agent:single
-  C1  Unit tests del command handler                 2h  🤖 agente   agent:single
-  D1  EmailController endpoints                      3h  🤖 agente   agent:single
+  B3  SendCitaConfirmationCommandHandler              4h  🤖 agente   agent-single
+  B4  EmailTemplateService (Infrastructure)          3h  🤖 agente   agent-single
+  C1  Unit tests del command handler                 2h  🤖 agente   agent-single
+  D1  EmailController endpoints                      3h  🤖 agente   agent-single
   D2  Integration test (Mailtrap sandbox)            4h  Diego T.    human
   E1  Code Review                                    2h  Carlos TL   human
 
@@ -157,11 +157,11 @@ Resumen de asignación:
 
 | Comando | Descripción |
 |---------|-------------|
-| `/report:hours` | Informe de imputación de horas (Excel, 4 pestañas) |
-| `/report:executive` | Informe ejecutivo multi-proyecto (Word + PPT con semáforos) |
-| `/report:capacity` | Estado de capacidades del equipo esta semana |
-| `/team:workload` | Mapa de carga de trabajo por persona |
-| `/kpi:dashboard` | Dashboard completo: velocity, cycle time, lead time, bug escape rate |
+| `/report-hours` | Informe de imputación de horas (Excel, 4 pestañas) |
+| `/report-executive` | Informe ejecutivo multi-proyecto (Word + PPT con semáforos) |
+| `/report-capacity` | Estado de capacidades del equipo esta semana |
+| `/team-workload` | Mapa de carga de trabajo por persona |
+| `/kpi-dashboard` | Dashboard completo: velocity, cycle time, lead time, bug escape rate |
 
 ---
 
@@ -171,7 +171,7 @@ _Escenario: Último día del sprint. El cliente pide el informe de imputación._
 
 **Tú escribes:**
 ```
-/report:hours --project GestiónClínica --sprint 2026-04
+/report-hours --project GestiónClínica --sprint 2026-04
 ```
 
 **Claude responde:**
@@ -209,7 +209,7 @@ _Escenario: Miércoles. Sospechas que alguien está sobrecargado._
 
 **Tú escribes:**
 ```
-/team:workload --project GestiónClínica
+/team-workload --project GestiónClínica
 ```
 
 **Claude responde:**
@@ -233,11 +233,11 @@ Carga del equipo — semana actual (lun 17/03 – vie 21/03)
 
 El proceso estándar para preparar un sprint:
 
-1. `/pbi:decompose {id}` — Claude analiza el PBI, sus criterios de aceptación y el contexto del equipo, y propone la tabla de tasks.
+1. `/pbi-decompose {id}` — Claude analiza el PBI, sus criterios de aceptación y el contexto del equipo, y propone la tabla de tasks.
 2. Claude pregunta si crear las tasks en Azure DevOps.
 3. Confirmas y Claude las crea vía REST API.
 
-Para preparar el sprint completo de una vez: `/pbi:plan-sprint` hace todo el ciclo automáticamente (capacity → selección de PBIs → descomposición → asignación → creación en AzDO).
+Para preparar el sprint completo de una vez: `/pbi-plan-sprint` hace todo el ciclo automáticamente (capacity → selección de PBIs → descomposición → asignación → creación en AzDO).
 
 **Algoritmo de scoring de asignación:**
 ```
@@ -253,7 +253,7 @@ _Escenario: Tienes el PBI AB#302 "Historial de citas por paciente" con 3 criteri
 
 **Tú escribes:**
 ```
-/pbi:decompose 302 --project GestiónClínica
+/pbi-decompose 302 --project GestiónClínica
 ```
 
 **Claude responde:**
@@ -273,10 +273,10 @@ PROPUESTA DE TASKS:
 ├────┼──────────────────────────────────────────┼──────┼──────┼──────────────┼───────────────┤
 │ B1 │ Diseño query HistorialCitasQuery + DTO   │  3h  │ Dev  │ Carlos TL    │ human         │
 │ B2 │ EF Core: IHistorialCitasRepository       │  2h  │ Dev  │ Diego T.     │ human         │
-│ B3 │ GetHistorialCitasQueryHandler            │  4h  │ Dev  │ 🤖 agente    │ agent:single  │
-│ C1 │ HistorialCitasController (GET endpoint)  │  3h  │ Dev  │ 🤖 agente    │ agent:single  │
+│ B3 │ GetHistorialCitasQueryHandler            │  4h  │ Dev  │ 🤖 agente    │ agent-single  │
+│ C1 │ HistorialCitasController (GET endpoint)  │  3h  │ Dev  │ 🤖 agente    │ agent-single  │
 │ C2 │ Paginación cursor-based (middleware)     │  3h  │ Dev  │ Laura S.     │ human         │
-│ D1 │ Unit tests del QueryHandler              │  2h  │ Dev  │ 🤖 agente    │ agent:single  │
+│ D1 │ Unit tests del QueryHandler              │  2h  │ Dev  │ 🤖 agente    │ agent-single  │
 │ D2 │ Integration test end-to-end              │  3h  │ QA   │ Ana Morales  │ human         │
 │ E1 │ Code Review                              │  2h  │ Rev  │ Carlos TL    │ human         │
 └────┴──────────────────────────────────────────┴──────┴──────┴──────────────┴───────────────┘
@@ -295,7 +295,7 @@ Cambia C2 al agente también, Laura ya tiene mucha carga. Crea las tasks.
 
 **Claude responde:**
 ```
-Ajustado: C2 → agent:single (añadiré en la spec el patrón de paginación de referencia).
+Ajustado: C2 → agent-single (añadiré en la spec el patrón de paginación de referencia).
 
 Creando 8 tasks en Azure DevOps para AB#302...
   ✅ AB#302-B1 creada → asignada a Carlos Mendoza
@@ -308,7 +308,7 @@ Creando 8 tasks en Azure DevOps para AB#302...
   ✅ AB#302-E1 creada → asignada a Carlos Mendoza
 
 8 tasks creadas. Las tasks de agente (B3, C1, C2, D1) ya tienen el tag
-"spec-driven" y están listas para /spec:generate cuando quieras.
+"spec-driven" y están listas para /spec-generate cuando quieras.
 ```
 
 ---

--- a/docs/readme/05-sdd.md
+++ b/docs/readme/05-sdd.md
@@ -9,20 +9,20 @@ Una Spec es un contrato que describe exactamente qué implementar. Si el contrat
 | Tipo | Quién implementa | Cuándo |
 |------|-----------------|--------|
 | `human` | Desarrollador del equipo | Lógica de dominio, migraciones, integraciones externas, Code Review |
-| `agent:single` | Un agente Claude | Handlers, Repositorios, Validators, Unit Tests, DTOs, Controllers |
-| `agent:team` | Implementador + Tester en paralelo | Tasks ≥ 6h con código producción + tests |
+| `agent-single` | Un agente Claude | Handlers, Repositorios, Validators, Unit Tests, DTOs, Controllers |
+| `agent-team` | Implementador + Tester en paralelo | Tasks ≥ 6h con código producción + tests |
 
 ## Flujo de trabajo SDD
 
 ```
-1. /pbi:decompose → propuesta de tasks con columna "Developer Type"
-2. /spec:generate {task_id} → genera el fichero .spec.md desde Azure DevOps
-3. /spec:review {spec_file} → valida la spec (calidad, completitud)
+1. /pbi-decompose → propuesta de tasks con columna "Developer Type"
+2. /spec-generate {task_id} → genera el fichero .spec.md desde Azure DevOps
+3. /spec-review {spec_file} → valida la spec (calidad, completitud)
 4. Si developer_type = agent:
-     /agent:run {spec_file} → agente implementa la spec
+     /agent-run {spec_file} → agente implementa la spec
    Si developer_type = human:
      Asignar al desarrollador
-5. /spec:review {spec_file} --check-impl → pre-check del código generado
+5. /spec-review {spec_file} --check-impl → pre-check del código generado
 6. Code Review (E1) → SIEMPRE humano (Tech Lead)
 7. PR → merge → Task: Done
 ```
@@ -59,7 +59,7 @@ _Escenario: La task AB#302-B3 "GetHistorialCitasQueryHandler" está lista para q
 
 **Tú escribes:**
 ```
-/spec:generate 302-B3 --project GestiónClínica
+/spec-generate 302-B3 --project GestiónClínica
 ```
 
 **Claude responde:**
@@ -67,7 +67,7 @@ _Escenario: La task AB#302-B3 "GetHistorialCitasQueryHandler" está lista para q
 Leyendo AB#302 (PBI padre) y AB#302-B3 (Task)...
 Analizando código existente en projects/gestion-clinica/source/...
 → Módulo: Citas / Capa: Application / Tipo: QueryHandler
-→ Developer type: agent:single (patrón repetible, interfaces definidas)
+→ Developer type: agent-single (patrón repetible, interfaces definidas)
 
 Spec generada:
   projects/gestion-clinica/specs/sprint-2026-05/AB302-B3-get-historial-citas-handler.spec.md
@@ -85,14 +85,14 @@ Vista previa de la sección más crítica (Contrato Técnico):
 │  }                                                              │
 └─────────────────────────────────────────────────────────────────┘
 
-¿Revisas la spec antes de implementar? → /spec:review AB302-B3-...
+¿Revisas la spec antes de implementar? → /spec-review AB302-B3-...
 ```
 
 ### Paso 2 — Validar la spec
 
 **Tú escribes:**
 ```
-/spec:review AB302-B3-get-historial-citas-handler.spec.md
+/spec-review AB302-B3-get-historial-citas-handler.spec.md
 ```
 
 **Claude responde:**
@@ -108,7 +108,7 @@ Revisando calidad de la spec...
 
 ══════════════════════
   ✅ SPEC LISTA
-  Puedes ejecutar /agent:run
+  Puedes ejecutar /agent-run
 ══════════════════════
 ```
 
@@ -116,7 +116,7 @@ Revisando calidad de la spec...
 
 **Tú escribes:**
 ```
-/agent:run projects/gestion-clinica/specs/sprint-2026-05/AB302-B3-get-historial-citas-handler.spec.md
+/agent-run projects/gestion-clinica/specs/sprint-2026-05/AB302-B3-get-historial-citas-handler.spec.md
 ```
 
 **Claude responde:**
@@ -170,7 +170,7 @@ _Escenario: Quieres ver el estado de todas las tasks SDD del sprint de un vistaz
 
 **Tú escribes:**
 ```
-/spec:status --project GestiónClínica
+/spec-status --project GestiónClínica
 ```
 
 **Claude responde:**
@@ -181,12 +181,12 @@ _Escenario: Quieres ver el estado de todas las tasks SDD del sprint de un vistaz
 
   Task                             Spec         Dev Type     Estado   h    Asignado
   ─────────────────────────────────────────────────────────────────────────────────
-  AB#302-B3 GetHistorialCitas      ✅ lista      agent:single  ✅ done  4h   agente
-  AB#302-C1 HistorialController    ✅ lista      agent:single  🔄 impl  3h   agente
-  AB#302-C2 Paginación cursor      ✅ lista      agent:single  ⏳ cola  3h   agente
-  AB#302-D1 Unit tests handler     ✅ lista      agent:single  ⏳ cola  2h   agente
-  AB#301-B3 SendConfirmationCmd    ⚠️ incompleta agent:single  🚫 bloq  4h   agente
-  AB#301-D1 EmailTemplateService   ⏳ pendiente  agent:single  ⏳ cola  3h   agente
+  AB#302-B3 GetHistorialCitas      ✅ lista      agent-single  ✅ done  4h   agente
+  AB#302-C1 HistorialController    ✅ lista      agent-single  🔄 impl  3h   agente
+  AB#302-C2 Paginación cursor      ✅ lista      agent-single  ⏳ cola  3h   agente
+  AB#302-D1 Unit tests handler     ✅ lista      agent-single  ⏳ cola  2h   agente
+  AB#301-B3 SendConfirmationCmd    ⚠️ incompleta agent-single  🚫 bloq  4h   agente
+  AB#301-D1 EmailTemplateService   ⏳ pendiente  agent-single  ⏳ cola  3h   agente
 
   Resumen:
     Completadas: 1 | En curso: 1 | En cola: 3 | Bloqueadas: 1
@@ -195,7 +195,7 @@ _Escenario: Quieres ver el estado de todas las tasks SDD del sprint de un vistaz
 
   ⚠️  AB#301-B3 bloqueada:
      La spec tiene una sección de Contrato Técnico incompleta —
-     falta la firma de IEmailService. Ejecuta /spec:review AB301-B3-...
+     falta la firma de IEmailService. Ejecuta /spec-review AB301-B3-...
      para ver qué falta exactamente.
 ```
 
@@ -206,7 +206,7 @@ _Escenario: Quieres ver el estado de todas las tasks SDD del sprint de un vistaz
 Para tasks grandes, puedes usar un equipo de agentes en paralelo:
 
 ```bash
-/agent:run {spec_file} --team
+/agent-run {spec_file} --team
 # Lanza: Implementador (opus) + Tester (haiku) en paralelo
 # Tiempo: ~50% menos que secuencial
 # Coste: ~$0.80-1.80 por spec
@@ -228,7 +228,7 @@ _Escenario: La task AB#301-B3 "SendCitaConfirmationCommandHandler" es compleja (
 
 **Tú escribes:**
 ```
-/agent:run projects/gestion-clinica/specs/sprint-2026-05/AB301-B3-send-confirmation-cmd.spec.md --team
+/agent-run projects/gestion-clinica/specs/sprint-2026-05/AB301-B3-send-confirmation-cmd.spec.md --team
 ```
 
 **Claude responde:**

--- a/docs/readme/08-pipelines.md
+++ b/docs/readme/08-pipelines.md
@@ -77,7 +77,7 @@ Claude genera la pipeline adaptada al Language Pack del proyecto. Estos son los 
 |---|---|---|---|---|---|
 | C#/.NET | `dotnet restore` | `dotnet build` | `dotnet format --verify` | `dotnet test` | `dotnet list package --vulnerable` |
 | TypeScript | `npm ci` | `npm run build` | `eslint . && prettier --check` | `vitest run` | `npm audit` |
-| Java/Spring | `mvn dependency:resolve` | `mvn package -DskipTests` | `mvn checkstyle:check` | `mvn test` | `mvn dependency-check:check` |
+| Java/Spring | `mvn dependency-resolve` | `mvn package -DskipTests` | `mvn checkstyle:check` | `mvn test` | `mvn dependency-check:check` |
 | Python | `pip install -r requirements.txt` | `— (interpretado)` | `ruff check . && mypy .` | `pytest` | `safety check` |
 | Go | `go mod download` | `go build ./...` | `golangci-lint run` | `go test ./...` | `govulncheck ./...` |
 | Rust | `— (cargo)` | `cargo build --release` | `cargo fmt --check && cargo clippy` | `cargo test` | `cargo audit` |
@@ -145,7 +145,7 @@ jobs:
 
 | Comando | Descripción |
 |---|---|
-| `/infra:plan {proyecto} {env}` | Genera plan de infraestructura incluyendo pipelines |
-| `/pr:review [PR]` | Revisión multi-perspectiva de PR (incluye validación de pipeline) |
+| `/infra-plan {proyecto} {env}` | Genera plan de infraestructura incluyendo pipelines |
+| `/pr-review [PR]` | Revisión multi-perspectiva de PR (incluye validación de pipeline) |
 
 ---

--- a/docs/readme/10-kpis-reglas.md
+++ b/docs/readme/10-kpis-reglas.md
@@ -44,9 +44,9 @@
 
 | Semanas | Fase | Objetivo |
 |---------|------|----------|
-| 1-2 | Configuración | Conectar con Azure DevOps, probar `/sprint:status` |
-| 3-4 | Gestión básica | Iterar con `/sprint:plan`, `/team:workload`, ajustar constantes |
-| 5-6 | Reporting | Activar `/report:hours` y `/report:executive` con datos reales |
+| 1-2 | Configuración | Conectar con Azure DevOps, probar `/sprint-status` |
+| 3-4 | Gestión básica | Iterar con `/sprint-plan`, `/team-workload`, ajustar constantes |
+| 5-6 | Reporting | Activar `/report-hours` y `/report-executive` con datos reales |
 | 7-8 | SDD piloto | Generar primeras specs, probar agente con 1-2 tasks de Application Layer |
 | 9+ | SDD a escala | Objetivo: 60%+ de tasks técnicas repetitivas implementadas por agentes |
 

--- a/docs/readme/11-onboarding.md
+++ b/docs/readme/11-onboarding.md
@@ -7,13 +7,13 @@ PM-Workspace incluye un flujo completo para incorporar programadores a un proyec
 ```
 Nuevo miembro se incorpora
     ↓
-/team:privacy-notice "Nombre"     ← 1. Nota informativa RGPD (obligatoria)
+/team-privacy-notice "Nombre"     ← 1. Nota informativa RGPD (obligatoria)
     ↓                                   El trabajador lee y firma el acuse
-/team:onboarding "Nombre"         ← 2. Contexto del proyecto + tour del código
+/team-onboarding "Nombre"         ← 2. Contexto del proyecto + tour del código
     ↓                                   El mentor valida cada fase
   [Primera task asistida]          ← 3. Mentor asigna task B/C, pair con Claude
     ↓                                   Code Review humano obligatorio
-/team:evaluate "Nombre"            ← 4. Cuestionario de competencias (8 dimensiones)
+/team-evaluate "Nombre"            ← 4. Cuestionario de competencias (8 dimensiones)
     ↓                                   Autoevaluación + calibración Tech Lead
   [Autonomía progresiva]           ← 5. Semanas 1-3 con supervisión decreciente
 ```
@@ -22,13 +22,13 @@ Las fases 3 y 5 son procesos humanos guiados por el mentor, no comandos.
 
 ### Fase 1 — Nota informativa RGPD
 
-Antes de recoger cualquier dato del trabajador, la ley exige entregarle una nota informativa (Art. 13 RGPD). El comando `/team:privacy-notice "Nombre" --project MiProyecto` genera el documento a partir de una plantilla que incluye: responsable del tratamiento, finalidad (asignación de tareas y formación), base legal (interés legítimo), derechos del trabajador (acceso, rectificación, supresión, oposición, portabilidad).
+Antes de recoger cualquier dato del trabajador, la ley exige entregarle una nota informativa (Art. 13 RGPD). El comando `/team-privacy-notice "Nombre" --project MiProyecto` genera el documento a partir de una plantilla que incluye: responsable del tratamiento, finalidad (asignación de tareas y formación), base legal (interés legítimo), derechos del trabajador (acceso, rectificación, supresión, oposición, portabilidad).
 
-El trabajador firma el acuse de recibo antes de continuar. Sin esta firma, `/team:evaluate` se bloquea.
+El trabajador firma el acuse de recibo antes de continuar. Sin esta firma, `/team-evaluate` se bloquea.
 
 ### Fase 2 — Onboarding: contexto y tour del código
 
-El comando `/team:onboarding "Nombre" --project MiProyecto` genera una guía personalizada que cubre:
+El comando `/team-onboarding "Nombre" --project MiProyecto` genera una guía personalizada que cubre:
 
 - **Contexto inmediato**: arquitectura del proyecto, capas, módulos, patrones usados, convenciones del equipo, miembros y roles
 - **Tour del codebase**: recorrido de un request de principio a fin (Controller → Handler → Repository → Entity), patrones con ejemplos reales del proyecto, estructura de tests, ubicación de specs SDD
@@ -41,7 +41,7 @@ El mentor asigna una task de complejidad B/C. El nuevo miembro la implementa con
 
 ### Fase 4 — Evaluación de competencias
 
-El comando `/team:evaluate "Nombre" --project MiProyecto` ejecuta un cuestionario interactivo en tres secciones: A (técnico del stack, 12 competencias), B (transversal, 7 competencias), C (dominio del proyecto, generado dinámicamente según los módulos).
+El comando `/team-evaluate "Nombre" --project MiProyecto` ejecuta un cuestionario interactivo en tres secciones: A (técnico del stack, 12 competencias), B (transversal, 7 competencias), C (dominio del proyecto, generado dinámicamente según los módulos).
 
 Para cada competencia se recoge nivel (1-5) e interés (S/N). El agente `business-analyst` compara la autoevaluación con evidencia observable (PRs, historial Git) y sugiere ajustes. El Tech Lead co-firma el resultado final.
 

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -2,66 +2,66 @@
 
 ## Sprint y Reporting
 ```
-/sprint:status [--project]        Estado del sprint con alertas
-/sprint:plan [--project]          Asistente de Sprint Planning
-/sprint:review [--project]        Resumen para Sprint Review
-/sprint:retro [--project]         Retrospectiva con datos
-/report:hours [--project]         Informe de horas (Excel)
-/report:executive                 Informe multi-proyecto (PPT/Word)
-/report:capacity [--project]      Estado de capacidades
-/team:workload [--project]        Carga por persona
-/board:flow [--project]           Cycle time y cuellos de botella
-/kpi:dashboard [--project]        Dashboard KPIs completo
+/sprint-status [--project]        Estado del sprint con alertas
+/sprint-plan [--project]          Asistente de Sprint Planning
+/sprint-review [--project]        Resumen para Sprint Review
+/sprint-retro [--project]         Retrospectiva con datos
+/report-hours [--project]         Informe de horas (Excel)
+/report-executive                 Informe multi-proyecto (PPT/Word)
+/report-capacity [--project]      Estado de capacidades
+/team-workload [--project]        Carga por persona
+/board-flow [--project]           Cycle time y cuellos de botella
+/kpi-dashboard [--project]        Dashboard KPIs completo
 ```
 
 ## PBI Decomposition
 ```
-/pbi:decompose {id}               Descomponer un PBI en tasks
-/pbi:decompose-batch {id1,id2}    Descomponer varios PBIs
-/pbi:assign {pbi_id}              (Re)asignar tasks de un PBI
-/pbi:plan-sprint                  Planning completo del sprint
+/pbi-decompose {id}               Descomponer un PBI en tasks
+/pbi-decompose-batch {id1,id2}    Descomponer varios PBIs
+/pbi-assign {pbi_id}              (Re)asignar tasks de un PBI
+/pbi-plan-sprint                  Planning completo del sprint
 ```
 
 ## Spec-Driven Development
 ```
-/spec:generate {task_id}          Generar Spec desde Task de Azure DevOps
-/spec:implement {spec_file}       Implementar Spec (agente o humano)
-/spec:review {spec_file}          Revisar calidad de Spec o implementación
-/spec:status [--project]          Dashboard de Specs del sprint
-/agent:run {spec_file} [--team]   Lanzar agente Claude sobre una Spec
+/spec-generate {task_id}          Generar Spec desde Task de Azure DevOps
+/spec-implement {spec_file}       Implementar Spec (agente o humano)
+/spec-review {spec_file}          Revisar calidad de Spec o implementación
+/spec-status [--project]          Dashboard de Specs del sprint
+/agent-run {spec_file} [--team]   Lanzar agente Claude sobre una Spec
 ```
 
 ## Product Discovery
 ```
-/pbi:jtbd {id}                   Generar JTBD (Jobs to be Done) para un PBI
-/pbi:prd {id}                    Generar PRD (Product Requirements) para un PBI
+/pbi-jtbd {id}                   Generar JTBD (Jobs to be Done) para un PBI
+/pbi-prd {id}                    Generar PRD (Product Requirements) para un PBI
 ```
 
 ## Calidad y Operaciones
 ```
-/pr:review [PR]                  Revisión multi-perspectiva de PR (BA, Dev, QA, Sec, DevOps)
-/context:load                    Carga de contexto al iniciar sesión (big picture)
-/session:save                    Guarda decisiones y pendientes antes de /clear
-/changelog:update                Actualizar CHANGELOG.md desde commits convencionales
-/evaluate:repo [URL]             Auditoría de seguridad y calidad de repo externo
+/pr-review [PR]                  Revisión multi-perspectiva de PR (BA, Dev, QA, Sec, DevOps)
+/context-load                    Carga de contexto al iniciar sesión (big picture)
+/session-save                    Guarda decisiones y pendientes antes de /clear
+/changelog-update                Actualizar CHANGELOG.md desde commits convencionales
+/evaluate-repo [URL]             Auditoría de seguridad y calidad de repo externo
 ```
 
 ## Gestión de Equipo
 ```
-/team:onboarding {nombre}       Guía de onboarding personalizada (contexto + código)
-/team:evaluate {nombre}         Cuestionario interactivo de competencias → perfil en equipo.md
-/team:privacy-notice {nombre}   Nota informativa RGPD obligatoria antes de evaluar
+/team-onboarding {nombre}       Guía de onboarding personalizada (contexto + código)
+/team-evaluate {nombre}         Cuestionario interactivo de competencias → perfil en equipo.md
+/team-privacy-notice {nombre}   Nota informativa RGPD obligatoria antes de evaluar
 ```
 
 ## Infraestructura y Entornos
 ```
-/infra:detect {proyecto} {env}  Detectar infraestructura existente
-/infra:plan {proyecto} {env}    Generar plan de infraestructura
-/infra:estimate {proyecto}      Estimar costes por entorno
-/infra:scale {recurso}          Proponer escalado (requiere aprobación humana)
-/infra:status {proyecto}        Estado de infraestructura actual
-/env:setup {proyecto}           Configurar entornos (DEV/PRE/PRO)
-/env:promote {proyecto} {o} {d} Promover entre entornos (PRE→PRO requiere aprobación)
+/infra-detect {proyecto} {env}  Detectar infraestructura existente
+/infra-plan {proyecto} {env}    Generar plan de infraestructura
+/infra-estimate {proyecto}      Estimar costes por entorno
+/infra-scale {recurso}          Proponer escalado (requiere aprobación humana)
+/infra-status {proyecto}        Estado de infraestructura actual
+/env-setup {proyecto}           Configurar entornos (DEV/PRE/PRO)
+/env-promote {proyecto} {o} {d} Promover entre entornos (PRE→PRO requiere aprobación)
 ```
 
 ---
@@ -112,7 +112,7 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 ### Flujo SDD con agentes en paralelo
 
 ```
-Usuario: /pbi:plan-sprint --project Alpha
+Usuario: /pbi-plan-sprint --project Alpha
 
   ┌─ business-analyst (Opus) ─────────────────┐
   │  Analiza PBIs candidatos                  │   EN PARALELO
@@ -167,7 +167,7 @@ Usuario: /pbi:plan-sprint --project Alpha
 ### Flujo de Infraestructura
 
 ```
-PM: /infra:plan {proyecto} {env}
+PM: /infra-plan {proyecto} {env}
 
   ┌─ architect (Opus) ────────────────────────┐
   │  Define requisitos técnicos               │
@@ -207,6 +207,6 @@ Para ajustar el comportamiento de Claude, edita los ficheros en:
 - `.claude/commands/` — slash commands para flujos de trabajo
 - `.claude/rules/` — reglas modulares cargadas bajo demanda
 
-Las métricas de uso de SDD se registran automáticamente en `projects/{proyecto}/specs/sdd-metrics.md` al ejecutar `/spec:review --check-impl`.
+Las métricas de uso de SDD se registran automáticamente en `projects/{proyecto}/specs/sdd-metrics.md` al ejecutar `/spec-review --check-impl`.
 
 ---

--- a/docs/readme/13-cobertura-contribucion.md
+++ b/docs/readme/13-cobertura-contribucion.md
@@ -8,33 +8,33 @@ Las siguientes responsabilidades clásicas del PM/Scrum Master quedan automatiza
 
 | Must | Cobertura | Simplificación |
 |------|-----------|----------------|
-| Sprint Planning (capacity + selección de PBIs) | `/sprint:plan` | Alta — calcula capacity real, propone PBIs hasta llenarla y descompone en tasks con un solo comando |
-| Descomposición de PBIs en tasks | `/pbi:decompose`, `/pbi:decompose-batch` | Alta — genera tabla de tasks con estimación, actividad y asignación. Elimina la reunión de refinamiento de tareas |
-| Asignación de trabajo (balanceo de carga) | `/pbi:assign` + scoring algorithm | Alta — el algoritmo expertise×disponibilidad×balance elimina la intuición subjetiva y garantiza reparto equitativo |
-| Seguimiento del burndown | `/sprint:status` | Alta — burndown automático en cualquier momento, con desviación respecto al ideal y proyección de cierre |
-| Control de capacity del equipo | `/report:capacity`, `/team:workload` | Alta — detecta sobrecarga individual y días libres sin necesidad de hojas de cálculo manuales |
-| Alertas de WIP y bloqueos | `/sprint:status` | Alta — alertas automáticas de items sin avance, personas al 100% y WIP sobre el límite |
-| Preparación de la Daily | `/sprint:status` | Media — proporciona el estado exacto y sugiere los puntos a tratar, pero la Daily es humana |
-| Informe de imputación de horas | `/report:hours` | Alta — Excel con 4 pestañas generado automáticamente desde Azure DevOps, sin edición manual |
-| Informe ejecutivo multi-proyecto | `/report:executive` | Alta — PPT/Word con semáforos de estado, listo para enviar a dirección |
-| Velocity y KPIs de equipo | `/kpi:dashboard` | Alta — velocity, cycle time, lead time, bug escape rate calculados con datos reales de AzDO |
-| Sprint Review (preparación) | `/sprint:review` | Media — genera el resumen de items completados y velocity, pero la demo la hace el equipo |
-| Sprint Retrospectiva (datos) | `/sprint:retro` | Media — proporciona los datos cuantitativos del sprint (qué fue bien, qué no), pero la dinámica es humana |
-| Implementación de tasks repetibles (multi-lenguaje) | SDD + `/agent:run` | Muy alta — Handlers, Repositories, Validators, Unit Tests implementados sin intervención humana en 16 lenguajes |
-| Gestión de infraestructura cloud | `/infra:plan`, `infrastructure-agent` | Alta — detección automática, creación al tier mínimo, escalado con aprobación humana |
-| Configuración multi-entorno | `/env:setup`, `environment-config.md` | Alta — DEV/PRE/PRO configurables, secrets protegidos, pipelines por entorno |
-| Control de calidad de specs | `/spec:review` | Alta — valida automáticamente que una spec tenga el nivel de detalle suficiente antes de implementar |
-| Onboarding de nuevos miembros | `/team:onboarding`, `/team:evaluate` | Alta — guía personalizada de incorporación + cuestionario de 26 competencias con conformidad RGPD |
+| Sprint Planning (capacity + selección de PBIs) | `/sprint-plan` | Alta — calcula capacity real, propone PBIs hasta llenarla y descompone en tasks con un solo comando |
+| Descomposición de PBIs en tasks | `/pbi-decompose`, `/pbi-decompose-batch` | Alta — genera tabla de tasks con estimación, actividad y asignación. Elimina la reunión de refinamiento de tareas |
+| Asignación de trabajo (balanceo de carga) | `/pbi-assign` + scoring algorithm | Alta — el algoritmo expertise×disponibilidad×balance elimina la intuición subjetiva y garantiza reparto equitativo |
+| Seguimiento del burndown | `/sprint-status` | Alta — burndown automático en cualquier momento, con desviación respecto al ideal y proyección de cierre |
+| Control de capacity del equipo | `/report-capacity`, `/team-workload` | Alta — detecta sobrecarga individual y días libres sin necesidad de hojas de cálculo manuales |
+| Alertas de WIP y bloqueos | `/sprint-status` | Alta — alertas automáticas de items sin avance, personas al 100% y WIP sobre el límite |
+| Preparación de la Daily | `/sprint-status` | Media — proporciona el estado exacto y sugiere los puntos a tratar, pero la Daily es humana |
+| Informe de imputación de horas | `/report-hours` | Alta — Excel con 4 pestañas generado automáticamente desde Azure DevOps, sin edición manual |
+| Informe ejecutivo multi-proyecto | `/report-executive` | Alta — PPT/Word con semáforos de estado, listo para enviar a dirección |
+| Velocity y KPIs de equipo | `/kpi-dashboard` | Alta — velocity, cycle time, lead time, bug escape rate calculados con datos reales de AzDO |
+| Sprint Review (preparación) | `/sprint-review` | Media — genera el resumen de items completados y velocity, pero la demo la hace el equipo |
+| Sprint Retrospectiva (datos) | `/sprint-retro` | Media — proporciona los datos cuantitativos del sprint (qué fue bien, qué no), pero la dinámica es humana |
+| Implementación de tasks repetibles (multi-lenguaje) | SDD + `/agent-run` | Muy alta — Handlers, Repositories, Validators, Unit Tests implementados sin intervención humana en 16 lenguajes |
+| Gestión de infraestructura cloud | `/infra-plan`, `infrastructure-agent` | Alta — detección automática, creación al tier mínimo, escalado con aprobación humana |
+| Configuración multi-entorno | `/env-setup`, `environment-config.md` | Alta — DEV/PRE/PRO configurables, secrets protegidos, pipelines por entorno |
+| Control de calidad de specs | `/spec-review` | Alta — valida automáticamente que una spec tenga el nivel de detalle suficiente antes de implementar |
+| Onboarding de nuevos miembros | `/team-onboarding`, `/team-evaluate` | Alta — guía personalizada de incorporación + cuestionario de 26 competencias con conformidad RGPD |
 
 ## 🔮 No contemplado actualmente — candidatos para el futuro
 
 Áreas que serían naturalmente automatizables con Claude y que representan una evolución lógica del workspace:
 
-**Gestión del backlog y refinement:** actualmente Claude descompone PBIs que ya existen, pero no asiste en la creación de nuevos PBIs desde cero (desde notas de cliente, emails, tickets de soporte). Un skill de `backlog:capture` que convierta inputs desestructurados en PBIs bien formados con criterios de aceptación sería un paso natural.
+**Gestión del backlog y refinement:** actualmente Claude descompone PBIs que ya existen, pero no asiste en la creación de nuevos PBIs desde cero (desde notas de cliente, emails, tickets de soporte). Un skill de `backlog-capture` que convierta inputs desestructurados en PBIs bien formados con criterios de aceptación sería un paso natural.
 
-**Gestión de riesgos (risk log):** el workspace detecta alertas de WIP y burndown, pero no mantiene un registro estructurado de riesgos con probabilidad, impacto y plan de mitigación. Un skill de `risk:log` que actualice el registro en cada `/sprint:status` y escale riesgos críticos al PM sería valioso.
+**Gestión de riesgos (risk log):** el workspace detecta alertas de WIP y burndown, pero no mantiene un registro estructurado de riesgos con probabilidad, impacto y plan de mitigación. Un skill de `risk-log` que actualice el registro en cada `/sprint-status` y escale riesgos críticos al PM sería valioso.
 
-**Release notes automáticas:** al cierre del sprint, Claude tiene toda la información para generar las release notes desde los items completados y los commits. El comando `/changelog:update` cubre parcialmente este caso (genera CHANGELOG desde commits), pero un `/sprint:release-notes` específico que combine commits + work items sería el siguiente paso.
+**Release notes automáticas:** al cierre del sprint, Claude tiene toda la información para generar las release notes desde los items completados y los commits. El comando `/changelog-update` cubre parcialmente este caso (genera CHANGELOG desde commits), pero un `/sprint-release-notes` específico que combine commits + work items sería el siguiente paso.
 
 **Gestión de deuda técnica:** el workspace no rastrea ni prioriza la deuda técnica. Un skill que analice el backlog en busca de items marcados como "refactor" o "tech-debt" y los proponga para sprints de mantenimiento sería un añadido útil.
 
@@ -72,7 +72,7 @@ Este proyecto está diseñado para crecer con las aportaciones de la comunidad. 
 
 ### Qué tipos de contribución aceptamos
 
-**Nuevos slash commands** (`.claude/commands/`) — el área de mayor impacto inmediato. Si has automatizado una conversación con Claude que resuelve un problema de PM no cubierto, empaquétala como comando y compártela. Ejemplos de alto interés: `risk:log`, `sprint:release-notes`, `backlog:capture`, `pr:status`.
+**Nuevos slash commands** (`.claude/commands/`) — el área de mayor impacto inmediato. Si has automatizado una conversación con Claude que resuelve un problema de PM no cubierto, empaquétala como comando y compártela. Ejemplos de alto interés: `risk-log`, `sprint-release-notes`, `backlog-capture`, `pr-status`.
 
 **Nuevas skills** (`.claude/skills/`) — skills que amplíen el comportamiento de Claude en áreas nuevas (gestión de deuda técnica, integración con Jira, soporte para metodologías Kanban o SAFe, nuevos proveedores cloud).
 
@@ -175,7 +175,7 @@ El test suite sigue pasando en modo mock (≥ 93/96). El nuevo comando o skill t
 Abre un Issue en GitHub con uno de estos prefijos en el título:
 
 ```
-[BUG]     /sprint:status no muestra alertas cuando WIP = 0
+[BUG]     /sprint-status no muestra alertas cuando WIP = 0
 [FEATURE] Añadir soporte para metodología Kanban
 [DOCS]    El ejemplo de SDD en el README no refleja el comportamiento actual
 [QUESTION] ¿Cómo configurar el workspace para proyectos con múltiples repos?

--- a/docs/readme_en/01-introduction.md
+++ b/docs/readme_en/01-introduction.md
@@ -32,18 +32,18 @@ I have 2 active projects configured:
   • ProjectBeta   — 4-person team, fixed price, sprint 2026-04 active
 
 I can help you with:
-  Sprint        → /sprint:status, /sprint:plan, /sprint:review, /sprint:retro
-  Reports       → /report:hours, /report:executive, /report:capacity
-  Backlog       → /pbi:decompose, /pbi:plan-sprint, /pbi:assign
-  SDD (agents)  → /spec:generate, /agent:run, /spec:status
+  Sprint        → /sprint-status, /sprint-plan, /sprint-review, /sprint-retro
+  Reports       → /report-hours, /report-executive, /report-capacity
+  Backlog       → /pbi-decompose, /pbi-plan-sprint, /pbi-assign
+  SDD (agents)  → /spec-generate, /agent-run, /spec-status
 
-Where do you want to start? If it's Monday, I recommend /sprint:status
+Where do you want to start? If it's Monday, I recommend /sprint-status
 to see the current sprint state before the Daily standup.
 ```
 
 **You type:**
 ```
-/sprint:status --project ProjectAlpha
+/sprint-status --project ProjectAlpha
 ```
 
 **Claude responds:**

--- a/docs/readme_en/04-usage-sprint-reports.md
+++ b/docs/readme_en/04-usage-sprint-reports.md
@@ -6,10 +6,10 @@ Run these commands inside Claude Code:
 
 | Command | Description |
 |---------|-------------|
-| `/sprint:status` | Sprint status: burndown, active items, WIP alerts |
-| `/sprint:plan` | Sprint Planning assistant: capacity + backlog PBI candidates |
-| `/sprint:review` | Sprint Review summary: velocity, completed items, demo |
-| `/sprint:retro` | Retrospective template with sprint data |
+| `/sprint-status` | Sprint status: burndown, active items, WIP alerts |
+| `/sprint-plan` | Sprint Planning assistant: capacity + backlog PBI candidates |
+| `/sprint-review` | Sprint Review summary: velocity, completed items, demo |
+| `/sprint-retro` | Retrospective template with sprint data |
 
 ---
 
@@ -19,7 +19,7 @@ _Scenario: Sprint in progress, day 4 of 10. You want to know if the team is on t
 
 **You type:**
 ```
-/sprint:status --project ClinicManagement
+/sprint-status --project ClinicManagement
 ```
 
 **Claude responds:**
@@ -82,7 +82,7 @@ _Scenario: It's the Friday before a new sprint. You want to prepare the planning
 
 **You type:**
 ```
-/sprint:plan --project ClinicManagement
+/sprint-plan --project ClinicManagement
 ```
 
 **Claude responds:**
@@ -126,11 +126,11 @@ _Scenario: It's the Friday before a new sprint. You want to prepare the planning
 
 | Command | Description |
 |---------|-------------|
-| `/report:hours` | Hours report (Excel, 4 tabs) |
-| `/report:executive` | Multi-project executive report (Word + PPT with traffic lights) |
-| `/report:capacity` | Team capacity status for the current week |
-| `/team:workload` | Workload map by person |
-| `/kpi:dashboard` | Full dashboard: velocity, cycle time, lead time, bug escape rate |
+| `/report-hours` | Hours report (Excel, 4 tabs) |
+| `/report-executive` | Multi-project executive report (Word + PPT with traffic lights) |
+| `/report-capacity` | Team capacity status for the current week |
+| `/team-workload` | Workload map by person |
+| `/kpi-dashboard` | Full dashboard: velocity, cycle time, lead time, bug escape rate |
 
 ---
 
@@ -140,7 +140,7 @@ _Scenario: Last day of the sprint. The client requests the hours report._
 
 **You type:**
 ```
-/report:hours --project ClinicManagement --sprint 2026-04
+/report-hours --project ClinicManagement --sprint 2026-04
 ```
 
 **Claude responds:**
@@ -178,7 +178,7 @@ _Scenario: Wednesday. You suspect someone is overloaded._
 
 **You type:**
 ```
-/team:workload --project ClinicManagement
+/team-workload --project ClinicManagement
 ```
 
 **Claude responds:**
@@ -202,11 +202,11 @@ Team workload — current week (Mon 17/03 – Fri 21/03)
 
 The standard process to prepare a sprint:
 
-1. `/pbi:decompose {id}` — Claude analyzes the PBI, its acceptance criteria, and team context, then proposes a task table.
+1. `/pbi-decompose {id}` — Claude analyzes the PBI, its acceptance criteria, and team context, then proposes a task table.
 2. Claude asks if you want to create the tasks in Azure DevOps.
 3. You confirm and Claude creates them via REST API.
 
-To prepare the full sprint at once: `/pbi:plan-sprint` runs the complete cycle automatically (capacity → PBI selection → decomposition → assignment → creation in AzDO).
+To prepare the full sprint at once: `/pbi-plan-sprint` runs the complete cycle automatically (capacity → PBI selection → decomposition → assignment → creation in AzDO).
 
 **Assignment scoring algorithm:**
 ```
@@ -222,7 +222,7 @@ _Scenario: You have PBI AB#302 "Patient appointment history" with 3 acceptance c
 
 **You type:**
 ```
-/pbi:decompose 302 --project ClinicManagement
+/pbi-decompose 302 --project ClinicManagement
 ```
 
 **Claude responds:**
@@ -242,10 +242,10 @@ TASK PROPOSAL:
 ├────┼──────────────────────────────────────────┼──────┼──────┼────────────────┼───────────────┤
 │ B1 │ HistorialCitasQuery design + DTO         │  3h  │ Dev  │ Carlos TL      │ human         │
 │ B2 │ EF Core: IHistorialCitasRepository       │  2h  │ Dev  │ Diego T.       │ human         │
-│ B3 │ GetHistorialCitasQueryHandler            │  4h  │ Dev  │ 🤖 agent       │ agent:single  │
-│ C1 │ HistorialCitasController (GET endpoint)  │  3h  │ Dev  │ 🤖 agent       │ agent:single  │
+│ B3 │ GetHistorialCitasQueryHandler            │  4h  │ Dev  │ 🤖 agent       │ agent-single  │
+│ C1 │ HistorialCitasController (GET endpoint)  │  3h  │ Dev  │ 🤖 agent       │ agent-single  │
 │ C2 │ Cursor-based pagination (middleware)     │  3h  │ Dev  │ Laura S.       │ human         │
-│ D1 │ Unit tests for QueryHandler              │  2h  │ Dev  │ 🤖 agent       │ agent:single  │
+│ D1 │ Unit tests for QueryHandler              │  2h  │ Dev  │ 🤖 agent       │ agent-single  │
 │ D2 │ End-to-end integration test              │  3h  │ QA   │ Ana Morales    │ human         │
 │ E1 │ Code Review                              │  2h  │ Rev  │ Carlos TL      │ human         │
 └────┴──────────────────────────────────────────┴──────┴──────┴────────────────┴───────────────┘
@@ -264,7 +264,7 @@ Change C2 to the agent too, Laura already has a heavy load. Create the tasks.
 
 **Claude responds:**
 ```
-Adjusted: C2 → agent:single (I'll add the reference pagination pattern to the spec).
+Adjusted: C2 → agent-single (I'll add the reference pagination pattern to the spec).
 
 Creating 8 tasks in Azure DevOps for AB#302...
   ✅ AB#302-B1 created → assigned to Carlos Mendoza
@@ -277,5 +277,5 @@ Creating 8 tasks in Azure DevOps for AB#302...
   ✅ AB#302-E1 created → assigned to Carlos Mendoza
 
 8 tasks created. Agent tasks (B3, C1, C2, D1) now have the
-"spec-driven" tag and are ready for /spec:generate whenever you want.
+"spec-driven" tag and are ready for /spec-generate whenever you want.
 ```

--- a/docs/readme_en/05-sdd.md
+++ b/docs/readme_en/05-sdd.md
@@ -9,20 +9,20 @@ A Spec is a contract that describes exactly what to implement. If the contract i
 | Type | Who implements | When |
 |------|----------------|------|
 | `human` | Team developer | Domain logic, migrations, external integrations, Code Review |
-| `agent:single` | One Claude agent | Handlers, Repositories, Validators, Unit Tests, DTOs, Controllers |
-| `agent:team` | Implementer + Tester in parallel | Tasks ≥ 6h with production code + tests |
+| `agent-single` | One Claude agent | Handlers, Repositories, Validators, Unit Tests, DTOs, Controllers |
+| `agent-team` | Implementer + Tester in parallel | Tasks ≥ 6h with production code + tests |
 
 ## SDD workflow
 
 ```
-1. /pbi:decompose → task proposal with "Developer Type" column
-2. /spec:generate {task_id} → generates .spec.md file from Azure DevOps
-3. /spec:review {spec_file} → validates the spec (quality, completeness)
+1. /pbi-decompose → task proposal with "Developer Type" column
+2. /spec-generate {task_id} → generates .spec.md file from Azure DevOps
+3. /spec-review {spec_file} → validates the spec (quality, completeness)
 4. If developer_type = agent:
-     /agent:run {spec_file} → agent implements the spec
+     /agent-run {spec_file} → agent implements the spec
    If developer_type = human:
      Assign to the developer
-5. /spec:review {spec_file} --check-impl → pre-check of generated code
+5. /spec-review {spec_file} --check-impl → pre-check of generated code
 6. Code Review (E1) → ALWAYS human (Tech Lead)
 7. PR → merge → Task: Done
 ```
@@ -59,7 +59,7 @@ _Scenario: Task AB#302-B3 "GetHistorialCitasQueryHandler" is ready for the agent
 
 **You type:**
 ```
-/spec:generate 302-B3 --project ClinicManagement
+/spec-generate 302-B3 --project ClinicManagement
 ```
 
 **Claude responds:**
@@ -67,7 +67,7 @@ _Scenario: Task AB#302-B3 "GetHistorialCitasQueryHandler" is ready for the agent
 Reading AB#302 (parent PBI) and AB#302-B3 (Task)...
 Analyzing existing code in projects/clinic-management/source/...
 → Module: Appointments / Layer: Application / Type: QueryHandler
-→ Developer type: agent:single (repeatable pattern, interfaces defined)
+→ Developer type: agent-single (repeatable pattern, interfaces defined)
 
 Spec generated:
   projects/clinic-management/specs/sprint-2026-05/AB302-B3-get-historial-citas-handler.spec.md
@@ -85,14 +85,14 @@ Preview of the most critical section (Technical Contract):
 │  }                                                              │
 └─────────────────────────────────────────────────────────────────┘
 
-Do you want to review the spec before implementing? → /spec:review AB302-B3-...
+Do you want to review the spec before implementing? → /spec-review AB302-B3-...
 ```
 
 **Step 2 — Validate the spec**
 
 **You type:**
 ```
-/spec:review AB302-B3-get-historial-citas-handler.spec.md
+/spec-review AB302-B3-get-historial-citas-handler.spec.md
 ```
 
 **Claude responds:**
@@ -108,7 +108,7 @@ Reviewing spec quality...
 
 ══════════════════════
   ✅ SPEC READY
-  You can run /agent:run
+  You can run /agent-run
 ══════════════════════
 ```
 
@@ -116,7 +116,7 @@ Reviewing spec quality...
 
 **You type:**
 ```
-/agent:run projects/clinic-management/specs/sprint-2026-05/AB302-B3-get-historial-citas-handler.spec.md
+/agent-run projects/clinic-management/specs/sprint-2026-05/AB302-B3-get-historial-citas-handler.spec.md
 ```
 
 **Claude responds:**
@@ -157,7 +157,7 @@ _Scenario: You want to see the status of all SDD tasks in the sprint at a glance
 
 **You type:**
 ```
-/spec:status --project ClinicManagement
+/spec-status --project ClinicManagement
 ```
 
 **Claude responds:**
@@ -168,12 +168,12 @@ _Scenario: You want to see the status of all SDD tasks in the sprint at a glance
 
   Task                             Spec         Dev Type     Status   h    Assigned
   ─────────────────────────────────────────────────────────────────────────────────
-  AB#302-B3 GetHistorialCitas      ✅ ready      agent:single  ✅ done  4h   agent
-  AB#302-C1 HistorialController    ✅ ready      agent:single  🔄 impl  3h   agent
-  AB#302-C2 Cursor pagination      ✅ ready      agent:single  ⏳ queue 3h   agent
-  AB#302-D1 Unit tests handler     ✅ ready      agent:single  ⏳ queue 2h   agent
-  AB#301-B3 SendConfirmationCmd    ⚠️ incomplete agent:single  🚫 blk   4h   agent
-  AB#301-D1 EmailTemplateService   ⏳ pending    agent:single  ⏳ queue 3h   agent
+  AB#302-B3 GetHistorialCitas      ✅ ready      agent-single  ✅ done  4h   agent
+  AB#302-C1 HistorialController    ✅ ready      agent-single  🔄 impl  3h   agent
+  AB#302-C2 Cursor pagination      ✅ ready      agent-single  ⏳ queue 3h   agent
+  AB#302-D1 Unit tests handler     ✅ ready      agent-single  ⏳ queue 2h   agent
+  AB#301-B3 SendConfirmationCmd    ⚠️ incomplete agent-single  🚫 blk   4h   agent
+  AB#301-D1 EmailTemplateService   ⏳ pending    agent-single  ⏳ queue 3h   agent
 
   Summary:
     Completed: 1 | In progress: 1 | In queue: 3 | Blocked: 1
@@ -182,7 +182,7 @@ _Scenario: You want to see the status of all SDD tasks in the sprint at a glance
 
   ⚠️  AB#301-B3 blocked:
      The spec has an incomplete Technical Contract section —
-     the IEmailService signature is missing. Run /spec:review AB301-B3-...
+     the IEmailService signature is missing. Run /spec-review AB301-B3-...
      to see exactly what's missing.
 ```
 
@@ -193,7 +193,7 @@ _Scenario: You want to see the status of all SDD tasks in the sprint at a glance
 For large tasks, you can use a team of agents in parallel:
 
 ```bash
-/agent:run {spec_file} --team
+/agent-run {spec_file} --team
 # Launches: Implementer (opus) + Tester (haiku) in parallel
 # Time: ~50% less than sequential
 # Cost: ~$0.80-1.80 per spec
@@ -215,7 +215,7 @@ _Scenario: Task AB#301-B3 "SendCitaConfirmationCommandHandler" is complex (6h), 
 
 **You type:**
 ```
-/agent:run projects/clinic-management/specs/sprint-2026-05/AB301-B3-send-confirmation-cmd.spec.md --team
+/agent-run projects/clinic-management/specs/sprint-2026-05/AB301-B3-send-confirmation-cmd.spec.md --team
 ```
 
 **Claude responds:**

--- a/docs/readme_en/10-kpis-rules.md
+++ b/docs/readme_en/10-kpis-rules.md
@@ -35,8 +35,8 @@
 
 | Weeks | Phase | Goal |
 |-------|-------|------|
-| 1-2 | Setup | Connect to Azure DevOps, try `/sprint:status` |
-| 3-4 | Basic management | Iterate with `/sprint:plan`, `/team:workload`, adjust constants |
-| 5-6 | Reporting | Activate `/report:hours` and `/report:executive` with real data |
+| 1-2 | Setup | Connect to Azure DevOps, try `/sprint-status` |
+| 3-4 | Basic management | Iterate with `/sprint-plan`, `/team-workload`, adjust constants |
+| 5-6 | Reporting | Activate `/report-hours` and `/report-executive` with real data |
 | 7-8 | SDD pilot | Generate first specs, test agent with 1-2 Application Layer tasks |
 | 9+ | SDD at scale | Goal: 60%+ of repetitive technical tasks implemented by agents |

--- a/docs/readme_en/11-onboarding.md
+++ b/docs/readme_en/11-onboarding.md
@@ -7,13 +7,13 @@ PM-Workspace includes a complete workflow for onboarding developers to a project
 ```
 New member joins the project
     ↓
-/team:privacy-notice "Name"       ← 1. GDPR privacy notice (mandatory)
+/team-privacy-notice "Name"       ← 1. GDPR privacy notice (mandatory)
     ↓                                   Worker reads and signs acknowledgment
-/team:onboarding "Name"           ← 2. Project context + codebase tour
+/team-onboarding "Name"           ← 2. Project context + codebase tour
     ↓                                   Mentor validates each phase
   [First assisted task]            ← 3. Mentor assigns B/C task, pair with Claude
     ↓                                   Human Code Review mandatory
-/team:evaluate "Name"              ← 4. Competency questionnaire (8 dimensions)
+/team-evaluate "Name"              ← 4. Competency questionnaire (8 dimensions)
     ↓                                   Self-assessment + Tech Lead calibration
   [Progressive autonomy]           ← 5. Weeks 1-3 with decreasing supervision
 ```
@@ -22,13 +22,13 @@ Phases 3 and 5 are human-driven processes guided by the mentor, not commands.
 
 ### Phase 1 — GDPR Privacy Notice
 
-Before collecting any worker data, the law requires delivering a privacy notice (Art. 13 GDPR). The command `/team:privacy-notice "Name" --project MyProject` generates the document from a template covering: data controller, purpose (task assignment and training), legal basis (legitimate interest), worker rights (access, rectification, erasure, objection, portability).
+Before collecting any worker data, the law requires delivering a privacy notice (Art. 13 GDPR). The command `/team-privacy-notice "Name" --project MyProject` generates the document from a template covering: data controller, purpose (task assignment and training), legal basis (legitimate interest), worker rights (access, rectification, erasure, objection, portability).
 
-The worker signs the acknowledgment before proceeding. Without this signature, `/team:evaluate` is blocked.
+The worker signs the acknowledgment before proceeding. Without this signature, `/team-evaluate` is blocked.
 
 ### Phase 2 — Onboarding: Context and Codebase Tour
 
-The command `/team:onboarding "Name" --project MyProject` generates a personalized guide covering:
+The command `/team-onboarding "Name" --project MyProject` generates a personalized guide covering:
 
 - **Immediate context**: project architecture, layers, modules, patterns, team conventions, members and roles
 - **Codebase tour**: end-to-end request walkthrough (Controller → Handler → Repository → Entity), patterns with real project examples, test structure, SDD spec locations
@@ -41,7 +41,7 @@ The mentor assigns a B/C complexity task. The new member implements it with Clau
 
 ### Phase 4 — Competency Evaluation
 
-The command `/team:evaluate "Name" --project MyProject` runs an interactive questionnaire in three sections: A (stack-specific technical skills, 12 competencies), B (cross-cutting skills, 7 competencies), C (project domain knowledge, dynamically generated from project modules).
+The command `/team-evaluate "Name" --project MyProject` runs an interactive questionnaire in three sections: A (stack-specific technical skills, 12 competencies), B (cross-cutting skills, 7 competencies), C (project domain knowledge, dynamically generated from project modules).
 
 For each competency, level (1-5) and interest (Y/N) are collected. The `business-analyst` agent compares self-assessment with observable evidence (PRs, Git history) and suggests adjustments. The Tech Lead co-signs the final result.
 

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -2,66 +2,66 @@
 
 ## Sprint and Reporting
 ```
-/sprint:status [--project]        Sprint status with alerts
-/sprint:plan [--project]          Sprint Planning assistant
-/sprint:review [--project]        Sprint Review summary
-/sprint:retro [--project]         Retrospective with data
-/report:hours [--project]         Hours report (Excel)
-/report:executive                 Multi-project report (PPT/Word)
-/report:capacity [--project]      Capacity status
-/team:workload [--project]        Workload by person
-/board:flow [--project]           Cycle time and bottlenecks
-/kpi:dashboard [--project]        Full KPI dashboard
+/sprint-status [--project]        Sprint status with alerts
+/sprint-plan [--project]          Sprint Planning assistant
+/sprint-review [--project]        Sprint Review summary
+/sprint-retro [--project]         Retrospective with data
+/report-hours [--project]         Hours report (Excel)
+/report-executive                 Multi-project report (PPT/Word)
+/report-capacity [--project]      Capacity status
+/team-workload [--project]        Workload by person
+/board-flow [--project]           Cycle time and bottlenecks
+/kpi-dashboard [--project]        Full KPI dashboard
 ```
 
 ## PBI Decomposition
 ```
-/pbi:decompose {id}               Break down a PBI into tasks
-/pbi:decompose-batch {id1,id2}    Break down multiple PBIs
-/pbi:assign {pbi_id}              (Re)assign tasks for a PBI
-/pbi:plan-sprint                  Full sprint planning
+/pbi-decompose {id}               Break down a PBI into tasks
+/pbi-decompose-batch {id1,id2}    Break down multiple PBIs
+/pbi-assign {pbi_id}              (Re)assign tasks for a PBI
+/pbi-plan-sprint                  Full sprint planning
 ```
 
 ## Spec-Driven Development
 ```
-/spec:generate {task_id}          Generate Spec from Azure DevOps Task
-/spec:implement {spec_file}       Implement Spec (agent or human)
-/spec:review {spec_file}          Review Spec quality or implementation
-/spec:status [--project]          Sprint Spec dashboard
-/agent:run {spec_file} [--team]   Launch Claude agent on a Spec
+/spec-generate {task_id}          Generate Spec from Azure DevOps Task
+/spec-implement {spec_file}       Implement Spec (agent or human)
+/spec-review {spec_file}          Review Spec quality or implementation
+/spec-status [--project]          Sprint Spec dashboard
+/agent-run {spec_file} [--team]   Launch Claude agent on a Spec
 ```
 
 ## Product Discovery
 ```
-/pbi:jtbd {id}                   Generate JTBD (Jobs to be Done) for a PBI
-/pbi:prd {id}                    Generate PRD (Product Requirements) for a PBI
+/pbi-jtbd {id}                   Generate JTBD (Jobs to be Done) for a PBI
+/pbi-prd {id}                    Generate PRD (Product Requirements) for a PBI
 ```
 
 ## Quality and Operations
 ```
-/pr:review [PR]                  Multi-perspective PR review (BA, Dev, QA, Sec, DevOps)
-/context:load                    Load session context on startup (big picture)
-/session:save                    Save decisions and pending tasks before /clear
-/changelog:update                Update CHANGELOG.md from conventional commits
-/evaluate:repo [URL]             Security and quality audit of external repo
+/pr-review [PR]                  Multi-perspective PR review (BA, Dev, QA, Sec, DevOps)
+/context-load                    Load session context on startup (big picture)
+/session-save                    Save decisions and pending tasks before /clear
+/changelog-update                Update CHANGELOG.md from conventional commits
+/evaluate-repo [URL]             Security and quality audit of external repo
 ```
 
 ## Team Management
 ```
-/team:onboarding {name}          Personalized onboarding guide (context + code)
-/team:evaluate {name}            Interactive competency questionnaire → equipo.md profile
-/team:privacy-notice {name}      Mandatory GDPR privacy notice before assessment
+/team-onboarding {name}          Personalized onboarding guide (context + code)
+/team-evaluate {name}            Interactive competency questionnaire → equipo.md profile
+/team-privacy-notice {name}      Mandatory GDPR privacy notice before assessment
 ```
 
 ## Infrastructure and Environments
 ```
-/infra:detect {project} {env}    Detect existing infrastructure
-/infra:plan {project} {env}      Generate infrastructure plan
-/infra:estimate {project}        Estimate costs per environment
-/infra:scale {resource}          Propose scaling (requires human approval)
-/infra:status {project}          Current infrastructure status
-/env:setup {project}             Configure environments (DEV/PRE/PRO)
-/env:promote {project} {s} {d}   Promote between environments (PRE→PRO requires approval)
+/infra-detect {project} {env}    Detect existing infrastructure
+/infra-plan {project} {env}      Generate infrastructure plan
+/infra-estimate {project}        Estimate costs per environment
+/infra-scale {resource}          Propose scaling (requires human approval)
+/infra-status {project}          Current infrastructure status
+/env-setup {project}             Configure environments (DEV/PRE/PRO)
+/env-promote {project} {s} {d}   Promote between environments (PRE→PRO requires approval)
 ```
 
 ---
@@ -100,7 +100,7 @@ The workspace includes 23 specialized agents organized in 3 groups, each optimiz
 ### SDD flow with parallel agents
 
 ```
-User: /pbi:plan-sprint --project Alpha
+User: /pbi-plan-sprint --project Alpha
 
   ┌─ business-analyst (Opus) ─────────────────┐
   │  Analyze candidate PBIs                   │   IN PARALLEL

--- a/docs/readme_en/13-coverage-contributing.md
+++ b/docs/readme_en/13-coverage-contributing.md
@@ -8,37 +8,37 @@ The following classic PM/Scrum Master responsibilities are automated or signific
 
 | Responsibility | Coverage | Simplification |
 |----------------|----------|----------------|
-| Sprint Planning (capacity + PBI selection) | `/sprint:plan` | High — calculates real capacity, proposes PBIs to fill it, and breaks them into tasks with a single command |
-| PBI breakdown into tasks | `/pbi:decompose`, `/pbi:decompose-batch` | High — generates task table with estimates, activity, and assignment. Eliminates task refinement meetings |
-| Work assignment (load balancing) | `/pbi:assign` + scoring algorithm | High — expertise×availability×balance algorithm removes subjective intuition and guarantees equitable distribution |
-| Burndown tracking | `/sprint:status` | High — automatic burndown at any time, with deviation from ideal and completion forecast |
-| Team capacity control | `/report:capacity`, `/team:workload` | High — detects individual overload and free days without manual spreadsheets |
-| WIP and blocker alerts | `/sprint:status` | High — automatic alerts for stalled items, people at 100%, and WIP over limit |
-| Daily standup preparation | `/sprint:status` | Medium — provides exact status and suggests talking points, but the standup itself is human |
-| Hours report | `/report:hours` | High — Excel with 4 tabs auto-generated from Azure DevOps, no manual editing |
-| Multi-project executive report | `/report:executive` | High — PPT/Word with status traffic lights, ready to send to management |
-| Team velocity and KPIs | `/kpi:dashboard` | High — velocity, cycle time, lead time, bug escape rate calculated from real AzDO data |
-| Sprint Review preparation | `/sprint:review` | Medium — generates completed items summary and velocity, but the demo is done by the team |
-| Sprint Retrospective data | `/sprint:retro` | Medium — provides quantitative sprint data, but the retrospective dynamics are human |
-| Repetitive multi-language task implementation | SDD + `/agent:run` | Very high — handlers, repositories, validators, unit tests implemented in 16 languages without human intervention |
-| Spec quality control | `/spec:review` | High — automatically validates that a spec has sufficient detail before implementation |
-| New member onboarding | `/team:onboarding`, `/team:evaluate` | High — personalized onboarding guide + 26-competency questionnaire with GDPR compliance |
-| Infrastructure planning and cost estimation | `/infra:plan`, `/infra:estimate` | High — multi-cloud infrastructure as code with automatic detection and cost analysis |
-| Multi-environment management | `/env:setup`, `/env:promote` | High — DEV/PRE/PRO environments with confidential configuration protection |
+| Sprint Planning (capacity + PBI selection) | `/sprint-plan` | High — calculates real capacity, proposes PBIs to fill it, and breaks them into tasks with a single command |
+| PBI breakdown into tasks | `/pbi-decompose`, `/pbi-decompose-batch` | High — generates task table with estimates, activity, and assignment. Eliminates task refinement meetings |
+| Work assignment (load balancing) | `/pbi-assign` + scoring algorithm | High — expertise×availability×balance algorithm removes subjective intuition and guarantees equitable distribution |
+| Burndown tracking | `/sprint-status` | High — automatic burndown at any time, with deviation from ideal and completion forecast |
+| Team capacity control | `/report-capacity`, `/team-workload` | High — detects individual overload and free days without manual spreadsheets |
+| WIP and blocker alerts | `/sprint-status` | High — automatic alerts for stalled items, people at 100%, and WIP over limit |
+| Daily standup preparation | `/sprint-status` | Medium — provides exact status and suggests talking points, but the standup itself is human |
+| Hours report | `/report-hours` | High — Excel with 4 tabs auto-generated from Azure DevOps, no manual editing |
+| Multi-project executive report | `/report-executive` | High — PPT/Word with status traffic lights, ready to send to management |
+| Team velocity and KPIs | `/kpi-dashboard` | High — velocity, cycle time, lead time, bug escape rate calculated from real AzDO data |
+| Sprint Review preparation | `/sprint-review` | Medium — generates completed items summary and velocity, but the demo is done by the team |
+| Sprint Retrospective data | `/sprint-retro` | Medium — provides quantitative sprint data, but the retrospective dynamics are human |
+| Repetitive multi-language task implementation | SDD + `/agent-run` | Very high — handlers, repositories, validators, unit tests implemented in 16 languages without human intervention |
+| Spec quality control | `/spec-review` | High — automatically validates that a spec has sufficient detail before implementation |
+| New member onboarding | `/team-onboarding`, `/team-evaluate` | High — personalized onboarding guide + 26-competency questionnaire with GDPR compliance |
+| Infrastructure planning and cost estimation | `/infra-plan`, `/infra-estimate` | High — multi-cloud infrastructure as code with automatic detection and cost analysis |
+| Multi-environment management | `/env-setup`, `/env-promote` | High — DEV/PRE/PRO environments with confidential configuration protection |
 
 ## 🔮 Not yet covered — candidates for the future
 
 Areas that would be naturally automatable with Claude and represent a logical evolution of the workspace:
 
-**Backlog management and refinement:** Claude currently breaks down existing PBIs, but doesn't assist in creating new PBIs from scratch (from client notes, emails, support tickets). A `backlog:capture` skill that converts unstructured inputs into well-formed PBIs with acceptance criteria would be a natural next step.
+**Backlog management and refinement:** Claude currently breaks down existing PBIs, but doesn't assist in creating new PBIs from scratch (from client notes, emails, support tickets). A `backlog-capture` skill that converts unstructured inputs into well-formed PBIs with acceptance criteria would be a natural next step.
 
-**Risk management (risk log):** the workspace detects WIP and burndown alerts, but doesn't maintain a structured risk register with probability, impact, and mitigation plans. A `risk:log` skill that updates the register on each `/sprint:status` and escalates critical risks to the PM would be valuable.
+**Risk management (risk log):** the workspace detects WIP and burndown alerts, but doesn't maintain a structured risk register with probability, impact, and mitigation plans. A `risk-log` skill that updates the register on each `/sprint-status` and escalates critical risks to the PM would be valuable.
 
-**Automatic release notes:** at sprint close, Claude has all the information to generate release notes from completed items and commits. The `/changelog:update` command partially covers this (generates CHANGELOG from commits), but a dedicated `/sprint:release-notes` that combines commits + work items would be the next step.
+**Automatic release notes:** at sprint close, Claude has all the information to generate release notes from completed items and commits. The `/changelog-update` command partially covers this (generates CHANGELOG from commits), but a dedicated `/sprint-release-notes` that combines commits + work items would be the next step.
 
 **Technical debt management:** the workspace doesn't track or prioritize technical debt. A skill that analyzes the backlog for items tagged "refactor" or "tech-debt" and proposes them for maintenance sprints would be a useful addition.
 
-**Pull request integration:** the `/pr:review` command now covers multi-perspective review of PRs, but the workspace doesn't yet track associated PR status in AzDO (reviewers, pending comments, review time). Full integration with Azure DevOps Git API would complete the cycle.
+**Pull request integration:** the `/pr-review` command now covers multi-perspective review of PRs, but the workspace doesn't yet track associated PR status in AzDO (reviewers, pending comments, review time). Full integration with Azure DevOps Git API would complete the cycle.
 
 **Production bug tracking:** the bug escape rate is calculated, but there's no automated flow for prioritizing incoming bugs, linking them to the current sprint, and proposing whether they impact the sprint goal.
 
@@ -74,7 +74,7 @@ This project is designed to grow with community contributions. If you use the wo
 
 ## What types of contributions we accept
 
-**New slash commands** (`.claude/commands/`) — the highest-impact area. If you've automated a Claude conversation that solves a PM problem not yet covered, package it as a command and share it. High-interest examples: `risk:log`, `sprint:release-notes`, `backlog:capture`.
+**New slash commands** (`.claude/commands/`) — the highest-impact area. If you've automated a Claude conversation that solves a PM problem not yet covered, package it as a command and share it. High-interest examples: `risk-log`, `sprint-release-notes`, `backlog-capture`.
 
 **New skills** (`.claude/skills/`) — skills that extend Claude's behavior in new areas (technical debt management, Jira integration, Kanban or SAFe methodology support, new cloud providers).
 
@@ -175,7 +175,7 @@ The test suite continues to pass in mock mode (≥ 93/96). The new command or sk
 Open an Issue on GitHub with one of these prefixes in the title:
 
 ```
-[BUG]     /sprint:status doesn't show alerts when WIP = 0
+[BUG]     /sprint-status doesn't show alerts when WIP = 0
 [FEATURE] Add support for Kanban methodology
 [DOCS]    The SDD example in the README doesn't reflect current behavior
 [QUESTION] How do I configure the workspace for projects with multiple repos?
@@ -193,7 +193,7 @@ Contributions must be respectful, technically sound, and focused on solving real
 
 To adjust Claude's behavior, edit the files in `.claude/skills/` (each skill has its `SKILL.md`) or add new slash commands in `.claude/commands/`.
 
-SDD usage metrics are automatically recorded in `projects/{project}/specs/sdd-metrics.md` when running `/spec:review --check-impl`.
+SDD usage metrics are automatically recorded in `projects/{project}/specs/sdd-metrics.md` when running `/spec-review --check-impl`.
 
 ---
 

--- a/projects/proyecto-alpha/CLAUDE.md
+++ b/projects/proyecto-alpha/CLAUDE.md
@@ -98,7 +98,7 @@ Ver composición completa en `equipo.md`.
 
 **Estado:** 🟢 En buen camino
 
-Para ver el estado detallado ejecutar: `/sprint:status proyecto-alpha`
+Para ver el estado detallado ejecutar: `/sprint-status proyecto-alpha`
 
 ---
 
@@ -202,15 +202,15 @@ sdd_config:
 
   # Tipos de task por defecto para este proyecto (basado en el stack)
   default_agent_tasks:
-    - "Command Handler (CRUD)"         # Application layer → agent:single
-    - "Query Handler"                  # Application layer → agent:single
-    - "FluentValidation Validator"     # Application layer → agent:single
-    - "AutoMapper Profile"             # Application layer → agent:single
-    - "DTO / Request / Response"       # Cualquier capa → agent:single (haiku)
-    - "Repository EF Core"             # Infrastructure → agent:single
-    - "Entity Configuration EF Core"   # Infrastructure → agent:single
-    - "Controller CRUD"                # API layer → agent:single
-    - "Unit Tests Application"         # Tests → agent:single (haiku)
+    - "Command Handler (CRUD)"         # Application layer → agent-single
+    - "Query Handler"                  # Application layer → agent-single
+    - "FluentValidation Validator"     # Application layer → agent-single
+    - "AutoMapper Profile"             # Application layer → agent-single
+    - "DTO / Request / Response"       # Cualquier capa → agent-single (haiku)
+    - "Repository EF Core"             # Infrastructure → agent-single
+    - "Entity Configuration EF Core"   # Infrastructure → agent-single
+    - "Controller CRUD"                # API layer → agent-single
+    - "Unit Tests Application"         # Tests → agent-single (haiku)
 
   default_human_tasks:
     - "Domain Entity (nuevo agregado)" # Domain → human

--- a/projects/proyecto-alpha/equipo.md
+++ b/projects/proyecto-alpha/equipo.md
@@ -229,5 +229,5 @@ Fuerza humano:
 | 2026-04 | 60h | 60h | 50h | 60h | ~40h estimadas | ~270h efectivas |
 | 2026-05 | 60h | 60h | 60h | 60h | ~40h estimadas | ~280h efectivas |
 
-> Las horas de agentes son estimadas. Varían según número de specs `agent:single` aprobadas ese sprint.
+> Las horas de agentes son estimadas. Varían según número de specs `agent-single` aprobadas ese sprint.
 > El Tech Lead decide sprint a sprint cuántas specs se delegan a agentes.

--- a/projects/proyecto-alpha/specs/sdd-metrics.md
+++ b/projects/proyecto-alpha/specs/sdd-metrics.md
@@ -1,7 +1,7 @@
 # SDD Metrics — Proyecto Alpha
 
 > Registro histórico de rendimiento del proceso Spec-Driven Development.
-> Actualizar al completar cada Spec (via `/spec:review` con `--check-impl`).
+> Actualizar al completar cada Spec (via `/spec-review` con `--check-impl`).
 
 ## Tabla de Métricas
 

--- a/projects/proyecto-alpha/specs/templates/spec-template.md
+++ b/projects/proyecto-alpha/specs/templates/spec-template.md
@@ -16,7 +16,7 @@
 **Fecha creación:** {YYYY-MM-DD}
 **Creado por:**     {PM/Tech Lead}
 
-**Developer Type:** human | agent:single | agent:team
+**Developer Type:** human | agent-single | agent-team
 **Asignado a:**     {nombre_dev | claude-agent | claude-agent-team}
 **Estimación:**     {Xh}
 **Estado:**         Pendiente | En Progreso | Completado | Bloqueado
@@ -304,7 +304,7 @@ dotnet test $TEST_PROJECT --filter "Category=Unit" --no-build
 **Último update:** {YYYY-MM-DD HH:MM}
 **Actualizado por:** {dev/agent}
 
-### Log de implementación (si agent:single o agent:team)
+### Log de implementación (si agent-single o agent-team)
 - {timestamp} — [AGENT] Iniciando implementación
 - {timestamp} — [AGENT] Handler creado: CreatePatientCommandHandler.cs
 - {timestamp} — [AGENT] Validator creado: CreatePatientCommandValidator.cs

--- a/projects/proyecto-beta/CLAUDE.md
+++ b/projects/proyecto-beta/CLAUDE.md
@@ -94,7 +94,7 @@ Ver composición completa en `equipo.md`.
 
 **Estado:** 🟡 Inicio de sprint
 
-Para ver el estado detallado ejecutar: `/sprint:status proyecto-beta`
+Para ver el estado detallado ejecutar: `/sprint-status proyecto-beta`
 
 ---
 
@@ -191,7 +191,7 @@ sdd_config:
       reason: "Sin componente de referencia en el código, el agente genera estructuras inconsistentes"
     - layer: "Blazor Components"
       task_type: "Componente basado en patrón existente"
-      default: "agent:single"
+      default: "agent-single"
       reason: "Si hay componente similar, el agente puede replicar el patrón"
 
     # Migraciones: siempre humano (precio fijo → riesgo de datos crítico)
@@ -201,11 +201,11 @@ sdd_config:
 
   # En Beta (N-Layer simple, no Clean Architecture completa), adaptar los tipos de task
   default_agent_tasks:
-    - "Service Method (CRUD)"          # Application/Services → agent:single
-    - "Repository Method EF Core"      # Data layer → agent:single
-    - "DTO / ViewModel"                # Cualquier capa → agent:single (haiku)
-    - "Unit Tests Services"            # Tests → agent:single (haiku)
-    - "Blazor Code-Behind (CRUD)"      # Presentación → agent:single si hay referencia
+    - "Service Method (CRUD)"          # Application/Services → agent-single
+    - "Repository Method EF Core"      # Data layer → agent-single
+    - "DTO / ViewModel"                # Cualquier capa → agent-single (haiku)
+    - "Unit Tests Services"            # Tests → agent-single (haiku)
+    - "Blazor Code-Behind (CRUD)"      # Presentación → agent-single si hay referencia
 
   default_human_tasks:
     - "Business Logic compleja"        # Siempre humano
@@ -217,7 +217,7 @@ sdd_config:
   # Presupuesto de tokens (más ajustado que Alpha por precio fijo)
   token_budget_usd: 20          # $20/sprint máximo
   max_parallel_agents: 3        # Máximo 3 agentes en paralelo (equipo pequeño de supervisión)
-  require_tech_lead_approval: true   # Laura debe aprobar antes de lanzar agent:team (riesgo precio fijo)
+  require_tech_lead_approval: true   # Laura debe aprobar antes de lanzar agent-team (riesgo precio fijo)
   cost_alert_per_spec_usd: 2.00     # Alertar si una spec supera $2 en tokens
 ```
 

--- a/projects/proyecto-beta/equipo.md
+++ b/projects/proyecto-beta/equipo.md
@@ -109,6 +109,6 @@ Coste estimado:         ~$0.02-0.05 por spec de tests
 agente_prioritario: true
 objetivo_agentizacion: "70% de tasks técnicas"
 budget_tokens_por_sprint: "Máx $20 USD en tokens Claude"
-aprobacion_requerida: "Tech Lead (Laura) antes de lanzar agent:team"
-coste_max_por_spec: "$2.00 USD (si supera, usar agent:single)"
+aprobacion_requerida: "Tech Lead (Laura) antes de lanzar agent-team"
+coste_max_por_spec: "$2.00 USD (si supera, usar agent-single)"
 ```

--- a/projects/proyecto-beta/specs/templates/spec-template.md
+++ b/projects/proyecto-beta/specs/templates/spec-template.md
@@ -16,7 +16,7 @@
 **Fecha creación:** {YYYY-MM-DD}
 **Creado por:**     {PM/Tech Lead}
 
-**Developer Type:** human | agent:single | agent:team
+**Developer Type:** human | agent-single | agent-team
 **Asignado a:**     {nombre_dev | claude-agent | claude-agent-team}
 **Estimación:**     {Xh}
 **Estado:**         Pendiente | En Progreso | Completado | Bloqueado
@@ -304,7 +304,7 @@ dotnet test $TEST_PROJECT --filter "Category=Unit" --no-build
 **Último update:** {YYYY-MM-DD HH:MM}
 **Actualizado por:** {dev/agent}
 
-### Log de implementación (si agent:single o agent:team)
+### Log de implementación (si agent-single o agent-team)
 - {timestamp} — [AGENT] Iniciando implementación
 - {timestamp} — [AGENT] Handler creado: CreatePatientCommandHandler.cs
 - {timestamp} — [AGENT] Validator creado: CreatePatientCommandValidator.cs

--- a/projects/sala-reservas/CLAUDE.md
+++ b/projects/sala-reservas/CLAUDE.md
@@ -110,7 +110,7 @@ Ver composición completa en `equipo.md`.
 
 **Capacity del sprint:** 198h (ver equipo.md)
 
-Para ver el estado: `/sprint:status sala-reservas`
+Para ver el estado: `/sprint-status sala-reservas`
 
 ---
 

--- a/projects/sala-reservas/specs/sdd-metrics.md
+++ b/projects/sala-reservas/specs/sdd-metrics.md
@@ -1,7 +1,7 @@
 # SDD Metrics — Sala Reservas (Proyecto de Test)
 
 > Registro histórico de rendimiento del proceso Spec-Driven Development.
-> Actualizar al completar cada Spec (via `/spec:review` con `--check-impl`).
+> Actualizar al completar cada Spec (via `/spec-review` con `--check-impl`).
 >
 > **Nota:** Este es el proyecto de test del PM-Workspace. Las métricas aquí
 > sirven también para validar que el proceso SDD funciona correctamente en un
@@ -11,8 +11,8 @@
 
 | Sprint | Task ID | Título (corto) | Dev Type | Spec Quality | Impl OK? | Review Issues | h Estimadas | h Reales | Notas |
 |--------|---------|----------------|----------|-------------|----------|---------------|------------|---------|-------|
-| 2026-04 | AB101-B3 | CreateSalaCommandHandler | agent:single | ✅ Completa | ⏳ Pendiente | — | 4h | — | Spec de referencia para testing SDD |
-| 2026-04 | AB102-D1 | Unit Tests Salas | agent:single | ✅ Completa | ⏳ Pendiente | — | 2h | — | Spec haiku — 15 tests |
+| 2026-04 | AB101-B3 | CreateSalaCommandHandler | agent-single | ✅ Completa | ⏳ Pendiente | — | 4h | — | Spec de referencia para testing SDD |
+| 2026-04 | AB102-D1 | Unit Tests Salas | agent-single | ✅ Completa | ⏳ Pendiente | — | 2h | — | Spec haiku — 15 tests |
 
 ## Instrucciones de actualización
 
@@ -99,8 +99,8 @@ Las siguientes specs están disponibles para testear el flujo SDD completo:
 
 | Spec File | Task | Modelo | Propósito del Test |
 |-----------|------|--------|--------------------|
-| `AB101-B3-create-sala-handler.spec.md` | AB#101-B3 | claude-opus-4-5-20251101 | Testear flujo agent:single para handler CQRS |
-| `AB102-D1-unit-tests-salas.spec.md` | AB#102-D1 | claude-haiku-4-5-20251001 | Testear flujo agent:single para unit tests |
+| `AB101-B3-create-sala-handler.spec.md` | AB#101-B3 | claude-opus-4-5-20251101 | Testear flujo agent-single para handler CQRS |
+| `AB102-D1-unit-tests-salas.spec.md` | AB#102-D1 | claude-haiku-4-5-20251001 | Testear flujo agent-single para unit tests |
 
 Para ejecutar un agente sobre estas specs (cuando el proyecto real exista):
 ```bash

--- a/projects/sala-reservas/specs/sprint-2026-04/AB101-B3-create-sala-handler.spec.md
+++ b/projects/sala-reservas/specs/sprint-2026-04/AB101-B3-create-sala-handler.spec.md
@@ -6,7 +6,7 @@
 **Fecha creación:** 2026-03-03
 **Creado por:**     Carlos Mendoza (Tech Lead)
 
-**Developer Type:** agent:single
+**Developer Type:** agent-single
 **Asignado a:**     claude-agent (dev:agent)
 **Estimación:**     4h
 **Estado:**         Pendiente

--- a/projects/sala-reservas/specs/sprint-2026-04/AB102-D1-unit-tests-salas.spec.md
+++ b/projects/sala-reservas/specs/sprint-2026-04/AB102-D1-unit-tests-salas.spec.md
@@ -6,7 +6,7 @@
 **Fecha creación:** 2026-03-03
 **Creado por:**     Carlos Mendoza (Tech Lead)
 
-**Developer Type:** agent:single
+**Developer Type:** agent-single
 **Modelo sugerido:** claude-haiku-4-5-20251001
 **Asignado a:**     claude-agent-fast (dev:agent-fast)
 **Estimación:**     2h

--- a/projects/sala-reservas/sprints/sprint-2026-04/planning.md
+++ b/projects/sala-reservas/sprints/sprint-2026-04/planning.md
@@ -44,17 +44,17 @@
 
 **Definition of Ready:** ✅ Criterios claros, reglas de negocio documentadas, estimación acordada
 
-**Desglose de Tasks (propuesto por Claude `/pbi:decompose 001`):**
+**Desglose de Tasks (propuesto por Claude `/pbi-decompose 001`):**
 
 | # | Task | h | Act. | Asignado a | Developer Type |
 |---|------|---|------|-----------|----------------|
 | B1 | Entidad `Sala` + Value Objects (`SalaId`, `CapacidadSala`) | 2h | Dev | Carlos | human |
 | B2 | Migration EF Core: tabla `Salas` + seed data (3 salas de ejemplo) | 1h | Dev | Diego | human |
-| B3 | Handlers: CreateSala, UpdateSala, DeleteSala (+ Validators) | 4h | Dev | 🤖 agent | agent:single |
-| B4 | Handlers: GetSalas (paginado), GetSalaById | 2h | Dev | 🤖 agent | agent:single |
-| C1 | `ISalaRepository` + implementación EF Core | 2h | Dev | 🤖 agent | agent:single |
-| C2 | `SalasController` (5 endpoints) + DTOs de API | 2h | Dev | 🤖 agent | agent:single |
-| D1 | Unit Tests: CreateSalaCommandHandler (7 scenarios) | 2h | Dev | 🤖 agent | agent:single |
+| B3 | Handlers: CreateSala, UpdateSala, DeleteSala (+ Validators) | 4h | Dev | 🤖 agent | agent-single |
+| B4 | Handlers: GetSalas (paginado), GetSalaById | 2h | Dev | 🤖 agent | agent-single |
+| C1 | `ISalaRepository` + implementación EF Core | 2h | Dev | 🤖 agent | agent-single |
+| C2 | `SalasController` (5 endpoints) + DTOs de API | 2h | Dev | 🤖 agent | agent-single |
+| D1 | Unit Tests: CreateSalaCommandHandler (7 scenarios) | 2h | Dev | 🤖 agent | agent-single |
 | D2 | Integration Tests: endpoints API Salas (Postman / WebApplicationFactory) | 2h | Dev | Ana | human |
 | E1 | Code Review | 1h | Dev | Carlos (TL) | human |
 | **Total** | | **18h** | | | 9h human / 9h agent |
@@ -81,13 +81,13 @@
 |---|------|---|------|-----------|----------------|
 | B1 | Entidad `Reserva` + Value Objects (`ReservaId`, `HorarioReserva`) | 3h | Dev | Carlos | human |
 | B2 | Migration EF Core: tabla `Reservas` + FK a Salas | 1h | Dev | Diego | human |
-| B3 | Handler: `CreateReservaCommand` + Validator | 4h | Dev | 🤖 agent | agent:single |
-| B4 | Handlers: `GetReservasQuery` (filtro sala+fecha), `GetReservaByIdQuery` | 2h | Dev | 🤖 agent | agent:single |
-| B5 | Handler: `CancelReservaCommand` + Validator | 2h | Dev | 🤖 agent | agent:single |
-| C1 | `IReservaRepository` + implementación EF Core | 3h | Dev | 🤖 agent | agent:single |
-| C2 | `ReservasController` (4 endpoints) + DTOs de API | 2h | Dev | 🤖 agent | agent:single |
-| D1 | Unit Tests: CreateReservaCommandHandler (10 scenarios) | 3h | Dev | 🤖 agent | agent:single |
-| D2 | Unit Tests: CancelReservaCommandHandler (4 scenarios) | 2h | Dev | 🤖 agent | agent:single |
+| B3 | Handler: `CreateReservaCommand` + Validator | 4h | Dev | 🤖 agent | agent-single |
+| B4 | Handlers: `GetReservasQuery` (filtro sala+fecha), `GetReservaByIdQuery` | 2h | Dev | 🤖 agent | agent-single |
+| B5 | Handler: `CancelReservaCommand` + Validator | 2h | Dev | 🤖 agent | agent-single |
+| C1 | `IReservaRepository` + implementación EF Core | 3h | Dev | 🤖 agent | agent-single |
+| C2 | `ReservasController` (4 endpoints) + DTOs de API | 2h | Dev | 🤖 agent | agent-single |
+| D1 | Unit Tests: CreateReservaCommandHandler (10 scenarios) | 3h | Dev | 🤖 agent | agent-single |
+| D2 | Unit Tests: CancelReservaCommandHandler (4 scenarios) | 2h | Dev | 🤖 agent | agent-single |
 | D3 | Integration Tests: endpoints API Reservas | 3h | Dev | Ana | human |
 | E1 | Code Review | 1h | Dev | Carlos (TL) | human |
 | **Total** | | **26h** | | | 11h human / 15h agent |
@@ -111,7 +111,7 @@
 |---|------|---|------|-----------|----------------|
 | B3 | Domain Service: `ValidarConflictoReservaService` | 3h | Dev | Carlos | human |
 | B4 | Integrar `ValidarConflictoReservaService` en `CreateReservaCommandHandler` | 2h | Dev | Laura | human |
-| D1 | Unit Tests: `ValidarConflictoReservaService` (6 scenarios) | 2h | Dev | 🤖 agent | agent:single |
+| D1 | Unit Tests: `ValidarConflictoReservaService` (6 scenarios) | 2h | Dev | 🤖 agent | agent-single |
 | D2 | Integration Test: escenario de conflicto end-to-end | 2h | Dev | Ana | human |
 | E1 | Code Review | 1h | Dev | Carlos (TL) | human |
 | **Total** | | **10h** | | | 8h human / 2h agent |

--- a/scripts/test-workspace.sh
+++ b/scripts/test-workspace.sh
@@ -619,7 +619,7 @@ test_sdd() {
   log_section "Dry-run de agente (sin ejecutar código real)"
   if command -v claude &>/dev/null; then
     info "Claude CLI disponible — para ejecutar el agente real:"
-    info "  /agent:run projects/sala-reservas/specs/sprint-2026-04/AB101-B3-create-sala-handler.spec.md"
+    info "  /agent-run projects/sala-reservas/specs/sprint-2026-04/AB101-B3-create-sala-handler.spec.md"
     pass "Claude CLI disponible para SDD real"
   else
     skip "Dry-run de agente" "Claude CLI no instalado"
@@ -775,7 +775,7 @@ fi)
 \`\`\`bash
 cd pm-workspace/
 claude
-# Luego: /sprint:status sala-reservas
+# Luego: /sprint-status sala-reservas
 \`\`\`
 
 ## Próximos pasos
@@ -785,7 +785,7 @@ $(if [[ $TESTS_FAILED -eq 0 ]]; then
   echo ""
   echo "1. Editar \`CLAUDE.md\` con tus datos reales de Azure DevOps"
   echo "2. Clonar tus repos en \`projects/{proyecto}/source/\`"
-  echo "3. Abrir con \`claude\` y ejecutar \`/sprint:status\`"
+  echo "3. Abrir con \`claude\` y ejecutar \`/sprint-status\`"
 else
   echo "⚠️  Hay $TESTS_FAILED tests fallidos. Resolver antes de usar en producción."
 fi)


### PR DESCRIPTION
## Summary

- Renamed all 106 unique command patterns from colon notation (`/project:audit`) to hyphen notation (`/project-audit`) across 164 files
- Claude Code only supports lowercase letters, numbers, and hyphens in slash command names — colons were never valid
- This is why `/project:audit` returned "Unknown skill" — it was interpreted as free text, not a slash command

## Impact

| Metric | Value |
|--------|-------|
| Files changed | 164 |
| Lines changed | 1,203 |
| Unique patterns renamed | 106 |
| Breaking changes | None (commands already used hyphens in filenames and YAML `name:` fields) |

## Test plan

- [ ] Type `/project-audit` in Claude Code — should appear in autocomplete and execute
- [ ] Type `/sprint-status` — should work as slash command
- [ ] Verify no colon notation remains: `grep -rP '/(sprint|project|pbi|report):' --include="*.md"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)