### PR TITLE
fix: correct agent, command, and hook counts in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ Sprints de 2 semanas · Daily 09:15 · Review + Retro viernes fin de sprint.
 ~/claude/                          ← Raíz de trabajo Y repositorio GitHub
 ├── CLAUDE.md                      ← Este fichero
 ├── .claude/                       ← Herramientas activas
-│   ├── agents/                    ← 23 subagentes → @.claude/rules/domain/agents-catalog.md
-│   ├── commands/                  ← 87 slash commands (+7 infra en skill) → @.claude/rules/domain/pm-workflow.md
+│   ├── agents/                    ← 24 subagentes → @.claude/rules/domain/agents-catalog.md
+│   ├── commands/                  ← 86 slash commands (+7 infra en skill) → @.claude/rules/domain/pm-workflow.md
 │   ├── hooks/                     ← 8 hooks programáticos (seguridad, TDD gate, lint, quality gates)
 │   ├── rules/domain/              ← Reglas bajo demanda (cargadas por @ cuando se necesitan)
 │   ├── rules/languages/           ← Convenciones por lenguaje (auto-carga por paths: frontmatter)
@@ -92,7 +92,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 
 ## 🤖 Subagentes y Flujos
 
-> Catálogo completo (23 agentes): `@.claude/rules/domain/agents-catalog.md`
+> Catálogo completo (24 agentes): `@.claude/rules/domain/agents-catalog.md`
 
 Cada agente tiene: `memory: project` (persistencia entre sesiones), `skills:` precargados, `permissionMode:` apropiado, y `hooks:` donde aplica. Los developer agents usan `isolation: worktree` para ramas paralelas sin conflicto.
 

--- a/README.en.md
+++ b/README.en.md
@@ -32,7 +32,7 @@ This workspace turns Claude Code into an **automated Project Manager / Scrum Mas
 
 **Intelligent memory system** — language rules with auto-loading by file type (`paths:` frontmatter), persistent auto memory per project, and support for external projects via symlinks and `--add-dir`.
 
-**Programmatic hooks** — 7 hooks that enforce critical rules automatically: force push blocking, secrets detection, destructive infrastructure operation prevention, auto-lint after edits, and quality gates before finishing. Configured in `.claude/settings.json`.
+**Programmatic hooks** — 8 hooks that enforce critical rules automatically: force push blocking, secrets detection, destructive infrastructure operation prevention, auto-lint after edits, and quality gates before finishing. Configured in `.claude/settings.json`.
 
 **Agents with advanced capabilities** — each subagent has persistent memory (`memory: project`), preloaded skills, appropriate permission mode, and developer agents use `isolation: worktree` for parallel implementation without conflicts. Experimental support for Agent Teams (lead + teammates).
 
@@ -75,7 +75,7 @@ Full documentation is organized into sections for easy reference:
 | [Test project](docs/readme_en/09-test-project.md) | `sala-reservas`: tests, mock data, validation |
 | [KPIs, rules, and roadmap](docs/readme_en/10-kpis-rules.md) | Metrics, critical rules, adoption plan |
 | [Onboarding new team members](docs/readme_en/11-onboarding.md) | 5-phase onboarding, competency evaluation, GDPR |
-| [Commands and agents](docs/readme_en/12-commands-agents.md) | 87 commands + 23 specialized agents |
+| [Commands and agents](docs/readme_en/12-commands-agents.md) | 86 commands + 24 specialized agents |
 | [Coverage and contributing](docs/readme_en/13-coverage-contributing.md) | What's covered, what's not, how to contribute |
 
 ### Other Documents

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 
 **Sistema de memoria inteligente** — reglas de lenguaje con auto-carga por tipo de fichero (`paths:` frontmatter), auto memory persistente por proyecto, y soporte para proyectos externos vía symlinks y `--add-dir`.
 
-**Hooks programáticos** — 7 hooks que refuerzan reglas críticas automáticamente: bloqueo de force push, detección de secrets, prevención de operaciones destructivas de infra, auto-lint tras edición, y quality gates antes de finalizar. Configurados en `.claude/settings.json`.
+**Hooks programáticos** — 8 hooks que refuerzan reglas críticas automáticamente: bloqueo de force push, detección de secrets, prevención de operaciones destructivas de infra, auto-lint tras edición, y quality gates antes de finalizar. Configurados en `.claude/settings.json`.
 
 **Agentes con capacidades avanzadas** — cada subagente tiene memoria persistente (`memory: project`), skills precargados, modo de permisos apropiado, y los developer agents usan `isolation: worktree` para implementación paralela sin conflictos. Soporte experimental para Agent Teams (lead + teammates).
 
@@ -75,7 +75,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 | [Proyecto de test](docs/readme/09-proyecto-test.md) | `sala-reservas`: tests, datos mock, validación |
 | [KPIs, reglas y roadmap](docs/readme/10-kpis-reglas.md) | Métricas, reglas críticas, plan de adopción |
 | [Onboarding de nuevos miembros](docs/readme/11-onboarding.md) | Incorporación en 5 fases, evaluación de competencias, RGPD |
-| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 87 comandos + 23 agentes especializados |
+| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 86 comandos + 24 agentes especializados |
 | [Cobertura y contribución](docs/readme/13-cobertura-contribucion.md) | Qué cubre, qué no, cómo contribuir |
 
 ### Otros documentos


### PR DESCRIPTION
## Summary

- Agents: 23 → **24** (mobile-developer was uncounted)
- Commands: 87 → **86** (actual count from .claude/commands/)
- Hooks in README: 7 → **8** (tdd-gate.sh from v0.18.0 wasn't in README descriptions)

Affected files: CLAUDE.md, README.md, README.en.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)