### PR TITLE
fix: revert developer_type to hyphen format (agent-single)

### DIFF
--- a/.claude/commands/agent-run.md
+++ b/.claude/commands/agent-run.md
@@ -29,7 +29,7 @@ Mostrar plan (spec, modelo, log path, max turns 40) → confirmar → lanzar age
 Lanzar en paralelo: Implementador (opus) + Tester (haiku). Tras `wait`, si pattern es `impl-test-review`, lanzar Reviewer (opus) que compara logs contra Spec.
 
 ### 4. Modo Batch (`--all-pending`)
-Buscar specs con `developer_type=agent:single` y `Estado=Pendiente` en el sprint. Mostrar lista + estimación de tokens → confirmar → lanzar en paralelo.
+Buscar specs con `developer_type=agent-single` y `Estado=Pendiente` en el sprint. Mostrar lista + estimación de tokens → confirmar → lanzar en paralelo.
 
 ### 5. Post-ejecución
 - Detectar blockers en logs (`grep BLOCKER`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Context optimization and 150-line discipline enforcement: every skill, agent, an
 
 ### Fixed
 
-**CI: spec developer_type format** — Spec files used `agent-single` but test suite expected `agent:single` (colon format). Fixed in 2 spec files + `agent-run.md` command. Failures since v0.17.0.
+**CI: spec developer_type format** — Test suite used `agent:single` (colon format) but specs and project convention use `agent-single` (hyphen format, required by Claude Code). Fixed test-workspace.sh validation regex + layer-assignment-matrix grep. Failures since v0.17.0.
 
 **Release workflow: missing npm install** — Added `setup-node@v4` and `npm install --prefix scripts` steps to `.github/workflows/release.yml`. The test suite requires `node_modules` for Excel/PowerPoint validation.
 

--- a/projects/sala-reservas/specs/sprint-2026-04/AB101-B3-create-sala-handler.spec.md
+++ b/projects/sala-reservas/specs/sprint-2026-04/AB101-B3-create-sala-handler.spec.md
@@ -6,7 +6,7 @@
 **Fecha creación:** 2026-03-03
 **Creado por:**     Carlos Mendoza (Tech Lead)
 
-**Developer Type:** agent:single
+**Developer Type:** agent-single
 **Asignado a:**     claude-agent (dev:agent)
 **Estimación:**     4h
 **Estado:**         Pendiente

--- a/projects/sala-reservas/specs/sprint-2026-04/AB102-D1-unit-tests-salas.spec.md
+++ b/projects/sala-reservas/specs/sprint-2026-04/AB102-D1-unit-tests-salas.spec.md
@@ -6,7 +6,7 @@
 **Fecha creación:** 2026-03-03
 **Creado por:**     Carlos Mendoza (Tech Lead)
 
-**Developer Type:** agent:single
+**Developer Type:** agent-single
 **Modelo sugerido:** claude-haiku-4-5-20251001
 **Asignado a:**     claude-agent-fast (dev:agent-fast)
 **Estimación:**     2h

--- a/scripts/test-workspace.sh
+++ b/scripts/test-workspace.sh
@@ -578,10 +578,10 @@ test_sdd() {
 
     # Verificar developer_type válido
     DEV_TYPE=$(grep "^\*\*Developer Type:\*\*" "$SPEC" | awk '{print $NF}')
-    if [[ "$DEV_TYPE" =~ ^(human|agent:single|agent:team)$ ]]; then
+    if [[ "$DEV_TYPE" =~ ^(human|agent-single|agent-team)$ ]]; then
       pass "Spec $SPEC_NAME: developer_type válido ($DEV_TYPE)"
     else
-      fail "Spec $SPEC_NAME: developer_type inválido" "Valor: '$DEV_TYPE', Esperado: human|agent:single|agent:team"
+      fail "Spec $SPEC_NAME: developer_type inválido" "Valor: '$DEV_TYPE', Esperado: human|agent-single|agent-team"
     fi
 
     # Verificar que no hay placeholders sin rellenar
@@ -596,7 +596,7 @@ test_sdd() {
   log_section "Validar layer-assignment-matrix"
   MATRIX="$WORKSPACE_ROOT/.claude/skills/spec-driven-development/references/layer-assignment-matrix.md"
   if [[ -f "$MATRIX" ]]; then
-    AGENT_ROWS=$(grep -c "agent:single\|agent:team" "$MATRIX" 2>/dev/null || true)
+    AGENT_ROWS=$(grep -c "agent-single\|agent-team" "$MATRIX" 2>/dev/null || true)
     HUMAN_ROWS=$(grep -c "\`human\`" "$MATRIX" 2>/dev/null || true)
     pass "Matrix de asignación: $AGENT_ROWS entradas de agente, $HUMAN_ROWS de humano"
   else


### PR DESCRIPTION
## Summary

- **Reverts** v0.20.0's incorrect change from `agent-single` to `agent:single` in spec files
- **Fixes** `test-workspace.sh` validation regex to accept `agent-single`/`agent-team` (hyphen format)
- **Fixes** layer-assignment-matrix grep to match hyphen format
- Claude Code does not support colons in these values — the project migrated to hyphens in a prior release

## Test plan

- [x] `test-workspace.sh --mock` passes: developer_type `agent-single` validated correctly
- [x] Matrix grep finds 29 agent entries with hyphen format
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)