### PR TITLE
fix(compliance): improve commands after testing v0.33.1

### DIFF
--- a/.claude/commands/compliance-scan.md
+++ b/.claude/commands/compliance-scan.md
@@ -6,7 +6,7 @@ agent: architect
 context_cost: medium
 ---
 
-# /compliance-scan {path} [--sector SECTOR] [--strict]
+# /compliance-scan {path} [--sector SECTOR] [--strict] [--lang es|en]
 
 > Detecta el sector regulatorio del proyecto, carga las normativas aplicables y verifica el cumplimiento del código fuente.
 
@@ -17,6 +17,7 @@ context_cost: medium
 - `{path}` — Ruta del proyecto a escanear (default: proyecto actual)
 - `--sector SECTOR` — Forzar sector (saltar detección): healthcare, finance, food, justice, public-admin, insurance, pharma, energy, telecom, education, defense, transport
 - `--strict` — Incluir hallazgos MEDIUM y LOW (default: solo CRITICAL y HIGH)
+- `--lang` — Idioma del informe: `es` (default) o `en`. Detectar de CLAUDE.md si existe.
 
 ## Prerequisitos
 
@@ -62,38 +63,38 @@ Asignar severidad según la matriz del SKILL.md:
 
 ### Paso 6 — Asignar IDs y acciones
 Cada hallazgo recibe un ID (formato: `RC-{NNN}`).
-Determinar si tiene auto-fix disponible (ver plantillas en SKILL.md).
+Marcar cada hallazgo con: `[AUTO-FIX]` o `[MANUAL]` según disponibilidad de corrección automática.
 
-### Paso 7 — Generar informe
+### Paso 7 — Calcular score y generar informe
+
+**Fórmula de compliance score**: `Score = (requisitos cumplidos / total requisitos) × 100`
 
 ## Output
 
-Guardar en: `output/compliance/{proyecto}-scan-{fecha}.md`
+Guardar en: `output/compliance/{proyecto}-scan-{fecha}.md` (fecha obligatoria en nombre)
 
 ```markdown
 # Compliance Scan — {proyecto}
 
 **Sector**: {sector} ({score}% confianza)
 **Fecha**: {ISO date}
-**Compliance Score**: {X}%
+**Compliance Score**: {X}% ({cumplidos}/{total} requisitos)
 
 ## Resumen
-| Severidad | Count |
-|-----------|-------|
-| CRITICAL  | N     |
-| HIGH      | N     |
-| MEDIUM    | N     |
-| LOW       | N     |
+| Severidad | Count | Auto-fix | Manual |
+|-----------|-------|----------|--------|
+| CRITICAL  | N     | N        | N      |
+| HIGH      | N     | N        | N      |
 
 ## Hallazgos
 
-### RC-001 [CRITICAL] {Regulación} §{artículo} — {descripción}
+### RC-001 [CRITICAL] [AUTO-FIX] {Regulación} §{artículo} — {descripción}
 **Ficheros afectados**: {lista}
 **Requisito**: {qué exige la norma}
 **Estado actual**: {qué se encontró en el código}
-**Acción**: `/compliance-fix RC-001` (auto-fix disponible)
+**Acción**: `/compliance-fix RC-001`
 
-### RC-002 [HIGH] {Regulación} — {descripción}
+### RC-002 [HIGH] [MANUAL] {Regulación} — {descripción}
 **Ficheros afectados**: {lista}
 **Acción**: Generar Task para corrección manual
 
@@ -111,3 +112,4 @@ Guardar en: `output/compliance/{proyecto}-scan-{fecha}.md`
 - El scan NO modifica código. Solo analiza y reporta.
 - Los IDs RC-XXX son estables para referencia en `/compliance-fix`.
 - Si el proyecto usa IA, considerar también `/ai-risk-assessment` para EU AI Act.
+- Usar mismo idioma (--lang) en scan, fix y report para consistencia.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.33.1] — 2026-02-28
+
+Compliance commands improvements after real-world testing with HealthPatientApi (.NET 10).
+
+### Fixed
+- Output file naming now requires date suffix (`{proyecto}-scan-{fecha}.md`) for historical comparison
+- Scoring formula documented: `Score = (requisitos cumplidos / total) × 100`
+- Dry-run vs actual execution clearly indicated in fix output header
+- Language consistency enforced: `--lang es|en` parameter added to scan and report
+
+### Changed
+- `/compliance-scan`: findings now marked `[AUTO-FIX]` or `[MANUAL]` for quick triage
+- `/compliance-scan`: summary table includes auto-fix/manual column split
+- `/compliance-fix`: includes configuration keys section (appsettings keys required)
+- `/compliance-fix`: re-verification includes sample output per fix
+- `/compliance-fix`: score recalculation after fixes
+- `/compliance-report`: score formula shown in header (`{N}/{M} requisitos`)
+
+### Added
+- Test project: gonzalezpazmonica/health-patient-api (.NET 10, healthcare sector)
+- Full compliance flow validated: scan → fix → report with 38 findings detected
+
+---
+
 ## [0.33.0] — 2026-02-28
 
 Regulatory Compliance Intelligence: automated sector detection, compliance scanning, and auto-fix with re-verification across 12 regulated industries.


### PR DESCRIPTION
## Summary

- Improved compliance commands after real-world testing on [health-patient-api](https://github.com/gonzalezpazmonica/health-patient-api) (.NET 10)
- Added `--lang es|en` parameter for language consistency across scan/fix/report
- Documented scoring formula and made output naming include dates
- Findings now marked `[AUTO-FIX]` or `[MANUAL]` for quick triage
- Fix output includes config keys section and sample verification output

## Test plan

- [x] Full flow tested: `/compliance-scan` → `/compliance-fix` → `/compliance-report`
- [x] Healthcare sector detected at 65 points (98% confidence)
- [x] 38 findings classified (18 CRITICAL, 12 HIGH, 5 MEDIUM, 3 LOW)
- [x] 4 auto-fixes applied (encryption, audit, RBAC, consent)
- [x] Project compiles with 0 errors, 0 warnings after fixes
- [x] All commands ≤150 lines (scan: 115, fix: 90, report: 93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)