### PR TITLE
fix: changelog link validation + missing v1.9.0 link

### DIFF
--- a/.claude/hooks/prompt-hook-commit.sh
+++ b/.claude/hooks/prompt-hook-commit.sh
@@ -54,6 +54,15 @@ if [[ ${#FIRST_LINE} -gt 72 ]]; then
   ISSUES+="First line exceeds 72 characters. "
 fi
 
+# Check: CHANGELOG version links when CHANGELOG is staged
+if git diff --cached --name-only 2>/dev/null | grep -q "CHANGELOG.md"; then
+  VALIDATOR="${CLAUDE_PROJECT_DIR:-.}/scripts/validate-changelog-links.sh"
+  if [[ -x "$VALIDATOR" ]]; then
+    LINK_ERR=$("$VALIDATOR" "${CLAUDE_PROJECT_DIR:-.}/CHANGELOG.md" 2>&1) || \
+      ISSUES+="CHANGELOG enlace faltante. "
+  fi
+fi
+
 if [[ -n "$ISSUES" ]]; then
   case "$PROMPT_HOOKS_MODE" in
     "warning")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[1.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v1.5.1...v1.6.0

--- a/scripts/validate-changelog-links.sh
+++ b/scripts/validate-changelog-links.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# validate-changelog-links.sh — Verifica que cada ## [X.Y.Z] tiene su enlace [X.Y.Z]: URL
+# Puede ejecutarse standalone o desde prompt-hook-commit.sh
+set -euo pipefail
+CHANGELOG="${1:-CHANGELOG.md}"
+[[ ! -f "$CHANGELOG" ]] && { echo "No CHANGELOG found"; exit 0; }
+
+ERRORS=0
+# Extract all version headers: ## [X.Y.Z] — ...
+while IFS= read -r header_version; do
+    # Check if a matching link reference exists: [X.Y.Z]: https://...
+    if ! grep -q "^\[${header_version}\]: https://" "$CHANGELOG"; then
+        echo "❌ Missing link for [${header_version}] in CHANGELOG.md"
+        ERRORS=$((ERRORS+1))
+    fi
+done < <(grep -oP '(?<=^## \[)[0-9]+\.[0-9]+\.[0-9]+(?=\])' "$CHANGELOG")
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo ""
+    echo "⚠️  $ERRORS version(s) sin enlace de referencia al final del CHANGELOG."
+    echo "   Formato esperado: [X.Y.Z]: https://github.com/.../compare/vA.B.C...vX.Y.Z"
+    exit 1
+fi
+echo "✅ Todos los enlaces de versión presentes en CHANGELOG.md"
+exit 0

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -9,6 +9,7 @@ Format: `| date | category | lesson | source |`
 
 | Date | Category | Lesson | Source |
 |---|---|---|---|
+| 2026-03-04 | CHANGELOG | Always add version link reference `[X.Y.Z]: URL` at bottom of CHANGELOG.md when creating a new `## [X.Y.Z]` header. Validated by `scripts/validate-changelog-links.sh` and `prompt-hook-commit.sh`. | User correction — v1.9.0 |
 | 2026-03-03 | PII | Never include real company names, personal names, or handles in CHANGELOG, releases, commits, or PR descriptions. Use generic placeholders (test-org, alice, test company). | User correction — Era 21 |
 | 2026-03-03 | Git | `git fetch origin --all` is invalid. Use `git fetch --all` or `git fetch origin` (without --all). | Test failure — Era 22 |
 | 2026-03-03 | Testing | `assert_ok` checking `$?` after `TOTAL=$((TOTAL+1))` always returns 0. Pass the command as arguments to the assert function instead. | Test failure — Era 22 |


### PR DESCRIPTION
## Summary

- Added missing `[1.9.0]` version link reference in CHANGELOG.md
- Created `scripts/validate-changelog-links.sh` that checks every `## [X.Y.Z]` header has a matching `[X.Y.Z]: URL` at the bottom
- Integrated validation into `prompt-hook-commit.sh` — warns automatically when committing with CHANGELOG.md staged and a link is missing
- Added lesson to `tasks/lessons.md` to prevent recurrence

## Test plan

- [x] `bash scripts/validate-changelog-links.sh CHANGELOG.md` → passes
- [x] Tested with truncated CHANGELOG (no links) → correctly detects missing links
- [x] `prompt-hook-commit.sh` syntax valid, ≤150 lines (84)

🤖 Generated with [Claude Code](https://claude.com/claude-code)