### PR TITLE
feat(emergency): multi-OS support Linux/macOS/Windows

### DIFF
--- a/.claude/commands/emergency-mode.md
+++ b/.claude/commands/emergency-mode.md
@@ -14,8 +14,8 @@ context_cost: low
 
 ## Prerequisitos
 
-- Acceso a terminal con bash
-- Para `setup`: conexión a internet (para descargar Ollama y modelo)
+- Linux/macOS: terminal con bash · Windows: PowerShell (usar scripts `.ps1`)
+- Para `setup`: conexión a internet (o caché de emergency-plan para offline)
 - Para `activate/status/test`: Ollama instalado previamente
 
 ## Subcomandos

--- a/.claude/commands/emergency-plan.md
+++ b/.claude/commands/emergency-plan.md
@@ -23,9 +23,9 @@ Si el proveedor cloud de LLM cae y además no hay internet, `/emergency-mode set
 
 ## Qué descarga
 
-1. **Script de instalación de Ollama** — `~/.pm-workspace-emergency/ollama-install.sh`
-2. **Binario de Ollama** — `~/.pm-workspace-emergency/ollama-{os}-{arch}`
-3. **Modelo LLM** — cacheado en Ollama o en directorio local
+1. **Script/Instalador de Ollama** — Linux: `ollama-install.sh` + binario extraído de tar.zst · macOS: binario extraído de tgz · Windows: `OllamaSetup.exe`
+2. **Binario de Ollama** — `~/.pm-workspace-emergency/ollama-bin` (Linux/macOS)
+3. **Modelo LLM** — cacheado en Ollama (`~/.ollama/models/`)
 
 ## Selección automática de modelo
 
@@ -40,14 +40,16 @@ Si no se especifica `--model`, se selecciona según la RAM disponible:
 ## Uso
 
 ```bash
-# Descarga automática según hardware
+# Linux / macOS — descarga automática según hardware
 ./scripts/emergency-plan.sh
-
-# Con modelo específico
-./scripts/emergency-plan.sh --model mistral:7b
-
-# Verificar si ya se ejecutó
-./scripts/emergency-plan.sh --check
+./scripts/emergency-plan.sh --model mistral:7b   # modelo específico
+./scripts/emergency-plan.sh --check               # verificar estado
+```
+```powershell
+# Windows (PowerShell)
+.\scripts\emergency-plan.ps1
+.\scripts\emergency-plan.ps1 -Model "mistral:7b"
+.\scripts\emergency-plan.ps1 -Check
 ```
 
 ## Verificación
@@ -72,11 +74,12 @@ La primera vez que se inicia Claude Code en una máquina nueva, `session-init.sh
 
 Todo se almacena en `~/.pm-workspace-emergency/`:
 ```
-~/.pm-workspace-emergency/
-├── .plan-executed          # Marcador de ejecución con timestamp
-├── plan-info.json          # Metadata (OS, RAM, modelo elegido)
-├── ollama-install.sh       # Script de instalación
-└── ollama-linux-x86_64     # Binario (Linux)
+~/.pm-workspace-emergency/        # Linux/macOS: $HOME  ·  Windows: %USERPROFILE%
+├── .plan-executed                 # Marcador de ejecución con timestamp
+├── plan-info.json                 # Metadata (OS, RAM, modelo elegido)
+├── ollama-install.sh              # Script instalación (solo Linux)
+├── ollama-bin                     # Binario extraído (Linux/macOS)
+└── OllamaSetup.exe                # Instalador (solo Windows)
 ```
 
-Los modelos de Ollama se cachean en `~/.ollama/models/` (directorio estándar de Ollama).
+Modelos: `~/.ollama/models/` (Linux/macOS) · `%USERPROFILE%\.ollama\models\` (Windows).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.32.3] — 2026-02-28
+
+Multi-OS emergency mode: full support for Linux, macOS, and Windows. Auto-detects OS and uses appropriate download strategy.
+
+### Added
+
+**`scripts/emergency-plan.ps1`** — Windows PowerShell version of emergency-plan. Downloads `OllamaSetup.exe`, detects hardware (RAM/GPU via WMI), auto-selects model, pre-downloads LLM via Ollama. Saves cache to `%USERPROFILE%\.pm-workspace-emergency\`.
+
+**`scripts/emergency-setup.ps1`** — Windows PowerShell version of emergency-setup. Silent Ollama installation from cache or download, server management, model verification, environment variable configuration via `[Environment]::SetEnvironmentVariable`.
+
+### Changed
+
+**`scripts/emergency-plan.sh`** — Added macOS support: downloads `ollama-darwin.tgz` (~70MB), extracts binary from root of archive. Improved RAM detection per OS (`sysctl` for macOS, `/proc/meminfo` for Linux). Windows detected with redirect to `.ps1` scripts.
+
+**`scripts/emergency-setup.sh`** — Added macOS support: online installation via `ollama-darwin.tgz` extraction, offline installation from cache binary. macOS-specific PATH guidance. Improved GPU detection (Apple Silicon Metal).
+
+---
+
 ## [0.32.2] — 2026-02-28
 
 Fix Ollama download: adapted to new release format (tar.zst archives with amd64/arm64 naming).

--- a/docs/EMERGENCY.en.md
+++ b/docs/EMERGENCY.en.md
@@ -9,11 +9,16 @@
 Run this **now**, while you have internet, so everything works offline:
 
 ```bash
+# Linux / macOS
 cd ~/claude
 ./scripts/emergency-plan.sh
+
+# Windows (PowerShell)
+cd ~\claude
+.\scripts\emergency-plan.ps1
 ```
 
-This pre-downloads the Ollama installer and LLM model to local cache (~5-10GB). If you lose connectivity, `emergency-setup` will use the cache automatically. It is automatically suggested the first time you start pm-workspace on a new machine.
+This pre-downloads the Ollama installer and LLM model to local cache (~5-10GB). Supports Linux (amd64/arm64), macOS (Intel/Apple Silicon) and Windows. If you lose connectivity, `emergency-setup` will use the cache automatically. It is automatically suggested the first time you start pm-workspace on a new machine.
 
 ## When to activate emergency mode?
 
@@ -28,11 +33,16 @@ Activate emergency mode if:
 ### Step 1: Run the installer
 
 ```bash
+# Linux / macOS
 cd ~/claude
 ./scripts/emergency-setup.sh
+
+# Windows (PowerShell)
+cd ~\claude
+.\scripts\emergency-setup.ps1
 ```
 
-The script will detect your hardware and guide you through:
+The script auto-detects your OS and hardware, then guides you through:
 1. Installing Ollama (local LLM manager)
 2. Downloading the recommended model for your RAM
 3. Automatic environment variable configuration
@@ -107,39 +117,25 @@ Or simply close and open a new terminal.
 
 ## Troubleshooting
 
-**"Ollama not installed"**
-```bash
-curl -fsSL https://ollama.ai/install.sh | sh
-```
+**"Ollama not installed"** → Linux: `curl -fsSL https://ollama.ai/install.sh | sh` · macOS: re-run `emergency-setup.sh` · Windows: run `OllamaSetup.exe` from cache.
 
-**"Server not responding"**
-```bash
-ollama serve &
-```
+**"Server not responding"** → `ollama serve &`
 
-**"Model not downloaded"**
-```bash
-ollama pull qwen2.5:7b
-```
+**"Model not downloaded"** → `ollama pull qwen2.5:7b`
 
-**"Very slow responses"**
-- Use a smaller model: `ollama pull qwen2.5:3b`
-- Close RAM-consuming applications
-- If you have NVIDIA GPU: Ollama uses it automatically
+**"Slow responses"** → Use smaller model (`qwen2.5:3b`), close RAM-heavy apps, NVIDIA GPU is used automatically.
 
-**"Out of memory"**
-- Downgrade to a smaller model (`qwen2.5:1.5b`)
-- Close browser and other heavy apps
-- Consider adding temporary swap
+**"Out of memory"** → Downgrade to `qwen2.5:1.5b`, close browser, consider temporary swap.
 
 ## Quick Reference
 
 ```
-./scripts/emergency-plan.sh           # Preventive pre-download (run with internet)
-./scripts/emergency-setup.sh          # Installation (online or offline with cache)
-./scripts/emergency-status.sh         # System diagnostics
-./scripts/emergency-fallback.sh help  # Operations without LLM
-source ~/.pm-workspace-emergency.env  # Activate emergency mode
+# Linux / macOS                         # Windows (PowerShell)
+./scripts/emergency-plan.sh             .\scripts\emergency-plan.ps1
+./scripts/emergency-setup.sh            .\scripts\emergency-setup.ps1
+./scripts/emergency-status.sh           (check Ollama manually)
+./scripts/emergency-fallback.sh help    (use Git Bash)
+source ~/.pm-workspace-emergency.env    (env vars set automatically)
 ```
 
 ---

--- a/docs/EMERGENCY.md
+++ b/docs/EMERGENCY.md
@@ -9,11 +9,16 @@
 Ejecuta esto **ahora**, mientras tienes conexión, para que todo funcione offline:
 
 ```bash
+# Linux / macOS
 cd ~/claude
 ./scripts/emergency-plan.sh
+
+# Windows (PowerShell)
+cd ~\claude
+.\scripts\emergency-plan.ps1
 ```
 
-Esto pre-descarga el instalador de Ollama y el modelo LLM en caché local (~5-10GB). Si algún día pierdes conexión, `emergency-setup` usará la caché automáticamente. Se sugiere automáticamente la primera vez que arrancas pm-workspace en una máquina nueva.
+Esto pre-descarga el instalador de Ollama y el modelo LLM en caché local (~5-10GB). Soporta Linux (amd64/arm64), macOS (Intel/Apple Silicon) y Windows. Si algún día pierdes conexión, `emergency-setup` usará la caché automáticamente. Se sugiere automáticamente la primera vez que arrancas pm-workspace en una máquina nueva.
 
 ## ¿Cuándo activar el modo emergencia?
 
@@ -28,11 +33,16 @@ Activa el modo emergencia si:
 ### Paso 1: Ejecutar el instalador
 
 ```bash
+# Linux / macOS
 cd ~/claude
 ./scripts/emergency-setup.sh
+
+# Windows (PowerShell)
+cd ~\claude
+.\scripts\emergency-setup.ps1
 ```
 
-El script detectará tu hardware y te guiará por:
+El script detectará automáticamente tu SO y hardware, y te guiará por:
 1. Instalación de Ollama (gestor de LLMs locales)
 2. Descarga del modelo recomendado para tu RAM
 3. Configuración automática de variables
@@ -107,39 +117,25 @@ O simplemente cierra y abre una nueva terminal.
 
 ## Troubleshooting
 
-**"Ollama no instalado"**
-```bash
-curl -fsSL https://ollama.ai/install.sh | sh
-```
+**"Ollama no instalado"** → Linux: `curl -fsSL https://ollama.ai/install.sh | sh` · macOS: re-ejecuta `emergency-setup.sh` · Windows: ejecuta `OllamaSetup.exe` desde la caché.
 
-**"Servidor no responde"**
-```bash
-ollama serve &
-```
+**"Servidor no responde"** → `ollama serve &`
 
-**"Modelo no descargado"**
-```bash
-ollama pull qwen2.5:7b
-```
+**"Modelo no descargado"** → `ollama pull qwen2.5:7b`
 
-**"Respuestas muy lentas"**
-- Usa un modelo más pequeño: `ollama pull qwen2.5:3b`
-- Cierra aplicaciones que consuman RAM
-- Si tienes GPU NVIDIA: Ollama la usa automáticamente
+**"Respuestas lentas"** → Usa modelo menor (`qwen2.5:3b`), cierra apps que consuman RAM, GPU NVIDIA se usa automáticamente.
 
-**"Out of memory"**
-- Baja a un modelo menor (`qwen2.5:1.5b`)
-- Cierra el navegador y otras apps pesadas
-- Considera añadir swap temporal
+**"Out of memory"** → Baja a `qwen2.5:1.5b`, cierra navegador, considera swap temporal.
 
 ## Referencia Rápida
 
 ```
-./scripts/emergency-plan.sh           # Pre-descarga preventiva (ejecutar con internet)
-./scripts/emergency-setup.sh          # Instalación (online u offline con caché)
-./scripts/emergency-status.sh         # Diagnóstico del sistema
-./scripts/emergency-fallback.sh help  # Operaciones sin LLM
-source ~/.pm-workspace-emergency.env  # Activar modo emergencia
+# Linux / macOS                         # Windows (PowerShell)
+./scripts/emergency-plan.sh             .\scripts\emergency-plan.ps1
+./scripts/emergency-setup.sh            .\scripts\emergency-setup.ps1
+./scripts/emergency-status.sh           (revisar Ollama manualmente)
+./scripts/emergency-fallback.sh help    (usar Git Bash)
+source ~/.pm-workspace-emergency.env    (variables configuradas automáticamente)
 ```
 
 ---

--- a/scripts/emergency-plan.ps1
+++ b/scripts/emergency-plan.ps1
@@ -1,0 +1,92 @@
+# emergency-plan.ps1 — Pre-descarga de Ollama y modelo LLM para offline (Windows)
+# Uso: .\scripts\emergency-plan.ps1 [-Model MODEL] [-Check] [-Help]
+param([string]$Model = "", [switch]$Check, [switch]$Help)
+
+$CacheDir = "$env:USERPROFILE\.pm-workspace-emergency"
+$MarkerFile = "$CacheDir\.plan-executed"
+
+if ($Help) {
+    Write-Host "PM-Workspace Emergency Plan — Pre-descarga Ollama + LLM para offline" -ForegroundColor Cyan
+    Write-Host "Uso: .\scripts\emergency-plan.ps1 [-Model MODEL] [-Check]"
+    Write-Host "Modelos: 8GB->qwen2.5:3b | 16GB->qwen2.5:7b | 32GB+->qwen2.5:14b"; exit 0
+}
+if ($Check) {
+    if (Test-Path $MarkerFile) { Write-Host "OK Emergency plan ejecutado ($(Get-Content $MarkerFile))" -ForegroundColor Green; exit 0 }
+    else { Write-Host "Emergency plan NO ejecutado" -ForegroundColor Yellow; exit 1 }
+}
+
+Write-Host "`nPM-Workspace - Emergency Plan (Windows)" -ForegroundColor Cyan
+Write-Host "Pre-descarga de recursos para instalacion offline.`n"
+
+# ── 1. Detectar hardware ─────────────────────────────────────────────────────
+Write-Host "[1/4] Detectando hardware..." -ForegroundColor Blue
+$Arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "x86" }
+$RamGB = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB)
+$GpuName = (Get-CimInstance Win32_VideoController | Select-Object -First 1).Name
+Write-Host "  OS: Windows · Arch: $Arch · RAM: ${RamGB}GB · GPU: $GpuName"
+
+if (-not $Model) {
+    if ($RamGB -ge 32) { $Model = "qwen2.5:14b" }
+    elseif ($RamGB -ge 16) { $Model = "qwen2.5:7b" }
+    else { $Model = "qwen2.5:3b" }
+    Write-Host "  Modelo: $Model (auto)" -ForegroundColor Cyan
+}
+New-Item -ItemType Directory -Force -Path $CacheDir | Out-Null
+
+# ── 2. Descargar Ollama ──────────────────────────────────────────────────────
+Write-Host "`n[2/4] Descargando Ollama para Windows..." -ForegroundColor Blue
+$InstallerPath = "$CacheDir\OllamaSetup.exe"
+
+if (Test-Path $InstallerPath) {
+    Write-Host "  OK Instalador ya en cache" -ForegroundColor Green
+} else {
+    Write-Host "  -> Descargando OllamaSetup.exe..." -ForegroundColor Yellow
+    try {
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri "https://ollama.com/download/OllamaSetup.exe" -OutFile $InstallerPath
+        Write-Host "  OK Instalador descargado" -ForegroundColor Green
+    } catch {
+        Write-Host "  WARN No se pudo descargar instalador: $_" -ForegroundColor Yellow
+    }
+}
+
+# ── 3. Pre-descargar modelo LLM ──────────────────────────────────────────────
+Write-Host "`n[3/4] Pre-descargando modelo $Model..." -ForegroundColor Blue
+$OllamaCmd = Get-Command ollama -ErrorAction SilentlyContinue
+
+if ($OllamaCmd) {
+    $ServerUp = try { (Invoke-WebRequest -Uri "http://localhost:11434/api/tags" -TimeoutSec 3).StatusCode -eq 200 } catch { $false }
+    if ($ServerUp) {
+        $Models = ollama list 2>$null
+        if ($Models -match [regex]::Escape($Model)) {
+            Write-Host "  OK Modelo ya disponible" -ForegroundColor Green
+        } else {
+            Write-Host "  -> Descargando modelo (puede tardar minutos)..." -ForegroundColor Yellow
+            ollama pull $Model
+            Write-Host "  OK Modelo descargado" -ForegroundColor Green
+        }
+    } else {
+        Write-Host "  -> Iniciando Ollama para descargar modelo..." -ForegroundColor Yellow
+        Start-Process ollama -ArgumentList "serve" -WindowStyle Hidden
+        Start-Sleep -Seconds 4
+        ollama pull $Model 2>$null
+        Write-Host "  OK Modelo pre-descargado" -ForegroundColor Green
+    }
+} else {
+    if (Test-Path $InstallerPath) {
+        Write-Host "  WARN Instala Ollama primero: ejecuta $InstallerPath" -ForegroundColor Yellow
+        Write-Host "  Luego re-ejecuta este script para descargar el modelo."
+    } else {
+        Write-Host "  WARN Ollama no instalado. Descarga desde https://ollama.com/download" -ForegroundColor Yellow
+    }
+}
+
+# ── 4. Guardar metadata y marcador ───────────────────────────────────────────
+Write-Host "`n[4/4] Guardando metadata..." -ForegroundColor Blue
+$Meta = @{ executed = (Get-Date -Format "o"); os = "Windows"; arch = $Arch; ram_gb = $RamGB; model = $Model }
+$Meta | ConvertTo-Json | Set-Content "$CacheDir\plan-info.json"
+Get-Date -Format "o" | Set-Content $MarkerFile
+
+Write-Host "`nOK Emergency Plan completado" -ForegroundColor Green
+Write-Host "Cache: $CacheDir · Modelo: $Model" -ForegroundColor Cyan
+Write-Host "Offline: .\scripts\emergency-setup.ps1 (usara cache local)"

--- a/scripts/emergency-plan.sh
+++ b/scripts/emergency-plan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # emergency-plan.sh — Pre-descarga de Ollama y modelo LLM para modo offline
-# Uso: ./scripts/emergency-plan.sh [--model MODEL] [--help]
+# Soporta: Linux (amd64/arm64), macOS (Intel/Apple Silicon), Windows (vía PowerShell)
 set -euo pipefail
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
@@ -8,33 +8,23 @@ BLUE='\033[0;34m'; CYAN='\033[0;36m'; NC='\033[0m'; BOLD='\033[1m'
 
 CACHE_DIR="$HOME/.pm-workspace-emergency"
 MARKER_FILE="$CACHE_DIR/.plan-executed"
-DEFAULT_MODEL="qwen2.5:7b"
 MODEL=""
 
 show_help() {
   echo -e "${BOLD}PM-Workspace Emergency Plan${NC} — Pre-descarga Ollama + LLM para offline"
   echo "Uso: $0 [--model MODEL] [--check] [--help]"
   echo "  --model MODEL  Modelo (default: auto según RAM). --check  Verifica si ya se ejecutó"
-  echo "Modelos: 8GB→qwen2.5:3b | 16GB→qwen2.5:7b | 32GB+→qwen2.5:14b"
+  echo "Soporta: Linux, macOS, Windows (usar .ps1). Modelos: 8GB→3b | 16GB→7b | 32GB+→14b"
   exit 0
 }
 
 check_plan() {
-  if [[ -f "$MARKER_FILE" ]]; then
-    echo -e "${GREEN}✓${NC} Emergency plan ya ejecutado ($(cat "$MARKER_FILE"))"
-    exit 0
-  else
-    exit 1
-  fi
+  [[ -f "$MARKER_FILE" ]] && { echo -e "${GREEN}✓${NC} Emergency plan ejecutado ($(cat "$MARKER_FILE"))"; exit 0; } || exit 1
 }
 
-# Parsear argumentos
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --model) MODEL="$2"; shift 2 ;;
-    --check) check_plan ;;
-    --help|-h) show_help ;;
-    *) shift ;;
+    --model) MODEL="$2"; shift 2 ;; --check) check_plan ;; --help|-h) show_help ;; *) shift ;;
   esac
 done
 
@@ -45,95 +35,81 @@ echo -e "Pre-descarga de recursos para instalación offline.\n"
 echo -e "${BLUE}[1/4]${NC} Detectando hardware..."
 OS="$(uname -s)"
 ARCH="$(uname -m)"
-RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || sysctl -n hw.memsize 2>/dev/null | awk '{print int($1/1024)}' || echo 0)
-RAM_GB=$((RAM_KB / 1024 / 1024))
+
+if [[ "$OS" == "Darwin" ]]; then
+  RAM_BYTES=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+  RAM_GB=$((RAM_BYTES / 1024 / 1024 / 1024))
+else
+  RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo 0)
+  RAM_GB=$((RAM_KB / 1024 / 1024))
+fi
 echo -e "  OS: ${GREEN}$OS${NC} · Arch: ${GREEN}$ARCH${NC} · RAM: ${GREEN}${RAM_GB}GB${NC}"
 
 if [[ -z "$MODEL" ]]; then
   if [[ $RAM_GB -ge 32 ]]; then MODEL="qwen2.5:14b"
   elif [[ $RAM_GB -ge 16 ]]; then MODEL="qwen2.5:7b"
-  else MODEL="qwen2.5:3b"
-  fi
-  echo -e "  Modelo seleccionado automáticamente: ${CYAN}$MODEL${NC}"
+  else MODEL="qwen2.5:3b"; fi
+  echo -e "  Modelo: ${CYAN}$MODEL${NC} (auto)"
 fi
-
 mkdir -p "$CACHE_DIR"
 
-# ── 2. Descargar instalador de Ollama ────────────────────────────────────────
-echo -e "\n${BLUE}[2/4]${NC} Descargando instalador de Ollama..."
-OLLAMA_SCRIPT="$CACHE_DIR/ollama-install.sh"
+# ── 2. Descargar Ollama según OS ─────────────────────────────────────────────
+echo -e "\n${BLUE}[2/4]${NC} Descargando Ollama para ${GREEN}$OS${NC}..."
+OLLAMA_BIN="$CACHE_DIR/ollama-bin"
 
-if [[ "$OS" == "Linux" ]]; then
-  if [[ -f "$OLLAMA_SCRIPT" ]]; then
-    echo -e "  ${GREEN}✓${NC} Instalador ya en caché"
-  else
-    echo -e "  ${YELLOW}→${NC} Descargando script de instalación..."
-    curl -fsSL https://ollama.ai/install.sh -o "$OLLAMA_SCRIPT"
-    chmod +x "$OLLAMA_SCRIPT"
-    echo -e "  ${GREEN}✓${NC} Instalador guardado en ${CYAN}$OLLAMA_SCRIPT${NC}"
-  fi
-
-  # Descargar binario directamente para offline completo
+if [[ -f "$OLLAMA_BIN" ]]; then
+  echo -e "  ${GREEN}✓${NC} Binario Ollama ya en caché"
+elif [[ "$OS" == "Linux" ]]; then
+  # Linux: tar.zst con binario en bin/ollama
   DL_ARCH="$ARCH"; [[ "$ARCH" == "x86_64" ]] && DL_ARCH="amd64"; [[ "$ARCH" == "aarch64" ]] && DL_ARCH="arm64"
-  OLLAMA_BIN="$CACHE_DIR/ollama-bin"
-  if [[ -f "$OLLAMA_BIN" ]]; then
-    echo -e "  ${GREEN}✓${NC} Binario Ollama ya en caché"
-  else
-    echo -e "  ${YELLOW}→${NC} Descargando binario Ollama (tar.zst)..."
-    DOWNLOAD_URL="https://ollama.com/download/ollama-linux-${DL_ARCH}.tar.zst"
-    TMP_TAR="$CACHE_DIR/ollama.tar.zst"
-    curl -fSL "$DOWNLOAD_URL" -o "$TMP_TAR" 2>/dev/null && {
-      TMP_EXTRACT="$CACHE_DIR/_extract"
-      mkdir -p "$TMP_EXTRACT" && tar --zstd -xf "$TMP_TAR" -C "$TMP_EXTRACT" 2>/dev/null
-      FOUND_BIN=$(find "$TMP_EXTRACT" -name "ollama" -type f | head -1)
-      [[ -n "$FOUND_BIN" ]] && cp "$FOUND_BIN" "$OLLAMA_BIN" && chmod +x "$OLLAMA_BIN" || OLLAMA_BIN=""
-      rm -rf "$TMP_EXTRACT" "$TMP_TAR"
-      echo -e "  ${GREEN}✓${NC} Binario extraído y guardado"
-    } || { echo -e "  ${YELLOW}⚠${NC} No se pudo descargar. Se usará script."; rm -f "$TMP_TAR"; OLLAMA_BIN=""; }
-  fi
+  curl -fsSL https://ollama.ai/install.sh -o "$CACHE_DIR/ollama-install.sh" && chmod +x "$CACHE_DIR/ollama-install.sh"
+  TMP_TAR="$CACHE_DIR/ollama.tar.zst"
+  echo -e "  ${YELLOW}→${NC} Descargando ollama-linux-${DL_ARCH}.tar.zst..."
+  curl -fSL "https://ollama.com/download/ollama-linux-${DL_ARCH}.tar.zst" -o "$TMP_TAR" && {
+    TMP_EX="$CACHE_DIR/_extract"; mkdir -p "$TMP_EX"
+    tar --zstd -xf "$TMP_TAR" -C "$TMP_EX" 2>/dev/null
+    FOUND=$(find "$TMP_EX" -name "ollama" -type f | head -1)
+    [[ -n "$FOUND" ]] && cp "$FOUND" "$OLLAMA_BIN" && chmod +x "$OLLAMA_BIN" || OLLAMA_BIN=""
+    rm -rf "$TMP_EX" "$TMP_TAR"
+    echo -e "  ${GREEN}✓${NC} Binario Linux extraído y cacheado"
+  } || { echo -e "  ${YELLOW}⚠${NC} Descarga falló. Se usará script de instalación."; rm -f "$TMP_TAR"; OLLAMA_BIN=""; }
 elif [[ "$OS" == "Darwin" ]]; then
-  echo -e "  ${YELLOW}⚠${NC} macOS: descarga Ollama desde ${CYAN}https://ollama.com/download${NC}"
-  echo -e "  El plan cacheará el modelo una vez Ollama esté instalado."
+  # macOS: tgz con binario ollama en raíz (~70MB)
+  TMP_TGZ="$CACHE_DIR/ollama-darwin.tgz"
+  echo -e "  ${YELLOW}→${NC} Descargando ollama-darwin.tgz..."
+  curl -fSL "https://ollama.com/download/ollama-darwin.tgz" -o "$TMP_TGZ" && {
+    TMP_EX="$CACHE_DIR/_extract"; mkdir -p "$TMP_EX"
+    tar xzf "$TMP_TGZ" -C "$TMP_EX" 2>/dev/null
+    [[ -f "$TMP_EX/ollama" ]] && cp "$TMP_EX/ollama" "$OLLAMA_BIN" && chmod +x "$OLLAMA_BIN" || OLLAMA_BIN=""
+    rm -rf "$TMP_EX" "$TMP_TGZ"
+    echo -e "  ${GREEN}✓${NC} Binario macOS extraído y cacheado"
+  } || { echo -e "  ${YELLOW}⚠${NC} Descarga falló. Instala desde https://ollama.com/download"; rm -f "$TMP_TGZ"; OLLAMA_BIN=""; }
+else
+  echo -e "  ${YELLOW}⚠${NC} SO no soportado por este script. En Windows usa: ${CYAN}scripts/emergency-plan.ps1${NC}"
 fi
 
 # ── 3. Pre-descargar modelo LLM ─────────────────────────────────────────────
 echo -e "\n${BLUE}[3/4]${NC} Pre-descargando modelo ${CYAN}$MODEL${NC}..."
-
 if command -v ollama &>/dev/null; then
-  # Si Ollama ya está instalado, usar ollama pull (guarda en su propio caché)
   if curl -s --max-time 3 http://localhost:11434/api/tags &>/dev/null; then
-    if ollama list 2>/dev/null | grep -q "$MODEL"; then
-      echo -e "  ${GREEN}✓${NC} Modelo ya disponible en Ollama"
-    else
-      echo -e "  ${YELLOW}→${NC} Descargando modelo (puede tardar minutos)..."
-      ollama pull "$MODEL"
-      echo -e "  ${GREEN}✓${NC} Modelo descargado y cacheado por Ollama"
-    fi
+    ollama list 2>/dev/null | grep -q "$MODEL" && echo -e "  ${GREEN}✓${NC} Modelo ya disponible" || {
+      echo -e "  ${YELLOW}→${NC} Descargando modelo..."; ollama pull "$MODEL"; echo -e "  ${GREEN}✓${NC} Modelo descargado"; }
   else
     echo -e "  ${YELLOW}→${NC} Iniciando Ollama para descargar modelo..."
-    ollama serve &>/dev/null &
-    OLLAMA_PID=$!
-    sleep 3
+    ollama serve &>/dev/null & OLLAMA_PID=$!; sleep 3
     ollama pull "$MODEL" 2>/dev/null || echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo ahora"
     kill "$OLLAMA_PID" 2>/dev/null || true
-    echo -e "  ${GREEN}✓${NC} Modelo cacheado"
   fi
+elif [[ -f "${OLLAMA_BIN:-}" ]]; then
+  echo -e "  ${YELLOW}→${NC} Usando binario cacheado para descargar modelo..."
+  "$OLLAMA_BIN" serve &>/dev/null & OLLAMA_PID=$!; sleep 4
+  "$OLLAMA_BIN" pull "$MODEL" 2>/dev/null || {
+    echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo. Se hará en emergency-setup."
+    kill "$OLLAMA_PID" 2>/dev/null || true; }
+  kill "$OLLAMA_PID" 2>/dev/null || true
+  echo -e "  ${GREEN}✓${NC} Modelo pre-descargado"
 else
-  # Ollama no instalado aún — instalar temporalmente para cachear modelo
-  if [[ "$OS" == "Linux" && -f "${OLLAMA_BIN:-}" ]]; then
-    echo -e "  ${YELLOW}→${NC} Usando binario local para descargar modelo..."
-    "$OLLAMA_BIN" serve &>/dev/null &
-    OLLAMA_PID=$!
-    sleep 4
-    "$OLLAMA_BIN" pull "$MODEL" 2>/dev/null || {
-      echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo. Se hará durante emergency-setup."
-      kill "$OLLAMA_PID" 2>/dev/null || true
-    }
-    kill "$OLLAMA_PID" 2>/dev/null || true
-    echo -e "  ${GREEN}✓${NC} Modelo pre-descargado"
-  else
-    echo -e "  ${YELLOW}⚠${NC} Instala Ollama primero para pre-descargar el modelo"
-  fi
+  echo -e "  ${YELLOW}⚠${NC} Instala Ollama primero para pre-descargar el modelo"
 fi
 
 # ── 4. Guardar metadata y marcador ───────────────────────────────────────────
@@ -145,4 +121,4 @@ date -Iseconds > "$MARKER_FILE"
 
 echo -e "\n${GREEN}${BOLD}✓ Emergency Plan completado${NC}"
 echo -e "Caché: ${CYAN}$CACHE_DIR${NC} · Modelo: ${CYAN}$MODEL${NC}"
-echo -e "Si pierdes conexión: ${CYAN}./scripts/emergency-setup.sh${NC} (usará caché local)"
+echo -e "Offline: ${CYAN}./scripts/emergency-setup.sh${NC} (usará caché local)"

--- a/scripts/emergency-setup.ps1
+++ b/scripts/emergency-setup.ps1
@@ -1,0 +1,104 @@
+# emergency-setup.ps1 — Setup rapido de LLM local para modo emergencia (Windows)
+# Uso: .\scripts\emergency-setup.ps1 [-Model MODEL] [-Help]
+param([string]$Model = "qwen2.5:7b", [switch]$Help)
+
+$CacheDir = "$env:USERPROFILE\.pm-workspace-emergency"
+
+if ($Help) {
+    Write-Host "PM-Workspace Emergency Setup — Instala Ollama + LLM local (Windows)" -ForegroundColor Cyan
+    Write-Host "Uso: .\scripts\emergency-setup.ps1 [-Model MODEL]"
+    Write-Host "Modelos: 8GB->qwen2.5:3b | 16GB->qwen2.5:7b (default) | 32GB+->qwen2.5:14b"; exit 0
+}
+
+Write-Host "`nPM-Workspace - Emergency Setup (Windows)" -ForegroundColor Cyan
+
+# ── 1. Detectar sistema y conectividad ───────────────────────────────────────
+Write-Host "`n[1/5] Detectando sistema..." -ForegroundColor Blue
+$Arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "x86" }
+$RamGB = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB)
+$GpuName = (Get-CimInstance Win32_VideoController | Select-Object -First 1).Name
+Write-Host "  OS: Windows · Arch: $Arch · RAM: ${RamGB}GB · GPU: $GpuName"
+
+if ($RamGB -lt 8 -and $Model -eq "qwen2.5:7b") { $Model = "qwen2.5:3b"; Write-Host "  WARN RAM < 8GB, modelo ajustado a $Model" -ForegroundColor Yellow }
+
+$Offline = $false
+try { $null = Invoke-WebRequest -Uri "https://ollama.ai" -TimeoutSec 5 -UseBasicParsing; Write-Host "  Internet: conectado" -ForegroundColor Green }
+catch {
+    $Offline = $true; Write-Host "  Internet: SIN CONEXION" -ForegroundColor Yellow
+    if (Test-Path "$CacheDir\.plan-executed") { Write-Host "  OK Cache local detectada" -ForegroundColor Green }
+    else { Write-Host "  ERROR Sin cache. Ejecuta emergency-plan.ps1 con conexion." -ForegroundColor Red; exit 1 }
+}
+
+# ── 2. Instalar Ollama ──────────────────────────────────────────────────────
+Write-Host "`n[2/5] Verificando Ollama..." -ForegroundColor Blue
+$OllamaCmd = Get-Command ollama -ErrorAction SilentlyContinue
+
+if ($OllamaCmd) {
+    $Ver = ollama --version 2>$null; Write-Host "  OK Ollama instalado ($Ver)" -ForegroundColor Green
+} else {
+    $InstallerPath = "$CacheDir\OllamaSetup.exe"
+    if ($Offline) {
+        if (Test-Path $InstallerPath) {
+            Write-Host "  -> Ejecutando instalador desde cache..." -ForegroundColor Yellow
+            Start-Process -FilePath $InstallerPath -ArgumentList "/SILENT" -Wait
+            # Refrescar PATH
+            $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+            Write-Host "  OK Ollama instalado desde cache" -ForegroundColor Green
+        } else { Write-Host "  ERROR No hay instalador en cache." -ForegroundColor Red; exit 1 }
+    } else {
+        Write-Host "  -> Descargando e instalando Ollama..." -ForegroundColor Yellow
+        $TmpInstaller = "$env:TEMP\OllamaSetup.exe"
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri "https://ollama.com/download/OllamaSetup.exe" -OutFile $TmpInstaller
+        Start-Process -FilePath $TmpInstaller -ArgumentList "/SILENT" -Wait
+        Remove-Item $TmpInstaller -Force -ErrorAction SilentlyContinue
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH", "User")
+        Write-Host "  OK Ollama instalado" -ForegroundColor Green
+    }
+}
+
+# ── 3. Iniciar servidor ─────────────────────────────────────────────────────
+Write-Host "`n[3/5] Verificando servidor Ollama..." -ForegroundColor Blue
+$ServerUp = try { (Invoke-WebRequest -Uri "http://localhost:11434/api/tags" -TimeoutSec 3).StatusCode -eq 200 } catch { $false }
+if ($ServerUp) { Write-Host "  OK Servidor activo en :11434" -ForegroundColor Green }
+else {
+    Write-Host "  -> Iniciando servidor..." -ForegroundColor Yellow
+    Start-Process ollama -ArgumentList "serve" -WindowStyle Hidden; Start-Sleep -Seconds 4
+    $ServerUp = try { (Invoke-WebRequest -Uri "http://localhost:11434/api/tags" -TimeoutSec 3).StatusCode -eq 200 } catch { $false }
+    if ($ServerUp) { Write-Host "  OK Servidor iniciado" -ForegroundColor Green }
+    else { Write-Host "  ERROR No se pudo iniciar. Ejecuta: ollama serve" -ForegroundColor Red; exit 1 }
+}
+
+# ── 4. Verificar/descargar modelo ────────────────────────────────────────────
+Write-Host "`n[4/5] Verificando modelo $Model..." -ForegroundColor Blue
+$Models = ollama list 2>$null
+if ($Models -match [regex]::Escape($Model)) { Write-Host "  OK Modelo disponible" -ForegroundColor Green }
+elseif ($Offline) {
+    if ($Models) {
+        $Available = ($Models | Select-Object -Skip 1 | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1)
+        Write-Host "  WARN $Model no disponible offline. Usando: $Available" -ForegroundColor Yellow; $Model = $Available
+    } else { Write-Host "  ERROR No hay modelos cacheados." -ForegroundColor Red }
+} else {
+    Write-Host "  -> Descargando (puede tardar minutos)..." -ForegroundColor Yellow
+    ollama pull $Model; Write-Host "  OK Modelo descargado" -ForegroundColor Green
+}
+
+# ── 5. Configurar variables ─────────────────────────────────────────────────
+Write-Host "`n[5/5] Configuracion para Claude Code..." -ForegroundColor Blue
+$EnvFile = "$env:USERPROFILE\.pm-workspace-emergency.env"
+@"
+# PM-Workspace Emergency Mode — generado $(Get-Date -Format "o")
+set ANTHROPIC_BASE_URL=http://localhost:11434
+set PM_EMERGENCY_MODEL=$Model
+set PM_EMERGENCY_MODE=active
+"@ | Set-Content $EnvFile
+
+# Tambien configurar variables de entorno del usuario
+[Environment]::SetEnvironmentVariable("ANTHROPIC_BASE_URL", "http://localhost:11434", "User")
+[Environment]::SetEnvironmentVariable("PM_EMERGENCY_MODEL", $Model, "User")
+[Environment]::SetEnvironmentVariable("PM_EMERGENCY_MODE", "active", "User")
+
+Write-Host "  OK Variables configuradas" -ForegroundColor Green
+Write-Host "`nOK Setup completado" -ForegroundColor Green
+Write-Host "Las variables de entorno se han configurado para el usuario actual."
+Write-Host "Estado: .\scripts\emergency-status.sh (en Git Bash) o revisar Ollama manualmente"


### PR DESCRIPTION
## Summary
- Emergency plan/setup now auto-detect OS (Linux, macOS, Windows)
- **Linux**: downloads `ollama-linux-{amd64,arm64}.tar.zst`, extracts binary
- **macOS**: downloads `ollama-darwin.tgz` (~70MB), extracts binary. Online install via tgz extraction
- **Windows**: new PowerShell scripts (`emergency-plan.ps1`, `emergency-setup.ps1`). Downloads `OllamaSetup.exe`, silent install, WMI hardware detection, env vars via `[Environment]::SetEnvironmentVariable`
- Updated emergency docs (ES/EN) with multi-OS commands and quick reference
- Updated command docs with PS1 examples

## Test plan
- [x] Verified `ollama-darwin.tgz` downloads and contains `ollama` binary at root
- [x] Verified `ollama-linux-amd64.tar.zst` downloads and extracts to `bin/ollama`
- [x] Verified `OllamaSetup.exe` exists in GitHub releases
- [x] All scripts under 150-line limit
- [x] All docs under 150-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)