### PR TITLE
feat: v0.32.1 — Emergency Plan (offline pre-download)

### DIFF
--- a/.claude/commands/emergency-plan.md
+++ b/.claude/commands/emergency-plan.md
@@ -1,0 +1,82 @@
+---
+name: emergency-plan
+description: Pre-descargar Ollama y modelo LLM en caché local para instalación offline
+developer_type: all
+agent: none
+context_cost: low
+---
+
+# /emergency-plan [--model MODEL]
+
+> Pre-descarga todos los recursos necesarios para que `/emergency-mode setup` funcione sin conexión a internet.
+
+---
+
+## ¿Por qué?
+
+Si el proveedor cloud de LLM cae y además no hay internet, `/emergency-mode setup` no podrá descargar Ollama ni el modelo. Con `/emergency-plan` ejecutado previamente, todo queda cacheado en local.
+
+## Prerequisitos
+
+- Conexión a internet (para la descarga inicial)
+- ~5-10GB de espacio libre (según modelo)
+
+## Qué descarga
+
+1. **Script de instalación de Ollama** — `~/.pm-workspace-emergency/ollama-install.sh`
+2. **Binario de Ollama** — `~/.pm-workspace-emergency/ollama-{os}-{arch}`
+3. **Modelo LLM** — cacheado en Ollama o en directorio local
+
+## Selección automática de modelo
+
+Si no se especifica `--model`, se selecciona según la RAM disponible:
+
+| RAM | Modelo | Tamaño descarga |
+|-----|--------|----------------|
+| <16GB | qwen2.5:3b | ~2GB |
+| 16-31GB | qwen2.5:7b | ~4.4GB |
+| ≥32GB | qwen2.5:14b | ~9GB |
+
+## Uso
+
+```bash
+# Descarga automática según hardware
+./scripts/emergency-plan.sh
+
+# Con modelo específico
+./scripts/emergency-plan.sh --model mistral:7b
+
+# Verificar si ya se ejecutó
+./scripts/emergency-plan.sh --check
+```
+
+## Verificación
+
+El script crea un marcador en `~/.pm-workspace-emergency/.plan-executed`.
+- `--check` retorna exit code 0 si ya se ejecutó, 1 si no
+- `session-init.sh` verifica este marcador y recuerda ejecutar el plan
+
+## Integración con emergency-setup
+
+Cuando `emergency-setup.sh` detecta que no hay internet:
+1. Busca el binario de Ollama en la caché local
+2. Lo instala desde el fichero local
+3. El modelo ya está cacheado por Ollama (descargado durante plan)
+4. Setup completo sin necesidad de internet
+
+## Sugerencia automática
+
+La primera vez que se inicia Claude Code en una máquina nueva, `session-init.sh` verifica si el emergency plan se ha ejecutado. Si no, muestra un recordatorio para que el usuario lo ejecute.
+
+## Caché local
+
+Todo se almacena en `~/.pm-workspace-emergency/`:
+```
+~/.pm-workspace-emergency/
+├── .plan-executed          # Marcador de ejecución con timestamp
+├── plan-info.json          # Metadata (OS, RAM, modelo elegido)
+├── ollama-install.sh       # Script de instalación
+└── ollama-linux-x86_64     # Binario (Linux)
+```
+
+Los modelos de Ollama se cachean en `~/.ollama/models/` (directorio estándar de Ollama).

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -24,6 +24,15 @@ done
 BRANCH=$(git -C "$HOME/claude" branch --show-current 2>/dev/null || echo "N/A")
 LAST_COMMITS=$(git -C "$HOME/claude" log --oneline -3 2>/dev/null || echo "N/A")
 
+# Verificar si emergency-plan se ha ejecutado alguna vez
+EMERGENCY_PLAN_STATUS=""
+PLAN_MARKER="$HOME/.pm-workspace-emergency/.plan-executed"
+if [ -f "$PLAN_MARKER" ]; then
+  EMERGENCY_PLAN_STATUS="Emergency plan: OK ✅"
+else
+  EMERGENCY_PLAN_STATUS="Emergency plan: NO ejecutado ⚠️ — Ejecuta /emergency-plan para preparar contingencia offline"
+fi
+
 # Establecer variables de entorno si CLAUDE_ENV_FILE existe
 if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "export PM_WORKSPACE_ROOT=$HOME/claude" >> "$CLAUDE_ENV_FILE"
@@ -35,9 +44,10 @@ jq -n --arg pat "$PAT_STATUS" \
       --arg tools "$TOOLS_STATUS" \
       --arg branch "$BRANCH" \
       --arg commits "$LAST_COMMITS" \
+      --arg emergency "$EMERGENCY_PLAN_STATUS" \
 '{
   hookSpecificOutput: {
     hookEventName: "SessionStart",
-    additionalContext: ("PM-Workspace Session Init:\n- " + $pat + "\n- Herramientas:" + $tools + "\n- Rama: " + $branch + "\n- Últimos commits:\n" + $commits)
+    additionalContext: ("PM-Workspace Session Init:\n- " + $pat + "\n- Herramientas:" + $tools + "\n- " + $emergency + "\n- Rama: " + $branch + "\n- Últimos commits:\n" + $commits)
   }
 }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.32.1] — 2026-02-28
+
+Emergency plan: preventive pre-download of Ollama and LLM for fully offline installation, with first-run detection and automatic suggestion.
+
+### Added
+
+**`/emergency-plan`** — Pre-downloads Ollama installer, binary, and LLM model to local cache (`~/.pm-workspace-emergency/`). Detects hardware and selects optimal model automatically. When `emergency-setup` runs without internet, it uses this cache for fully offline installation. Includes `--check` flag to verify execution status.
+
+**`scripts/emergency-plan.sh`** — Interactive pre-download script: detects OS/RAM/GPU, downloads Ollama installer + binary, pulls LLM model into Ollama cache, saves metadata (`plan-info.json`), and creates execution marker. Supports `--model` for custom model selection and `--check` for status verification.
+
+### Changed
+
+**`scripts/emergency-setup.sh`** — Now detects internet connectivity at startup. When offline, automatically uses local cache from `emergency-plan` to install Ollama binary and use pre-downloaded model. Falls back gracefully with clear instructions if cache is missing.
+
+**`session-init.sh`** — Now checks if `emergency-plan` has been executed on the current machine. If not, shows a reminder in the session context suggesting the user run `/emergency-plan` to prepare for offline contingency.
+
+---
+
 ## [0.32.0] — 2026-02-28
 
 Emergency mode: local LLM contingency plan with Ollama setup, hardware detection, offline PM operations, and step-by-step emergency documentation.

--- a/README.en.md
+++ b/README.en.md
@@ -118,7 +118,7 @@ Full documentation is organized into sections for easy reference:
 
 ## Quick Command Reference
 
-> 124 commands · 24 agents · 16 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
+> 125 commands · 24 agents · 16 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
 
 ### Technical Debt Intelligence
 ```
@@ -220,7 +220,7 @@ Full documentation is organized into sections for easy reference:
 
 ### Emergency
 ```
-/emergency-mode {setup|status|activate|deactivate|test}
+/emergency-plan [--model MODEL]    /emergency-mode {setup|status|activate|deactivate|test}
 ```
 
 ### External Integrations

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 
 ## Referencia rápida de comandos
 
-> 124 comandos · 24 agentes · 16 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
+> 125 comandos · 24 agentes · 16 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
 
 ### Inteligencia de Deuda Técnica
 ```
@@ -220,7 +220,7 @@ La documentación completa está organizada en secciones para facilitar la consu
 
 ### Emergencia
 ```
-/emergency-mode {setup|status|activate|deactivate|test}
+/emergency-plan [--model MODEL]    /emergency-mode {setup|status|activate|deactivate|test}
 ```
 
 ### Integraciones Externas

--- a/docs/EMERGENCY.en.md
+++ b/docs/EMERGENCY.en.md
@@ -4,6 +4,17 @@
 
 ---
 
+## Step 0: Preventive preparation (RECOMMENDED)
+
+Run this **now**, while you have internet, so everything works offline:
+
+```bash
+cd ~/claude
+./scripts/emergency-plan.sh
+```
+
+This pre-downloads the Ollama installer and LLM model to local cache (~5-10GB). If you lose connectivity, `emergency-setup` will use the cache automatically. It is automatically suggested the first time you start pm-workspace on a new machine.
+
 ## When to activate emergency mode?
 
 Activate emergency mode if:
@@ -25,6 +36,8 @@ The script will detect your hardware and guide you through:
 1. Installing Ollama (local LLM manager)
 2. Downloading the recommended model for your RAM
 3. Automatic environment variable configuration
+
+If offline, it will automatically use the local cache from `emergency-plan`.
 
 If your machine has **less than 16GB RAM**, use a smaller model:
 ```bash
@@ -122,8 +135,8 @@ ollama pull qwen2.5:7b
 ## Quick Reference
 
 ```
-./scripts/emergency-setup.sh          # Initial installation
-./scripts/emergency-setup.sh --help   # Installation options
+./scripts/emergency-plan.sh           # Preventive pre-download (run with internet)
+./scripts/emergency-setup.sh          # Installation (online or offline with cache)
 ./scripts/emergency-status.sh         # System diagnostics
 ./scripts/emergency-fallback.sh help  # Operations without LLM
 source ~/.pm-workspace-emergency.env  # Activate emergency mode

--- a/docs/EMERGENCY.md
+++ b/docs/EMERGENCY.md
@@ -4,6 +4,17 @@
 
 ---
 
+## Paso 0: Preparación preventiva (RECOMENDADO)
+
+Ejecuta esto **ahora**, mientras tienes conexión, para que todo funcione offline:
+
+```bash
+cd ~/claude
+./scripts/emergency-plan.sh
+```
+
+Esto pre-descarga el instalador de Ollama y el modelo LLM en caché local (~5-10GB). Si algún día pierdes conexión, `emergency-setup` usará la caché automáticamente. Se sugiere automáticamente la primera vez que arrancas pm-workspace en una máquina nueva.
+
 ## ¿Cuándo activar el modo emergencia?
 
 Activa el modo emergencia si:
@@ -25,6 +36,8 @@ El script detectará tu hardware y te guiará por:
 1. Instalación de Ollama (gestor de LLMs locales)
 2. Descarga del modelo recomendado para tu RAM
 3. Configuración automática de variables
+
+Si no hay internet, usará la caché local de `emergency-plan` automáticamente.
 
 Si tu equipo tiene **menos de 16GB de RAM**, usa un modelo más pequeño:
 ```bash
@@ -122,8 +135,8 @@ ollama pull qwen2.5:7b
 ## Referencia Rápida
 
 ```
-./scripts/emergency-setup.sh          # Instalación inicial
-./scripts/emergency-setup.sh --help   # Opciones de instalación
+./scripts/emergency-plan.sh           # Pre-descarga preventiva (ejecutar con internet)
+./scripts/emergency-setup.sh          # Instalación (online u offline con caché)
 ./scripts/emergency-status.sh         # Diagnóstico del sistema
 ./scripts/emergency-fallback.sh help  # Operaciones sin LLM
 source ~/.pm-workspace-emergency.env  # Activar modo emergencia

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -195,8 +195,9 @@
 /ai-audit-log [--project]         Log de auditoría de ejecuciones IA
 ```
 
-## Emergencia (1 comando)
+## Emergencia (2 comandos)
 ```
+/emergency-plan [--model MODEL]  Pre-descargar Ollama y modelo LLM para instalación offline
 /emergency-mode {subcommand}     Gestionar modo emergencia con LLM local (setup/status/activate/deactivate/test)
 ```
 

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -195,8 +195,9 @@
 /ai-audit-log [--project]         AI execution audit log
 ```
 
-## Emergency (1 command)
+## Emergency (2 commands)
 ```
+/emergency-plan [--model MODEL]  Pre-download Ollama and LLM model for offline installation
 /emergency-mode {subcommand}     Manage emergency mode with local LLM (setup/status/activate/deactivate/test)
 ```
 

--- a/scripts/emergency-plan.sh
+++ b/scripts/emergency-plan.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# emergency-plan.sh — Pre-descarga de Ollama y modelo LLM para modo offline
+# Uso: ./scripts/emergency-plan.sh [--model MODEL] [--help]
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; NC='\033[0m'; BOLD='\033[1m'
+
+CACHE_DIR="$HOME/.pm-workspace-emergency"
+MARKER_FILE="$CACHE_DIR/.plan-executed"
+DEFAULT_MODEL="qwen2.5:7b"
+MODEL=""
+
+show_help() {
+  echo -e "${BOLD}PM-Workspace Emergency Plan${NC} — Pre-descarga Ollama + LLM para offline"
+  echo "Uso: $0 [--model MODEL] [--check] [--help]"
+  echo "  --model MODEL  Modelo (default: auto según RAM). --check  Verifica si ya se ejecutó"
+  echo "Modelos: 8GB→qwen2.5:3b | 16GB→qwen2.5:7b | 32GB+→qwen2.5:14b"
+  exit 0
+}
+
+check_plan() {
+  if [[ -f "$MARKER_FILE" ]]; then
+    echo -e "${GREEN}✓${NC} Emergency plan ya ejecutado ($(cat "$MARKER_FILE"))"
+    exit 0
+  else
+    exit 1
+  fi
+}
+
+# Parsear argumentos
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) MODEL="$2"; shift 2 ;;
+    --check) check_plan ;;
+    --help|-h) show_help ;;
+    *) shift ;;
+  esac
+done
+
+echo -e "\n${BOLD}${CYAN}PM-Workspace · Emergency Plan${NC}"
+echo -e "Pre-descarga de recursos para instalación offline.\n"
+
+# ── 1. Detectar hardware y elegir modelo ─────────────────────────────────────
+echo -e "${BLUE}[1/4]${NC} Detectando hardware..."
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || sysctl -n hw.memsize 2>/dev/null | awk '{print int($1/1024)}' || echo 0)
+RAM_GB=$((RAM_KB / 1024 / 1024))
+echo -e "  OS: ${GREEN}$OS${NC} · Arch: ${GREEN}$ARCH${NC} · RAM: ${GREEN}${RAM_GB}GB${NC}"
+
+if [[ -z "$MODEL" ]]; then
+  if [[ $RAM_GB -ge 32 ]]; then MODEL="qwen2.5:14b"
+  elif [[ $RAM_GB -ge 16 ]]; then MODEL="qwen2.5:7b"
+  else MODEL="qwen2.5:3b"
+  fi
+  echo -e "  Modelo seleccionado automáticamente: ${CYAN}$MODEL${NC}"
+fi
+
+mkdir -p "$CACHE_DIR"
+
+# ── 2. Descargar instalador de Ollama ────────────────────────────────────────
+echo -e "\n${BLUE}[2/4]${NC} Descargando instalador de Ollama..."
+OLLAMA_SCRIPT="$CACHE_DIR/ollama-install.sh"
+
+if [[ "$OS" == "Linux" ]]; then
+  if [[ -f "$OLLAMA_SCRIPT" ]]; then
+    echo -e "  ${GREEN}✓${NC} Instalador ya en caché"
+  else
+    echo -e "  ${YELLOW}→${NC} Descargando script de instalación..."
+    curl -fsSL https://ollama.ai/install.sh -o "$OLLAMA_SCRIPT"
+    chmod +x "$OLLAMA_SCRIPT"
+    echo -e "  ${GREEN}✓${NC} Instalador guardado en ${CYAN}$OLLAMA_SCRIPT${NC}"
+  fi
+
+  # Descargar binario directamente para offline completo
+  OLLAMA_BIN="$CACHE_DIR/ollama-${OS,,}-${ARCH}"
+  if [[ -f "$OLLAMA_BIN" ]]; then
+    echo -e "  ${GREEN}✓${NC} Binario Ollama ya en caché"
+  else
+    echo -e "  ${YELLOW}→${NC} Descargando binario Ollama..."
+    DOWNLOAD_URL="https://ollama.com/download/ollama-linux-${ARCH}"
+    curl -fSL "$DOWNLOAD_URL" -o "$OLLAMA_BIN" 2>/dev/null || {
+      echo -e "  ${YELLOW}⚠${NC} No se pudo descargar binario. Se usará script de instalación."
+      OLLAMA_BIN=""
+    }
+    [[ -n "$OLLAMA_BIN" && -f "$OLLAMA_BIN" ]] && chmod +x "$OLLAMA_BIN"
+    echo -e "  ${GREEN}✓${NC} Binario guardado"
+  fi
+elif [[ "$OS" == "Darwin" ]]; then
+  echo -e "  ${YELLOW}⚠${NC} macOS: descarga Ollama desde ${CYAN}https://ollama.com/download${NC}"
+  echo -e "  El plan cacheará el modelo una vez Ollama esté instalado."
+fi
+
+# ── 3. Pre-descargar modelo LLM ─────────────────────────────────────────────
+echo -e "\n${BLUE}[3/4]${NC} Pre-descargando modelo ${CYAN}$MODEL${NC}..."
+
+if command -v ollama &>/dev/null; then
+  # Si Ollama ya está instalado, usar ollama pull (guarda en su propio caché)
+  if curl -s --max-time 3 http://localhost:11434/api/tags &>/dev/null; then
+    if ollama list 2>/dev/null | grep -q "$MODEL"; then
+      echo -e "  ${GREEN}✓${NC} Modelo ya disponible en Ollama"
+    else
+      echo -e "  ${YELLOW}→${NC} Descargando modelo (puede tardar minutos)..."
+      ollama pull "$MODEL"
+      echo -e "  ${GREEN}✓${NC} Modelo descargado y cacheado por Ollama"
+    fi
+  else
+    echo -e "  ${YELLOW}→${NC} Iniciando Ollama para descargar modelo..."
+    ollama serve &>/dev/null &
+    OLLAMA_PID=$!
+    sleep 3
+    ollama pull "$MODEL" 2>/dev/null || echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo ahora"
+    kill "$OLLAMA_PID" 2>/dev/null || true
+    echo -e "  ${GREEN}✓${NC} Modelo cacheado"
+  fi
+else
+  # Ollama no instalado aún — instalar temporalmente para cachear modelo
+  if [[ "$OS" == "Linux" && -f "${OLLAMA_BIN:-}" ]]; then
+    echo -e "  ${YELLOW}→${NC} Usando binario local para descargar modelo..."
+    "$OLLAMA_BIN" serve &>/dev/null &
+    OLLAMA_PID=$!
+    sleep 4
+    "$OLLAMA_BIN" pull "$MODEL" 2>/dev/null || {
+      echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo. Se hará durante emergency-setup."
+      kill "$OLLAMA_PID" 2>/dev/null || true
+    }
+    kill "$OLLAMA_PID" 2>/dev/null || true
+    echo -e "  ${GREEN}✓${NC} Modelo pre-descargado"
+  else
+    echo -e "  ${YELLOW}⚠${NC} Instala Ollama primero para pre-descargar el modelo"
+  fi
+fi
+
+# ── 4. Guardar metadata y marcador ───────────────────────────────────────────
+echo -e "\n${BLUE}[4/4]${NC} Guardando metadata..."
+cat > "$CACHE_DIR/plan-info.json" << JSONEOF
+{"executed":"$(date -Iseconds)","os":"$OS","arch":"$ARCH","ram_gb":$RAM_GB,"model":"$MODEL"}
+JSONEOF
+date -Iseconds > "$MARKER_FILE"
+
+echo -e "\n${GREEN}${BOLD}✓ Emergency Plan completado${NC}"
+echo -e "Caché: ${CYAN}$CACHE_DIR${NC} · Modelo: ${CYAN}$MODEL${NC}"
+echo -e "Si pierdes conexión: ${CYAN}./scripts/emergency-setup.sh${NC} (usará caché local)"


### PR DESCRIPTION
## Summary
- New `/emergency-plan` command + `scripts/emergency-plan.sh` for preventive pre-download
- `emergency-setup.sh` now detects internet connectivity and uses local cache when offline
- `session-init.sh` checks for emergency-plan execution and suggests it on first run
- Counts: 125 commands, 16 skills, 12 hooks, 24 agents

## Test plan
- [ ] `./scripts/emergency-plan.sh --help` shows help
- [ ] `./scripts/emergency-plan.sh --check` returns exit 1 (not yet executed)
- [ ] `./scripts/emergency-setup.sh --help` shows help
- [ ] All scripts pass `bash -n` syntax check
- [ ] All files ≤150 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)