### PR TITLE
fix: restructure READMEs + compact CLAUDE.md for CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,16 +108,12 @@ Ciclo: Explorar → Planificar → Implementar → Commit. Arquitectura: **Comma
 ## Hooks · Memoria
 
 > Hooks (14): `.claude/settings.json` — Arranque blindado (sin red, sin dependencias externas)
-> Memoria: `@docs/memory-system.md` · Store: `scripts/memory-store.sh` (JSONL, dedup, topic_key, `<private>`)
-> Agent Notes: `@docs/agent-notes-protocol.md` · Security: `/security-review {spec}` — OWASP pre-implementación
+> Memoria: `@docs/memory-system.md` · Store: `scripts/memory-store.sh` (JSONL, dedup, topic_key, `<private>`) · Agent Notes: `@docs/agent-notes-protocol.md` · Security: `/security-review {spec}` — OWASP pre-implementación
 
 ---
 
 ## Checklist Nuevo Proyecto
 
-- [ ] `projects/[nombre]/CLAUDE.md` (≤150 líneas)
-- [ ] Entrada en `CLAUDE.local.md` o tabla Proyectos Activos
-- [ ] Entornos (DEV/PRE/PRO) + `config.local/` + `.env.example`
-- [ ] Cloud/infra si aplica
-- [ ] `scripts/setup-memory.sh [nombre]`
-- [ ] `agent-notes/`, `adrs/` si hay decisiones arquitectónicas
+- [ ] `projects/[nombre]/CLAUDE.md` (≤150 líneas) + entrada en `CLAUDE.local.md`
+- [ ] Entornos (DEV/PRE/PRO) + `config.local/` + `.env.example` + cloud/infra si aplica
+- [ ] `scripts/setup-memory.sh [nombre]` + `agent-notes/`, `adrs/` si hay decisiones

--- a/README.en.md
+++ b/README.en.md
@@ -152,38 +152,9 @@ I've organized all documentation into sections so you can quickly find what you 
 
 ---
 
-## v0.71.0 — Observability Core
-
-- `/obs-connect` — Connect to Grafana, Datadog, App Insights, OpenTelemetry
-- `/obs-query` — Natural language queries to observability data
-- `/obs-dashboard` — Dashboards digested by role
-- `/obs-status` — Health check of connected sources
-
----
-
-## v0.72.0 — Trace Intelligence
-
-- `/trace-search` — Search and filter traces in Grafana, Datadog, App Insights with natural language
-- `/trace-analyze` — Deep trace analysis: waterfall, bottleneck detection, error chain
-- `/error-investigate` — AI-assisted error investigation with root cause hypothesis
-- `/incident-correlate` — Cross-source incident correlation with post-mortem draft
-
-**Era 17 — AI Tooling & Auto-Compact (3/3). ERA 17 COMPLETE!**
-
-## v0.84.0–v0.89.0 — Era 18: Compliance, Distribution & Intelligent Hooks
-
-- `/aepd-compliance` — AEPD compliance audit for agentic AI (4 phases: technology → compliance → vulnerabilities → measures)
-- `/excel-report` — Interactive Excel templates (capacity, CEO, time-tracking) in multi-tab CSV
-- `/savia-gallery` — Interactive catalog of 271 commands by role and vertical with source tracking
-- skills.sh publishing infrastructure — Adapter script + format for marketplace publishing
-- Intelligent hooks — Prompt hooks (semantic) and Agent hooks (pre-merge quality gate)
-- AI Competency Framework — 6 AI-era competencies for `/adoption-assess --ai-skills`
-
-**Era 18 — Compliance, Distribution & Intelligent Hooks (6/6). ERA 18 COMPLETE!**
-
 ## Quick Command Reference
 
-> 327 commands · 24 agents · 22 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
+> 329+ commands · 24 agents · 22 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
 
 ### User Profile, Updates and Community
 ```
@@ -459,48 +430,19 @@ These are the rules that are never skipped — not even by me:
 
 ---
 
-## v0.90.0 — Era 19: Open Source Synergy
+## Version History
 
-- `/mcp-browse` — Browse 66+ MCPs from the claude-code-templates ecosystem
-- `/component-search` — Search 5,788+ components (agents, commands, hooks, MCPs, skills)
-- `docs/recommended-mcps.md` — Curated MCP catalog for PM/Scrum teams
-- `hooks/README.md` — Categorized documentation for all 14 hooks (security, quality gates, agents, workflow)
-- `agent-observability-patterns.md` — Observability patterns inspired by analytics dashboard
-- `component-marketplace.md` — Component marketplace integration rule
+> Full changelog at [CHANGELOG.md](CHANGELOG.md) · All releases at [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
 
-**Era 19 — Open Source Synergy (6/6). ERA 19 COMPLETE!**
-
-## v0.91.0–v0.98.0 — Era 20: Persistent Intelligence & Adaptive Workflows
-
-- v0.91.0 — 5 bug fixes + 165 new tests (64→229). 7 test scripts + orchestrator `test-stress-runner.sh`
-- `/agent-memory` — Persistent memory for 9 agents with 3 scopes (project/local/user)
-- `/savia-recall` — Query Savia's accumulated contextual memory
-- `/savia-forget` — GDPR-compliant memory pruning (Art. 17 RGPD)
-- 57 commands with smart frontmatter (`model`, `context_cost`, `allowed-tools`)
-- `/rpi-start` — Research → Plan → Implement workflow with GO/NO-GO gates
-- `/rpi-status` — Track active RPI workflow progress
-- `/onboard --role {dev|pm|qa}` — Guided onboarding with role-specific checklists
-- `/mcp-recommend` — MCP recommendations by stack and team role
-- 3 adaptive output modes: Coaching · Executive · Technical
-- Hook classification: 2 async + 10 blocking, 9/16 event coverage
-- `pr-guardian.yml` — 8 automated PR validation gates (context guard, ShellCheck, Gitleaks, hook safety, PR Digest in Spanish)
-- `/pr-digest` — Contextual PR analysis with risk classification and executive summary
-
-**Era 20 — Persistent Intelligence (14/14). ERA 20 COMPLETE!**
-
-## v0.99.0–v1.5.1 — Era 21: Savia Everywhere
-
-- Company Savia: shared Git repo with async messaging, E2E encryption (RSA-4096 + AES-256-CBC), @handle addressing, privacy-check pre-push
-- Git Persistence Engine: TSV indexes for low-context lookups (~60-80% token reduction)
-- Savia Flow Git-Native: tasks/sprints/timesheets in Git folders, Kanban board, 17 commands
-- Travel Mode: portable Savia on USB with AES-256-CBC encryption, SHA256 verification, auto-installer
-- Savia School: education vertical with 12 commands, GDPR Art. 8/15/17, encrypted evaluations
-- Script Hardening: 6 critical + 7 medium fixes across 9 scripts, macOS/Linux/WSL compatibility
-- Subject Sensitivity: validates sensitive data in encrypted message subjects (12 pattern categories)
-- 18 test suites (197 tests), including E2E encryption confidentiality testing
-- Research of 12+ Claude Code ecosystem repos, 12 improvement proposals
-
-**Era 21 — Savia Everywhere (v0.99.0–v1.5.1). ERA 21 COMPLETE!**
+| Version | Era | Summary |
+|---|---|---|
+| **v1.7.0** | — | Company Savia v3: orphan branch isolation, quality framework (rules #21-#22), Agent Self-Memory, PII gate, drift detection. 120 Savia tests. |
+| **v1.6.0** | — | Company Savia v2: directory restructure, TSV indexes, simplified user paths. |
+| **v0.99–v1.5.1** | Era 21 | Savia Everywhere: Company Savia, Git Persistence Engine, Savia Flow, Travel Mode, Savia School, E2E encryption. |
+| **v0.91–v0.98** | Era 20 | Persistent Intelligence: agent memory, smart frontmatter, RPI workflow, PR Guardian, 3 output modes. |
+| **v0.90** | Era 19 | Open Source Synergy: claude-code-templates integration, `/mcp-browse`, `/component-search`. |
+| **v0.84–v0.89** | Era 18 | Compliance & Hooks: `/aepd-compliance`, Excel reports, Savia Gallery, intelligent hooks. |
+| **v0.71–v0.72** | Era 17 | Observability & Traces: `/obs-connect`, `/trace-search`, `/error-investigate`. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,38 +152,9 @@ He organizado toda la documentación en secciones para que encuentres rápido lo
 
 ---
 
-## v0.71.0 — Observability Core
-
-- `/obs-connect` — Conectar Grafana, Datadog, App Insights, OpenTelemetry
-- `/obs-query` — Consultas en lenguaje natural a datos de observabilidad
-- `/obs-dashboard` — Dashboards digeridos por rol
-- `/obs-status` — Health check de fuentes conectadas
-
----
-
-## v0.72.0 — Trace Intelligence
-
-- `/trace-search` — Buscar y filtrar trazas en Grafana, Datadog, App Insights con lenguaje natural
-- `/trace-analyze` — Análisis profundo de trazas: waterfall, cuellos de botella, cadena de errores
-- `/error-investigate` — Investigación asistida de errores con root cause analysis
-- `/incident-correlate` — Correlación multi-fuente para análisis integral de incidentes con post-mortem draft
-
-**Era 17 — AI Tooling & Auto-Compact (3/3). ERA 17 COMPLETA!**
-
-## v0.84.0–v0.89.0 — Era 18: Compliance, Distribution & Intelligent Hooks
-
-- `/aepd-compliance` — Auditoría AEPD para IA agéntica (4 fases: tecnología → cumplimiento → vulnerabilidades → medidas)
-- `/excel-report` — Plantillas Excel interactivas (capacity, CEO, time-tracking) en CSV multi-tab
-- `/savia-gallery` — Catálogo interactivo de 271 comandos por rol y vertical con source tracking
-- skills.sh publishing infrastructure — Adapter script + formato para publicar en marketplace
-- Intelligent hooks — Prompt hooks (semánticos) y Agent hooks (quality gate pre-merge)
-- AI Competency Framework — 6 competencias AI-era para `/adoption-assess --ai-skills`
-
-**Era 18 — Compliance, Distribution & Intelligent Hooks (6/6). ERA 18 COMPLETA!**
-
 ## Referencia rápida de comandos
 
-> 327 comandos · 24 agentes · 22 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
+> 329+ comandos · 24 agentes · 22 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
 
 ### Perfil de Usuario, Actualización y Comunidad
 ```
@@ -463,48 +434,19 @@ Estas son las reglas que nunca se saltan — ni yo misma:
 
 ---
 
-## v0.90.0 — Era 19: Open Source Synergy
+## Historial de versiones
 
-- `/mcp-browse` — Explorar catálogo de 66+ MCPs del ecosistema claude-code-templates
-- `/component-search` — Buscar entre 5.788+ componentes (agents, commands, hooks, MCPs, skills)
-- `docs/recommended-mcps.md` — Catálogo curado de MCPs recomendados para equipos PM/Scrum
-- `hooks/README.md` — Documentación categorizada de los 14 hooks (seguridad, quality gates, agentes, workflow)
-- `agent-observability-patterns.md` — Patrones de observabilidad inspirados en analytics dashboard
-- `component-marketplace.md` — Regla de integración con marketplace de componentes
+> Changelog completo en [CHANGELOG.md](CHANGELOG.md) · Todas las releases en [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
 
-**Era 19 — Open Source Synergy (6/6). ERA 19 COMPLETA!**
-
-## v0.91.0–v0.98.0 — Era 20: Persistent Intelligence & Adaptive Workflows
-
-- v0.91.0 — 5 bug fixes + 165 nuevos tests (64→229). 7 scripts de test + orquestador `test-stress-runner.sh`
-- `/agent-memory` — Memoria persistente para 9 agentes con 3 scopes (project/local/user)
-- `/savia-recall` — Consultar la memoria contextual acumulada de Savia
-- `/savia-forget` — Borrado de memoria conforme RGPD (Art. 17)
-- 57 comandos con frontmatter inteligente (`model`, `context_cost`, `allowed-tools`)
-- `/rpi-start` — Workflow Research → Plan → Implement con gates GO/NO-GO
-- `/rpi-status` — Seguimiento de workflows RPI activos
-- `/onboard --role {dev|pm|qa}` — Onboarding guiado con checklist por rol
-- `/mcp-recommend` — Recomendaciones MCP por stack y rol del equipo
-- 3 modos de output adaptativos: Coaching · Executive · Technical
-- Hooks clasificados: 2 async + 10 blocking, cobertura 9/16 eventos
-- `pr-guardian.yml` — 8 gates automáticos de validación de PRs (context guard, ShellCheck, Gitleaks, hook safety, PR Digest en español)
-- `/pr-digest` — Análisis contextual de PRs con clasificación de riesgo y resumen ejecutivo
-
-**Era 20 — Persistent Intelligence (14/14). ERA 20 COMPLETA!**
-
-## v0.99.0–v1.5.1 — Era 21: Savia Everywhere
-
-- Company Savia: repositorio Git compartido con mensajería async, cifrado E2E (RSA-4096 + AES-256-CBC), @handle addressing, privacy-check pre-push
-- Git Persistence Engine: índices TSV para lookups de bajo contexto (~60-80% reducción de tokens)
-- Savia Flow Git-Native: tasks/sprints/timesheets en carpetas Git, tablero Kanban, 17 comandos
-- Travel Mode: Savia portable en USB con cifrado AES-256-CBC, verificación SHA256, auto-installer
-- Savia School: vertical educativo con 12 comandos, GDPR Art. 8/15/17, evaluaciones cifradas
-- Script Hardening: 6 bugs críticos + 7 medium en 9 scripts, compatibilidad macOS/Linux/WSL
-- Subject Sensitivity: validación de datos sensibles en subjects de mensajes cifrados (12 categorías de patrón)
-- 18 suites de test (197 tests), incluido E2E confidencialidad del cifrado
-- Investigación de 12+ repos del ecosistema Claude Code, 12 propuestas de mejora
-
-**Era 21 — Savia Everywhere (v0.99.0–v1.5.1). ERA 21 COMPLETA!**
+| Versión | Era | Resumen |
+|---|---|---|
+| **v1.7.0** | — | Company Savia v3: aislamiento por ramas orphan, quality framework (reglas #21-#22), Agent Self-Memory, PII gate, drift detection. 120 tests Savia. |
+| **v1.6.0** | — | Company Savia v2: reestructuración de directorios, índices TSV, simplificación de rutas de usuario. |
+| **v0.99–v1.5.1** | Era 21 | Savia Everywhere: Company Savia, Git Persistence Engine, Savia Flow, Travel Mode, Savia School, cifrado E2E. |
+| **v0.91–v0.98** | Era 20 | Persistent Intelligence: agent memory, frontmatter inteligente, RPI workflow, PR Guardian, 3 modos output. |
+| **v0.90** | Era 19 | Open Source Synergy: integración con claude-code-templates, `/mcp-browse`, `/component-search`. |
+| **v0.84–v0.89** | Era 18 | Compliance & Hooks: `/aepd-compliance`, Excel reports, Savia Gallery, intelligent hooks. |
+| **v0.71–v0.72** | Era 17 | Observability & Traces: `/obs-connect`, `/trace-search`, `/error-investigate`. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Removed 3 scattered release note blocks from both README.md and README.en.md (v0.71–v0.72, v0.84–v0.89, v0.90–v1.5.1)
- Added clean "Version History" table with all eras + v1.6.0 and v1.7.0, pointing to CHANGELOG.md
- Updated command count from 327 to 329+
- Compacted CLAUDE.md from 123→119 lines to pass CI gate (max: 120)

## Test plan

- [x] CI Gate 3 should pass (CLAUDE.md ≤120 lines)
- [x] Both READMEs structurally consistent
- [x] Version history matches CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)