### PR TITLE
docs: add Era 17 to ROADMAP and fix README counters

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -125,7 +125,7 @@ I've organized all documentation into sections so you can quickly find what you 
 | [Test project](docs/readme_en/09-test-project.md) | `sala-reservas`: tests, mock data, validation |
 | [KPIs, rules, and roadmap](docs/readme_en/10-kpis-rules.md) | Metrics, critical rules, adoption plan |
 | [Onboarding new team members](docs/readme_en/11-onboarding.md) | 5-phase onboarding, competency evaluation, GDPR |
-| [Commands and agents](docs/readme_en/12-commands-agents.md) | 142 commands + 24 specialized agents |
+| [Commands and agents](docs/readme_en/12-commands-agents.md) | 268 commands + 24 specialized agents |
 | [Coverage and contributing](docs/readme_en/13-coverage-contributing.md) | What's covered, what's not, how to contribute |
 
 ### Other Documents
@@ -162,7 +162,7 @@ I've organized all documentation into sections so you can quickly find what you 
 - `/error-investigate` — AI-assisted error investigation with root cause hypothesis
 - `/incident-correlate` — Cross-source incident correlation with post-mortem draft
 
-**Era 13 — Observability & Intelligence (2/2). ERA 13 COMPLETE!**
+**Era 17 — AI Tooling & Auto-Compact (3/3). ERA 17 COMPLETE!**
 
 ## Quick Command Reference
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ He organizado toda la documentación en secciones para que encuentres rápido lo
 | [Proyecto de test](docs/readme/09-proyecto-test.md) | `sala-reservas`: tests, datos mock, validación |
 | [KPIs, reglas y roadmap](docs/readme/10-kpis-reglas.md) | Métricas, reglas críticas, plan de adopción |
 | [Onboarding de nuevos miembros](docs/readme/11-onboarding.md) | Incorporación en 5 fases, evaluación de competencias, RGPD |
-| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 142 comandos + 24 agentes especializados |
+| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 268 comandos + 24 agentes especializados |
 | [Cobertura y contribución](docs/readme/13-cobertura-contribucion.md) | Qué cubre, qué no, cómo contribuir |
 
 ### Otros documentos
@@ -162,7 +162,7 @@ He organizado toda la documentación en secciones para que encuentres rápido lo
 - `/error-investigate` — Investigación asistida de errores con root cause analysis
 - `/incident-correlate` — Correlación multi-fuente para análisis integral de incidentes con post-mortem draft
 
-**Era 13 — Observabilidad e Inteligencia (2/2). ERA 13 COMPLETA!**
+**Era 17 — AI Tooling & Auto-Compact (3/3). ERA 17 COMPLETA!**
 
 ## Referencia rápida de comandos
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 262 commands, 24 agents, 20 skills, and its own persona (Savia). This roadmap groups the 73 released versions into thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 268 commands, 24 agents, 21 skills, and its own persona (Savia). This roadmap groups the 73 released versions into thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -97,7 +97,17 @@ Improvements driven by E2E test results + Fowler Knowledge Priming + NVIDIA mult
 
 ---
 
-## 💡 Proposed — v0.80.0+
+## ✅ Era 17 — AI Tooling & Auto-Compact (v0.80.0–v0.82.0, Mar 2026)
+
+Realistic mock engine, AI role tooling (Knowledge Priming + Persona Tuning), and automatic context compression for E2E harness.
+
+- **Context Optimization v2** (v0.80.0) — Mock engine calibrado por tipo de comando, state file para acumulación de contexto, probabilidad de overflow contextual.
+- **AI Role Tooling** (v0.81.0) — `/knowledge-prime` (7 secciones Fowler), `/savia-persona-tune` (5 perfiles de tono).
+- **Auto-Compact** (v0.82.0) — `--auto-compact` flag, `--compact-threshold=N`, harness refactorizado en 3 ficheros (≤150 líneas).
+
+---
+
+## 💡 Proposed — v0.83.0+
 
 Ideas under consideration. Open an issue or vote with 👍 to prioritize.
 
@@ -108,8 +118,6 @@ Ideas under consideration. Open an issue or vote with 👍 to prioritize.
 **Observability extensions** — New Relic, Splunk, Elastic APM connectors. LLM-specific observability (token usage, prompt latency, model drift).
 
 **Developer experience** — VS Code / Cursor extension, CLI mode, mobile companion (read-only sprint status).
-
-**AI Role Tooling** (from Kelman Celis taxonomy) — `/knowledge-prime` (auto-generate .priming/ from codebase), `/savia-persona-tune` (behavioral AI trainer: adjust tone/style per project), realistic mock engine per command type (synthetic data synthesizer pattern).
 
 ---
 


### PR DESCRIPTION
## Summary
- **ROADMAP.md**: Added Era 17 (v0.80.0–v0.82.0) with Context Optimization v2, AI Role Tooling, and Auto-Compact. Updated Proposed section to start at v0.83.0+ and removed already-shipped AI Role Tooling proposal. Updated intro counters (268 commands, 21 skills).
- **README.md** (ES): Fixed command counter from 142 to 268, updated era reference from 13 to 17.
- **README.en.md** (EN): Same fixes as Spanish version for consistency.

## Test plan
- [x] ROADMAP follows existing era pattern structure
- [x] Counters consistent across ROADMAP and both READMEs (268 commands, 24 agents, 21 skills)
- [x] Spanish ↔ English READMEs aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)