### PR TITLE
feat(memory): intelligent memory system with path-specific auto-loading

### DIFF
--- a/.claude/commands/memory-sync.md
+++ b/.claude/commands/memory-sync.md
@@ -1,0 +1,100 @@
+---
+name: memory-sync
+description: Sincroniza insights del sprint en los topic files de auto memory
+---
+
+# /memory-sync — Sincronización de Memoria por Proyecto
+
+## Descripción
+
+Consolida los insights, decisiones y aprendizajes de la sesión actual en los topic files de auto memory del proyecto activo.
+
+## Prerequisitos
+
+- Proyecto activo identificado (leer `CLAUDE.md` del proyecto o preguntar)
+- Directorio de auto memory existente en `~/.claude/projects/<project>/memory/`
+
+## Procedimiento
+
+### 1. Identificar proyecto y directorio de memoria
+
+```bash
+# El directorio se deriva del git root
+MEMORY_DIR="$HOME/.claude/projects/$(basename $(git rev-parse --show-toplevel 2>/dev/null || echo $PWD))/memory"
+```
+
+Si no existe, crear la estructura:
+```
+memory/
+├── MEMORY.md
+├── sprint-history.md
+├── architecture.md
+├── debugging.md
+├── team-patterns.md
+└── devops-notes.md
+```
+
+### 2. Recopilar información de la sesión
+
+Revisar en contexto:
+- Decisiones arquitectónicas tomadas
+- Bugs resueltos y sus soluciones
+- Cambios en convenciones o patrones del equipo
+- Configuraciones de entorno descubiertas
+- Impedimentos encontrados y resoluciones
+- Velocidad y métricas del sprint si están disponibles
+
+### 3. Actualizar topic files
+
+Distribuir la información en los ficheros apropiados:
+
+| Información | Topic file |
+|---|---|
+| Decisiones de diseño, patrones elegidos | `architecture.md` |
+| Bugs, errores, soluciones | `debugging.md` |
+| Velocidad, burndown, impedimentos | `sprint-history.md` |
+| Preferencias del equipo, convenciones | `team-patterns.md` |
+| Pipelines, entornos, config | `devops-notes.md` |
+
+### 4. Actualizar MEMORY.md (índice)
+
+Mantener MEMORY.md como índice conciso (≤ 200 líneas):
+- Una línea por insight clave
+- Referencias a topic files para detalles
+- Fecha de última actualización
+
+Formato del índice:
+```markdown
+# Memory — {Proyecto}
+> Última sync: YYYY-MM-DD
+
+## Resumen
+- [Breve] descripción del proyecto y stack
+- Sprint actual: Sprint N (fecha inicio — fecha fin)
+
+## Topic Files
+- `sprint-history.md` — Velocidad promedio, impedimentos recurrentes
+- `architecture.md` — Decisiones clave, ADRs informales
+- `debugging.md` — Problemas resueltos y workarounds
+- `team-patterns.md` — Convenciones del equipo, preferencias
+- `devops-notes.md` — Config de CI/CD, entornos, secretos
+
+## Insights Recientes
+- {línea 1}
+- {línea 2}
+- ...
+```
+
+### 5. Banner de resultado
+
+```
+════════════════════════════════════════════════════════
+  /memory-sync — {Proyecto}
+  ✅ Sincronización completada
+  📁 {N} topic files actualizados
+  📝 MEMORY.md: {líneas}/200 líneas usadas
+  📅 Última sync: {fecha}
+════════════════════════════════════════════════════════
+```
+
+⚡ /compact

--- a/.claude/rules/domain/azure-repos-config.md
+++ b/.claude/rules/domain/azure-repos-config.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/azure-pipelines*.yml"
+  - "**/.azuredevops/**"
+---
+
 # Regla: Configuración Azure Repos
 
 > Configuración para gestión de repositorios Git en Azure DevOps.

--- a/.claude/rules/domain/github-flow.md
+++ b/.claude/rules/domain/github-flow.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/.github/**"
+  - "**/.gitignore"
+  - "**/.gitattributes"
+---
+
 # GitHub Flow — Reglas de Branching
 
 > Fuente oficial: https://docs.github.com/get-started/quickstart/github-flow

--- a/.claude/rules/domain/infrastructure-as-code.md
+++ b/.claude/rules/domain/infrastructure-as-code.md
@@ -1,3 +1,13 @@
+---
+paths:
+  - "**/*.tf"
+  - "**/*.tfvars"
+  - "**/*.bicep"
+  - "**/Dockerfile"
+  - "**/docker-compose*.yml"
+  - "**/*.cdktf.*"
+---
+
 # Regla: Infrastructure as Code — Soporte Multi-Cloud
 # ── Azure CLI, Terraform, AWS CLI, GCP CLI y otros proveedores ──────────────
 

--- a/.claude/rules/languages/angular-conventions.md
+++ b/.claude/rules/languages/angular-conventions.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.component.ts"
+  - "**/*.module.ts"
+  - "**/*.service.ts"
+  - "**/*.directive.ts"
+---
+
 # Regla: Convenciones y Prácticas Angular
 # ── Aplica a todos los proyectos Angular en este workspace ──
 

--- a/.claude/rules/languages/cobol-conventions.md
+++ b/.claude/rules/languages/cobol-conventions.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.cob"
+  - "**/*.cbl"
+  - "**/*.cpy"
+---
+
 # Regla: Convenciones y Prácticas COBOL
 # ── Aplica a todos los proyectos COBOL en este workspace ──────────────────────
 

--- a/.claude/rules/languages/csharp-rules.md
+++ b/.claude/rules/languages/csharp-rules.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.cs"
+---
+
 # Reglas de Análisis Estático C#/.NET — Knowledge Base para Agente de Revisión
 
 > Fuente: [SonarSource sonar-dotnet](https://github.com/SonarSource/sonar-dotnet) · [Reglas C#](https://rules.sonarsource.com/csharp/)

--- a/.claude/rules/languages/dotnet-conventions.md
+++ b/.claude/rules/languages/dotnet-conventions.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.cs"
+  - "**/*.csproj"
+  - "**/*.sln"
+  - "**/*.razor"
+---
+
 # Regla: Convenciones y Prácticas .NET
 # ── Aplica a todos los proyectos .NET en este workspace ──────────────────────
 

--- a/.claude/rules/languages/flutter-conventions.md
+++ b/.claude/rules/languages/flutter-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.dart"
+  - "**/pubspec.yaml"
+---
+
 # Regla: Convenciones y Prácticas Flutter/Dart
 # ── Aplica a todos los proyectos Flutter en este workspace ──────────────────────
 

--- a/.claude/rules/languages/go-conventions.md
+++ b/.claude/rules/languages/go-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.go"
+  - "**/go.mod"
+---
+
 # Regla: Convenciones y Prácticas Go
 # ── Aplica a todos los proyectos Go en este workspace ──────────────────────────
 

--- a/.claude/rules/languages/go-rules.md
+++ b/.claude/rules/languages/go-rules.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.go"
+---
+
 # Reglas de Análisis Estático Go — Knowledge Base para Agente de Revisión
 
 > Fuente: [go vet](https://golang.org/cmd/vet/), [staticcheck](https://staticcheck.io/), [gosec](https://github.com/securego/gosec)

--- a/.claude/rules/languages/java-conventions.md
+++ b/.claude/rules/languages/java-conventions.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.java"
+  - "**/pom.xml"
+  - "**/build.gradle"
+---
+
 # Regla: Convenciones y Prácticas Java/Spring Boot
 # ── Aplica a todos los proyectos Java en este workspace ──
 

--- a/.claude/rules/languages/java-rules.md
+++ b/.claude/rules/languages/java-rules.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.java"
+---
+
 # Reglas de Análisis Estático Java — Knowledge Base para Agente de Revisión
 
 > Fuente: [SonarJava](https://rules.sonarsource.com/java/), [SpotBugs](https://spotbugs.readthedocs.io/), [PMD](https://pmd.github.io/)

--- a/.claude/rules/languages/kotlin-conventions.md
+++ b/.claude/rules/languages/kotlin-conventions.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.kt"
+  - "**/*.kts"
+  - "**/build.gradle.kts"
+---
+
 # Regla: Convenciones y Prácticas Kotlin/Android
 # ── Aplica a todos los proyectos Kotlin en este workspace ──────────────────────
 

--- a/.claude/rules/languages/php-conventions.md
+++ b/.claude/rules/languages/php-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.php"
+  - "**/composer.json"
+---
+
 # Regla: Convenciones y Prácticas PHP/Laravel
 # ── Aplica a todos los proyectos Laravel en este workspace ──────────────────────
 

--- a/.claude/rules/languages/python-conventions.md
+++ b/.claude/rules/languages/python-conventions.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.py"
+  - "**/pyproject.toml"
+  - "**/requirements.txt"
+---
+
 # Regla: Convenciones y Prácticas Python
 # ── Aplica a todos los proyectos Python en este workspace ──
 

--- a/.claude/rules/languages/python-rules.md
+++ b/.claude/rules/languages/python-rules.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.py"
+---
+
 # Reglas de Análisis Estático Python — Knowledge Base para Agente de Revisión
 
 > Fuente: [Bandit](https://bandit.readthedocs.io/), [Ruff](https://docs.astral.sh/ruff/rules/), [SonarPython](https://rules.sonarsource.com/python/)

--- a/.claude/rules/languages/react-conventions.md
+++ b/.claude/rules/languages/react-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.tsx"
+  - "**/*.jsx"
+---
+
 # Regla: Convenciones y Prácticas React
 # ── Aplica a todos los proyectos React (Vite, Next.js, Remix) en este workspace ──
 

--- a/.claude/rules/languages/ruby-conventions.md
+++ b/.claude/rules/languages/ruby-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.rb"
+  - "**/Gemfile"
+---
+
 # Regla: Convenciones y Prácticas Ruby on Rails
 # ── Aplica a todos los proyectos Rails en este workspace ───────────────────────
 

--- a/.claude/rules/languages/rust-conventions.md
+++ b/.claude/rules/languages/rust-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.rs"
+  - "**/Cargo.toml"
+---
+
 # Regla: Convenciones y Prácticas Rust
 # ── Aplica a todos los proyectos Rust en este workspace ────────────────────────
 

--- a/.claude/rules/languages/swift-conventions.md
+++ b/.claude/rules/languages/swift-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.swift"
+  - "**/Package.swift"
+---
+
 # Regla: Convenciones y Prácticas Swift/iOS
 # ── Aplica a todos los proyectos Swift e iOS en este workspace ──────────────────────
 

--- a/.claude/rules/languages/terraform-conventions.md
+++ b/.claude/rules/languages/terraform-conventions.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.tf"
+  - "**/*.tfvars"
+  - "**/*.hcl"
+---
+
 # Regla: Convenciones y Prácticas Terraform / Infrastructure as Code
 # ── Aplica a todos los proyectos Terraform en este workspace ───────────────────
 

--- a/.claude/rules/languages/typescript-conventions.md
+++ b/.claude/rules/languages/typescript-conventions.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.mts"
+  - "**/*.cts"
+---
+
 # Regla: Convenciones y Prácticas TypeScript/Node.js
 # ── Aplica a todos los proyectos TypeScript (backend y full-stack) en este workspace ──
 

--- a/.claude/rules/languages/typescript-rules.md
+++ b/.claude/rules/languages/typescript-rules.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.mts"
+---
+
 # Reglas de Análisis Estático TypeScript/Node.js — Knowledge Base para Agente de Revisión
 
 > Fuente: ESLint, @typescript-eslint, SonarJS, Node.js security best practices

--- a/.claude/rules/languages/vbnet-conventions.md
+++ b/.claude/rules/languages/vbnet-conventions.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.vb"
+  - "**/*.vbproj"
+---
+
 # Regla: Convenciones y Prácticas VB.NET
 # ── Aplica a todos los proyectos VB.NET en este workspace ──────────────────────
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.16.0] — 2026-02-27
+
+Intelligent memory system: path-specific auto-loading for all 24 language/domain rule files, auto memory templates per project, new `/memory-sync` command, and comprehensive documentation for symlinks, `--add-dir`, and user-level rules.
+
+### Added
+
+**Path-specific rules (`paths:` frontmatter)** — 21 language files and 3 domain files now include YAML frontmatter with `paths:` patterns. Claude Code auto-loads the correct conventions when touching files of that language (e.g., `.cs` triggers dotnet-conventions, `.py` triggers python-conventions). No manual `@` import needed for language rules.
+
+**`/memory-sync` command** — Consolidates session insights (architecture decisions, debugging solutions, sprint metrics, team patterns) into auto memory topic files. Keeps `MEMORY.md` under 200 lines as an index.
+
+**`scripts/setup-memory.sh`** — Initializes auto memory structure for a project: creates `MEMORY.md` index + 5 topic files (sprint-history, architecture, debugging, team-patterns, devops-notes).
+
+**`docs/memory-system.md`** — Comprehensive guide covering: memory hierarchy, path-specific rules, auto memory, `@` imports, symlinks for shared rules, `--add-dir` for external projects, and user-level rules in `~/.claude/rules/`.
+
+### Changed
+
+**CLAUDE.md** — New §"Sistema de Memoria" section. Added `rules/languages/` to structure diagram. New checklist item for auto memory setup. Reference to `docs/memory-system.md`.
+
+**README.md + README.en.md** — Added "Memory and Context" command section, memory system feature description, and doc reference in the documentation table.
+
+### Why
+
+Claude Code's memory system (v2025+) supports path-specific frontmatter, auto memory with topic files, and hierarchical rule loading. PM-Workspace was loading all language rules manually via `@` imports. With `paths:` frontmatter, the correct conventions activate automatically — reducing context pollution and eliminating manual loading errors. Auto memory provides persistent learning across sessions per project.
+
+---
+
 ## [0.15.1] — 2026-02-27
 
 Auto-compact post-command: prevents context saturation after heavy commands. Removed `@command-ux-feedback.md` dependency from 7 commands (saves 148 lines per execution). After every slash command, Claude now suggests `/compact` to free context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 > Config detallada: @.claude/rules/domain/pm-config.md · @.claude/rules/domain/pm-workflow.md
 > Proyectos privados: @.claude/rules/pm-config.local.md (git-ignorado, no en este repo)
 > Buenas prácticas: @docs/best-practices-claude-code.md
+> Sistema de memoria: @docs/memory-system.md
 
 ---
 
@@ -42,6 +43,7 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 │   ├── agents/                    ← 24 subagentes → @.claude/rules/domain/agents-catalog.md
 │   ├── commands/                  ← 83 slash commands (+7 infra en skill) → @.claude/rules/domain/pm-workflow.md
 │   ├── rules/domain/              ← Reglas bajo demanda (cargadas por @ cuando se necesitan)
+│   ├── rules/languages/           ← Convenciones por lenguaje (auto-carga por paths: frontmatter)
 │   └── skills/                    ← 13 skills reutilizables
 ├── docs/                          ← Metodología, guías, secciones README
 ├── projects/                      ← Proyectos reales (git-ignorados)
@@ -125,6 +127,20 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 
 ---
 
+## 🧠 Sistema de Memoria
+
+> Guía completa: `@docs/memory-system.md`
+
+**Auto-carga por lenguaje**: Las reglas en `rules/languages/` incluyen frontmatter `paths:` — se cargan automáticamente al tocar ficheros del lenguaje (`.cs`, `.py`, `.go`, etc.). No necesitas `@` manual para convenciones de lenguaje.
+
+**Auto Memory**: Claude guarda notas por proyecto en `~/.claude/projects/<proyecto>/memory/`. Usa `/memory-sync` para consolidar insights del sprint. Inicializar con `scripts/setup-memory.sh [proyecto]`.
+
+**User rules**: Preferencias personales globales en `~/.claude/rules/` (estilo comunicación, formato reportes).
+
+**Proyectos externos**: Usa `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 claude --add-dir ~/claude` o symlinks a `rules/languages/`.
+
+---
+
 ## ✅ Checklist Nuevo Proyecto
 
 - [ ] `projects/[nombre]/` con `CLAUDE.md` específico (≤150 líneas)
@@ -134,4 +150,5 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 - [ ] Entornos definidos (DEV/PRE/PRO o los que apliquen)
 - [ ] `config.local/` creado + `.gitignore` · `.env.example` sin valores reales
 - [ ] Cloud provider e infraestructura definidos si aplica
+- [ ] Auto memory inicializada: `scripts/setup-memory.sh [nombre]`
 - [ ] `README.md` actualizado

--- a/README.en.md
+++ b/README.en.md
@@ -30,6 +30,8 @@ This workspace turns Claude Code into an **automated Project Manager / Scrum Mas
 
 **Multi-environment** — support for DEV/PRE/PRO (configurable) with secrets protection — connection strings never go into the repository.
 
+**Intelligent memory system** — language rules with auto-loading by file type (`paths:` frontmatter), persistent auto memory per project, and support for external projects via symlinks and `--add-dir`.
+
 ---
 
 ## Documentation
@@ -81,6 +83,7 @@ Full documentation is organized into sections for easy reference:
 | [Team KPIs](docs/kpis-equipo.md) | KPI definitions |
 | [Report templates](docs/plantillas-informes.md) | Reporting templates |
 | [Workflow](docs/flujo-trabajo.md) | Complete workflow |
+| [Memory system](docs/memory-system.md) | Auto-loading, auto memory, symlinks, `--add-dir` |
 
 ---
 
@@ -107,11 +110,15 @@ Full documentation is organized into sections for easy reference:
 /env-setup {proj}             /env-promote {proj} {source} {dest}
 ```
 
+### Memory and Context
+```
+/memory-sync    /context-load    /session-save    /help [filter]
+```
+
 ### Quality and Team
 ```
-/pr-review [PR]    /pr-pending    /context-load    /changelog-update    /evaluate-repo [URL]
+/pr-review [PR]    /pr-pending    /changelog-update    /evaluate-repo [URL]
 /team-onboarding {name}    /team-evaluate {name}    /team-privacy-notice {name}
-/help [filter]
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 
 **Multi-entorno** — soporte para DEV/PRE/PRO (configurable) con protección de secrets — las connection strings nunca van al repositorio.
 
+**Sistema de memoria inteligente** — reglas de lenguaje con auto-carga por tipo de fichero (`paths:` frontmatter), auto memory persistente por proyecto, y soporte para proyectos externos vía symlinks y `--add-dir`.
+
 ---
 
 ## Documentación
@@ -81,6 +83,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 | [KPIs de equipo](docs/kpis-equipo.md) | Definición de KPIs |
 | [Plantillas de informes](docs/plantillas-informes.md) | Templates para reporting |
 | [Flujo de trabajo](docs/flujo-trabajo.md) | Workflow completo |
+| [Sistema de memoria](docs/memory-system.md) | Auto-carga, auto memory, symlinks, `--add-dir` |
 
 ---
 
@@ -107,11 +110,15 @@ La documentación completa está organizada en secciones para facilitar la consu
 /env-setup {proy}             /env-promote {proy} {origen} {destino}
 ```
 
+### Memoria y Contexto
+```
+/memory-sync    /context-load    /session-save    /help [filtro]
+```
+
 ### Calidad y Equipo
 ```
-/pr-review [PR]    /pr-pending    /context-load    /changelog-update    /evaluate-repo [URL]
+/pr-review [PR]    /pr-pending    /changelog-update    /evaluate-repo [URL]
 /team-onboarding {nombre}    /team-evaluate {nombre}    /team-privacy-notice {nombre}
-/help [filtro]
 ```
 
 ---

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -1,0 +1,159 @@
+# Sistema de Memoria — PM-Workspace
+
+> Guía para aprovechar el sistema de memoria persistente de Claude Code en pm-workspace.
+
+---
+
+## Jerarquía de Memoria
+
+PM-Workspace usa la jerarquía completa de memoria de Claude Code:
+
+| Tipo | Ubicación | Propósito | Compartido |
+|---|---|---|---|
+| **Proyecto (global)** | `~/claude/CLAUDE.md` | Rol PM, reglas críticas, estructura | Equipo (repo) |
+| **Reglas modulares** | `.claude/rules/domain/*.md` | Reglas bajo demanda por tema | Equipo (repo) |
+| **Reglas por lenguaje** | `.claude/rules/languages/*.md` | Convenciones con auto-carga por `paths:` | Equipo (repo) |
+| **Proyecto local** | `~/claude/CLAUDE.local.md` | Config privada: PATs, proyectos reales | Solo tú |
+| **Proyecto específico** | `projects/{nombre}/CLAUDE.md` | Config por proyecto Azure DevOps | Equipo (repo) |
+| **Auto Memory** | `~/.claude/projects/*/memory/` | Notas automáticas de Claude por proyecto | Solo tú |
+| **Usuario** | `~/.claude/CLAUDE.md` | Preferencias personales globales | Solo tú |
+| **User rules** | `~/.claude/rules/*.md` | Preferencias modulares personales | Solo tú |
+
+---
+
+## Path-Specific Rules (auto-carga por tipo de fichero)
+
+Las reglas de lenguaje incluyen frontmatter YAML `paths:` que activa la carga automática cuando Claude trabaja con ficheros del lenguaje correspondiente:
+
+```yaml
+---
+paths:
+  - "**/*.cs"
+  - "**/*.csproj"
+---
+# Regla: Convenciones .NET
+```
+
+**Beneficio**: No necesitas cargar manualmente con `@` las convenciones del lenguaje. Se activan solas al tocar un `.cs`, `.py`, `.go`, etc.
+
+### Lenguajes con auto-carga
+
+| Lenguaje | Extensiones |
+|---|---|
+| C#/.NET | `.cs`, `.csproj`, `.sln`, `.razor` |
+| TypeScript | `.ts`, `.mts`, `.cts` |
+| Angular | `.component.ts`, `.module.ts`, `.service.ts` |
+| React | `.tsx`, `.jsx` |
+| Java | `.java`, `pom.xml`, `build.gradle` |
+| Python | `.py`, `pyproject.toml`, `requirements.txt` |
+| Go | `.go`, `go.mod` |
+| Rust | `.rs`, `Cargo.toml` |
+| PHP | `.php`, `composer.json` |
+| Swift | `.swift`, `Package.swift` |
+| Kotlin | `.kt`, `.kts`, `build.gradle.kts` |
+| Ruby | `.rb`, `Gemfile` |
+| VB.NET | `.vb`, `.vbproj` |
+| COBOL | `.cob`, `.cbl`, `.cpy` |
+| Flutter | `.dart`, `pubspec.yaml` |
+| Terraform | `.tf`, `.tfvars`, `.hcl` |
+
+### Reglas de dominio con auto-carga
+
+| Regla | Extensiones |
+|---|---|
+| Infrastructure as Code | `.tf`, `.tfvars`, `.bicep`, `Dockerfile`, `docker-compose*.yml` |
+| GitHub Flow | `.github/**`, `.gitignore`, `.gitattributes` |
+| Azure Repos | `azure-pipelines*.yml`, `.azuredevops/**` |
+
+---
+
+## Auto Memory
+
+Claude guarda automáticamente notas sobre cada proyecto en `~/.claude/projects/<project>/memory/`. Estructura recomendada:
+
+```
+~/.claude/projects/<project>/memory/
+├── MEMORY.md              ← Índice (máx. 200 líneas, se carga al inicio)
+├── sprint-history.md      ← Velocidad, burndown, impedimentos por sprint
+├── architecture.md        ← Decisiones arquitectónicas del proyecto
+├── debugging.md           ← Problemas resueltos y sus soluciones
+├── team-patterns.md       ← Preferencias y patrones del equipo
+└── devops-notes.md        ← Config de pipelines, entornos, secretos
+```
+
+**Solo las primeras 200 líneas de MEMORY.md se cargan al inicio.** Topic files se leen bajo demanda.
+
+### Pedir a Claude que recuerde algo
+
+```
+> Recuerda que en este proyecto usamos pnpm, no npm
+> Guarda en memoria que los tests de integración necesitan Redis local
+> Anota que el equipo prefiere commits en español
+```
+
+### Sincronizar memoria con `/memory-sync`
+
+El comando `/memory-sync` consolida insights del sprint actual en los topic files de auto memory.
+
+---
+
+## Imports con `@`
+
+CLAUDE.md soporta imports con sintaxis `@ruta/al/fichero`:
+
+```markdown
+Config detallada: @.claude/rules/domain/pm-config.md
+Buenas prácticas: @docs/best-practices-claude-code.md
+```
+
+Las rutas son relativas al fichero que contiene el import. Los imports se resuelven recursivamente (máx. 5 niveles).
+
+---
+
+## Symlinks para Reglas Compartidas
+
+Si trabajas en proyectos fuera de `~/claude/`, puedes compartir las reglas de lenguaje via symlinks:
+
+```bash
+# En el proyecto externo, crear symlink a los language packs
+ln -s ~/claude/.claude/rules/languages/ /ruta/proyecto/.claude/rules/languages
+
+# O solo un lenguaje específico
+ln -s ~/claude/.claude/rules/languages/python-conventions.md /ruta/proyecto/.claude/rules/python.md
+```
+
+---
+
+## `--add-dir` para Proyectos Externos
+
+Para trabajar en un proyecto externo manteniendo acceso a las reglas del workspace:
+
+```bash
+# Cargar reglas de pm-workspace mientras trabajas en otro repo
+CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 claude --add-dir ~/claude
+```
+
+---
+
+## User-Level Rules (`~/.claude/rules/`)
+
+Preferencias personales que aplican en TODOS tus proyectos (no solo pm-workspace):
+
+```
+~/.claude/rules/
+├── pm-preferences.md     ← Estilo de comunicación del PM
+├── report-format.md      ← Formato preferido de reportes
+└── git-workflow.md       ← Preferencias de Git personales
+```
+
+Estas reglas tienen menor prioridad que las del proyecto.
+
+---
+
+## Best Practices
+
+1. **MEMORY.md conciso** — máx. 200 líneas. Mover detalles a topic files
+2. **Topic files enfocados** — un tema por fichero (debugging, architecture, etc.)
+3. **Revisar periódicamente** — actualizar memoria al cambiar de sprint
+4. **No duplicar** — si algo ya está en CLAUDE.md del proyecto, no repetirlo en auto memory
+5. **`paths:` solo donde aplica** — no añadir frontmatter a reglas de dominio genéricas

--- a/scripts/setup-memory.sh
+++ b/scripts/setup-memory.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# setup-memory.sh — Inicializa estructura de auto memory para un proyecto
+# Uso: ./scripts/setup-memory.sh [nombre-proyecto]
+#
+# Si no se proporciona nombre, usa el basename del directorio git actual.
+
+set -euo pipefail
+
+PROJECT_NAME="${1:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")}"
+MEMORY_DIR="$HOME/.claude/projects/$PROJECT_NAME/memory"
+
+echo "══════════════════════════════════════════════════════"
+echo "  Setup Auto Memory — $PROJECT_NAME"
+echo "══════════════════════════════════════════════════════"
+
+if [ -d "$MEMORY_DIR" ]; then
+    echo "⚠️  Ya existe: $MEMORY_DIR"
+    echo "   Creando solo los ficheros que falten..."
+else
+    mkdir -p "$MEMORY_DIR"
+    echo "✅ Directorio creado: $MEMORY_DIR"
+fi
+
+# Crear MEMORY.md si no existe
+if [ ! -f "$MEMORY_DIR/MEMORY.md" ]; then
+    cat > "$MEMORY_DIR/MEMORY.md" << 'MEMEOF'
+# Memory — PROJECT_NAME
+> Última sync: FECHA
+
+## Resumen
+- Proyecto: [descripción breve]
+- Stack: [lenguajes y frameworks principales]
+- Sprint actual: Sprint N
+
+## Topic Files
+- `sprint-history.md` — Velocidad, burndown, impedimentos
+- `architecture.md` — Decisiones arquitectónicas, ADRs
+- `debugging.md` — Problemas resueltos y workarounds
+- `team-patterns.md` — Convenciones y preferencias del equipo
+- `devops-notes.md` — CI/CD, entornos, secretos
+
+## Insights Recientes
+- (pendiente de primera sync)
+MEMEOF
+    sed -i "s/PROJECT_NAME/$PROJECT_NAME/g" "$MEMORY_DIR/MEMORY.md"
+    sed -i "s/FECHA/$(date +%Y-%m-%d)/g" "$MEMORY_DIR/MEMORY.md"
+    echo "✅ MEMORY.md creado"
+else
+    echo "⏭️  MEMORY.md ya existe"
+fi
+
+# Crear topic files si no existen
+for TOPIC in sprint-history architecture debugging team-patterns devops-notes; do
+    if [ ! -f "$MEMORY_DIR/$TOPIC.md" ]; then
+        TITLE=$(echo "$TOPIC" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')
+        cat > "$MEMORY_DIR/$TOPIC.md" << TOPICEOF
+# $TITLE — $PROJECT_NAME
+
+> Actualizado: $(date +%Y-%m-%d)
+
+---
+
+(Sin notas todavía. Claude añadirá contenido aquí automáticamente.)
+TOPICEOF
+        echo "✅ $TOPIC.md creado"
+    else
+        echo "⏭️  $TOPIC.md ya existe"
+    fi
+done
+
+echo ""
+echo "══════════════════════════════════════════════════════"
+echo "  ✅ Auto Memory inicializada para: $PROJECT_NAME"
+echo "  📁 $MEMORY_DIR"
+echo "══════════════════════════════════════════════════════"
+echo ""
+echo "Uso:"
+echo "  - Claude guardará notas aquí automáticamente"
+echo "  - Ejecuta /memory-sync para consolidar manualmente"
+echo "  - Edita con /memory en Claude Code"


### PR DESCRIPTION
## Summary

- **24 rule files** now include `paths:` YAML frontmatter for automatic loading when Claude touches files of that type (`.cs` → dotnet-conventions, `.py` → python-conventions, `.tf` → terraform + IaC rules, etc.)
- New **`/memory-sync`** command to consolidate session insights into auto memory topic files
- New **`scripts/setup-memory.sh`** to initialize per-project memory structure (MEMORY.md index + 5 topic files)
- New **`docs/memory-system.md`** — comprehensive guide covering the full memory hierarchy, symlinks, `--add-dir`, and user-level rules
- Updated CLAUDE.md, README.md, README.en.md with memory system documentation

## Test plan

- [ ] Verify frontmatter format in a sample of language files (dotnet, python, go)
- [ ] Run `scripts/validate-commands.sh` — passes with pre-existing warnings only
- [ ] Run `scripts/setup-memory.sh test-project` to verify memory initialization
- [ ] Confirm `/memory-sync` command file is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)