### PR TITLE
fix(ci): make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
           chmod +x scripts/test-workspace.sh
           ./scripts/test-workspace.sh --mock
 
+      - name: Delete existing release if present
+        run: gh release delete "${{ steps.version.outputs.VERSION }}" --yes 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

- Release workflow failed on v0.73.0 ([run #22577297756](https://github.com/gonzalezpazmonica/pm-workspace/actions/runs/22577297756)) because the release was already created manually via `gh release create`
- Added a step to delete any existing release before creating, making the workflow idempotent
- Works correctly whether release is created manually first or only by CI

## Test plan

- [x] Verified v0.73.0 release exists and was created manually
- [x] New step uses `|| true` so it won't fail if no prior release exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)