### PR TITLE
docs: actualizar referencia de comandos con 102 funcionalidades

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -38,6 +38,12 @@ This workspace turns Claude Code into an **automated Project Manager / Scrum Mas
 
 **Multi-agent coordination** — agent-notes system for persistent inter-agent memory, TDD gate that blocks implementation without prior tests, pre-implementation security review (OWASP on the spec, not just code), Architecture Decision Records (ADR) for traceable decisions, and scope serialization rules for safe parallel sessions.
 
+**Automated code review** — pre-commit hook that analyzes staged files against domain rules (REJECT/REQUIRE/PREFER), with SHA256 cache to skip re-reviewing unchanged files. Guardian angel integrated into the commit flow.
+
+**Security and compliance** — SAST analysis against OWASP Top 10, dependency vulnerability auditing, SBOM generation (CycloneDX), git history credential scanning, and enhanced leak detection (AWS, GitHub, OpenAI, Azure, JWT patterns).
+
+**Validation and CI/CD** — plan gate that warns when implementing without an approved spec, file size validation (≤150 lines), frontmatter and settings.json schema validation, and CI pipeline with automated checks on every PR.
+
 ---
 
 ## Documentation
@@ -97,42 +103,87 @@ Full documentation is organized into sections for easy reference:
 
 ## Quick Command Reference
 
+> 102 commands · 24 agents · 13 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
+
 ### Sprint and Reporting
 ```
 /sprint-status    /sprint-plan    /sprint-review    /sprint-retro
-/report-hours     /report-executive    /report-capacity
-/team-workload    /board-flow    /kpi-dashboard
+/sprint-release-notes    /report-hours    /report-executive    /report-capacity
+/team-workload    /board-flow    /kpi-dashboard    /kpi-dora
 ```
 
 ### PBI and SDD
 ```
-/pbi-decompose {id}    /pbi-plan-sprint    /pbi-assign {id}
-/spec-generate {id}    /spec-review {file}    /agent-run {file}
-/spec-explore {id}     /spec-design {spec}    /spec-verify {spec}
-/spec-status    /pbi-jtbd {id}    /pbi-prd {id}
+/pbi-decompose {id}    /pbi-decompose-batch {ids}    /pbi-assign {id}
+/pbi-plan-sprint    /pbi-jtbd {id}    /pbi-prd {id}
+/spec-generate {id}    /spec-explore {id}    /spec-design {spec}
+/spec-implement {spec}    /spec-review {file}    /spec-verify {spec}
+/spec-status    /agent-run {file}
+```
+
+### Repositories, PRs and Pipelines
+```
+/repos-list    /repos-branches {repo}    /repos-search {query}
+/repos-pr-create    /repos-pr-list    /repos-pr-review {pr}
+/pr-review [PR]    /pr-pending
+/pipeline-status    /pipeline-run {pipe}    /pipeline-logs {id}
+/pipeline-artifacts {id}    /pipeline-create {repo}
 ```
 
 ### Infrastructure and Environments
 ```
 /infra-detect {proj} {env}    /infra-plan {proj} {env}    /infra-estimate {proj}
-/infra-scale {resource}       /infra-status {proj}
-/env-setup {proj}             /env-promote {proj} {source} {dest}
+/infra-scale {resource}    /infra-status {proj}
+/env-setup {proj}    /env-promote {proj} {source} {dest}
+```
+
+### Projects and Planning
+```
+/project-kickoff {name}    /project-assign {name}    /project-audit {name}
+/project-roadmap {name}    /project-release-plan {name}
+/epic-plan {proj}    /backlog-capture    /retro-actions
 ```
 
 ### Memory and Context
 ```
-/memory-sync    /context-load    /session-save    /help [filter]
+/memory-sync    /memory-save    /memory-search    /memory-context
+/context-load    /session-save    /help [filter]
 ```
 
-### Architecture and Security
+### Security and Auditing
 ```
-/adr-create {proj} {title}    /security-review {spec}    /agent-notes-archive {proj}
+/security-review {spec}    /security-audit    /security-alerts
+/credential-scan    /dependencies-audit    /sbom-generate
 ```
 
-### Quality and Team
+### Quality and Validation
 ```
-/pr-review [PR]    /pr-pending    /changelog-update    /evaluate-repo [URL]
+/changelog-update    /evaluate-repo [URL]    /validate-filesize
+/validate-schema    /review-cache-stats    /review-cache-clear
+/testplan-status    /testplan-results {id}
+```
+
+### Team and Onboarding
+```
 /team-onboarding {name}    /team-evaluate {name}    /team-privacy-notice {name}
+```
+
+### Architecture and Diagrams
+```
+/adr-create {proj} {title}    /agent-notes-archive {proj}
+/diagram-generate {proj}    /diagram-import {file}
+/diagram-config    /diagram-status
+/debt-track    /dependency-map    /legacy-assess    /risk-log
+```
+
+### External Integrations
+```
+/jira-sync    /linear-sync    /notion-sync    /confluence-publish
+/wiki-publish    /wiki-sync    /slack-search    /notify-slack
+/notify-whatsapp    /whatsapp-search    /notify-nctalk    /nctalk-search
+/figma-extract    /gdrive-upload    /github-activity    /github-issues
+/sentry-bugs    /sentry-health    /inbox-check    /inbox-start
+/worktree-setup {spec}
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 
 **Coordinación multi-agente** — sistema de agent-notes para memoria inter-agente persistente, TDD gate que bloquea implementación sin tests previos, security review pre-implementación (OWASP en la spec, no solo en el código), Architecture Decision Records (ADR) para decisiones trazables, y reglas de serialización de scope para sesiones paralelas seguras.
 
+**Code Review automatizado** — hook pre-commit que analiza ficheros staged contra reglas de dominio (REJECT/REQUIRE/PREFER), con caché SHA256 que evita re-revisar ficheros sin cambios. Guardian angel integrado en el flujo de commit.
+
+**Seguridad y compliance** — análisis SAST contra OWASP Top 10, auditoría de vulnerabilidades en dependencias, generación de SBOM (CycloneDX), escaneo de credenciales en historial git, y detección mejorada de leaks (AWS, GitHub, OpenAI, Azure, JWT).
+
+**Validación y CI/CD** — plan gate que avisa si se implementa sin spec aprobada, validación de tamaño de ficheros (≤150 líneas), schema de frontmatter y settings.json, y pipeline CI con checks automáticos en cada PR.
+
 ---
 
 ## Documentación
@@ -97,42 +103,87 @@ La documentación completa está organizada en secciones para facilitar la consu
 
 ## Referencia rápida de comandos
 
+> 102 comandos · 24 agentes · 13 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
+
 ### Sprint y Reporting
 ```
 /sprint-status    /sprint-plan    /sprint-review    /sprint-retro
-/report-hours     /report-executive    /report-capacity
-/team-workload    /board-flow    /kpi-dashboard
+/sprint-release-notes    /report-hours    /report-executive    /report-capacity
+/team-workload    /board-flow    /kpi-dashboard    /kpi-dora
 ```
 
 ### PBI y SDD
 ```
-/pbi-decompose {id}    /pbi-plan-sprint    /pbi-assign {id}
-/spec-generate {id}    /spec-review {file}    /agent-run {file}
-/spec-explore {id}     /spec-design {spec}    /spec-verify {spec}
-/spec-status    /pbi-jtbd {id}    /pbi-prd {id}
+/pbi-decompose {id}    /pbi-decompose-batch {ids}    /pbi-assign {id}
+/pbi-plan-sprint    /pbi-jtbd {id}    /pbi-prd {id}
+/spec-generate {id}    /spec-explore {id}    /spec-design {spec}
+/spec-implement {spec}    /spec-review {file}    /spec-verify {spec}
+/spec-status    /agent-run {file}
+```
+
+### Repositorios, PRs y Pipelines
+```
+/repos-list    /repos-branches {repo}    /repos-search {query}
+/repos-pr-create    /repos-pr-list    /repos-pr-review {pr}
+/pr-review [PR]    /pr-pending
+/pipeline-status    /pipeline-run {pipe}    /pipeline-logs {id}
+/pipeline-artifacts {id}    /pipeline-create {repo}
 ```
 
 ### Infraestructura y Entornos
 ```
 /infra-detect {proy} {env}    /infra-plan {proy} {env}    /infra-estimate {proy}
-/infra-scale {recurso}        /infra-status {proy}
-/env-setup {proy}             /env-promote {proy} {origen} {destino}
+/infra-scale {recurso}    /infra-status {proy}
+/env-setup {proy}    /env-promote {proy} {origen} {destino}
+```
+
+### Proyectos y Planificación
+```
+/project-kickoff {nombre}    /project-assign {nombre}    /project-audit {nombre}
+/project-roadmap {nombre}    /project-release-plan {nombre}
+/epic-plan {proy}    /backlog-capture    /retro-actions
 ```
 
 ### Memoria y Contexto
 ```
-/memory-sync    /context-load    /session-save    /help [filtro]
+/memory-sync    /memory-save    /memory-search    /memory-context
+/context-load    /session-save    /help [filtro]
 ```
 
-### Arquitectura y Seguridad
+### Seguridad y Auditoría
 ```
-/adr-create {proy} {título}    /security-review {spec}    /agent-notes-archive {proy}
+/security-review {spec}    /security-audit    /security-alerts
+/credential-scan    /dependencies-audit    /sbom-generate
 ```
 
-### Calidad y Equipo
+### Calidad y Validación
 ```
-/pr-review [PR]    /pr-pending    /changelog-update    /evaluate-repo [URL]
+/changelog-update    /evaluate-repo [URL]    /validate-filesize
+/validate-schema    /review-cache-stats    /review-cache-clear
+/testplan-status    /testplan-results {id}
+```
+
+### Equipo y Onboarding
+```
 /team-onboarding {nombre}    /team-evaluate {nombre}    /team-privacy-notice {nombre}
+```
+
+### Arquitectura y Diagramas
+```
+/adr-create {proy} {título}    /agent-notes-archive {proy}
+/diagram-generate {proy}    /diagram-import {fichero}
+/diagram-config    /diagram-status
+/debt-track    /dependency-map    /legacy-assess    /risk-log
+```
+
+### Integraciones Externas
+```
+/jira-sync    /linear-sync    /notion-sync    /confluence-publish
+/wiki-publish    /wiki-sync    /slack-search    /notify-slack
+/notify-whatsapp    /whatsapp-search    /notify-nctalk    /nctalk-search
+/figma-extract    /gdrive-upload    /github-activity    /github-issues
+/sentry-bugs    /sentry-health    /inbox-check    /inbox-start
+/worktree-setup {spec}
 ```
 
 ---

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -1,74 +1,179 @@
 # Referencia Rápida de Comandos
 
-## Sprint y Reporting
+## Sprint y Reporting (12 comandos)
 ```
 /sprint-status [--project]        Estado del sprint con alertas
 /sprint-plan [--project]          Asistente de Sprint Planning
 /sprint-review [--project]        Resumen para Sprint Review
 /sprint-retro [--project]         Retrospectiva con datos
+/sprint-release-notes [--project] Generar release notes del sprint
 /report-hours [--project]         Informe de horas (Excel)
 /report-executive                 Informe multi-proyecto (PPT/Word)
-/report-capacity [--project]      Estado de capacidades
+/report-capacity [--project]      Estado de capacidades del equipo
 /team-workload [--project]        Carga por persona
 /board-flow [--project]           Cycle time y cuellos de botella
 /kpi-dashboard [--project]        Dashboard KPIs completo
+/kpi-dora [--project]             Métricas DORA (deploy freq, lead time, MTTR, change fail)
 ```
 
-## PBI Decomposition
+## PBI y Decomposition (6 comandos)
 ```
 /pbi-decompose {id}               Descomponer un PBI en tasks
 /pbi-decompose-batch {id1,id2}    Descomponer varios PBIs
 /pbi-assign {pbi_id}              (Re)asignar tasks de un PBI
 /pbi-plan-sprint                  Planning completo del sprint
+/pbi-jtbd {id}                    Generar JTBD (Jobs to be Done)
+/pbi-prd {id}                     Generar PRD (Product Requirements)
 ```
 
-## Spec-Driven Development
+## Spec-Driven Development (8 comandos)
 ```
 /spec-generate {task_id}          Generar Spec desde Task de Azure DevOps
+/spec-explore {id}                Exploración pre-spec del codebase
+/spec-design {spec}               Diseño técnico a partir de spec
 /spec-implement {spec_file}       Implementar Spec (agente o humano)
 /spec-review {spec_file}          Revisar calidad de Spec o implementación
+/spec-verify {spec}               Verificar implementación vs spec (Given/When/Then)
 /spec-status [--project]          Dashboard de Specs del sprint
 /agent-run {spec_file} [--team]   Lanzar agente Claude sobre una Spec
 ```
 
-## Product Discovery
+## Repositorios y PRs (8 comandos)
 ```
-/pbi-jtbd {id}                   Generar JTBD (Jobs to be Done) para un PBI
-/pbi-prd {id}                    Generar PRD (Product Requirements) para un PBI
-```
-
-## Calidad y Operaciones
-```
-/pr-review [PR]                  Revisión multi-perspectiva de PR (BA, Dev, QA, Sec, DevOps)
-/context-load                    Carga de contexto al iniciar sesión (big picture)
-/session-save                    Guarda decisiones y pendientes antes de /clear
-/changelog-update                Actualizar CHANGELOG.md desde commits convencionales
-/evaluate-repo [URL]             Auditoría de seguridad y calidad de repo externo
+/repos-list [--project]           Listar repositorios del proyecto
+/repos-branches {repo}            Ramas activas de un repositorio
+/repos-search {query}             Buscar en código fuente
+/repos-pr-create {repo}           Crear Pull Request
+/repos-pr-list [--project]        Listar PRs abiertas
+/repos-pr-review {pr_id}          Revisar un PR de Azure DevOps
+/pr-review [PR]                   Revisión multi-perspectiva (BA, Dev, QA, Sec, DevOps)
+/pr-pending [--project]           PRs pendientes de revisión
 ```
 
-## Gestión de Equipo
+## Pipelines CI/CD (5 comandos)
 ```
-/team-onboarding {nombre}       Guía de onboarding personalizada (contexto + código)
-/team-evaluate {nombre}         Cuestionario interactivo de competencias → perfil en equipo.md
-/team-privacy-notice {nombre}   Nota informativa RGPD obligatoria antes de evaluar
+/pipeline-status [--project]      Estado de pipelines
+/pipeline-run {pipeline}          Ejecutar un pipeline
+/pipeline-logs {run_id}           Ver logs de ejecución
+/pipeline-artifacts {run_id}      Descargar artefactos
+/pipeline-create {repo}           Crear pipeline desde plantilla
 ```
 
-## Infraestructura y Entornos
+## Infraestructura y Entornos (7 comandos)
 ```
-/infra-detect {proyecto} {env}  Detectar infraestructura existente
-/infra-plan {proyecto} {env}    Generar plan de infraestructura
-/infra-estimate {proyecto}      Estimar costes por entorno
-/infra-scale {recurso}          Proponer escalado (requiere aprobación humana)
-/infra-status {proyecto}        Estado de infraestructura actual
-/env-setup {proyecto}           Configurar entornos (DEV/PRE/PRO)
-/env-promote {proyecto} {o} {d} Promover entre entornos (PRE→PRO requiere aprobación)
+/infra-detect {proyecto} {env}    Detectar infraestructura existente
+/infra-plan {proyecto} {env}      Generar plan de infraestructura
+/infra-estimate {proyecto}        Estimar costes por entorno
+/infra-scale {recurso}            Proponer escalado (requiere aprobación humana)
+/infra-status {proyecto}          Estado de infraestructura actual
+/env-setup {proyecto}             Configurar entornos (DEV/PRE/PRO)
+/env-promote {proyecto} {o} {d}   Promover entre entornos
+```
+
+## Proyectos y Planificación (7 comandos)
+```
+/project-kickoff {nombre}         Iniciar nuevo proyecto (estructura + Azure DevOps)
+/project-assign {nombre}          Asignar equipo al proyecto
+/project-audit {nombre}           Auditoría de salud del proyecto
+/project-roadmap {nombre}         Generar roadmap visual
+/project-release-plan {nombre}    Plan de releases
+/epic-plan {proyecto}             Planificación multi-sprint de épicas
+/backlog-capture                  Captura rápida de items al backlog
+```
+
+## Memoria y Contexto (6 comandos)
+```
+/memory-sync [--project]          Sincronizar insights en auto memory
+/memory-save {tipo} {contenido}   Guardar en memoria persistente
+/memory-search {query}            Buscar en memoria
+/memory-context                   Inyectar contexto de memoria
+/context-load                     Carga de contexto al iniciar sesión
+/session-save                     Guardar decisiones antes de /clear
+```
+
+## Seguridad y Auditoría (5 comandos)
+```
+/security-review {spec}           Revisión OWASP pre-implementación
+/security-audit [--project]       Análisis SAST contra OWASP Top 10
+/security-alerts [--project]      Alertas de seguridad activas
+/credential-scan [--project]      Escanear historial git por credenciales filtradas
+/dependencies-audit [--project]   Auditoría de vulnerabilidades en dependencias
+```
+
+## Testing (2 comandos)
+```
+/testplan-status [--project]      Estado de test plans
+/testplan-results {plan_id}       Resultados de ejecución de tests
+```
+
+## Calidad y Validación (7 comandos)
+```
+/changelog-update                 Actualizar CHANGELOG desde commits
+/evaluate-repo [URL]              Auditoría de repo externo
+/validate-filesize                Validar ≤150 líneas por fichero
+/validate-schema                  Validar schema de frontmatter y settings
+/review-cache-stats               Estadísticas de caché de code review
+/review-cache-clear               Limpiar caché de code review
+/sbom-generate [--project]        Generar SBOM (Software Bill of Materials)
+```
+
+## Equipo y Onboarding (3 comandos)
+```
+/team-onboarding {nombre}         Guía de onboarding personalizada
+/team-evaluate {nombre}           Cuestionario de competencias
+/team-privacy-notice {nombre}     Nota informativa RGPD
+```
+
+## Integraciones Externas (12 comandos)
+```
+/jira-sync {proyecto}             Sync Jira ↔ Azure DevOps
+/linear-sync {proyecto}           Sync Linear ↔ Azure DevOps
+/notion-sync {proyecto}           Sync documentación ↔ Notion
+/confluence-publish {doc}         Publicar en Confluence
+/wiki-publish {doc}               Publicar en Wiki de Azure DevOps
+/wiki-sync [--project]            Sincronizar wiki
+/slack-search {query}             Buscar en Slack
+/notify-slack {canal} {msg}       Notificar en Slack
+/notify-whatsapp {dest} {msg}     Notificar por WhatsApp
+/whatsapp-search {query}          Buscar en WhatsApp
+/notify-nctalk {sala} {msg}       Notificar en Nextcloud Talk
+/nctalk-search {query}            Buscar en Nextcloud Talk
+```
+
+## Diagramas (4 comandos)
+```
+/diagram-generate {proyecto}      Generar diagrama de arquitectura
+/diagram-import {fichero}         Importar diagrama → generar Work Items
+/diagram-config                   Configurar herramientas de diagramas
+/diagram-status [--project]       Estado de diagramas del proyecto
+```
+
+## Otros (10+ comandos)
+```
+/help [filtro]                    Catálogo de comandos y primeros pasos
+/adr-create {proyecto} {título}   Crear Architecture Decision Record
+/agent-notes-archive {proy}       Archivar agent-notes del sprint
+/debt-track [--project]           Seguimiento de deuda técnica
+/dependency-map [--project]       Mapa de dependencias entre servicios
+/legacy-assess {proyecto}         Evaluación de sistema legacy
+/risk-log [--project]             Registro de riesgos del proyecto
+/retro-actions [--project]        Seguimiento de acciones de retrospectiva
+/worktree-setup {spec}            Configurar git worktree para implementación paralela
+/inbox-check                      Revisar inbox de voz pendiente
+/inbox-start                      Iniciar transcripción de buzón de voz
+/figma-extract {url}              Extraer diseño desde Figma
+/gdrive-upload {fichero}          Subir fichero a Google Drive
+/github-activity [--project]      Actividad reciente en GitHub
+/github-issues [--project]        Issues de GitHub
+/sentry-bugs [--project]          Bugs desde Sentry → PBIs
+/sentry-health [--project]        Salud técnica desde Sentry
 ```
 
 ---
 
 ## Equipo de Subagentes Especializados
 
-El workspace incluye 23 subagentes que Claude puede invocar en paralelo o en secuencia,
+El workspace incluye 24 subagentes que Claude puede invocar en paralelo o en secuencia,
 cada uno optimizado para su tarea con el modelo LLM más adecuado:
 
 **Agentes de gestión y arquitectura:**
@@ -108,6 +213,7 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | `commit-guardian` | Sonnet 4.6 | Pre-commit: 10 checks (rama, security, build, tests, format, code review) |
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, docs de proyecto |
 | `azure-devops-operator` | Haiku 4.5 | WIQL, work items, sprint, capacity |
+| `diagram-architect` | Sonnet 4.6 | Diseño de diagramas de arquitectura, C4, flujos de datos |
 
 ### Flujo SDD con agentes en paralelo
 

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -1,74 +1,179 @@
 # Quick Command Reference
 
-## Sprint and Reporting
+## Sprint and Reporting (12 commands)
 ```
 /sprint-status [--project]        Sprint status with alerts
 /sprint-plan [--project]          Sprint Planning assistant
 /sprint-review [--project]        Sprint Review summary
 /sprint-retro [--project]         Retrospective with data
+/sprint-release-notes [--project] Generate sprint release notes
 /report-hours [--project]         Hours report (Excel)
 /report-executive                 Multi-project report (PPT/Word)
-/report-capacity [--project]      Capacity status
-/team-workload [--project]        Workload by person
+/report-capacity [--project]      Team capacity status
+/team-workload [--project]        Workload per person
 /board-flow [--project]           Cycle time and bottlenecks
 /kpi-dashboard [--project]        Full KPI dashboard
+/kpi-dora [--project]             DORA metrics (deploy freq, lead time, MTTR, change fail)
 ```
 
-## PBI Decomposition
+## PBI and Decomposition (6 commands)
 ```
 /pbi-decompose {id}               Break down a PBI into tasks
 /pbi-decompose-batch {id1,id2}    Break down multiple PBIs
 /pbi-assign {pbi_id}              (Re)assign tasks for a PBI
 /pbi-plan-sprint                  Full sprint planning
+/pbi-jtbd {id}                    Generate JTBD (Jobs to be Done)
+/pbi-prd {id}                     Generate PRD (Product Requirements)
 ```
 
-## Spec-Driven Development
+## Spec-Driven Development (8 commands)
 ```
 /spec-generate {task_id}          Generate Spec from Azure DevOps Task
+/spec-explore {id}                Pre-spec codebase exploration
+/spec-design {spec}               Technical design from spec
 /spec-implement {spec_file}       Implement Spec (agent or human)
 /spec-review {spec_file}          Review Spec quality or implementation
+/spec-verify {spec}               Verify implementation vs spec (Given/When/Then)
 /spec-status [--project]          Sprint Spec dashboard
 /agent-run {spec_file} [--team]   Launch Claude agent on a Spec
 ```
 
-## Product Discovery
+## Repositories and PRs (8 commands)
 ```
-/pbi-jtbd {id}                   Generate JTBD (Jobs to be Done) for a PBI
-/pbi-prd {id}                    Generate PRD (Product Requirements) for a PBI
-```
-
-## Quality and Operations
-```
-/pr-review [PR]                  Multi-perspective PR review (BA, Dev, QA, Sec, DevOps)
-/context-load                    Load session context on startup (big picture)
-/session-save                    Save decisions and pending tasks before /clear
-/changelog-update                Update CHANGELOG.md from conventional commits
-/evaluate-repo [URL]             Security and quality audit of external repo
+/repos-list [--project]           List project repositories
+/repos-branches {repo}            Active branches for a repository
+/repos-search {query}             Search source code
+/repos-pr-create {repo}           Create Pull Request
+/repos-pr-list [--project]        List open PRs
+/repos-pr-review {pr_id}          Review an Azure DevOps PR
+/pr-review [PR]                   Multi-perspective review (BA, Dev, QA, Sec, DevOps)
+/pr-pending [--project]           PRs pending review
 ```
 
-## Team Management
+## Pipelines CI/CD (5 commands)
 ```
-/team-onboarding {name}          Personalized onboarding guide (context + code)
-/team-evaluate {name}            Interactive competency questionnaire → equipo.md profile
-/team-privacy-notice {name}      Mandatory GDPR privacy notice before assessment
+/pipeline-status [--project]      Pipeline status
+/pipeline-run {pipeline}          Run a pipeline
+/pipeline-logs {run_id}           View execution logs
+/pipeline-artifacts {run_id}      Download artifacts
+/pipeline-create {repo}           Create pipeline from template
 ```
 
-## Infrastructure and Environments
+## Infrastructure and Environments (7 commands)
 ```
-/infra-detect {project} {env}    Detect existing infrastructure
-/infra-plan {project} {env}      Generate infrastructure plan
-/infra-estimate {project}        Estimate costs per environment
-/infra-scale {resource}          Propose scaling (requires human approval)
-/infra-status {project}          Current infrastructure status
-/env-setup {project}             Configure environments (DEV/PRE/PRO)
-/env-promote {project} {s} {d}   Promote between environments (PRE→PRO requires approval)
+/infra-detect {project} {env}     Detect existing infrastructure
+/infra-plan {project} {env}       Generate infrastructure plan
+/infra-estimate {project}         Estimate costs per environment
+/infra-scale {resource}           Propose scaling (requires human approval)
+/infra-status {project}           Current infrastructure status
+/env-setup {project}              Configure environments (DEV/PRE/PRO)
+/env-promote {project} {s} {d}    Promote between environments
+```
+
+## Projects and Planning (7 commands)
+```
+/project-kickoff {name}           Start new project (structure + Azure DevOps)
+/project-assign {name}            Assign team to project
+/project-audit {name}             Project health audit
+/project-roadmap {name}           Generate visual roadmap
+/project-release-plan {name}      Release plan
+/epic-plan {project}              Multi-sprint epic planning
+/backlog-capture                  Quick backlog item capture
+```
+
+## Memory and Context (6 commands)
+```
+/memory-sync [--project]          Sync insights to auto memory
+/memory-save {type} {content}     Save to persistent memory
+/memory-search {query}            Search memory
+/memory-context                   Inject memory context
+/context-load                     Load session context on startup
+/session-save                     Save decisions before /clear
+```
+
+## Security and Auditing (5 commands)
+```
+/security-review {spec}           OWASP pre-implementation review
+/security-audit [--project]       SAST analysis against OWASP Top 10
+/security-alerts [--project]      Active security alerts
+/credential-scan [--project]      Scan git history for leaked credentials
+/dependencies-audit [--project]   Dependency vulnerability audit
+```
+
+## Testing (2 commands)
+```
+/testplan-status [--project]      Test plan status
+/testplan-results {plan_id}       Test execution results
+```
+
+## Quality and Validation (7 commands)
+```
+/changelog-update                 Update CHANGELOG from commits
+/evaluate-repo [URL]              External repo audit
+/validate-filesize                Validate ≤150 lines per file
+/validate-schema                  Validate frontmatter and settings schema
+/review-cache-stats               Code review cache statistics
+/review-cache-clear               Clear code review cache
+/sbom-generate [--project]        Generate SBOM (Software Bill of Materials)
+```
+
+## Team and Onboarding (3 commands)
+```
+/team-onboarding {name}           Personalized onboarding guide
+/team-evaluate {name}             Competency questionnaire
+/team-privacy-notice {name}       GDPR privacy notice
+```
+
+## External Integrations (12 commands)
+```
+/jira-sync {project}              Sync Jira ↔ Azure DevOps
+/linear-sync {project}            Sync Linear ↔ Azure DevOps
+/notion-sync {project}            Sync documentation ↔ Notion
+/confluence-publish {doc}         Publish to Confluence
+/wiki-publish {doc}               Publish to Azure DevOps Wiki
+/wiki-sync [--project]            Sync wiki
+/slack-search {query}             Search Slack
+/notify-slack {channel} {msg}     Notify on Slack
+/notify-whatsapp {dest} {msg}     Notify via WhatsApp
+/whatsapp-search {query}          Search WhatsApp
+/notify-nctalk {room} {msg}       Notify on Nextcloud Talk
+/nctalk-search {query}            Search Nextcloud Talk
+```
+
+## Diagrams (4 commands)
+```
+/diagram-generate {project}       Generate architecture diagram
+/diagram-import {file}            Import diagram → generate Work Items
+/diagram-config                   Configure diagram tools
+/diagram-status [--project]       Project diagram status
+```
+
+## Other (10 commands)
+```
+/help [filter]                    Command catalog and first steps
+/adr-create {project} {title}     Create Architecture Decision Record
+/agent-notes-archive {proj}       Archive sprint agent-notes
+/debt-track [--project]           Technical debt tracking
+/dependency-map [--project]       Service dependency map
+/legacy-assess {project}          Legacy system assessment
+/risk-log [--project]             Project risk register
+/retro-actions [--project]        Retrospective action tracking
+/worktree-setup {spec}            Set up git worktree for parallel implementation
+/inbox-check                      Check pending voice inbox
+/inbox-start                      Start voice mailbox transcription
+/figma-extract {url}              Extract design from Figma
+/gdrive-upload {file}             Upload file to Google Drive
+/github-activity [--project]      Recent GitHub activity
+/github-issues [--project]        GitHub issues
+/sentry-bugs [--project]          Sentry bugs → PBIs
+/sentry-health [--project]        Technical health from Sentry
 ```
 
 ---
 
 ## Specialized Agent Team
 
-The workspace includes 23 specialized agents organized in 3 groups, each optimized for its task with the most suitable LLM model:
+The workspace includes 24 specialized agents organized in 3 groups, each optimized for its task with the most suitable LLM model:
 
 ### Management & Architecture Agents
 
@@ -78,6 +183,7 @@ The workspace includes 23 specialized agents organized in 3 groups, each optimiz
 | `business-analyst` | Opus 4.6 | PBI analysis, business rules, acceptance criteria, JTBD, PRD, competency assessment |
 | `sdd-spec-writer` | Opus 4.6 | Generation and validation of executable SDD Specs |
 | `infrastructure-agent` | Opus 4.6 | IaC (Terraform, CloudFormation, Bicep), detect + plan multi-cloud infrastructure |
+| `diagram-architect` | Sonnet 4.6 | Architecture diagram design, C4, data flows |
 
 ### Language-Specific Developer Agents (16 Language Packs)
 


### PR DESCRIPTION
## Summary
- Reescritura de `docs/readme/12-comandos-agentes.md` y su versión EN: de 29-45 comandos documentados a los 102 reales, organizados en 15 categorías
- Ampliación de Quick Reference en ambos READMEs: de 6 a 11 categorías con los 102 comandos
- Añadidos 3 párrafos en "¿Qué es esto?" cubriendo features de v0.22-v0.25 (code review, seguridad/compliance, validación/CI)
- Actualización de conteo de agentes (23→24, incluyendo diagram-architect)

## Test plan
- [ ] Verificar que los 102 comandos aparecen en ambos docs de referencia
- [ ] Verificar consistencia de conteos (102 comandos, 24 agentes, 13 skills, 12 hooks)
- [ ] Verificar que CI pasa

🤖 Generated with [Claude Code](https://claude.com/claude-code)