### PR TITLE
docs: Savia Flow implementation example (SocialApp)

### DIFF
--- a/docs/savia-flow/00-indice.md
+++ b/docs/savia-flow/00-indice.md
@@ -114,6 +114,29 @@ Preguntas frecuentes de PMs sobre Savia Flow:
 
 **Público objetivo:** Todos (especialmente PMs en evaluación)
 
+### **12. 12-ejemplo-implantacion-inicio.md** (~150 líneas)
+Ejemplo práctico completo — Fase 1: Inicio del proyecto SocialApp:
+- Configuración Azure DevOps con `/flow-setup`
+- Definición del equipo y roles Savia Flow
+- Primer ciclo de exploración: outcomes, specs, JTBD
+- Primer intake a producción con descomposición en tasks
+
+### **13. 13-ejemplo-implantacion-dia-a-dia.md** (~145 líneas)
+Ejemplo práctico — Fase 2: Dual-track en acción:
+- Sync semanal con métricas y intake
+- Quality gates en funcionamiento (5 niveles)
+- Coordinación front↔back con API contract first
+- Detección de bottlenecks con `/flow-board`
+
+### **14. 14-ejemplo-implantacion-release.md** (~146 líneas)
+Ejemplo práctico — Fase 3: Release y mejora continua:
+- Pre-release readiness y deploy pipeline
+- Validación de outcomes con métricas reales
+- Retro mensual con datos y acciones concretas
+- Métricas finales del MVP (12 semanas) y lecciones aprendidas
+
+**Público objetivo:** Todos (caso práctico end-to-end con equipo real)
+
 ---
 
 ## Cómo Usar Esta Suite
@@ -134,7 +157,8 @@ Preguntas frecuentes de PMs sobre Savia Flow:
 2. Aprende los Roles Evolucionados (04)
 3. Domina las Métricas de Flujo (05)
 4. Implementa Spec-Driven Development (06) y Quality Gates (07)
-5. Usa el Glosario (09) como referencia
+5. Sigue el ejemplo práctico completo (12, 13, 14) paso a paso
+6. Usa el Glosario (09) como referencia
 
 ### Para Especialistas Técnicos
 1. Lee el Whitepaper enfocándose en Los 7 Pilares (01)

--- a/docs/savia-flow/12-ejemplo-implantacion-inicio.md
+++ b/docs/savia-flow/12-ejemplo-implantacion-inicio.md
@@ -1,0 +1,147 @@
+# Ejemplo de Implantación: SocialApp — Fase 1: Inicio
+
+> Caso práctico completo: desde la decisión de crear una red social hasta el primer spec en producción.
+> Equipo: Mónica (CEO/CTO), Elena (Producto/QA), Ana (Front mid-junior), Isabel (Back senior).
+
+---
+
+## Semana 0 — La decisión
+
+Mónica decide construir SocialApp, una red social tipo Twitter. Stack: Ionic (Android/Web/iOS), microservicios Node.js, API Gateway, MongoDB, RabbitMQ. Elena será producto y QA. Ana hará front con Ionic. Isabel llevará back y arquitectura.
+
+### Paso 1: Mónica configura el entorno
+
+```
+Mónica → /flow-setup --project SocialApp --plan
+```
+
+**Savia responde** con el plan de configuración de Azure DevOps: 8 columnas de board (3 exploración + 5 producción), 4 campos custom (Track, Outcome ID, Cycle Time Start/End), 2 area paths. Mónica revisa y confirma:
+
+```
+Mónica → /flow-setup --project SocialApp --execute
+```
+
+Savia crea todo en Azure DevOps. El tablero dual-track queda:
+
+```
+EXPLORACIÓN                          │ PRODUCCIÓN
+Discovery → Spec-Writing → Spec-Ready│ Ready → Building → Gates → Deployed → Validating
+```
+
+### Paso 2: Mónica define el equipo y sus roles
+
+```
+Mónica → /profile-setup
+```
+
+Savia hace onboarding conversacional. Mónica configura: ella misma como Flow Facilitator (métricas, desbloqueo), Elena como AI PM + Quality Architect (WIP 3, discovery + specs + gates), Ana como Pro Builder Front (WIP 2, Ionic), Isabel como Pro Builder Back + Arch (WIP 2, APIs + MongoDB + RabbitMQ).
+
+### Paso 3: Elena define los outcomes
+
+```
+Elena → /pbi-jtbd
+```
+
+Savia guía el discovery con Jobs To Be Done. Elena define 4 outcomes (Epics): (1) User Onboarding — registro <3 min, 70% completion, mes 1. (2) Social Feed — timeline <500ms p95, mes 1-2. (3) Real-time Messaging — entrega <1s, mes 2-3. (4) Notifications — engagement +30%, mes 3.
+
+```
+Elena → /pbi-prd
+```
+
+Savia genera PRD por outcome. Elena revisa, ajusta y crea Epics en Azure DevOps.
+
+### Paso 4: Mónica valida la capacidad
+
+```
+Mónica → /capacity-forecast --sprints 6
+```
+
+Savia calcula: 2 builders × 6h efectivas/día × 10 días/sprint = 120h/sprint. Con el stack definido (Ionic + microservicios + RabbitMQ), estima 4-6 specs por outcome. Timeline realista: 3 meses para MVP.
+
+---
+
+## Semana 1 — Primer ciclo de exploración
+
+### Elena escribe las primeras specs
+
+Elena empieza por el Outcome 1 (User Onboarding). Pide ayuda a Savia:
+
+```
+Elena → /flow-spec --outcome "User Onboarding"
+```
+
+Savia genera un stub de spec con las 5 secciones:
+1. **Outcome**: referencia al Epic + métricas de éxito
+2. **Functional Spec**: escenarios Given/When/Then
+3. **Technical Constraints**: stack, performance, seguridad
+4. **Dependencies**: qué servicios necesita
+5. **Definition of Done**: checklist verificable
+
+Elena completa la spec "User Registration" con los detalles de negocio. Savia la crea como User Story en Azure DevOps en la columna **Spec-Writing** con Area Path = Exploration.
+
+```
+Elena → /flow-spec --outcome "User Onboarding"
+```
+
+Repite para "Profile Setup Wizard". Ahora tiene 2 specs en Spec-Writing.
+
+### Isabel consulta las restricciones técnicas
+
+Isabel revisa las specs en progreso para validar viabilidad:
+
+```
+Isabel → /flow-board --track exploration
+```
+
+Savia muestra el track de exploración. Isabel ve que "User Registration" necesita auth-service con bcrypt + OAuth2. Comenta en la User Story: "Necesitamos JWT + refresh tokens. Propongo auth-service como primer microservicio."
+
+### Elena marca specs como Spec-Ready
+
+Cuando Elena termina una spec completa (outcome claro, métricas, Given/When/Then, constraints técnicas validadas por Isabel, DoD testable), la mueve a **Spec-Ready**:
+
+```
+Elena cambia el estado → Spec-Ready (en Azure DevOps)
+```
+
+---
+
+## Semana 1 — Primer intake a producción
+
+### Mónica hace el intake semanal
+
+En el sync del lunes (30 min), Mónica ejecuta:
+
+```
+Mónica → /flow-intake
+```
+
+Savia muestra los items Spec-Ready:
+```
+📋 Items Spec-Ready: 2
+  #1001 User Registration — Outcome: User Onboarding
+  #1002 Profile Setup Wizard — Outcome: User Onboarding
+
+👥 Capacidad builders:
+  Ana (Front): 0/2 WIP ✅
+  Isabel (Back): 0/2 WIP ✅
+
+📌 Asignación propuesta:
+  #1001 → Isabel (back: auth-service) + Ana (front: registration page)
+  #1002 → Ana (front: profile wizard) — esperar a que #1001 esté en Gates
+```
+
+Mónica confirma. Savia mueve los items: Area Path Exploration → Production, estado → Ready.
+
+### Isabel descompone la spec en tasks
+
+Isabel recibe la spec #1001 y pide a Savia que la descomponga:
+
+```
+Isabel → /pbi-decompose --id 1001
+```
+
+Savia genera tasks con estimación:
+
+Savia genera 10 tasks: setup auth-service (4h, Isabel), modelo User + bcrypt (3h, Isabel), endpoints register/login (4h, Isabel), OAuth2 Google (6h, Isabel), Ionic registration page (4h, Ana), integración API (3h, Ana), OAuth2 Capacitor (4h, Ana), event RabbitMQ (2h, Isabel), tests unitarios (3h, Isabel), E2E (3h, Ana). Total: 36h (~3.5 días con 2 personas en paralelo). Isabel confirma y Savia crea los tasks en Azure DevOps.
+
+> **Continúa en** [13-ejemplo-implantacion-dia-a-dia.md](13-ejemplo-implantacion-dia-a-dia.md)

--- a/docs/savia-flow/13-ejemplo-implantacion-dia-a-dia.md
+++ b/docs/savia-flow/13-ejemplo-implantacion-dia-a-dia.md
@@ -1,0 +1,145 @@
+# Ejemplo de Implantación: SocialApp — Fase 2: Día a Día
+
+> El flujo dual-track en acción: exploración y producción en paralelo, specs, gates, coordinación.
+> Continuación de [12-ejemplo-implantacion-inicio.md](12-ejemplo-implantacion-inicio.md).
+
+---
+
+## Semana 2 — Dual-track en paralelo
+
+El equipo ya tiene ritmo: Elena explora y escribe specs mientras Ana e Isabel construyen.
+
+### Lunes: sync semanal (30 min)
+
+Mónica abre la reunión con métricas:
+
+```
+Mónica → /flow-metrics
+```
+
+Savia muestra: Cycle Time 4 días (target 3-7 ✅), Throughput 2 items/semana (arrancando), Spec-Ready buffer 1 item (⚠️ target ≥3). Mónica detecta el problema: Elena necesita acelerar exploración.
+
+```
+Mónica → /flow-intake
+```
+
+Savia muestra 1 item Spec-Ready: "Profile Setup Wizard" (#1002). Ana tiene 1/2 WIP. Savia asigna #1002 → Ana. Mónica confirma.
+
+**Decisión del sync**: Elena dedica 80% a exploración esta semana (buffer <3).
+
+### Martes-Jueves: cada rol en acción
+
+**Elena (exploración)** escribe specs del Outcome 2 (Social Feed):
+
+```
+Elena → /flow-spec --outcome "Social Feed"
+```
+
+Savia genera stub para "Timeline Feed". Elena completa: feed por follows + algoritmo, carga <500ms p95, Redis cache TTL 60s, MongoDB aggregation pipeline, event post.created → RabbitMQ. Escenarios Given/When/Then: feed vacío (nuevo usuario), feed con 1000+ posts (paginación), post con imagen (preview async).
+
+Elena consulta con Isabel antes de marcar Spec-Ready:
+
+```
+Elena → "Isabel, ¿es viable MongoDB aggregation + Redis para el timeline?"
+Isabel → "Sí, pero necesitamos índice compuesto en follows + created_at. Y el cache TTL debería ser 30s, no 60."
+Elena → Actualiza spec, marca Spec-Ready ✅
+```
+
+**Ana (producción)** construye el Profile Setup Wizard (#1002):
+
+```
+Ana → /my-focus
+```
+
+Savia muestra: "Profile Setup Wizard — Ionic wizard 3 pasos (avatar, bio, interests). Spec #1002. Tasks: Ionic wizard component (4h), upload avatar con Capacitor (3h), integración user-service API (2h), tests E2E (2h)."
+
+Ana trabaja en el wizard. Cuando completa los tasks, mueve el item a **Gates**.
+
+**Isabel (producción)** termina auth-service (#1001) y lo pasa a Gates:
+
+```
+Isabel → mueve #1001 a Gates
+```
+
+### Los Quality Gates en acción
+
+Cuando un item llega a **Gates**, Savia ejecuta la validación automática:
+
+```
+Savia (automático al mover a Gates) →
+  Gate 1: Lint + format ✅ (2s)
+  Gate 2: Unit tests 87% coverage ✅ (12s)
+  Gate 3: Integration tests — auth-service + MongoDB ✅ (45s)
+  Gate 4: Security — bcrypt rounds OK, rate limiting OK, CORS ✅ (30s)
+  Gate 5: Pendiente review humano → asignar a Elena (QA)
+```
+
+**Elena (QA)** recibe la notificación de Gate 5:
+
+```
+Elena → revisa #1001 User Registration
+  ✅ Flujo email registration: OK
+  ✅ Flujo OAuth Google: OK
+  ⚠️ Falta: mensaje de error cuando email ya registrado no es claro
+  → Crea Bug #1010 vinculado a #1001, asigna a Isabel (2h)
+```
+
+Elena mueve #1001 a **Deployed** (con el bug como follow-up, no bloquea deploy a DEV).
+
+---
+
+## Semana 3 — Coordinación front ↔ back
+
+### El patrón "API contract first"
+
+Isabel empieza la spec "Timeline Feed" (#1003). El front (Ana) necesita el API para construir la pantalla. Savia facilita:
+
+```
+Isabel → /pbi-decompose --id 1003
+```
+
+Tasks generados: 1.1 modelo Post + MongoDB (4h, Isabel), 1.2 GET /feed + paginación (4h, Isabel) ← **API contract**, 1.3 event post.created → RabbitMQ (3h, Isabel), 2.1 Ionic timeline + infinite scroll (6h, Ana) ← depende de 1.2, 2.2 integración API (3h, Ana) ← depende de 1.2.
+
+**Clave**: Isabel entrega el **API contract** (task 1.2) primero. Ana puede empezar con mock mientras Isabel implementa, y conectar cuando el endpoint esté listo.
+
+```
+Isabel → completa task 1.2 (API contract publicado en Swagger)
+Isabel → avisa a Ana: "GET /feed listo en DEV, Swagger actualizado"
+Ana → cambia de mock a API real, continúa con infinite scroll
+```
+
+### Cómo Savia ayuda a detectar bloqueos
+
+Jueves, Mónica hace check rápido:
+
+```
+Mónica → /flow-board
+```
+
+Savia muestra:
+
+```
+EXPLORACIÓN                              │ PRODUCCIÓN
+Discovery   Spec-Writing   Spec-Ready    │ Ready    Building    Gates     Deployed
+────────────────────────────────────────────────────────────────────────────────────
+DMs (#1005)  Reactions(#1004)  ──         │  ──     Timeline   Profile    Registration
+                                         │          (#1003)   (#1002)    (#1001)
+                                         │         Ana+Isabel  Ana 🔴     ──
+
+⚠️ Spec-Ready buffer: 0 items — Elena debe priorizar exploración
+⚠️ Ana: Profile (#1002) en Gates >2 días — verificar Gate 5
+```
+
+Mónica actúa: "Elena, ¿puedes marcar Spec-Ready la de Reactions hoy? Ana se va a quedar sin trabajo pronto." Elena acelera.
+
+---
+
+## Cómo se ve una semana tipo
+
+**Lun**: Sync 30min (todos) → Mónica: `/flow-metrics` + `/flow-intake`. **Mar-Jue**: Elena en discovery/specs, Ana+Isabel building, Mónica oversight + desbloqueo. Mónica hace spec review con Elena el miércoles. El jueves `/flow-board` para detectar stuck. **Vie**: Elena QA gates, Ana+Isabel PR review + deploy DEV, Mónica métricas.
+
+### Interacción con agentes
+
+Isabel genera specs ejecutables para agentes: `/spec-generate --task 1003-1 --type agent-single`. Savia genera spec para feed-service, Isabel revisa contrato y lanza al agente. Ana usa `/spec-generate --task 1003-2 --type human` (tipo human porque el infinite scroll tiene matices UX).
+
+> **Continúa en** [14-ejemplo-implantacion-release.md](14-ejemplo-implantacion-release.md)

--- a/docs/savia-flow/14-ejemplo-implantacion-release.md
+++ b/docs/savia-flow/14-ejemplo-implantacion-release.md
@@ -1,0 +1,146 @@
+# Ejemplo de Implantación: SocialApp — Fase 3: Release y Mejora
+
+> Del primer deploy a producción al ciclo de mejora continua. Métricas, retro y lecciones.
+> Continuación de [13-ejemplo-implantacion-dia-a-dia.md](13-ejemplo-implantacion-dia-a-dia.md).
+
+---
+
+## Semana 4 — Primer release a producción
+
+### Pre-release: Mónica verifica readiness
+
+```
+Mónica → /release-readiness --project SocialApp
+```
+
+Savia audita: 3 specs deployed, gates pasados (lint, tests, security, QA review), bug #1010 resuelto, health checks OK. Resultado: ✅ Release readiness PASS. 3 features en DEV, 0 bugs abiertos. ⚠️ Recomendado: tests de carga antes de PRO.
+
+### Deploy pipeline: DEV → PRE → PRO
+
+Isabel verifica con `/pipeline-status`: Build ✅ → Tests ✅ → DEV ✅ (auto) → PRE ⏳. Mónica aprueba PRE. Elena ejecuta tests de aceptación, aprueba. Mónica aprueba PRO (doble gate: PM + PO).
+
+### Post-deploy: validación de outcomes
+
+Una vez en PRO, Elena valida que los outcomes se cumplen:
+
+```
+Elena → /outcome-track --epic "User Onboarding"
+```
+
+Savia muestra métricas reales vs target:
+
+```
+📊 Outcome: User Onboarding
+  Signup completion: 68% (target 70%) — ⚠️ casi, monitorizar 1 semana
+  Time to first post: 2.5 min (target <3 min) — ✅
+  Bounce rate registro: 32% (target <30%) — ⚠️ close, revisar UX
+```
+
+Elena decide: el outcome necesita una iteración más. Crea nueva spec en exploración: "Onboarding UX Optimization" → simplificar formulario, A/B test.
+
+---
+
+## Mes 1 — Retro mensual (90 min)
+
+### Mónica facilita con datos
+
+```
+Mónica → /flow-metrics --trend 4
+Mónica → /retro-patterns --sprints 4
+```
+
+Savia genera el dashboard del primer mes:
+
+```
+📊 Métricas mes 1:
+  Cycle Time: 4.5d → 3.8d (mejorando ✅)
+  Lead Time: 12d → 9d (mejorando ✅)
+  Throughput: 2 → 3 items/semana (creciendo ✅)
+  CFR: 0% (2 deploys sin incidentes ✅)
+  Spec-Ready buffer: 1 → 3 (estabilizado ✅)
+  Rework rate: 20% → 12% (specs reducen retrabajo ✅)
+```
+
+Savia también identifica patrones:
+
+```
+🔍 Patrones detectados:
+  ✅ API contract first funciona — 0 bloqueos front↔back en semana 3-4
+  ⚠️ Elena saturada en gates — considerar automatizar Gate 5 parcialmente
+  ⚠️ Ana necesita más specs front-only — exploración muy back-heavy
+  💡 Isabel podría hacer pair con Ana en componentes complejos Ionic
+```
+
+### El equipo decide
+
+Acciones: (1) Elena automatiza parte de Gate 5 con checklist — solo items complejos requieren review manual. (2) Elena incluye más specs front-only en exploración. (3) Isabel dedica 2h/semana a pair programming con Ana en patrones Ionic avanzados.
+
+---
+
+## Mes 2-3 — El flujo maduro
+
+### Cómo se ve el board en el mes 2
+
+```
+Mónica → /flow-board
+```
+
+```
+EXPLORACIÓN                              │ PRODUCCIÓN
+Discovery    Spec-Writing   Spec-Ready   │ Ready    Building    Gates     Deployed
+─────────────────────────────────────────────────────────────────────────────────
+Push(#1012)  Groups(#1011)  DMs(#1007)   │ React.   Mentions   Notif.    Timeline
+             Notif.C(#1009) Reac.(#1006) │ (#1008)  (#1005)    (#1004)   Feed, Reg
+                                         │                               Profile
+```
+
+Buffer Spec-Ready: 2 items (saludable). Pipeline fluido. Elena ha encontrado su ritmo: 2-3 specs/semana.
+
+### El ritmo del equipo estabilizado
+
+Cada persona ha interiorizado su flujo con Savia:
+
+**Mónica** (15 min/día): `/flow-board` por la mañana, `/flow-metrics` los lunes. Interviene solo cuando hay bottleneck o decisión de prioridad. El resto del tiempo hace trabajo de CEO/CTO.
+
+**Elena** (discovery 60%, gates 40%): abre sesión con `/flow-spec` para escribir specs. Cuando hay items en Gates, cambia a QA. Si el buffer Spec-Ready baja de 3, prioriza exploración.
+
+**Ana** (100% building): abre sesión con `/my-focus` para ver su siguiente item. Usa `/spec-generate --type human` para specs de componentes Ionic. Cuando termina, mueve a Gates.
+
+**Isabel** (90% building, 10% arch): igual que Ana pero con microservicios. Consulta arquitectura cuando Elena le pide revisar restricciones técnicas de specs. Entrega API contracts primero para no bloquear a Ana.
+
+---
+
+## Release final: MVP en producción
+
+### Semana 12 — Cierre del MVP
+
+```
+Mónica → /flow-metrics --trend 12
+```
+
+Métricas finales del proyecto:
+
+```
+📊 SocialApp MVP — 12 semanas
+  Features deployed: 12 (4 outcomes completos)
+  Cycle Time: 3.2 días (media)
+  Lead Time: 8 días (media)
+  Throughput: 3.5 items/semana (estable)
+  CFR: 2% (1 incidente menor en 50 deploys)
+  Rework rate: 8% (vs 60%+ sin specs)
+  Specs escritas: 14 | Rechazadas: 1 | Iteradas: 3
+```
+
+```
+Mónica → /ceo-report --project SocialApp
+```
+
+Savia genera informe ejecutivo: MVP entregado en plazo, 4 outcomes validados, equipo de 4 personas. Stack completo funcionando: Ionic + 5 microservicios + RabbitMQ + MongoDB.
+
+### Lecciones aprendidas
+
+**Lo que funcionó**: specs ejecutables eliminaron 80% de ambigüedad (agentes correctos a la primera 85%), API contract first eliminó bloqueos front↔back desde semana 3, buffer Spec-Ready como indicador de salud del flujo, gates automáticos capturaron 12 bugs antes de QA humano.
+
+**Lo que ajustamos**: Isabel subió WIP de 2 a 3 en mes 2 (microservicios pequeños), Gate 5 parcialmente automático (Elena no podía revisar todo), pair programming Isabel↔Ana 2h/semana (clave para crecimiento de Ana).
+
+> **Índice completo**: [00-indice.md](00-indice.md)


### PR DESCRIPTION
## Summary

- 3 new documents in `docs/savia-flow/` — complete end-to-end example of Savia Flow implementation
- **Part 1** (12): Setup, team config, first exploration cycle, first intake
- **Part 2** (13): Dual-track in action, quality gates, front↔back with API contract first
- **Part 3** (14): Release pipeline, outcome validation, monthly retro, 12-week MVP metrics
- Updated `00-indice.md` with new documents and learning paths

Each document shows exact Savia commands, who runs them, and what Savia returns.

## Test plan

- [x] `bash scripts/validate-ci-local.sh` — 15/15 passed, 0 warnings
- [x] All 3 new files ≤150 lines (147, 145, 146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)