### PR TITLE
fix(emergency): macOS compatibility and emulator validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ Multi-OS emergency mode: full support for Linux, macOS, and Windows. Auto-detect
 
 **`scripts/emergency-setup.sh`** — Added macOS support: online installation via `ollama-darwin.tgz` extraction, offline installation from cache binary. macOS-specific PATH guidance. Improved GPU detection (Apple Silicon Metal).
 
+### Fixed
+
+**macOS compatibility** — Replaced GNU-specific `date -Iseconds` with portable `iso_date()` function that falls back to `date -u` on macOS. Fixed `&;` syntax error in setup script.
+
+**Validated with emulators** — PowerShell Core (pwsh 7.4.6) for Windows PS1 syntax/execution, bash syntax checker and macOS-specific pattern analysis for shell scripts.
+
 ---
 
 ## [0.32.2] — 2026-02-28

--- a/scripts/emergency-plan.sh
+++ b/scripts/emergency-plan.sh
@@ -9,6 +9,7 @@ BLUE='\033[0;34m'; CYAN='\033[0;36m'; NC='\033[0m'; BOLD='\033[1m'
 CACHE_DIR="$HOME/.pm-workspace-emergency"
 MARKER_FILE="$CACHE_DIR/.plan-executed"
 MODEL=""
+iso_date() { date -Iseconds 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%S+00:00"; }
 
 show_help() {
   echo -e "${BOLD}PM-Workspace Emergency Plan${NC} — Pre-descarga Ollama + LLM para offline"
@@ -115,9 +116,9 @@ fi
 # ── 4. Guardar metadata y marcador ───────────────────────────────────────────
 echo -e "\n${BLUE}[4/4]${NC} Guardando metadata..."
 cat > "$CACHE_DIR/plan-info.json" << JSONEOF
-{"executed":"$(date -Iseconds)","os":"$OS","arch":"$ARCH","ram_gb":$RAM_GB,"model":"$MODEL"}
+{"executed":"$(iso_date)","os":"$OS","arch":"$ARCH","ram_gb":$RAM_GB,"model":"$MODEL"}
 JSONEOF
-date -Iseconds > "$MARKER_FILE"
+iso_date > "$MARKER_FILE"
 
 echo -e "\n${GREEN}${BOLD}✓ Emergency Plan completado${NC}"
 echo -e "Caché: ${CYAN}$CACHE_DIR${NC} · Modelo: ${CYAN}$MODEL${NC}"

--- a/scripts/emergency-setup.sh
+++ b/scripts/emergency-setup.sh
@@ -7,6 +7,7 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
 BLUE='\033[0;34m'; CYAN='\033[0;36m'; NC='\033[0m'; BOLD='\033[1m'
 
 DEFAULT_MODEL="qwen2.5:7b"; MODEL=""
+iso_date() { date -Iseconds 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%S+00:00"; }
 [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && {
   echo -e "${BOLD}PM-Workspace Emergency Setup${NC} — Instala Ollama + LLM local"
   echo "Uso: $0 [--model MODEL]. Soporta Linux/macOS. Windows: usar .ps1"
@@ -91,7 +92,8 @@ if curl -s http://localhost:11434/api/tags &>/dev/null; then
   echo -e "  ${GREEN}✓${NC} Servidor activo en :11434"
 else
   echo -e "  ${YELLOW}→${NC} Iniciando servidor..."
-  ollama serve &>/dev/null &; sleep 3
+  ollama serve &>/dev/null &
+  sleep 3
   curl -s http://localhost:11434/api/tags &>/dev/null \
     && echo -e "  ${GREEN}✓${NC} Servidor iniciado" \
     || { echo -e "  ${RED}✗${NC} No se pudo iniciar. Ejecuta: ollama serve"; exit 1; }
@@ -115,7 +117,7 @@ fi
 echo -e "\n${BLUE}[5/5]${NC} Configuración para Claude Code..."
 ENV_FILE="$HOME/.pm-workspace-emergency.env"
 cat > "$ENV_FILE" << ENVEOF
-# PM-Workspace Emergency Mode — generado $(date -Iseconds)
+# PM-Workspace Emergency Mode — generado $(iso_date)
 export ANTHROPIC_BASE_URL="http://localhost:11434"
 export PM_EMERGENCY_MODEL="$MODEL"
 export PM_EMERGENCY_MODE="active"


### PR DESCRIPTION
## Summary
- Replace GNU `date -Iseconds` with portable `iso_date()` that falls back to `date -u` on macOS
- Fix `&;` syntax error in emergency-setup.sh (line 95)
- Updated CHANGELOG with validation details

## Validation performed
- **Windows**: PowerShell Core 7.4.6 — syntax parse OK, dry-run execution OK (hardware detection, metadata, env vars)
- **macOS**: Bash syntax check OK, pattern analysis for macOS-specific issues (no /proc, no GNU date, no bash 4+ features outside Linux guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)