### PR TITLE
feat: governance hardening — scope guard, parallel serialization, ADR loading (v0.19.0)

### DIFF
--- a/.claude/commands/context-load.md
+++ b/.claude/commands/context-load.md
@@ -44,7 +44,7 @@ Verificar raíz (`~/claude/`).
 - Si no existe → `ℹ️ Sin sesiones anteriores guardadas`
 
 ```
-📋 Paso 3/5 — Estado de proyectos...
+📋 Paso 3/6 — Estado de proyectos...
 ```
 Leer `CLAUDE.local.md` → tabla de proyectos activos.
 Para cada proyecto, comprobar si existe y mostrar 1 línea de estado:
@@ -53,7 +53,20 @@ Para cada proyecto, comprobar si existe y mostrar 1 línea de estado:
 - Riesgos: `projects/{p}/risk-register.md` → riesgos críticos si existe
 
 ```
-📋 Paso 4/5 — Actividad Git reciente...
+📋 Paso 4/6 — ADRs activos...
+```
+Para cada proyecto activo, buscar ADRs con `status: accepted`:
+```bash
+grep -l "status: accepted" projects/*/adrs/*.md 2>/dev/null
+```
+- Si existen → leer título y fecha de cada ADR activo, mostrar resumen (máx. 5 ADRs más recientes)
+- Si no existen → `ℹ️ Sin ADRs activos`
+- Formato: `🏛️ ADR-001: {título} ({fecha}) — {proyecto}`
+
+**Propósito**: Prevenir deriva arquitectónica a largo plazo al recordar decisiones activas al inicio de cada sesión.
+
+```
+📋 Paso 5/6 — Actividad Git reciente...
 ```
 ```bash
 git log --oneline -5 --decorate
@@ -61,7 +74,7 @@ git log --oneline -5 --decorate
 Ramas activas no mergeadas (si hay).
 
 ```
-📋 Paso 5/5 — Herramientas disponibles...
+📋 Paso 6/6 — Herramientas disponibles...
 ```
 Solo si stack = Azure DevOps: verificar `az`, PAT.
 Siempre: `claude --version`, `git --version`.
@@ -89,6 +102,10 @@ Siempre: `claude --version`, `git --version`.
      • {proyecto1} — audit: X/10 | deuda: N items | riesgos: N
      • {proyecto2} — sin audit previo
 
+  🏛️ ADRs activos: N
+     • ADR-001: {título} ({fecha}) — {proyecto}
+     • ADR-002: {título} ({fecha}) — {proyecto}
+
   📝 Últimos cambios:
      • {commit 1}
      • {commit 2}
@@ -105,7 +122,7 @@ Si no hay proyectos → sugerir `/help --setup`.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ✅ /context-load — Completado
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-📁 {N} proyectos | 📋 {N} decisiones recientes | ⏳ {N} pendientes
+📁 {N} proyectos | 🏛️ {N} ADRs activos | 📋 {N} decisiones recientes | ⏳ {N} pendientes
 💡 ¿Por dónde empezamos?
 ```
 

--- a/.claude/hooks/scope-guard.sh
+++ b/.claude/hooks/scope-guard.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# scope-guard.sh — Detecta ficheros modificados fuera del scope de la spec SDD activa
+# Usado por: settings.json (Stop hook)
+# Lógica: Si hay una spec activa con sección "Ficheros a Crear/Modificar",
+#         compara los ficheros modificados (git diff) contra los declarados.
+#         Si hay ficheros fuera del scope → warning al PM (exit 0, NO bloquea).
+# Exit codes: 0 = pass (con warning si aplica), 2 = bloqueo (no usado aquí)
+
+INPUT=$(cat)
+
+# Buscar spec activa: la más reciente en el proyecto actual
+# El agente SDD trabaja dentro de projects/{proyecto}/
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+
+# Obtener ficheros modificados (tracked, no staged + staged)
+MODIFIED=$(git diff --name-only 2>/dev/null; git diff --cached --name-only 2>/dev/null)
+MODIFIED=$(echo "$MODIFIED" | sort -u | grep -v '^$')
+
+if [ -z "$MODIFIED" ]; then
+  exit 0
+fi
+
+# Buscar spec activa: fichero .spec.md más reciente modificado en los últimos 60 min
+SPEC_FILE=$(find "$PROJECT_ROOT" -name "*.spec.md" -newer /tmp/.scope-guard-marker 2>/dev/null | head -1)
+
+# Si no hay marker, buscar la spec más recientemente modificada
+if [ -z "$SPEC_FILE" ]; then
+  SPEC_FILE=$(find "$PROJECT_ROOT" -name "*.spec.md" -mmin -60 2>/dev/null | sort -t/ -k1,1 | tail -1)
+fi
+
+# Si no hay spec activa, no podemos verificar scope
+if [ -z "$SPEC_FILE" ] || [ ! -f "$SPEC_FILE" ]; then
+  exit 0
+fi
+
+# Extraer ficheros declarados en la spec
+# Busca la sección "Ficheros a Crear/Modificar" o "Files to Create/Modify"
+# y extrae paths de líneas que parecen rutas de fichero
+DECLARED=$(sed -n '/[Ff]icheros\|[Ff]iles to [Cc]reate/,/^## /p' "$SPEC_FILE" \
+  | grep -oE '[a-zA-Z0-9_./\-]+\.[a-z]{1,5}' \
+  | sort -u)
+
+if [ -z "$DECLARED" ]; then
+  # La spec no tiene sección de ficheros declarados → no podemos verificar
+  exit 0
+fi
+
+# Comparar: buscar ficheros modificados que NO están en la lista declarada
+OUT_OF_SCOPE=""
+for FILE in $MODIFIED; do
+  BASENAME=$(basename "$FILE")
+  # Verificar si el fichero o su basename está en los declarados
+  MATCH=0
+  for DECL in $DECLARED; do
+    DECL_BASE=$(basename "$DECL")
+    if [ "$FILE" = "$DECL" ] || [ "$BASENAME" = "$DECL_BASE" ]; then
+      MATCH=1
+      break
+    fi
+    # Match parcial: si el path declarado termina igual que el modificado
+    if echo "$FILE" | grep -qF "$DECL"; then
+      MATCH=1
+      break
+    fi
+  done
+  if [ "$MATCH" -eq 0 ]; then
+    # Excluir ficheros que siempre son legítimos fuera del scope
+    case "$BASENAME" in
+      *.spec.md|*.test.*|*Test*|*test*|*.md|*.json|*.yml|*.yaml) continue ;;
+      .gitignore|Dockerfile|docker-compose*|*.csproj|*.sln|package.json) continue ;;
+    esac
+    case "$FILE" in
+      */test/*|*/tests/*|*/Test/*|*/Tests/*|*/__tests__/*) continue ;;
+      */agent-notes/*|*/adrs/*|*/specs/*|*/output/*) continue ;;
+    esac
+    OUT_OF_SCOPE="$OUT_OF_SCOPE\n  - $FILE"
+  fi
+done
+
+if [ -n "$OUT_OF_SCOPE" ]; then
+  echo "⚠️ SCOPE GUARD: Ficheros modificados FUERA del scope de la spec activa ($SPEC_FILE):" >&2
+  echo -e "$OUT_OF_SCOPE" >&2
+  echo "" >&2
+  echo "Revisa si estos cambios son intencionales o si el agente expandió el alcance." >&2
+  echo "Ficheros declarados en la spec: $(echo "$DECLARED" | tr '\n' ', ')" >&2
+  # Warning, no bloqueo — el PM decide
+  exit 0
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,12 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-quality-gate.sh",
             "timeout": 15,
             "statusMessage": "Verificando quality gates..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/scope-guard.sh",
+            "timeout": 10,
+            "statusMessage": "Verificando scope de la spec..."
           }
         ]
       }

--- a/.claude/skills/spec-driven-development/SKILL.md
+++ b/.claude/skills/spec-driven-development/SKILL.md
@@ -204,6 +204,8 @@ claude --model $CLAUDE_MODEL_AGENT \
 
 ### 3.3 Patrón `agent-team` — Agentes especializados en paralelo
 
+**Regla de serialización**: ANTES de lanzar tareas paralelas, verificar que los scopes (ficheros declarados en cada spec) no se solapan. Si dos specs tocan los mismos módulos → serializar o asignar a un solo agente. Ver `@docs/agent-teams-sdd.md` §"Regla de Serialización de Scope".
+
 Para tasks grandes, se lanza un equipo de agentes con roles distintos:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.19.0] — 2026-02-27
+
+Governance hardening inspired by Fernando García Varela's article on AI governance failure modes: scope guard hook to detect silent scope creep, parallel session serialization rule to prevent contradictory changes, and ADR loading at session start to prevent architectural drift.
+
+### Added
+
+**Scope Guard Hook** — `.claude/hooks/scope-guard.sh` (Stop): detects files modified outside the declared scope of the active SDD spec. Compares `git diff` against the "Ficheros a Crear/Modificar" section of the most recently touched `.spec.md` file. Issues a warning to the PM (does not block) when out-of-scope files are found. Excludes test files, config, agent-notes, and other legitimate ancillary changes.
+
+**Parallel session serialization rule** — New critical rule #18 in CLAUDE.md: "ANTES de lanzar Agent Teams o tareas paralelas, verificar que los scopes no se solapan. Si dos specs tocan los mismos módulos → serializar." Prevents the failure mode where two agents produce internally coherent but mutually contradictory code that merges cleanly but behaves incorrectly.
+
+### Changed
+
+**`/context-load` expanded (5→6 steps)** — New step 4/6 "ADRs activos": reads Architecture Decision Records with `status: accepted` from all active projects at session start. Shows up to 5 most recent ADRs with title, date, and project. Prevents long-term architectural drift by reminding the PM of active design decisions.
+
+**`docs/agent-teams-sdd.md`** — New §"Regla de Serialización de Scope" with verification protocol, example showing conflict detection, risk explanation, and reference to scope-guard hook as second line of defense.
+
+**SDD skill** — Added serialization rule reference in §3.3 (agent-team pattern): must verify scope overlap before launching parallel tasks.
+
+**`.claude/settings.json`** — Added `scope-guard.sh` as second Stop hook (after `stop-quality-gate.sh`).
+
+**CLAUDE.md** — New rule #18 (parallel serialization). Hooks count 8→9. New scope-guard entry in hooks section.
+
+**README.md + README.en.md** — Updated hooks count (8→9), added scope guard and serialization features in descriptions. New critical rule #9 (parallel scope verification).
+
+### Why
+
+Inspired by Fernando García Varela's article "IA y Código. Domesticando a mi Nueva Mascota!!!" — after 6 months of serious AI adoption, he identified structural failure modes that productivity studies miss. Two gaps in pm-workspace matched his findings: (1) no programmatic detection of scope creep during agent execution, and (2) no formal protocol for verifying scope disjunction before parallel sessions. The scope guard hook provides runtime detection, the serialization rule provides prevention, and ADR loading at session start addresses his concern about architectural decisions drifting over time.
+
+---
+
 ## [0.18.0] — 2026-02-27
 
 Multi-agent coordination inspired by Miguel Palacios' agent team model: agent-notes for persistent inter-agent memory, TDD gate hook for test-first enforcement, security review pre-implementation, Architecture Decision Records, and enhanced SDD handoff protocol with full traceability.
@@ -596,7 +626,8 @@ Initial public release of PM-Workspace.
 
 ---
 
-[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.15.1...v0.16.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Antes de actuar sobre un proyecto, **leer siempre su CLAUDE.md específico**.
 15. **UX Feedback OBLIGATORIO**: TODO slash command DEBE mostrar: banner inicio, verificación prerequisitos ✅/❌, progreso por pasos, resultado, banner fin. Si falta config → preguntar → guardar → reintentar. **El silencio es un bug.**
 16. **Contexto y Auto-compact**: Resultado > 30 líneas → fichero + resumen. Subagente (`Task`) para análisis pesados. **TRAS CADA slash command ejecutado**, terminar con `⚡ /compact` para que el PM libere contexto. Una tarea por sesión. Si el PM pide otro comando sin compactar → recordar: "Ejecuta `/compact` primero para liberar contexto."
 17. **Anti-improvisación**: Un comando SOLO ejecuta lo definido en su `.md`. Escenario no cubierto → error con sugerencia, NO inventar.
+18. **Serialización de paralelo**: ANTES de lanzar Agent Teams o tareas paralelas, verificar que los scopes (ficheros en cada spec) no se solapan. Si dos specs tocan los mismos módulos → serializar. Hook `scope-guard.sh` detecta ficheros fuera del scope al terminar.
 
 ---
 
@@ -137,7 +138,7 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 
 > Config: `.claude/settings.json` · Scripts: `.claude/hooks/`
 
-8 hooks que refuerzan reglas críticas automáticamente (sin depender de disciplina del agente):
+9 hooks que refuerzan reglas críticas automáticamente (sin depender de disciplina del agente):
 - **SessionStart**: `session-init.sh` — verifica PAT, herramientas, rama git, establece env vars
 - **PreToolUse (Bash)**: `validate-bash-global.sh` — bloquea `rm -rf /`, `chmod 777`, `curl|bash`, `sudo`
 - **PreToolUse (Bash)**: `block-force-push.sh` — bloquea `push --force`, push a main, `commit --amend`, `reset --hard`
@@ -146,6 +147,7 @@ IaC preferido: Terraform. También: Azure CLI, AWS CLI, GCP CLI, Bicep, CDK, Pul
 - **PreToolUse (Edit/Write)**: `tdd-gate.sh` — bloquea edición de código de producción sin tests previos (developer agents)
 - **PostToolUse (Edit/Write)**: `post-edit-lint.sh` — auto-lint async (ruff, eslint, gofmt, rustfmt, rubocop, etc.)
 - **Stop**: `stop-quality-gate.sh` — detecta secrets en staged changes antes de terminar
+- **Stop**: `scope-guard.sh` — detecta ficheros modificados fuera del scope de la spec SDD activa
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -32,11 +32,11 @@ This workspace turns Claude Code into an **automated Project Manager / Scrum Mas
 
 **Intelligent memory system** — language rules with auto-loading by file type (`paths:` frontmatter), persistent auto memory per project, and support for external projects via symlinks and `--add-dir`.
 
-**Programmatic hooks** — 8 hooks that enforce critical rules automatically: force push blocking, secrets detection, destructive infrastructure operation prevention, auto-lint after edits, and quality gates before finishing. Configured in `.claude/settings.json`.
+**Programmatic hooks** — 9 hooks that enforce critical rules automatically: force push blocking, secrets detection, destructive infrastructure operation prevention, auto-lint after edits, quality gates before finishing, and scope guard that detects files modified outside the SDD spec's declared scope. Configured in `.claude/settings.json`.
 
 **Agents with advanced capabilities** — each subagent has persistent memory (`memory: project`), preloaded skills, appropriate permission mode, and developer agents use `isolation: worktree` for parallel implementation without conflicts. Experimental support for Agent Teams (lead + teammates).
 
-**Multi-agent coordination** — agent-notes system for persistent inter-agent memory, TDD gate that blocks implementation without prior tests, pre-implementation security review (OWASP on the spec, not just code), and Architecture Decision Records (ADR) for traceable decisions.
+**Multi-agent coordination** — agent-notes system for persistent inter-agent memory, TDD gate that blocks implementation without prior tests, pre-implementation security review (OWASP on the spec, not just code), Architecture Decision Records (ADR) for traceable decisions, and scope serialization rules for safe parallel sessions.
 
 ---
 
@@ -146,6 +146,7 @@ Full documentation is organized into sections for easy reference:
 6. **Infrastructure**: NEVER `terraform apply` in PRE/PRO without human approval; always minimum tier
 7. **Git**: NEVER commit directly to `main` — always branch + PR
 8. **Commands**: validate with `scripts/validate-commands.sh` before committing
+9. **Parallel**: verify scope overlap before launching Agent Teams; serialize if conflict
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 
 **Sistema de memoria inteligente** — reglas de lenguaje con auto-carga por tipo de fichero (`paths:` frontmatter), auto memory persistente por proyecto, y soporte para proyectos externos vía symlinks y `--add-dir`.
 
-**Hooks programáticos** — 8 hooks que refuerzan reglas críticas automáticamente: bloqueo de force push, detección de secrets, prevención de operaciones destructivas de infra, auto-lint tras edición, y quality gates antes de finalizar. Configurados en `.claude/settings.json`.
+**Hooks programáticos** — 9 hooks que refuerzan reglas críticas automáticamente: bloqueo de force push, detección de secrets, prevención de operaciones destructivas de infra, auto-lint tras edición, quality gates antes de finalizar, y scope guard que detecta ficheros modificados fuera del alcance de la spec SDD. Configurados en `.claude/settings.json`.
 
 **Agentes con capacidades avanzadas** — cada subagente tiene memoria persistente (`memory: project`), skills precargados, modo de permisos apropiado, y los developer agents usan `isolation: worktree` para implementación paralela sin conflictos. Soporte experimental para Agent Teams (lead + teammates).
 
-**Coordinación multi-agente** — sistema de agent-notes para memoria inter-agente persistente, TDD gate que bloquea implementación sin tests previos, security review pre-implementación (OWASP en la spec, no solo en el código), y Architecture Decision Records (ADR) para decisiones trazables.
+**Coordinación multi-agente** — sistema de agent-notes para memoria inter-agente persistente, TDD gate que bloquea implementación sin tests previos, security review pre-implementación (OWASP en la spec, no solo en el código), Architecture Decision Records (ADR) para decisiones trazables, y reglas de serialización de scope para sesiones paralelas seguras.
 
 ---
 
@@ -146,6 +146,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 6. **Infraestructura**: NUNCA `terraform apply` en PRE/PRO sin aprobación humana; siempre tier mínimo
 7. **Git**: NUNCA commit directo en `main` — siempre rama + PR
 8. **Comandos**: validar con `scripts/validate-commands.sh` antes de commit
+9. **Paralelo**: verificar solapamiento de scope antes de lanzar Agent Teams; serializar si hay conflicto
 
 ---
 

--- a/docs/agent-teams-sdd.md
+++ b/docs/agent-teams-sdd.md
@@ -29,6 +29,29 @@ PM (Lead)
 - Modifican los mismos ficheros
 - Una sola spec es suficientemente compleja para ocupar toda la sesión
 
+## Regla de Serialización de Scope
+
+**ANTES de lanzar Agent Teams**, el PM DEBE verificar que los scopes no se solapan:
+
+1. Para cada spec asignada, leer la sección "Ficheros a Crear/Modificar"
+2. Generar la lista completa de ficheros que cada spec tocará
+3. Si dos o más specs tocan los mismos ficheros → **serializar** (una después de otra) o asignar al mismo agente
+4. Si los scopes son disjuntos → proceder con paralelo
+
+```
+# Ejemplo de verificación:
+Spec #1234 → src/Auth/LoginHandler.cs, src/Auth/TokenService.cs
+Spec #1235 → src/Notifications/EmailService.cs, src/Notifications/SmsService.cs
+Spec #1236 → src/Auth/LoginHandler.cs, src/Dashboard/MetricsController.cs
+                   ^^^^^^^^^^^^^^^^^^^^
+# Conflicto: Spec #1234 y #1236 tocan LoginHandler.cs → SERIALIZAR
+# Spec #1235 es independiente → puede ir en paralelo con cualquiera
+```
+
+**Riesgo**: Sin esta verificación, dos agentes pueden modificar el mismo fichero en worktrees separados. Ambos cambios serán internamente coherentes pero mutuamente contradictorios. El merge será limpio (sin conflictos git) pero el comportamiento será incorrecto.
+
+El hook `scope-guard.sh` (Stop) detecta ficheros modificados fuera del scope de la spec, proporcionando una segunda línea de defensa.
+
 ## Ejemplo de Uso
 
 ```


### PR DESCRIPTION
## Summary

- **Scope Guard Hook** (`scope-guard.sh`): Stop hook that detects files modified outside the SDD spec's declared scope. Warns PM without blocking.
- **Parallel Serialization Rule**: New critical rule #18 requiring scope overlap verification before launching Agent Teams. Prevents contradictory parallel changes.
- **ADR Loading in /context-load**: New step 4/6 loads active ADRs at session start to prevent long-term architectural drift.

Inspired by Fernando García Varela's article on AI governance failure modes.

## Files changed (9)

- `.claude/hooks/scope-guard.sh` — NEW: scope guard hook
- `.claude/settings.json` — added scope-guard to Stop hooks
- `.claude/commands/context-load.md` — expanded 5→6 steps with ADR loading
- `.claude/skills/spec-driven-development/SKILL.md` — serialization rule in agent-team section
- `CLAUDE.md` — rule #18, hooks 8→9, scope-guard entry
- `CHANGELOG.md` — v0.19.0 entry
- `README.md` — hooks 8→9, scope guard + serialization features, rule #9
- `README.en.md` — same updates in English
- `docs/agent-teams-sdd.md` — new "Regla de Serialización de Scope" section

## Test plan

- [ ] Verify scope-guard.sh is executable and parses spec files correctly
- [ ] Verify /context-load shows ADR step in protocol
- [ ] Verify hooks count is 9 across CLAUDE.md, README.md, README.en.md
- [ ] Verify CHANGELOG links are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)