### PR TITLE
fix(changelog): add missing v0.16.0 link reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -514,7 +514,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.14.0...v0.14.1


### PR DESCRIPTION
## Summary

- Add missing `[0.16.0]` link definition at bottom of CHANGELOG.md (was rendering without compare link on GitHub)
- Update `[Unreleased]` to point to `v0.16.0...HEAD` instead of `v0.15.1...HEAD`

## Test plan

- [x] Verify `[0.16.0]` renders as clickable link on GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)