### PR TITLE
feat: v0.31.0 — Architecture Intelligence

### DIFF
--- a/.claude/commands/arch-compare.md
+++ b/.claude/commands/arch-compare.md
@@ -1,0 +1,107 @@
+---
+name: arch-compare
+description: Comparar dos patrones de arquitectura para toma de decisiones
+developer_type: all
+agent: architect
+context_cost: low
+---
+
+# /arch-compare {pattern1} {pattern2}
+
+> Genera una comparativa detallada entre dos patrones de arquitectura.
+
+---
+
+## Prerequisitos
+
+- Ninguno
+
+## Parámetros
+
+- `{pattern1}` — Primer patrón (clean, hexagonal, ddd, cqrs, mvc, mvvm, microservices, event-driven)
+- `{pattern2}` — Segundo patrón
+- `--context {description}` — (Opcional) Contexto del proyecto para personalizar
+
+## Patrones Reconocidos
+
+| Alias | Patrón |
+|-------|--------|
+| clean | Clean Architecture |
+| hexagonal, ports-adapters | Hexagonal (Ports & Adapters) |
+| ddd | Domain-Driven Design |
+| cqrs | CQRS (+ Event Sourcing) |
+| mvc | MVC / MVT |
+| mvvm | MVVM / MVP |
+| microservices, micro | Microservices |
+| event-driven, eda | Event-Driven Architecture |
+| layered | Layered (N-Tier) |
+| monolith | Modular Monolith |
+
+## Flujo de Ejecución
+
+### 1. Validar Patrones
+
+Verificar que ambos patrones son reconocidos. Si no, sugerir el más cercano.
+
+### 2. Generar Comparativa
+
+```markdown
+# ⚖️ {Pattern1} vs {Pattern2}
+
+**Fecha**: {fecha}
+{si hay contexto: **Contexto**: {descripción}}
+
+## Tabla Comparativa
+
+| Dimensión | {Pattern1} | {Pattern2} |
+|-----------|------------|------------|
+| **Complejidad inicial** | {Baja/Media/Alta} | {Baja/Media/Alta} |
+| **Curva de aprendizaje** | {descripción} | {descripción} |
+| **Testabilidad** | {⭐⭐⭐⭐⭐} | {⭐⭐⭐⭐⭐} |
+| **Escalabilidad** | {descripción} | {descripción} |
+| **Mantenibilidad** | {descripción} | {descripción} |
+| **Equipo mínimo** | {n personas} | {n personas} |
+| **Ideal para** | {tipo de proyecto} | {tipo de proyecto} |
+| **NO usar para** | {tipo de proyecto} | {tipo de proyecto} |
+| **Frameworks populares** | {lista} | {lista} |
+| **Herramientas de enforcement** | {lista} | {lista} |
+
+## {Pattern1} — Pros y Contras
+
+### ✅ Ventajas
+- {ventaja con explicación}
+
+### ❌ Desventajas
+- {desventaja con explicación}
+
+## {Pattern2} — Pros y Contras
+
+### ✅ Ventajas
+- {ventaja con explicación}
+
+### ❌ Desventajas
+- {desventaja con explicación}
+
+## ¿Cuándo elegir cada uno?
+
+**Elige {Pattern1} si**: {condiciones}
+**Elige {Pattern2} si**: {condiciones}
+**Combínalos si**: {condiciones donde ambos aportan}
+
+## Migración entre patrones
+
+{Es posible migrar de uno a otro? Cómo? Esfuerzo estimado?}
+```
+
+### 3. Personalizar por contexto
+
+Si el usuario proporcionó `--context`:
+- Añadir sección "Recomendación para tu caso" con scoring
+- Indicar cuál patrón se adapta mejor al contexto dado
+
+Output: se muestra en consola (no genera fichero salvo que se pida)
+
+## Post-ejecución
+
+- Sugerir `/arch-recommend` para recomendación formal
+- Sugerir `/adr-create` para documentar la decisión

--- a/.claude/commands/arch-detect.md
+++ b/.claude/commands/arch-detect.md
@@ -1,0 +1,103 @@
+---
+name: arch-detect
+description: Detectar el patrón de arquitectura de un repositorio o proyecto
+developer_type: all
+agent: architect
+context_cost: medium
+---
+
+# /arch-detect {repo|path}
+
+> Analiza un repositorio o path local para identificar qué patrón de arquitectura sigue.
+
+---
+
+## Prerequisitos
+
+- Repositorio accesible (local o URL clonable)
+- Si es Azure DevOps: PAT configurado
+
+## Parámetros
+
+- `{repo|path}` — Ruta local o nombre del repositorio en Azure DevOps
+
+## Flujo de Ejecución
+
+### 1. Identificar lenguaje y framework
+
+Detectar por extensiones, `package.json`, `pom.xml`, `*.csproj`, `Cargo.toml`, `go.mod`, `Gemfile`, `composer.json`, `pubspec.yaml`, etc.
+
+Cargar reference correspondiente: `@.claude/skills/architecture-intelligence/references/patterns-{lang}.md`
+
+### 2. Fase 1 — Análisis de Estructura (40%)
+
+Listar carpetas del proyecto y comparar con patrones conocidos del lenguaje.
+
+Para cada patrón, calcular match de carpetas:
+- `score_estructura = carpetas_encontradas / carpetas_esperadas × 100`
+
+### 3. Fase 2 — Análisis de Dependencias (30%)
+
+Buscar imports/using/require entre módulos:
+- ¿Domain importa Infrastructure? → violación Clean/Hexagonal
+- ¿Hay dependencias circulares? → violación cualquier patrón
+- ¿Hay bus de comandos/eventos? → indicador CQRS/EDA
+
+`score_dependencias = reglas_cumplidas / reglas_totales × 100`
+
+### 4. Fase 3 — Análisis de Naming (20%)
+
+Buscar sufijos indicativos en nombres de ficheros y clases:
+- Controller, Service, Repository, UseCase, Command, Query, Handler
+- Port, Adapter, Aggregate, ValueObject, DomainEvent, ViewModel
+
+`score_naming = indicadores_encontrados / indicadores_esperados × 100`
+
+### 5. Fase 4 — Análisis de Config (10%)
+
+Buscar ficheros de configuración indicativos:
+- docker-compose.yml, DI config, event bus config, API gateway
+
+`score_config = configs_encontradas / configs_esperadas × 100`
+
+### 6. Calcular Score Final
+
+Para cada patrón candidato:
+`score_total = (estructura × 0.4) + (dependencias × 0.3) + (naming × 0.2) + (config × 0.1)`
+
+### 7. Generar Reporte
+
+```markdown
+# 🏗️ Architecture Detection — {proyecto}
+
+**Lenguaje**: {lang} · **Framework**: {framework}
+**Fecha**: {fecha}
+
+## Patrón Principal: {nombre} — Score: {score}%
+**Nivel de Adherencia**: {Alto|Medio|Bajo}
+
+### Evidencia
+| Fase | Score | Detalle |
+|------|-------|---------|
+| Estructura | {n}% | {carpetas encontradas} |
+| Dependencias | {n}% | {reglas cumplidas/violadas} |
+| Naming | {n}% | {indicadores encontrados} |
+| Configuración | {n}% | {configs encontradas} |
+
+### Violaciones Detectadas
+1. ⚠️ {violación} — Severidad: {CRITICAL|WARNING}
+
+### Patrones Secundarios
+- {patrón}: {score}%
+
+### Recomendación
+{acción sugerida para mejorar adherencia}
+```
+
+Output: `output/architecture/{proyecto}-detection.md`
+
+## Post-ejecución
+
+- Sugerir `/arch-suggest` si hay violaciones
+- Sugerir `/arch-fitness` para monitorización continua
+- Si score <50%: advertir que el patrón no está bien definido

--- a/.claude/commands/arch-fitness.md
+++ b/.claude/commands/arch-fitness.md
@@ -1,0 +1,107 @@
+---
+name: arch-fitness
+description: Ejecutar fitness functions de arquitectura para verificar integridad
+developer_type: all
+agent: architect
+context_cost: medium
+---
+
+# /arch-fitness {repo|path}
+
+> Define y ejecuta reglas de integridad arquitectónica (fitness functions) para un proyecto.
+
+---
+
+## Prerequisitos
+
+- Repositorio accesible
+- Recomendado: ejecutar `/arch-detect` primero
+
+## Parámetros
+
+- `{repo|path}` — Ruta local o repositorio
+- `--rules {file}` — (Opcional) Fichero custom de reglas
+- `--fix` — (Opcional) Sugerir fixes automáticos
+
+## Flujo de Ejecución
+
+### 1. Detectar Patrón y Lenguaje
+
+Si no hay detección previa, ejecutar detección rápida (solo estructura).
+Cargar reglas base del patrón detectado.
+
+### 2. Definir Reglas de Fitness
+
+Reglas automáticas según patrón:
+
+**Clean Architecture / Hexagonal**:
+- CRITICAL: Domain NO importa Infrastructure
+- CRITICAL: Domain NO importa Presentation
+- WARNING: Application NO importa Presentation directamente
+- WARNING: No dependencias circulares entre capas
+
+**DDD**:
+- CRITICAL: Aggregates solo accesibles via Repository
+- WARNING: Value Objects son inmutables (no setters públicos)
+- WARNING: Domain Events nombrados en pasado (OrderCreated, UserRegistered)
+
+**MVC / MVVM**:
+- WARNING: Controllers/ViewModels NO acceden a DB directamente
+- WARNING: Views NO contienen lógica de negocio
+- CRITICAL: Models NO dependen de Views
+
+**Genéricas (todos los patrones)**:
+- WARNING: No ficheros >300 líneas (configurable)
+- WARNING: No más de 10 imports/dependencias por fichero
+- CRITICAL: No secrets hardcodeados (regex patterns)
+- WARNING: Naming conventions del patrón (sufijos esperados)
+
+### 3. Ejecutar Análisis
+
+Para cada regla:
+1. Escanear ficheros relevantes
+2. Buscar violaciones (imports, naming, estructura)
+3. Clasificar: PASS / FAIL
+4. Si FAIL: listar ficheros y líneas
+
+### 4. Generar Reporte
+
+```markdown
+# 🏋️ Architecture Fitness — {proyecto}
+
+**Patrón**: {nombre} · **Reglas ejecutadas**: {n}
+**Fecha**: {fecha}
+
+## Resultado Global: {PASS|FAIL} ({passed}/{total} reglas)
+
+### ✅ Reglas PASS
+1. ✅ Domain independence — Sin violaciones
+2. ✅ No circular dependencies — Limpio
+
+### ❌ Reglas FAIL
+1. ❌ **Domain NO importa Infrastructure** — CRITICAL
+   - `src/domain/UserService.ts` línea 3: `import { PrismaClient }`
+   - `src/domain/OrderRepo.ts` línea 1: `import { db }`
+   - **Fix**: Crear interface en domain, implementar en infrastructure
+
+2. ❌ **File size limit** — WARNING
+   - `src/controllers/MainController.ts`: 452 líneas (max: 300)
+   - **Fix**: Dividir en controllers por recurso
+
+### 📊 Resumen
+| Severidad | Pass | Fail |
+|-----------|------|------|
+| CRITICAL | {n} | {n} |
+| WARNING | {n} | {n} |
+
+### 📈 Tendencia
+{comparar con ejecución anterior si existe}
+```
+
+Output: `output/architecture/{proyecto}-fitness.md`
+
+## Post-ejecución
+
+- Si hay FAIL CRITICAL → recomendar resolución inmediata
+- Sugerir integrar como check de CI (crear script verificador)
+- Guardar resultado para comparación futura (tendencia)

--- a/.claude/commands/arch-recommend.md
+++ b/.claude/commands/arch-recommend.md
@@ -1,0 +1,101 @@
+---
+name: arch-recommend
+description: Recomendar la mejor arquitectura para un proyecto nuevo
+developer_type: all
+agent: architect
+context_cost: medium
+---
+
+# /arch-recommend {requirements}
+
+> Recomienda el patrón de arquitectura óptimo para un proyecto nuevo basándose en sus requisitos.
+
+---
+
+## Prerequisitos
+
+- Descripción del proyecto o requisitos
+
+## Parámetros
+
+- `{requirements}` — Descripción libre: tipo de app, lenguaje, escala, equipo, etc.
+
+## Flujo de Ejecución
+
+### 1. Extraer Requisitos
+
+Del input del usuario, identificar:
+- **Tipo de aplicación**: API REST, web app, mobile, batch, IoT, etc.
+- **Lenguaje/framework**: Si ya decidido
+- **Escala esperada**: Usuarios, requests/s, datos
+- **Tamaño del equipo**: 1-3, 4-10, 10+
+- **Complejidad del dominio**: Simple (CRUD), Media, Compleja (DDD)
+- **Requisitos especiales**: Real-time, offline, multi-tenant, compliance
+
+Si faltan datos críticos, preguntar antes de recomendar.
+
+### 2. Algoritmo de Recomendación
+
+Scoring por patrón basado en requisitos:
+
+| Factor | Clean | Hexagonal | DDD | CQRS | MVC | Microservices |
+|--------|-------|-----------|-----|------|-----|---------------|
+| CRUD simple | 30 | 20 | 10 | 10 | 90 | 10 |
+| Dominio complejo | 80 | 85 | 95 | 70 | 30 | 60 |
+| Alta testabilidad | 90 | 95 | 80 | 75 | 40 | 70 |
+| Equipo pequeño | 70 | 60 | 40 | 30 | 90 | 20 |
+| Equipo grande | 80 | 80 | 90 | 85 | 50 | 95 |
+| Escala alta | 60 | 65 | 70 | 90 | 40 | 95 |
+| Reads >> Writes | 50 | 50 | 60 | 95 | 50 | 70 |
+| Real-time | 50 | 60 | 60 | 70 | 40 | 80 |
+| Prototipo/MVP | 20 | 15 | 10 | 5 | 95 | 5 |
+
+### 3. Cargar Reference del Lenguaje
+
+Cargar `@.claude/skills/architecture-intelligence/references/patterns-{lang}.md`
+Adaptar recomendación al idioma del framework.
+
+### 4. Generar Reporte
+
+```markdown
+# 🎯 Architecture Recommendation — {proyecto}
+
+**Requisitos**: {resumen}
+**Fecha**: {fecha}
+
+## Patrón Recomendado: {nombre}
+
+### ¿Por qué este patrón?
+{justificación basada en requisitos del proyecto}
+
+### ¿Cuándo NO usar este patrón?
+{limitaciones y riesgos}
+
+### Folder Structure Propuesta
+{tree adaptado al lenguaje}
+
+### Dependencias Sugeridas
+| Dependencia | Propósito |
+|-------------|-----------|
+| {nombre} | {para qué} |
+
+### Alternativa Considerada: {nombre}
+{por qué no se eligió, cuándo cambiar}
+
+## 📋 ADR Draft
+
+**ADR-XXX: Arquitectura {nombre} para {proyecto}**
+
+**Status**: Proposed
+**Context**: {requisitos del proyecto}
+**Decision**: Usar {patrón} porque {razones}
+**Consequences**: {positivas y negativas}
+```
+
+Output: `output/architecture/{proyecto}-recommendation.md`
+
+## Post-ejecución
+
+- Sugerir crear ADR con `/adr-create`
+- Sugerir usar `/project-kickoff` con la estructura propuesta
+- Si el usuario acepta, ofrecer generar scaffold del proyecto

--- a/.claude/commands/arch-suggest.md
+++ b/.claude/commands/arch-suggest.md
@@ -1,0 +1,99 @@
+---
+name: arch-suggest
+description: Sugerir mejoras de arquitectura basadas en detección previa
+developer_type: all
+agent: architect
+context_cost: medium
+---
+
+# /arch-suggest {repo|path}
+
+> Analiza un proyecto y genera sugerencias priorizadas de mejora arquitectónica.
+
+---
+
+## Prerequisitos
+
+- Ejecutar `/arch-detect` primero (o se ejecutará automáticamente)
+- Acceso al repositorio
+
+## Parámetros
+
+- `{repo|path}` — Ruta local o nombre del repositorio
+
+## Flujo de Ejecución
+
+### 1. Cargar detección previa
+
+Si existe `output/architecture/{proyecto}-detection.md`, leerlo.
+Si no existe, ejecutar `/arch-detect` primero.
+
+### 2. Analizar violaciones
+
+Para cada violación del reporte de detección:
+- Clasificar severidad: CRITICAL (rompe el patrón) vs WARNING (desvío menor)
+- Identificar ficheros afectados
+- Proponer solución concreta con ejemplo
+
+### 3. Identificar oportunidades de refactoring
+
+Buscar:
+- **God classes/modules**: ficheros >300 líneas con múltiples responsabilidades
+- **Dependencias inversas**: módulos de bajo nivel usados por alto nivel
+- **Código duplicado**: patrones repetidos que deberían ser abstracciones
+- **Missing abstractions**: implementaciones directas sin interfaces/traits
+- **Tight coupling**: clases que instancian dependencias (new) en lugar de recibirlas
+
+### 4. Priorizar por impacto × esfuerzo
+
+Matriz de priorización:
+
+| | Esfuerzo Bajo | Esfuerzo Alto |
+|---|---|---|
+| **Impacto Alto** | 🟢 Quick Win | 🟡 Proyecto |
+| **Impacto Bajo** | 🔵 Nice to have | ⚪ Postpone |
+
+### 5. Generar Reporte
+
+```markdown
+# 🔍 Architecture Suggestions — {proyecto}
+
+**Patrón Detectado**: {nombre} ({score}%)
+**Fecha**: {fecha}
+
+## 🟢 Quick Wins (alto impacto, bajo esfuerzo)
+1. **{título}** — {descripción}
+   - Ficheros: {lista}
+   - Acción: {qué hacer}
+   - Ejemplo: {antes → después}
+
+## 🟡 Proyectos (alto impacto, alto esfuerzo)
+1. **{título}** — {descripción}
+   - Estimación: {horas}
+   - Beneficio: {qué mejora}
+
+## 🔵 Nice to Have
+1. **{título}** — {descripción}
+
+## ⚠️ Violaciones Críticas a Resolver
+1. **{violación}**
+   - Severidad: CRITICAL
+   - Impacto: {qué rompe}
+   - Solución: {cómo arreglarlo}
+
+## 📊 Métricas de Salud Arquitectónica
+| Métrica | Valor | Target |
+|---------|-------|--------|
+| Adherencia al patrón | {n}% | >80% |
+| Dependencias inversas | {n} | 0 |
+| Ficheros >300 líneas | {n} | 0 |
+| Coupling index | {n} | <0.3 |
+```
+
+Output: `output/architecture/{proyecto}-suggestions.md`
+
+## Post-ejecución
+
+- Si hay violaciones CRITICAL → sugerir crear tasks en Azure DevOps
+- Sugerir `/arch-fitness` para prevenir regresiones
+- Sugerir `/adr-create` para documentar decisiones de refactoring

--- a/.claude/rules/domain/architecture-patterns.md
+++ b/.claude/rules/domain/architecture-patterns.md
@@ -1,0 +1,118 @@
+---
+name: architecture-patterns
+description: Catálogo de patrones de arquitectura cross-language con markers de detección
+developer_type: all
+context_cost: medium
+paths: [".claude/commands/arch-*.md"]
+---
+
+# Patrones de Arquitectura — Referencia Rápida
+
+> Detalle por lenguaje: `@.claude/skills/architecture-intelligence/references/patterns-{lang}.md`
+
+---
+
+## 1. Clean Architecture (Robert C. Martin)
+
+**Capas**: Entities → Use Cases → Interface Adapters → Frameworks & Drivers
+**Cuándo usarlo**: Aplicaciones enterprise, dominios complejos, longevidad del proyecto >2 años
+**Cuándo NO**: Prototipos, CRUD simple, microservicios ultra-ligeros
+**Markers de detección**:
+- Carpetas: `Domain/`, `Application/`, `Infrastructure/`, `Presentation/` (o `Api/`, `Web/`)
+- Interfaces en Domain/Application, implementaciones en Infrastructure
+- DTOs en Application, Entities en Domain
+- Dependency Injection configurado en entry point
+
+## 2. Hexagonal (Ports & Adapters — Alistair Cockburn)
+
+**Capas**: Core Domain ↔ Ports (interfaces) ↔ Adapters (implementaciones)
+**Cuándo usarlo**: Alta testabilidad requerida, múltiples canales de entrada/salida
+**Cuándo NO**: Apps con un solo canal de entrada, equipos pequeños sin experiencia
+**Markers de detección**:
+- Carpetas: `ports/`, `adapters/`, `domain/` o `core/`
+- Interfaces (ports) como contratos: `UserPort`, `StoragePort`
+- Adapters implementando ports: `PostgresUserAdapter`, `HttpUserAdapter`
+- Core sin dependencias externas (solo stdlib)
+
+## 3. Domain-Driven Design (DDD — Eric Evans)
+
+**Conceptos**: Bounded Contexts, Aggregates, Value Objects, Repositories, Domain Events
+**Cuándo usarlo**: Dominios de negocio complejos, múltiples subdominios, equipos grandes
+**Cuándo NO**: CRUD simple, dominios anémicos, equipos sin knowledge del negocio
+**Markers de detección**:
+- Carpetas organizadas por dominio (no por capa): `orders/`, `inventory/`, `billing/`
+- Clases: `Aggregate`, `ValueObject`, `DomainEvent`, `Repository`
+- Ubiquitous Language en nombres de clases y métodos
+- Bounded Contexts como módulos o servicios separados
+
+## 4. CQRS (Command Query Responsibility Segregation)
+
+**Separación**: Command model (escritura) ↔ Query model (lectura)
+**Cuándo usarlo**: Reads >> Writes, modelos de lectura/escritura muy diferentes, event sourcing
+**Cuándo NO**: CRUD uniforme, dominio simple, equipo sin experiencia en eventos
+**Markers de detección**:
+- Carpetas: `commands/`, `queries/`, `handlers/`
+- Clases: `CreateOrderCommand`, `GetOrderQuery`, `CommandHandler`, `QueryHandler`
+- MediatR, Axon, o bus de comandos/queries
+- Modelos separados para lectura y escritura
+
+## 5. Event-Driven Architecture (EDA)
+
+**Componentes**: Event Producers → Event Broker → Event Consumers
+**Cuándo usarlo**: Sistemas distribuidos, desacoplamiento fuerte, procesamiento asíncrono
+**Cuándo NO**: Transacciones ACID estrictas, latencia baja crítica, sistema monolítico
+**Markers de detección**:
+- Carpetas: `events/`, `listeners/`, `subscribers/`, `handlers/`
+- Clases: `OrderCreatedEvent`, `EventHandler`, `EventBus`
+- Dependencias: Kafka, RabbitMQ, EventStore, MassTransit, NServiceBus
+- Patrones: Saga, Outbox, Event Sourcing
+
+## 6. MVC / MVVM / MVP
+
+**MVC**: Model-View-Controller (web apps, Rails, Django, Spring MVC)
+**MVVM**: Model-View-ViewModel (WPF, SwiftUI, Android Jetpack, Angular)
+**MVP**: Model-View-Presenter (legacy Android, Windows Forms)
+**Cuándo usarlo**: Apps con UI como componente principal
+**Markers de detección**:
+- MVC: `controllers/`, `models/`, `views/` — frameworks: Rails, Django, Spring MVC, Laravel
+- MVVM: `viewmodels/` o `*ViewModel` classes — bindings, @Published, ObservableObject
+- MVP: `presenters/`, interfaces `View` que el presenter consume
+
+## 7. Microservices
+
+**Principios**: Servicios independientes, BD por servicio, API contracts, deploy independiente
+**Cuándo usarlo**: Equipos grandes (>15), dominios separables, escala diferenciada
+**Cuándo NO**: MVP, equipos <5, dominio monolítico, overhead de infra no justificado
+**Markers de detección**:
+- Múltiples `Dockerfile` o `docker-compose.yml` con servicios
+- API Gateway (Kong, Nginx, Ocelot)
+- Service discovery (Consul, Eureka)
+- Repos separados o monorepo con servicios independientes
+
+---
+
+## Herramientas de Enforcement por Lenguaje
+
+| Lenguaje | Herramienta | Tipo |
+|----------|-------------|------|
+| Java | ArchUnit | Test de arquitectura |
+| C#/.NET | NetArchTest, ArchUnitNET | Test de arquitectura |
+| TypeScript | eslint-plugin-boundaries, dependency-cruiser | Lint + análisis |
+| Python | import-linter, pytestarch | Test de arquitectura |
+| Go | go vet + custom analyzers | Análisis estático |
+| Rust | cargo clippy + module analysis | Lint |
+| Kotlin | ArchUnit (JVM) | Test de arquitectura |
+| PHP | deptrac, phpat | Análisis de dependencias |
+
+---
+
+## Fitness Functions (Reglas de Integridad)
+
+Las fitness functions verifican que la arquitectura se mantiene intacta:
+
+**Estructurales**: Dependencias entre capas, no imports circulares, naming conventions
+**Rendimiento**: Tiempo de respuesta <100ms, throughput mínimo
+**Seguridad**: Auth en endpoints protegidos, no secrets hardcodeados
+**Operacionales**: Health checks, readiness probes, logs estructurados
+
+**Implementación**: Tests unitarios que verifican reglas → CI/CD pipeline → fail si viola

--- a/.claude/skills/architecture-intelligence/SKILL.md
+++ b/.claude/skills/architecture-intelligence/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: architecture-intelligence
+description: Detección de patrones de arquitectura, sugerencias de mejora y recomendaciones para proyectos nuevos
+developer_type: all
+context_cost: medium
+references:
+  - references/patterns-dotnet.md
+  - references/patterns-typescript.md
+  - references/patterns-java.md
+  - references/patterns-python.md
+  - references/patterns-go.md
+  - references/patterns-rust.md
+  - references/patterns-php.md
+  - references/patterns-mobile.md
+  - references/patterns-ruby.md
+  - references/patterns-legacy.md
+  - references/patterns-terraform.md
+---
+
+# Architecture Intelligence — Skill
+
+> Detección, análisis y recomendación de patrones de arquitectura para los 16 lenguajes soportados.
+
+---
+
+## Algoritmo de Detección
+
+La detección de patrones sigue 4 fases con scoring acumulativo:
+
+### Fase 1: Análisis de Estructura de Carpetas (peso: 40%)
+
+Buscar carpetas que correspondan a patrones conocidos:
+
+| Patrón | Carpetas esperadas |
+|--------|-------------------|
+| Clean Architecture | `Domain/`, `Application/`, `Infrastructure/`, `Presentation/` |
+| Hexagonal | `ports/`, `adapters/`, `domain/` o `core/` |
+| DDD | Carpetas por dominio: `orders/`, `users/`, `billing/` |
+| CQRS | `commands/`, `queries/`, `handlers/` |
+| MVC | `controllers/`, `models/`, `views/` |
+| MVVM | `viewmodels/`, `views/`, `models/` |
+| Microservices | Múltiples `Dockerfile`, `docker-compose.yml`, API gateway config |
+
+### Fase 2: Análisis de Imports/Dependencias (peso: 30%)
+
+Verificar dirección de dependencias:
+- Clean/Hexagonal: Domain NO importa Infrastructure → ✅
+- Domain importa Infrastructure → ❌ violación
+- Dependencias circulares → ❌ violación
+- Buscar: MediatR, Axon, EventStore → CQRS/Event-Driven
+
+### Fase 3: Análisis de Naming Conventions (peso: 20%)
+
+Buscar sufijos/prefijos indicativos:
+- `*Controller`, `*Service`, `*Repository` → MVC/Layered
+- `*Command`, `*Query`, `*Handler` → CQRS
+- `*Aggregate`, `*ValueObject`, `*DomainEvent` → DDD
+- `*Port`, `*Adapter` → Hexagonal
+- `*ViewModel`, `*Presenter` → MVVM/MVP
+- `*UseCase`, `*Interactor` → Clean Architecture
+
+### Fase 4: Análisis de Configuración (peso: 10%)
+
+Buscar ficheros de configuración:
+- `docker-compose.yml` con múltiples servicios → Microservices
+- DI container config → Clean/Hexagonal
+- Event bus config → Event-Driven
+- API gateway config → Microservices
+
+### Scoring
+
+Cada patrón recibe score 0-100. Se reporta:
+- **Patrón principal**: score más alto
+- **Patrones secundarios**: scores >30 que no son el principal
+- **Nivel de adherencia**: Alto (>80), Medio (50-80), Bajo (<50)
+- **Violaciones**: reglas rotas del patrón detectado
+
+---
+
+## Fitness Functions — Templates
+
+### Regla: No dependencias inversas entre capas
+
+```
+RULE: "Domain layer independence"
+CHECK: Files in {domain_folder} do NOT import from {infrastructure_folder}
+SEVERITY: CRITICAL
+```
+
+### Regla: Naming conventions
+
+```
+RULE: "Controller naming"
+CHECK: Files in {controllers_folder} end with "Controller" suffix
+SEVERITY: WARNING
+```
+
+### Regla: No dependencias circulares
+
+```
+RULE: "No circular dependencies"
+CHECK: Module dependency graph has no cycles
+SEVERITY: CRITICAL
+```
+
+### Regla: Tamaño de módulos
+
+```
+RULE: "Module size limit"
+CHECK: Each module/package has ≤ {max_files} files
+SEVERITY: WARNING
+```
+
+---
+
+## Integración con Language Packs
+
+Para cada lenguaje, cargar el reference correspondiente:
+- Detectar lenguaje del proyecto (por extensiones, package manager, framework)
+- Cargar `references/patterns-{lang}.md` para markers específicos
+- Combinar con reglas genéricas de `@.claude/rules/domain/architecture-patterns.md`
+
+## Output
+
+Los templates de output están definidos en cada comando (`/arch-detect`, `/arch-suggest`, `/arch-recommend`).
+Output se genera en `output/architecture/{proyecto}-{tipo}.md`.

--- a/.claude/skills/architecture-intelligence/references/patterns-dotnet.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-dotnet.md
@@ -1,0 +1,76 @@
+---
+name: patterns-dotnet
+description: Patrones de arquitectura para C#/.NET y VB.NET
+context_cost: low
+---
+
+# Patrones — C# / .NET
+
+## 1. Clean Architecture (⭐ Recomendado)
+
+**Folder Structure**:
+```
+MyApp.Domain/           → Entities, Value Objects, Interfaces
+MyApp.Application/      → Use Cases, DTOs, Validators, MediatR handlers
+MyApp.Infrastructure/   → EF Core, External APIs, Email, File Storage
+MyApp.Api/              → Controllers, Middleware, Program.cs
+MyApp.Tests/            → Unit + Integration tests
+```
+
+**Detection Markers**:
+- Proyectos separados por capa (`.csproj` por capa)
+- `Program.cs` o `Startup.cs` con DI container configuration
+- MediatR para CQRS (IRequest, IRequestHandler)
+- FluentValidation para validaciones
+- AutoMapper para mapping DTO↔Entity
+
+**Tools**: NetArchTest, ArchUnitNET, SonarQube
+
+## 2. CQRS + MediatR
+
+**Detection Markers**:
+- Carpetas `Commands/`, `Queries/`, `Handlers/`
+- Clases `*Command : IRequest<T>`, `*Query : IRequest<T>`
+- `*CommandHandler : IRequestHandler<T>`
+- NuGet: MediatR, MediatR.Extensions.Microsoft.DependencyInjection
+
+## 3. Hexagonal (Ports & Adapters)
+
+**Detection Markers**:
+- Carpetas `Ports/`, `Adapters/`
+- Interfaces como ports en Domain: `IUserRepository`, `IEmailService`
+- Implementaciones en Infrastructure: `SqlUserRepository`, `SmtpEmailService`
+- Sin referencia de Domain a Infrastructure en `.csproj`
+
+## 4. MVVM (WPF / MAUI / Blazor)
+
+**Detection Markers**:
+- Carpetas `ViewModels/`, `Views/`, `Models/`
+- Clases heredando `INotifyPropertyChanged` o `ObservableObject`
+- Data Binding en XAML: `{Binding PropertyName}`
+- CommunityToolkit.Mvvm NuGet
+
+## 5. Microservices
+
+**Detection Markers**:
+- Múltiples `.sln` o proyectos con `Dockerfile` propio
+- Ocelot o YARP como API Gateway
+- MassTransit o NServiceBus para messaging
+- Health checks con `Microsoft.Extensions.Diagnostics.HealthChecks`
+
+## Fitness Functions (.NET)
+
+```csharp
+// NetArchTest example
+var result = Types.InAssembly(domainAssembly)
+    .ShouldNot()
+    .HaveDependencyOn("MyApp.Infrastructure")
+    .GetResult();
+Assert.True(result.IsSuccessful);
+```
+
+## Anti-patterns comunes
+- God controllers (>200 líneas)
+- Anemic domain models (solo DTOs sin lógica)
+- Repository over repository (doble abstracción innecesaria)
+- Inyección de DbContext en controllers directamente

--- a/.claude/skills/architecture-intelligence/references/patterns-go.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-go.md
@@ -1,0 +1,96 @@
+---
+name: patterns-go
+description: Patrones de arquitectura para Go (Golang)
+context_cost: low
+---
+
+# Patrones — Go
+
+## 1. Clean Architecture (⭐ Recomendado)
+
+**Folder Structure**:
+```
+project/
+├── cmd/
+│   └── server/
+│       └── main.go        → Entry point
+├── internal/
+│   ├── domain/            → Business entities, interfaces
+│   ├── usecase/           → Application logic
+│   ├── handler/           → HTTP/gRPC handlers (presentation)
+│   └── repository/        → Data access implementations
+├── pkg/                   → Exportable packages
+├── config/                → Configuration
+├── migrations/            → Database migrations
+└── go.mod
+```
+
+**Detection Markers**:
+- `cmd/` para entry points (convención Go estándar)
+- `internal/` para código no exportable
+- `pkg/` para código exportable
+- Interfaces en `domain/`, implementaciones en `repository/`
+- Constructor functions: `NewUserService(repo UserRepository)`
+
+## 2. Hexagonal
+
+**Folder Structure**:
+```
+internal/
+├── core/
+│   ├── domain/           → Business models
+│   ├── ports/            → Interface definitions
+│   └── services/         → Business logic
+├── adapters/
+│   ├── handlers/         → HTTP, gRPC, CLI
+│   └── repositories/     → Postgres, Redis, etc.
+└── server/               → Server setup, routing
+```
+
+**Detection Markers**:
+- `ports/` con interfaces Go (implícitas)
+- `adapters/` con implementaciones
+- Core sin imports de infrastructure
+- Constructor injection via interfaces
+
+## 3. DDD (Go idiomático)
+
+**Detection Markers**:
+- Packages por bounded context: `order/`, `user/`, `inventory/`
+- Aggregate root pattern con métodos en structs
+- Value objects como structs inmutables
+- Repository interfaces en domain package
+
+## 4. Standard Layout (golang-standards)
+
+**Detection Markers**:
+- Sigue `github.com/golang-standards/project-layout`
+- `cmd/`, `internal/`, `pkg/`, `api/`, `web/`
+- `Makefile` con targets estándar (build, test, lint)
+
+## 5. Microservices (go-kit / go-zero)
+
+**Detection Markers**:
+- go-kit: `endpoint.Endpoint`, `transport.Server`, `service` interfaces
+- go-zero: `.api` files, `handler/`, `logic/`, `svc/`
+- Múltiples binarios en `cmd/`
+- gRPC `.proto` files
+
+## Go-Specific Patterns
+- **Interfaces implícitas**: No se declara "implements", se cumple por duck typing
+- **Table-driven tests**: `[]struct{ name string, input, expected }` pattern
+- **Functional options**: `WithTimeout(5*time.Second)` constructor pattern
+- **Error wrapping**: `fmt.Errorf("doing X: %w", err)` chain
+
+## Tools de Enforcement
+- **go vet**: Análisis estático builtin
+- **golangci-lint**: Meta-linter con 50+ linters
+- **depguard**: Restricción de imports por package
+- **go-cleanarch**: Verificación de Clean Architecture
+- **architecture-lint**: Custom rules para Go
+
+## Anti-patterns comunes
+- Package `utils/` o `helpers/` (falta cohesión)
+- Interfaces con demasiados métodos (Go prefiere interfaces pequeñas)
+- Goroutine leaks (falta context cancellation)
+- Deep package nesting (Go prefiere flat packages)

--- a/.claude/skills/architecture-intelligence/references/patterns-java.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-java.md
@@ -1,0 +1,88 @@
+---
+name: patterns-java
+description: Patrones de arquitectura para Java/Spring
+context_cost: low
+---
+
+# Patrones — Java / Spring
+
+## 1. DDD + CQRS (⭐ Recomendado para dominios complejos)
+
+**Folder Structure**:
+```
+com.example.app/
+├── domain/
+│   ├── model/           → Aggregates, Entities, Value Objects
+│   ├── event/           → Domain Events
+│   ├── repository/      → Repository interfaces
+│   └── service/         → Domain Services
+├── application/
+│   ├── command/         → Commands + Handlers
+│   ├── query/           → Queries + Handlers
+│   └── service/         → Application Services
+├── infrastructure/
+│   ├── persistence/     → JPA Repositories, Entities
+│   ├── messaging/       → Kafka, RabbitMQ adapters
+│   └── external/        → External API clients
+└── presentation/
+    ├── rest/            → REST Controllers
+    └── dto/             → Request/Response DTOs
+```
+
+**Detection Markers**:
+- Package-by-feature (no package-by-layer)
+- Axon Framework: `@Aggregate`, `@CommandHandler`, `@EventSourcingHandler`
+- Spring stereotypes: `@Service`, `@Repository`, `@Controller`, `@Component`
+- JPA entities separadas de domain entities
+
+**Tools**: ArchUnit (estándar de facto)
+
+## 2. Clean Architecture
+
+**Detection Markers**:
+- Módulos Maven/Gradle por capa: `domain`, `application`, `infrastructure`, `web`
+- Dependency inversion: domain no depende de infrastructure
+- Use case classes con naming: `CreateOrderUseCase`, `GetUserByIdUseCase`
+
+## 3. Hexagonal
+
+**Detection Markers**:
+- Packages: `port.in/`, `port.out/`, `adapter.in/`, `adapter.out/`
+- Interfaces como driving ports (entrada) y driven ports (salida)
+- Spring `@Configuration` para wiring adapters
+
+## 4. Microservices (Spring Boot)
+
+**Detection Markers**:
+- Múltiples `pom.xml`/`build.gradle` con `spring-boot-starter-web`
+- Spring Cloud: Eureka, Config Server, Gateway
+- `application.yml` con service discovery config
+- Feign clients para inter-service communication
+
+## 5. MVC (Spring MVC tradicional)
+
+**Detection Markers**:
+- `@Controller` + `@RequestMapping`
+- Thymeleaf/JSP templates en `resources/templates/`
+- `@ModelAttribute`, form backing beans
+- Sin separación domain/infrastructure
+
+## Fitness Functions (ArchUnit)
+
+```java
+@ArchTest
+static final ArchRule domainShouldNotDependOnInfrastructure =
+    noClasses().that().resideInAPackage("..domain..")
+        .should().dependOnClassesThat().resideInAPackage("..infrastructure..");
+
+@ArchTest
+static final ArchRule controllersShouldNotAccessRepositories =
+    noClasses().that().haveNameMatching(".*Controller")
+        .should().dependOnClassesThat().haveNameMatching(".*Repository");
+```
+
+## Anti-patterns comunes
+- Service classes con 500+ líneas (God Service)
+- Anemic domain model (entities sin comportamiento)
+- N+1 queries en JPA (falta de fetch strategy)
+- Transaction script en lugar de domain model

--- a/.claude/skills/architecture-intelligence/references/patterns-legacy.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-legacy.md
@@ -1,0 +1,111 @@
+---
+name: patterns-legacy
+description: Patrones de arquitectura para COBOL y VB.NET
+context_cost: low
+---
+
+# Patrones — Legacy (COBOL / VB.NET)
+
+---
+
+## COBOL
+
+### Estructura Canónica
+
+```cobol
+IDENTIFICATION DIVISION.    → Metadata del programa
+ENVIRONMENT DIVISION.       → Config de ficheros y sistema
+DATA DIVISION.              → Declaración de variables
+  WORKING-STORAGE SECTION.  → Variables locales
+  FILE SECTION.             → Record layouts
+PROCEDURE DIVISION.         → Código ejecutable
+  PERFORM SECTION-A.        → Llamadas a secciones
+```
+
+### Patrones Comunes
+
+**1. Vertical Model (monolítico)**
+- Un programa maneja toda la lógica
+- Detection: programa >1000 líneas sin CALL statements
+- Riesgo: mantenimiento imposible a largo plazo
+
+**2. One Access Program per Table**
+- Un COBOL program por tabla/fichero → interfaz de acceso
+- Detection: programas con naming `*-ACCESS`, `*-IO`, `*-CRUD`
+- Beneficio: encapsulación de acceso a datos
+
+**3. Batch Processing**
+- Detection: JCL files, SORT steps, sequential file processing
+- Pattern: READ → PROCESS → WRITE en loop
+- Detection: `PERFORM UNTIL END-OF-FILE`
+
+**4. CICS Transaction**
+- Detection: `EXEC CICS` statements
+- Online transaction processing
+- Screen maps (BMS)
+
+### Patrones de Modernización
+
+**API Wrapper**: Exponer lógica COBOL via REST
+- Detection: middleware como MicroFocus, IBM CICS Web Services
+- No requiere reescritura del COBOL
+
+**Strangler Fig**: Reemplazar módulos gradualmente
+- Nuevas funcionalidades en lenguaje moderno
+- COBOL como backend hasta completar migración
+
+**Rewrite incremental**: Módulo por módulo a Java/.NET
+- Herramientas: Modern Systems COBOL-2-Java, Micro Focus
+
+### Anti-patterns COBOL
+- GO TO spaghetti (en lugar de PERFORM structured)
+- Programas >5000 líneas sin modularización
+- Hardcoded values en PROCEDURE DIVISION
+- Falta de copybooks para record layouts compartidos
+
+---
+
+## VB.NET
+
+### Patrones (idénticos a C#/.NET)
+
+VB.NET comparte el ecosistema .NET completo. Los patrones son los mismos que C#:
+
+**1. Clean Architecture** (⭐ Recomendado) → Ver `patterns-dotnet.md`
+**2. MVVM** para WPF/WinForms
+**3. Layered Architecture** (tradicional)
+
+### Folder Structure
+
+```
+MyApp/
+├── MyApp.Presentation/   → WinForms, WPF, ASP.NET
+├── MyApp.Business/       → Business logic layer
+├── MyApp.Data/           → Data access (EF, ADO.NET)
+└── MyApp.Common/         → Shared utilities
+```
+
+### Detection Markers VB.NET
+- Extensiones `.vb` en lugar de `.cs`
+- `Imports` en lugar de `using`
+- `Sub Main()` como entry point
+- `Module` keyword (módulos estáticos)
+- `Dim`, `As`, `ByRef`, `ByVal` keywords
+- `.vbproj` project files
+
+### VB.NET-Specific Considerations
+- Verboso pero legible (My.Computer, My.Application)
+- Interoperable 100% con C# en mismo .sln
+- Mismas herramientas: NetArchTest, ArchUnitNET, NuGet
+- Visual Studio con soporte completo
+
+### Patrones de Modernización VB.NET
+- **Migrate to C#**: Herramientas como SharpDevelop, Code Converter
+- **Incremental**: Nuevos proyectos en C#, existentes en VB.NET
+- **Shared library**: Core en C#, UI legacy en VB.NET
+
+### Anti-patterns VB.NET
+- Code-behind monolítico (todo en Form1.vb)
+- DataSet tipados como capa de negocio
+- Falta de DI (new everywhere)
+- Mezcla de lógica UI y negocio en event handlers

--- a/.claude/skills/architecture-intelligence/references/patterns-mobile.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-mobile.md
@@ -1,0 +1,146 @@
+---
+name: patterns-mobile
+description: Patrones de arquitectura para Swift (iOS), Kotlin (Android) y Flutter
+context_cost: low
+---
+
+# Patrones — Mobile (Swift / Kotlin / Flutter)
+
+---
+
+## Swift (iOS)
+
+### 1. MVVM (⭐ Recomendado)
+
+**Folder Structure**:
+```
+App/
+├── Models/              → Data models, DTOs
+├── ViewModels/          → Presentation logic, state
+├── Views/               → SwiftUI views or UIKit VCs
+├── Services/            → Network, storage, auth
+├── Repositories/        → Data access abstraction
+└── Coordinator/         → Navigation (optional)
+```
+
+**Detection Markers**:
+- `*ViewModel` classes con `@Published` properties
+- `ObservableObject` protocol conformance
+- SwiftUI: `@StateObject`, `@ObservedObject`, `@EnvironmentObject`
+- Combine: `AnyPublisher`, `sink`, `assign`
+
+### 2. VIPER (apps complejas)
+
+**Detection Markers**:
+- Carpetas por módulo: `View/`, `Interactor/`, `Presenter/`, `Entity/`, `Router/`
+- Protocols definiendo contratos entre componentes
+- Router/Wireframe para navegación
+- Cada módulo auto-contenido
+
+### 3. Clean Architecture (The Composable Architecture - TCA)
+
+**Detection Markers**:
+- `import ComposableArchitecture`
+- `Reducer`, `Store`, `Effect`, `Action`, `State`
+- Composición de reducers
+
+**iOS Tools**: SwiftLint, SwiftFormat, XCTest, Quick/Nimble
+
+---
+
+## Kotlin (Android)
+
+### 1. MVVM (⭐ Recomendado — Google official)
+
+**Folder Structure**:
+```
+app/src/main/java/com/example/
+├── ui/
+│   └── feature/
+│       ├── FeatureFragment.kt
+│       ├── FeatureViewModel.kt
+│       └── FeatureAdapter.kt
+├── data/
+│   ├── local/            → Room database, DAOs
+│   ├── remote/           → Retrofit services
+│   └── repository/       → Repository implementations
+├── domain/
+│   ├── model/            → Domain models
+│   ├── repository/       → Repository interfaces
+│   └── usecase/          → Use cases
+└── di/                   → Hilt modules
+```
+
+**Detection Markers**:
+- `ViewModel` classes extending `androidx.lifecycle.ViewModel`
+- `@HiltViewModel` annotation
+- `StateFlow`, `LiveData`, `MutableStateFlow`
+- Room: `@Entity`, `@Dao`, `@Database`
+- Retrofit: `@GET`, `@POST`, `interface ApiService`
+- Coroutines: `viewModelScope.launch`, `suspend fun`
+
+### 2. MVI (Model-View-Intent)
+
+**Detection Markers**:
+- `sealed class Intent`, `sealed class State`
+- Unidirectional data flow
+- Orbit-MVI, MVIKotlin libraries
+
+**Android Tools**: Detekt (lint), MockK (testing), Turbine (Flow testing)
+
+---
+
+## Flutter
+
+### 1. MVVM + GetX (⭐ Recomendado para rapidez)
+
+**Folder Structure**:
+```
+lib/
+├── app/
+│   ├── modules/          → Feature modules
+│   │   └── home/
+│   │       ├── bindings/
+│   │       ├── controllers/  → GetxController (ViewModel)
+│   │       └── views/
+│   ├── routes/           → Route definitions
+│   └── data/
+│       ├── models/       → Data models
+│       ├── providers/    → API providers
+│       └── repositories/ → Data access
+└── main.dart
+```
+
+**Detection Markers GetX**: `GetxController`, `Get.put()`, `Obx()`, `GetMaterialApp`
+
+### 2. BLoC Pattern
+
+**Detection Markers**:
+- `flutter_bloc` package
+- `*Bloc` classes, `*Event`, `*State` sealed classes
+- `BlocProvider`, `BlocBuilder`, `BlocListener`
+
+### 3. Provider Pattern
+
+**Detection Markers**:
+- `ChangeNotifier` classes
+- `Provider.of<T>()`, `Consumer<T>`
+- `MultiProvider` en widget tree
+
+### 4. Clean Architecture (Flutter)
+
+**Detection Markers**:
+- `domain/`, `data/`, `presentation/` layers
+- Use case classes con `call()` method
+- Repository interfaces en domain
+
+**Flutter Tools**: flutter_test, mockito, flutter_lints, very_good_analysis
+
+---
+
+## Anti-patterns comunes (cross-mobile)
+- Business logic en Views/Activities/Widgets
+- No separation de networking de UI
+- State management inconsistente (mezclar patrones)
+- Deep widget/view hierarchy sin composition
+- Falta de offline-first para datos críticos

--- a/.claude/skills/architecture-intelligence/references/patterns-php.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-php.md
@@ -1,0 +1,100 @@
+---
+name: patterns-php
+description: Patrones de arquitectura para PHP/Laravel
+context_cost: low
+---
+
+# Patrones — PHP / Laravel
+
+## 1. DDD + Clean Architecture (⭐ Recomendado para apps enterprise)
+
+**Folder Structure**:
+```
+app/
+├── Domain/
+│   ├── User/
+│   │   ├── Models/        → Eloquent models + domain logic
+│   │   ├── Events/        → Domain events
+│   │   ├── ValueObjects/  → Immutable value objects
+│   │   └── Repositories/  → Repository interfaces
+│   └── Order/
+├── Application/
+│   ├── User/
+│   │   ├── Commands/      → CreateUser, UpdateUser
+│   │   ├── Queries/       → GetUserById, ListUsers
+│   │   └── Services/      → Application services
+│   └── Order/
+├── Infrastructure/
+│   ├── Persistence/       → Eloquent repository implementations
+│   ├── External/          → API clients, mail services
+│   └── Providers/         → Service providers
+└── Presentation/
+    ├── Http/
+    │   ├── Controllers/   → HTTP controllers
+    │   ├── Requests/      → Form requests (validation)
+    │   └── Resources/     → API resources (transformers)
+    └── Console/           → Artisan commands
+```
+
+**Detection Markers**:
+- Carpetas `Domain/`, `Application/`, `Infrastructure/` dentro de `app/`
+- Repository interfaces en Domain, implementaciones en Infrastructure
+- Value Objects como clases inmutables
+- Service Providers para binding interfaces
+
+## 2. MVC — Laravel Estándar
+
+**Folder Structure**:
+```
+app/
+├── Http/
+│   ├── Controllers/       → Request handlers
+│   ├── Middleware/         → Request/response filters
+│   └── Requests/          → Form validation
+├── Models/                → Eloquent models
+├── Providers/             → Service providers
+└── Services/ (opcional)   → Business logic
+```
+
+**Detection Markers**:
+- `artisan` en raíz → Laravel
+- `app/Http/Controllers/` con `extends Controller`
+- `app/Models/` con `extends Model` (Eloquent)
+- `routes/web.php`, `routes/api.php`
+- `config/`, `database/migrations/`, `resources/views/`
+
+## 3. Service Layer Pattern
+
+**Detection Markers**:
+- Carpeta `app/Services/` con clases de negocio
+- Controllers delegan a services
+- Services no dependen de HTTP (testables independientemente)
+
+## 4. Repository Pattern
+
+**Detection Markers**:
+- `app/Repositories/` con interfaces y implementaciones
+- Binding en `AppServiceProvider`: `$this->app->bind(Interface, Implementation)`
+- Abstracción sobre Eloquent
+
+## 5. Event-Driven (Laravel Events)
+
+**Detection Markers**:
+- `app/Events/` con event classes
+- `app/Listeners/` con event handlers
+- `EventServiceProvider` con registros
+- Laravel Horizon para queue management
+
+## Laravel-Specific Tools
+- **Laravel Pint**: Code style fixer (PSR-12)
+- **PHPStan / Larastan**: Análisis estático
+- **Pest / PHPUnit**: Testing
+- **Deptrac**: Architecture dependency checking
+- **PHPAT**: PHP Architecture Tester
+
+## Anti-patterns comunes
+- Fat controllers (lógica de negocio en controllers)
+- Eloquent en controllers (en lugar de repository/service)
+- God models (1000+ líneas en un Model)
+- Falta de Form Requests (validación inline)
+- Middleware overuse (lógica que debería estar en services)

--- a/.claude/skills/architecture-intelligence/references/patterns-python.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-python.md
@@ -1,0 +1,96 @@
+---
+name: patterns-python
+description: Patrones de arquitectura para Python (Django, FastAPI, Flask)
+context_cost: low
+---
+
+# Patrones — Python
+
+## 1. MVT — Django (⭐ Recomendado para full-stack)
+
+**Folder Structure**:
+```
+project/
+├── apps/
+│   └── app_name/
+│       ├── models.py       → Data models (ORM)
+│       ├── views.py        → Business logic + response
+│       ├── urls.py          → URL routing
+│       ├── forms.py         → Form validation
+│       ├── admin.py         → Admin interface config
+│       ├── serializers.py   → DRF serializers (si API)
+│       ├── templates/       → HTML templates
+│       └── tests/
+├── config/ or project/     → Settings, root URLs
+├── static/                 → CSS, JS, images
+└── manage.py
+```
+
+**Detection Markers**:
+- `manage.py` en raíz → Django
+- `models.py`, `views.py`, `urls.py` en cada app
+- `settings.py` con `INSTALLED_APPS`
+- Django REST Framework: `serializers.py`, `viewsets.py`
+
+## 2. Modular — FastAPI (⭐ Recomendado para APIs)
+
+**Folder Structure**:
+```
+app/
+├── api/
+│   ├── routes/           → Endpoint routers
+│   ├── dependencies.py   → Dependency injection
+│   └── middleware.py      → Middleware
+├── core/
+│   ├── config.py         → Settings (pydantic BaseSettings)
+│   └── security.py       → Auth logic
+├── models/               → SQLAlchemy/Pydantic models
+├── schemas/              → Pydantic request/response schemas
+├── services/             → Business logic
+├── repositories/         → Data access layer
+└── main.py               → FastAPI app creation
+```
+
+**Detection Markers**:
+- `FastAPI()` instance en `main.py`
+- Pydantic models: `class X(BaseModel)`
+- `@router.get/post/put/delete` decorators
+- `Depends()` para dependency injection
+- async/await usage
+
+## 3. Clean Architecture (Python)
+
+**Detection Markers**:
+- Carpetas: `domain/`, `application/`, `infrastructure/`, `presentation/`
+- Interfaces con ABC (Abstract Base Class)
+- Repository pattern con ABC
+- Use cases como clases independientes
+
+## 4. Layered (Flask)
+
+**Detection Markers**:
+- `Flask(__name__)` instance
+- Blueprints para modularización
+- `@app.route` decorators
+- Sin estructura de capas estricta (Flask es micro)
+
+## 5. Hexagonal (Python)
+
+**Detection Markers**:
+- Carpetas: `ports/`, `adapters/`
+- ABC interfaces como ports
+- Inyección de dependencias manual o con `dependency-injector`
+
+## Tools de Enforcement
+- **import-linter**: Define contratos de imports entre capas
+- **pytestarch**: Tests de arquitectura (inspirado en ArchUnit)
+- **pylint-import-modules**: Restricción de imports
+- **mypy**: Type checking estricto
+- **ruff**: Linting rápido con reglas de imports
+
+## Anti-patterns comunes
+- Fat views (lógica de negocio en views.py)
+- Queries N+1 en Django ORM (falta select_related/prefetch_related)
+- Circular imports entre apps
+- Settings hardcodeados (en lugar de environment variables)
+- Models.py con 1000+ líneas (falta modularización)

--- a/.claude/skills/architecture-intelligence/references/patterns-ruby.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-ruby.md
@@ -1,0 +1,88 @@
+---
+name: patterns-ruby
+description: Patrones de arquitectura para Ruby on Rails
+context_cost: low
+---
+
+# Patrones — Ruby on Rails
+
+## 1. MVC (⭐ Rails nativo)
+
+**Folder Structure**:
+```
+app/
+├── controllers/          → Request handlers
+├── models/               → ActiveRecord + domain logic
+├── views/                → ERB/Haml templates
+├── helpers/              → View helpers
+├── mailers/              → Email senders
+├── jobs/                 → Background jobs
+├── channels/             → ActionCable WebSocket
+└── assets/               → CSS, JS (legacy)
+```
+
+**Detection Markers**:
+- `Gemfile` con `gem 'rails'`
+- `config/routes.rb` con `resources`, `get`, `post`
+- Controllers hereden de `ApplicationController`
+- Models hereden de `ApplicationRecord`
+- `db/migrate/` con migraciones timestamped
+- `config/database.yml` con connection config
+
+## 2. Service Objects (⭐ Recomendado para lógica compleja)
+
+**Detection Markers**:
+- Carpeta `app/services/` con clases de negocio
+- Naming: `CreateOrderService`, `ProcessPaymentService`
+- Pattern: `def call` o `def perform` como entry point
+- Controllers delegan a services: `CreateOrderService.new(params).call`
+
+## 3. Query Objects
+
+**Detection Markers**:
+- Carpeta `app/queries/` → `ActiveUsersQuery`, `ExpiredOrdersQuery`
+- Encapsulan queries complejas fuera del model
+- Pattern: `def call` retorna relation
+
+## 4. Presenters / Decorators
+
+**Detection Markers**:
+- Carpeta `app/presenters/` o `app/decorators/`
+- Draper gem: `class UserDecorator < Draper::Decorator`
+- Abstraen lógica de presentación de views
+
+## 5. Modular (Rails Engines)
+
+**Detection Markers**:
+- Carpetas en `engines/` o `components/`
+- `module MyEngine; class Engine < ::Rails::Engine`
+- Bounded contexts como engines independientes
+- Gemfile con `gem 'my_engine', path: 'engines/my_engine'`
+
+## 6. Event-Driven
+
+**Detection Markers**:
+- Wisper gem: `publish(:order_created, order)`
+- ActiveSupport::Notifications
+- `app/events/`, `app/subscribers/`
+- Sidekiq/Resque para processing async
+
+## Rails-Specific Patterns
+- **Concerns**: `app/models/concerns/`, `app/controllers/concerns/` (shared behavior)
+- **Hotwire/Turbo**: `data-turbo-frame`, `turbo_stream` (server-driven interactivity)
+- **Stimulus**: `data-controller`, `data-action` attributes
+
+## Tools de Enforcement
+- **RuboCop**: Linting + style enforcement
+- **Packwerk**: Modular boundaries enforcement (Shopify)
+- **RSpec**: Testing framework
+- **Brakeman**: Security scanner
+- **Bullet**: N+1 query detection
+- **Simplecov**: Coverage reporting
+
+## Anti-patterns comunes
+- Fat models (>200 líneas sin concerns/services)
+- Fat controllers (lógica de negocio en controllers)
+- Callbacks hell (before_save chains complejas)
+- Falta de service objects para operaciones multi-model
+- Skip validations en producción

--- a/.claude/skills/architecture-intelligence/references/patterns-rust.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-rust.md
@@ -1,0 +1,88 @@
+---
+name: patterns-rust
+description: Patrones de arquitectura para Rust
+context_cost: low
+---
+
+# Patrones — Rust
+
+## 1. Hexagonal Architecture (⭐ Recomendado)
+
+Rust es idiomáticamente hexagonal: traits = ports, structs = adapters, ownership = dependency direction.
+
+**Folder Structure**:
+```
+src/
+├── domain/
+│   ├── mod.rs            → Domain models, business rules
+│   ├── entities.rs       → Core entities
+│   └── errors.rs         → Domain errors
+├── ports/
+│   ├── mod.rs            → Trait definitions (interfaces)
+│   ├── inbound.rs        → Driving ports (API contracts)
+│   └── outbound.rs       → Driven ports (DB, external)
+├── adapters/
+│   ├── http/             → Actix-web/Axum handlers
+│   ├── persistence/      → Diesel/SQLx implementations
+│   └── external/         → External API clients
+├── application/
+│   ├── mod.rs            → Use cases
+│   └── services.rs       → Application services
+├── lib.rs
+└── main.rs
+```
+
+**Detection Markers**:
+- `pub trait` definitions como ports
+- `impl Trait for Struct` como adapters
+- `mod` organization por concern
+- Constructor injection: `fn new(repo: impl UserRepository) -> Self`
+- `Result<T, E>` para error handling explícito
+
+## 2. Clean Architecture
+
+**Detection Markers**:
+- Workspace con múltiples crates: `domain`, `application`, `infrastructure`, `web`
+- `Cargo.toml` workspace con members
+- Domain crate sin dependencias externas
+- Use cases como funciones o structs con `execute()` method
+
+## 3. Actor Model (Actix)
+
+**Detection Markers**:
+- `impl Actor for MyActor`
+- `impl Handler<Message> for MyActor`
+- `Addr<MyActor>` para comunicación
+- Actix-web: `HttpServer::new`, `web::resource`
+
+## 4. Data-Oriented Design
+
+**Detection Markers**:
+- Structs of Arrays (SoA) en lugar de Array of Structs (AoS)
+- `Vec<ComponentA>`, `Vec<ComponentB>` en paralelo
+- ECS (Entity Component System): bevy, specs, legion
+- Iteradores y traits para procesamiento
+
+## Rust-Specific Patterns
+- **Zero-cost abstractions**: Traits compilados a dispatch estático
+- **Ownership model**: Fuerza dirección clara de dependencias
+- **Error handling**: `thiserror` para library errors, `anyhow` para application errors
+- **Builder pattern**: `MyStruct::builder().field(x).build()`
+- **Newtype pattern**: `struct UserId(Uuid)` para type safety
+
+## Web Frameworks y Detección
+- **Axum**: `Router::new().route()`, extractors, tower middleware
+- **Actix-web**: `HttpServer`, `App::new().service()`, `#[get]` macros
+- **Rocket**: `#[launch]`, `#[get]`, `#[post]` macros
+
+## Tools de Enforcement
+- **cargo clippy**: Lint con 500+ reglas
+- **cargo deny**: Auditoría de dependencias + licencias
+- **cargo audit**: Vulnerabilidades en dependencias
+- **cargo test**: Tests integrados con `#[cfg(test)]`
+
+## Anti-patterns comunes
+- `.unwrap()` en producción (en lugar de error handling)
+- `.clone()` excesivo (evitable con referencias)
+- Lifetimes innecesariamente complejos
+- Módulos monolíticos (>500 líneas sin sub-módulos)

--- a/.claude/skills/architecture-intelligence/references/patterns-terraform.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-terraform.md
@@ -1,0 +1,113 @@
+---
+name: patterns-terraform
+description: Patrones de arquitectura para Terraform (Infrastructure as Code)
+context_cost: low
+---
+
+# Patrones — Terraform (IaC)
+
+## 1. Service Stack Pattern (⭐ Recomendado)
+
+Un stack por servicio y entorno → deploy independiente.
+
+**Folder Structure**:
+```
+infrastructure/
+├── modules/                → Módulos reutilizables
+│   ├── networking/
+│   │   ├── main.tf
+│   │   ├── variables.tf
+│   │   └── outputs.tf
+│   ├── compute/
+│   ├── database/
+│   └── storage/
+├── services/               → Un stack por servicio
+│   ├── api/
+│   │   ├── dev/
+│   │   │   ├── main.tf
+│   │   │   └── terraform.tfvars
+│   │   ├── staging/
+│   │   └── production/
+│   └── worker/
+└── shared/                 → Infra compartida (VPC, DNS)
+```
+
+**Detection Markers**:
+- Separación por servicio + entorno
+- `.tfvars` por entorno
+- `backend.tf` con remote state (S3, Azure Storage, GCS)
+- Módulos referenciados por path o registry
+
+## 2. Three-Tier (Platform / Product / Shared)
+
+**Folder Structure**:
+```
+terraform/
+├── platform/             → Infra base (VPC, IAM, DNS) — DevOps team
+├── products/             → Servicios de negocio — Product teams
+│   └── service-a/
+└── shared/               → Módulos y variables compartidas
+```
+
+**Detection Markers**:
+- Separación platform/products
+- Shared modules referenced cross-tier
+- Different state files per tier
+
+## 3. Monolithic (Terralith) — ⚠️ No recomendado
+
+**Detection Markers**:
+- Un solo `main.tf` con toda la infra
+- Sin módulos o muy pocos
+- Un solo state file para todo
+- Riesgo: blast radius, slow plans, coupling
+
+## 4. Module-Based (DRY)
+
+**Detection Markers**:
+- `modules/` con componentes reutilizables
+- Cada módulo: `main.tf`, `variables.tf`, `outputs.tf`
+- Llamadas: `module "vpc" { source = "./modules/networking" }`
+- Versionado de módulos en registry
+
+## 5. Workspace-Based
+
+**Detection Markers**:
+- `terraform workspace` commands
+- Mismo código, diferentes workspaces (dev, staging, prod)
+- `terraform.workspace` en conditionals
+- ⚠️ Limitado para diferencias grandes entre entornos
+
+## Terraform Best Practices
+
+### Naming Conventions
+- Resources: `resource_type_purpose` → `aws_s3_bucket_logs`
+- Modules: `purpose` → `module "networking"`
+- Variables: `descriptive_name` → `var.database_instance_class`
+
+### State Management
+- **Remote state**: S3+DynamoDB (AWS), Azure Storage (Azure), GCS (GCP)
+- **State locking**: Evita cambios concurrentes
+- **State encryption**: Cifrado at rest
+
+### Security
+- **No secrets en `.tf`**: Usar vault, SSM, o Key Vault
+- **Least privilege**: IAM roles mínimos
+- **Policy as Code**: Sentinel (HashiCorp), OPA (Open Policy Agent)
+
+## Tools de Enforcement
+- **Terragrunt**: DRY config, remote state management
+- **TFLint**: Linting de Terraform files
+- **Checkov**: Security scanning para IaC
+- **Terraform-docs**: Auto-generación de documentación
+- **Infracost**: Estimación de costes antes de apply
+- **Terratest**: Tests de infraestructura en Go
+- **Sentinel**: Policy as Code (Terraform Cloud/Enterprise)
+
+## Anti-patterns comunes
+- State file en git (debe ser remote)
+- Hardcoded values (en lugar de variables)
+- Sin módulos (copy-paste entre entornos)
+- `terraform apply` sin `plan` previo
+- Sin remote locking → conflictos de state
+- Recursos nombrados con entorno hardcoded

--- a/.claude/skills/architecture-intelligence/references/patterns-typescript.md
+++ b/.claude/skills/architecture-intelligence/references/patterns-typescript.md
@@ -1,0 +1,90 @@
+---
+name: patterns-typescript
+description: Patrones de arquitectura para TypeScript (Angular, React, Node.js)
+context_cost: low
+---
+
+# Patrones — TypeScript (Angular / React / Node.js)
+
+## 1. Clean Architecture (⭐ Recomendado para backends)
+
+**Folder Structure (Node.js/Express/NestJS)**:
+```
+src/
+├── domain/            → Entities, Value Objects, Repository interfaces
+├── application/       → Use Cases, DTOs, Services
+├── infrastructure/    → Database, External APIs, Repositories impl
+├── presentation/      → Controllers, Routes, Middleware
+└── shared/            → Utils, Constants, Types
+```
+
+**Detection Markers**:
+- Carpetas por capa con imports unidireccionales
+- Interfaces en domain, implementaciones en infrastructure
+- NestJS: `@Module`, `@Injectable`, `@Controller` decorators
+- Express: router files + service classes + repository pattern
+
+## 2. Component-Based (⭐ Recomendado para frontends)
+
+**React Folder Structure**:
+```
+src/
+├── components/        → Reusable UI components
+├── pages/ or views/   → Route-level components
+├── hooks/             → Custom hooks (useX naming)
+├── services/          → API calls, business logic
+├── store/ or context/ → State management
+├── types/             → TypeScript interfaces/types
+└── utils/             → Helper functions
+```
+
+**Angular Folder Structure**:
+```
+src/app/
+├── core/              → Singleton services, guards, interceptors
+├── shared/            → Shared components, pipes, directives
+├── features/          → Feature modules (lazy loaded)
+│   └── feature-name/
+│       ├── components/
+│       ├── services/
+│       └── feature.module.ts
+└── app.module.ts
+```
+
+**Detection Markers React**: `useState`, `useEffect`, custom hooks, JSX/TSX
+**Detection Markers Angular**: `@NgModule`, `@Component`, `*.module.ts`, RxJS
+
+## 3. Redux / State Management Pattern
+
+**Detection Markers**:
+- Carpetas: `store/`, `slices/`, `reducers/`, `actions/`
+- Redux: `createSlice`, `configureStore`, `useSelector`, `useDispatch`
+- Zustand: `create()` stores
+- MobX: `makeObservable`, `@observable`
+
+## 4. Hexagonal (Node.js backends)
+
+**Detection Markers**:
+- Carpetas: `ports/`, `adapters/`, `core/`
+- TypeScript interfaces como ports
+- Dependency injection (NestJS, tsyringe, inversify)
+
+## 5. Micro-frontends
+
+**Detection Markers**:
+- Module Federation config (webpack)
+- Múltiples `package.json` en monorepo
+- Shared dependencies configuration
+- Host/remote application setup
+
+## Tools de Enforcement
+- **eslint-plugin-boundaries**: Reglas de imports entre capas
+- **dependency-cruiser**: Grafo de dependencias y reglas
+- **nx**: Monorepo con boundaries enforcement
+- **madge**: Detección de dependencias circulares
+
+## Anti-patterns comunes
+- Prop drilling excesivo (>3 niveles sin context/store)
+- Business logic en componentes UI
+- `any` type usage (pérdida de type safety)
+- Barrel exports circulares (`index.ts` loops)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.31.0] — 2026-02-28
+
+Architecture intelligence: pattern detection, improvement suggestions, recommendations for new projects, fitness functions, and pattern comparisons across 16 languages.
+
+### Added
+
+**`/arch-detect {repo|path}`** — Detects the architecture pattern of a repository using a 4-phase scoring algorithm: folder structure analysis (40%), dependency direction analysis (30%), naming convention analysis (20%), and configuration analysis (10%). Identifies primary pattern, adherence level (High/Medium/Low), violations, and secondary patterns. Supports all 16 languages with language-specific detection markers.
+
+**`/arch-suggest {repo|path}`** — Generates prioritized architecture improvement suggestions based on detection results. Classifies findings into Quick Wins (high impact, low effort), Projects (high impact, high effort), and Nice to Have. Identifies god classes, inverse dependencies, missing abstractions, and tight coupling. Includes architectural health metrics.
+
+**`/arch-recommend {requirements}`** — Recommends the optimal architecture pattern for a new project based on requirements (app type, language, scale, team size, domain complexity). Uses weighted scoring across 7 patterns and 9 factors. Generates folder structure proposal, dependency suggestions, and ADR draft.
+
+**`/arch-fitness {repo|path}`** — Defines and executes architecture fitness functions (integrity rules). Includes pattern-specific rules (layer independence, no circular dependencies, naming conventions) and generic rules (file size limits, import limits, no hardcoded secrets). Reports PASS/FAIL per rule with affected files and suggested fixes.
+
+**`/arch-compare {pattern1} {pattern2}`** — Generates detailed comparison between two architecture patterns across 10 dimensions: complexity, learning curve, testability, scalability, maintainability, minimum team size, ideal use case, anti-use case, popular frameworks, and enforcement tools. Optional project context for personalized recommendation.
+
+**Architecture Intelligence skill** — New skill with pattern detection algorithm, fitness function templates, and reference catalog with 11 language-specific pattern files covering .NET, TypeScript, Java, Python, Go, Rust, PHP, Mobile (Swift/Kotlin/Flutter), Ruby, Legacy (COBOL/VB.NET), and Terraform.
+
+**Architecture patterns domain rule** — Cross-language reference with 7 pattern definitions, detection markers, enforcement tools per language, and fitness function categories.
+
+---
+
 ## [0.30.0] — 2026-02-28
 
 Technical debt intelligence: automated analysis, business-impact prioritization, and sprint debt budgeting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Entornos DEV/PRE/PRO (configurables). Config sensible NUNCA en repo. IaC preferi
 
 ## 🛠️ Operaciones
 
-Skills: azure-devops-queries · product-discovery · pbi-decomposition · spec-driven-development · diagram-generation · diagram-import · azure-pipelines · sprint-management · capacity-planning · executive-reporting · time-tracking-report · team-onboarding · voice-inbox. Detalle: `.claude/skills/{nombre}/SKILL.md`
+Skills: azure-devops-queries · product-discovery · pbi-decomposition · spec-driven-development · diagram-generation · diagram-import · azure-pipelines · sprint-management · capacity-planning · executive-reporting · time-tracking-report · team-onboarding · voice-inbox · predictive-analytics · developer-experience · architecture-intelligence. Detalle: `.claude/skills/{nombre}/SKILL.md`
 
 Ciclo: Explorar → Planificar → Implementar → Commit. Arquitectura: **Command → Agent → Skills** — subagentes solo con `Task`.
 

--- a/README.en.md
+++ b/README.en.md
@@ -54,6 +54,8 @@ This workspace turns Claude Code into an **automated Project Manager / Scrum Mas
 
 **Technical debt intelligence** — automated hotspot analysis, temporal coupling and code smell detection, business impact prioritization with scoring model (proximity × churn × velocity × risk), and per-sprint debt budget with velocity impact projection.
 
+**Architecture Intelligence** — automatic detection of architecture patterns (Clean, Hexagonal, DDD, CQRS, MVC/MVVM, Microservices, Event-Driven) in repositories of any language, improvement suggestions prioritized by impact, architecture recommendations for new projects based on requirements, fitness functions for architectural integrity verification, and pattern comparisons for decision-making. Reference catalog with language-specific patterns for all 16 supported languages.
+
 ---
 
 ## Documentation
@@ -113,7 +115,7 @@ Full documentation is organized into sections for easy reference:
 
 ## Quick Command Reference
 
-> 117 commands · 24 agents · 15 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
+> 123 commands · 24 agents · 16 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
 
 ### Technical Debt Intelligence
 ```
@@ -197,6 +199,12 @@ Full documentation is organized into sections for easy reference:
 ### Team and Onboarding
 ```
 /team-onboarding {name}    /team-evaluate {name}    /team-privacy-notice {name}
+```
+
+### Architecture Intelligence
+```
+/arch-detect {repo|path}    /arch-suggest {repo|path}    /arch-recommend {reqs}
+/arch-fitness {repo|path}    /arch-compare {pattern1} {pattern2}
 ```
 
 ### Architecture and Diagrams

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Este workspace convierte a Claude Code en un **Project Manager / Scrum Master au
 
 **Inteligencia de deuda técnica** — análisis automático de hotspots, coupling temporal y code smells, priorización por impacto de negocio con modelo de scoring (proximity × churn × velocity × risk), y presupuesto de deuda por sprint con proyección de impacto en velocity.
 
+**Architecture Intelligence** — detección automática de patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, MVC/MVVM, Microservices, Event-Driven) en repositorios de cualquier lenguaje, sugerencias de mejora priorizadas por impacto, recomendación de arquitectura para proyectos nuevos basada en requisitos, fitness functions para verificar integridad arquitectónica, y comparativas entre patrones para toma de decisiones. Catálogo de referencia con patrones específicos para los 16 lenguajes soportados.
+
 ---
 
 ## Documentación
@@ -113,7 +115,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 
 ## Referencia rápida de comandos
 
-> 117 comandos · 24 agentes · 15 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
+> 123 comandos · 24 agentes · 16 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
 
 ### Inteligencia de Deuda Técnica
 ```
@@ -197,6 +199,12 @@ La documentación completa está organizada en secciones para facilitar la consu
 ### Equipo y Onboarding
 ```
 /team-onboarding {nombre}    /team-evaluate {nombre}    /team-privacy-notice {nombre}
+```
+
+### Architecture Intelligence
+```
+/arch-detect {repo|path}    /arch-suggest {repo|path}    /arch-recommend {reqs}
+/arch-fitness {repo|path}    /arch-compare {patrón1} {patrón2}
 ```
 
 ### Arquitectura y Diagramas

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -172,6 +172,15 @@
 /diagram-status [--project]       Estado de diagramas del proyecto
 ```
 
+## Architecture Intelligence (5 comandos)
+```
+/arch-detect {repo|path}         Detectar patrón de arquitectura del proyecto
+/arch-suggest {repo|path}        Sugerir mejoras de arquitectura priorizadas
+/arch-recommend {requisitos}     Recomendar arquitectura para proyecto nuevo
+/arch-fitness {repo|path}        Ejecutar fitness functions de arquitectura
+/arch-compare {patrón1} {patrón2} Comparar dos patrones de arquitectura
+```
+
 ## Inteligencia de Deuda Técnica (3 comandos)
 ```
 /debt-analyze [--project]         Análisis automático de deuda (hotspots, coupling, smells)

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -172,6 +172,15 @@
 /diagram-status [--project]       Project diagram status
 ```
 
+## Architecture Intelligence (5 commands)
+```
+/arch-detect {repo|path}         Detect architecture pattern of a project
+/arch-suggest {repo|path}        Suggest prioritized architecture improvements
+/arch-recommend {requirements}   Recommend architecture for new project
+/arch-fitness {repo|path}        Run architecture fitness functions
+/arch-compare {pattern1} {pattern2} Compare two architecture patterns
+```
+
 ## Technical Debt Intelligence (3 commands)
 ```
 /debt-analyze [--project]         Automated debt analysis (hotspots, coupling, smells)


### PR DESCRIPTION
## Summary
- 5 new commands: `/arch-detect`, `/arch-suggest`, `/arch-recommend`, `/arch-fitness`, `/arch-compare`
- New `architecture-intelligence` skill with 11 language-specific reference files
- New `architecture-patterns` domain rule with 7 cross-language patterns
- Pattern detection algorithm with 4-phase scoring (structure, dependencies, naming, config)
- Fitness functions for architectural integrity verification
- Counts: 123 commands, 16 skills, 12 hooks, 24 agents

## Test plan
- [ ] `/arch-detect` identifies Clean Architecture in a .NET project
- [ ] `/arch-recommend` generates recommendation for "API REST en TypeScript"
- [ ] `/arch-compare clean hexagonal` produces comparison table
- [ ] All files ≤150 lines verified
- [ ] Command and skill counts match across all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)