### PR TITLE
feat(context): auto-compact post-command — saves 148 lines/execution

### DIFF
--- a/.claude/commands/context-load.md
+++ b/.claude/commands/context-load.md
@@ -7,8 +7,6 @@ description: >
 
 # Carga de Contexto — Inicio de Sesión
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 > Ejecuta al empezar una sesión nueva para tener contexto completo.
 
 ## 1. Banner de inicio

--- a/.claude/commands/debt-track.md
+++ b/.claude/commands/debt-track.md
@@ -11,8 +11,6 @@ description: >
 
 > Uso: `/debt-track --project {p}` o `/debt-track --project {p} --add`
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 ## 1. Banner de inicio
 
 ```

--- a/.claude/commands/evaluate-repo.md
+++ b/.claude/commands/evaluate-repo.md
@@ -9,8 +9,6 @@ description: >
 
 **Repositorio:** $ARGUMENTS
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 > Si no se pasa argumento, evalúa el repositorio actual.
 
 ## 1. Banner de inicio

--- a/.claude/commands/kpi-dora.md
+++ b/.claude/commands/kpi-dora.md
@@ -11,8 +11,6 @@ description: >
 
 > Uso: `/kpi-dora --project {p}` o `/kpi-dora --project {p} --sprints 10`
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 ## 1. Banner de inicio
 
 ```

--- a/.claude/commands/project-audit.md
+++ b/.claude/commands/project-audit.md
@@ -11,8 +11,6 @@ description: >
 
 > Uso: `/project-audit --project {p}` o `/project-audit --project {p} --deep`
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 ## 1. Banner de inicio
 
 ```

--- a/.claude/commands/session-save.md
+++ b/.claude/commands/session-save.md
@@ -9,8 +9,6 @@ description: >
 
 **Argumentos:** $ARGUMENTS
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 > Ejecuta ANTES de `/clear` o al terminar una sesión para no perder contexto.
 
 ## 1. Banner de inicio

--- a/.claude/commands/sprint-status.md
+++ b/.claude/commands/sprint-status.md
@@ -7,8 +7,6 @@ description: Estado del sprint actual — progreso, burndown, alertas.
 
 **Argumentos:** $ARGUMENTS
 
-Aplica siempre @.claude/rules/domain/command-ux-feedback.md
-
 ## 1. Banner de inicio
 
 ```

--- a/.claude/rules/domain/command-ux-feedback.md
+++ b/.claude/rules/domain/command-ux-feedback.md
@@ -143,6 +143,34 @@ Un comando SOLO puede hacer lo que su fichero `.md` define explícitamente:
 
 Esto reduce tokens (Claude no "piensa qué hacer") y garantiza comportamiento predecible.
 
-## 9. Aplicación
+## 9. Auto-compact post-comando (OBLIGATORIO)
+
+TRAS CADA slash command — sin excepción — el banner de finalización DEBE incluir:
+
+```
+⚡ /compact — Ejecuta para liberar contexto antes del siguiente comando
+```
+
+### Reglas de auto-compact
+
+1. **Siempre sugerir**: No importa si el comando fue ligero o pesado. SIEMPRE terminar con `⚡ /compact`
+2. **Bloqueo suave**: Si el PM pide otro comando sin haber compactado, responder:
+   ```
+   ⚠️ Contexto alto — ejecuta `/compact` antes de continuar.
+   Esto preservará los resultados y liberará espacio para el siguiente comando.
+   ```
+3. **Resumen de compactación**: Cuando el PM ejecute `/compact`, Claude DEBE preservar:
+   - Ficheros modificados en la sesión
+   - Scores de audits/evaluaciones
+   - Decisiones del PM
+   - Errores y cómo se resolvieron
+   - Último comando ejecutado y su resultado
+
+### Por qué es obligatorio
+
+Sin compactación entre comandos, el contexto se satura (~88% tras un solo audit)
+y el siguiente comando falla o produce resultados degradados.
+
+## 10. Aplicación
 
 TODOS los comandos sin excepción. Prioridad sobre contenido de cada comando.

--- a/.claude/rules/domain/context-health.md
+++ b/.claude/rules/domain/context-health.md
@@ -42,28 +42,25 @@ Esto evita que el análisis intermedio contamine el contexto principal.
 - `/spec-generate` → subagente genera spec, guarda en fichero
 - Cualquier comando que lea más de 5 ficheros internamente
 
-## 3. Compactación proactiva
+## 3. Auto-compact post-comando (OBLIGATORIO)
 
-### Cuándo sugerir `/compact`
-- Después de 10+ turnos de conversación
-- Después de ejecutar 3+ comandos en la misma sesión
-- Antes de ejecutar un comando pesado (audit, spec, evaluate)
-- Si el PM cambia de tema o proyecto
+### Regla principal
+**TRAS CADA slash command** → terminar con `⚡ /compact` en el banner de finalización.
+Sin excepciones. Un solo comando pesado satura el contexto (~88%).
 
-### Mensaje de sugerencia
+### Bloqueo suave
+Si el PM pide otro comando sin compactar → responder:
 ```
-💡 Llevamos N turnos. Para mantener la precisión de los comandos,
-   te recomiendo ejecutar /compact antes de continuar.
-   (Preservará las decisiones y resultados de esta sesión)
+⚠️ Contexto alto — ejecuta `/compact` antes de continuar.
 ```
 
-### Instrucciones de compactación para CLAUDE.md
-Al compactar, SIEMPRE preservar:
-- Lista de ficheros modificados en la sesión
-- Resultados de audits/evaluaciones (scores, hallazgos críticos)
+### Al compactar, SIEMPRE preservar
+- Ficheros modificados en la sesión
+- Scores de audits/evaluaciones (hallazgos críticos)
 - Decisiones tomadas por el PM
 - Estado del sprint/proyecto activo
 - Errores encontrados y cómo se resolvieron
+- Último comando ejecutado y su resultado
 
 ## 4. Sesiones enfocadas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.15.1] — 2026-02-27
+
+Auto-compact post-command: prevents context saturation after heavy commands. Removed `@command-ux-feedback.md` dependency from 7 commands (saves 148 lines per execution). After every slash command, Claude now suggests `/compact` to free context.
+
+### Added
+
+**Auto-compact protocol** — New §9 in `command-ux-feedback.md`: after EVERY slash command, banner must include `⚡ /compact`. Soft block if PM requests another command without compacting first.
+
+### Changed
+
+**7 commands freed from `@command-ux-feedback.md`** — Removed on-demand load of 148-line rule file from: `project-audit`, `sprint-status`, `kpi-dora`, `debt-track`, `evaluate-repo`, `context-load`, `session-save`. UX rules already enforced via CLAUDE.md #15-#17.
+**`context-health.md` §3 rewritten** — "Compactación proactiva" → "Auto-compact post-comando (OBLIGATORIO)". Simplified rules, added soft-block mechanism.
+**CLAUDE.md rule #16 updated** — Now mandates auto-compact suggestion after every command execution.
+
+---
+
 ## [0.15.0] — 2026-02-27
 
 Command naming fix: Claude Code only supports hyphens in slash command names, not colons. All 106 unique command references across 164 files renamed from colon notation (`/project:audit`) to hyphen notation (`/project-audit`). This fix ensures all documented commands actually work as slash commands.
@@ -472,7 +488,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.13.2...v0.14.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 13. **Git**: NUNCA commit directo en `main` — siempre rama + PR
 14. **Comandos**: ANTES de commit que toque `commands/`, ejecutar `scripts/validate-commands.sh`
 15. **UX Feedback OBLIGATORIO**: TODO slash command DEBE mostrar: banner inicio, verificación prerequisitos ✅/❌, progreso por pasos, resultado, banner fin. Si falta config → preguntar → guardar → reintentar. **El silencio es un bug.**
-16. **Contexto**: Resultado > 30 líneas → fichero + resumen. Subagente (`Task`) para análisis pesados. `/compact` tras 10+ turnos. Una tarea por sesión.
+16. **Contexto y Auto-compact**: Resultado > 30 líneas → fichero + resumen. Subagente (`Task`) para análisis pesados. **TRAS CADA slash command ejecutado**, terminar con `⚡ /compact` para que el PM libere contexto. Una tarea por sesión. Si el PM pide otro comando sin compactar → recordar: "Ejecuta `/compact` primero para liberar contexto."
 17. **Anti-improvisación**: Un comando SOLO ejecuta lo definido en su `.md`. Escenario no cubierto → error con sugerencia, NO inventar.
 
 ---
@@ -121,7 +121,7 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 - **Comandos** → `@.claude/rules/domain/pm-workflow.md`
 - Explorar → Planificar → Implementar → Commit
 - Arquitectura: **Command → Agent → Skills** — subagentes solo con `Task`
-- **Compactación**: Al hacer `/compact`, preservar: ficheros modificados, scores de audits, decisiones del PM, errores y cómo se resolvieron. Sugerir `/compact` tras 10 turnos o 3 comandos.
+- **Auto-compact**: TRAS CADA slash command, terminar con `⚡ /compact`. Al compactar → preservar: ficheros modificados, scores, decisiones del PM, errores y resoluciones, último comando y resultado.
 
 ---
 


### PR DESCRIPTION
## Summary

- After EVERY slash command, Claude now ends with `⚡ /compact` suggestion
- Soft-block: if PM requests another command without compacting, Claude reminds first
- Removed `@command-ux-feedback.md` (148 lines) from 7 commands — UX rules already in CLAUDE.md #15-#17

## Impact

| Metric | Before | After |
|--------|--------|-------|
| On-demand context per command | +148 lines (@command-ux-feedback) | 0 lines |
| Post-command compact suggestion | Sometimes (after 10+ turns) | **Always** |
| Second command without compact | Allowed (causes saturation) | **Soft-blocked** |

## Root cause

A single `/project-audit` consumed 88% of context, leaving no room for follow-up commands. Key contributors:
1. `@command-ux-feedback.md` loaded 148 extra lines per command
2. No automatic compact suggestion after command execution
3. No guard preventing sequential commands without compacting

## Test plan

- [ ] Run `/project-audit --project X` — banner should end with `⚡ /compact`
- [ ] Without compacting, try another command — should see soft-block warning
- [ ] After `/compact`, next command should work normally
- [ ] Verify `@command-ux-feedback.md` is NOT loaded during command execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)