### PR TITLE
fix(emergency): adapt Ollama download to tar.zst format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.32.2] — 2026-02-28
+
+Fix Ollama download: adapted to new release format (tar.zst archives with amd64/arm64 naming).
+
+### Fixed
+
+**`scripts/emergency-plan.sh`** — Updated Ollama binary download to use new tar.zst format (`ollama-linux-amd64.tar.zst`) instead of deprecated raw binary (`ollama-linux-x86_64`). Maps `x86_64→amd64` and `aarch64→arm64`. Extracts binary from archive automatically.
+
+**`scripts/emergency-setup.sh`** — Updated offline cache binary path to match new `ollama-bin` naming from emergency-plan.
+
+---
+
 ## [0.32.1] — 2026-02-28
 
 Emergency plan: preventive pre-download of Ollama and LLM for fully offline installation, with first-run detection and automatic suggestion.

--- a/scripts/emergency-setup.sh
+++ b/scripts/emergency-setup.sh
@@ -65,10 +65,11 @@ if command -v ollama &>/dev/null; then
 else
   if [[ "$OFFLINE" == true ]]; then
     # Instalación desde caché local
-    OLLAMA_BIN="$CACHE_DIR/ollama-${OS,,}-${ARCH}"
+    OLLAMA_BIN="$CACHE_DIR/ollama-bin"
     if [[ -f "$OLLAMA_BIN" ]]; then
       echo -e "  ${YELLOW}→${NC} Instalando Ollama desde caché local..."
-      sudo cp "$OLLAMA_BIN" /usr/local/bin/ollama 2>/dev/null || cp "$OLLAMA_BIN" "$HOME/.local/bin/ollama" 2>/dev/null && mkdir -p "$HOME/.local/bin"
+      mkdir -p "$HOME/.local/bin"
+      sudo cp "$OLLAMA_BIN" /usr/local/bin/ollama 2>/dev/null || cp "$OLLAMA_BIN" "$HOME/.local/bin/ollama"
       echo -e "  ${GREEN}✓${NC} Ollama instalado desde caché"
     else
       echo -e "  ${RED}✗${NC} No hay binario Ollama en caché."


### PR DESCRIPTION
## Summary
- Ollama changed distribution from raw binaries (`ollama-linux-x86_64`) to tar.zst archives (`ollama-linux-amd64.tar.zst`)
- Updated `emergency-plan.sh` to download tar.zst, extract binary, and cache it correctly
- Updated `emergency-setup.sh` offline install path to match new cache naming (`ollama-bin`)

## Test plan
- [x] Verified download URL returns 200 and downloads 1.7GB tar.zst
- [x] Verified extraction finds binary at `bin/ollama`
- [x] Verified extracted binary runs (`ollama --version` → 0.17.4)
- [x] Both scripts stay under 150-line limit