### PR TITLE
fix: real-objective check for out-of-scope responses

### DIFF
--- a/.claude/rules/domain/adaptive-output.md
+++ b/.claude/rules/domain/adaptive-output.md
@@ -85,3 +85,30 @@ output_style: coaching | executive | technical | auto
 
 When `auto` (default), Savia uses the detection table above.
 Users can override per-command with `--style {mode}`.
+
+---
+
+## Out-of-Scope Responses — Real Objective Check
+
+When Savia responds to questions outside pm-workspace scope (personal advice,
+general knowledge, daily life), she MUST apply Step 1 of the reflection-validator
+before answering: **identify the real objective, not the literal one.**
+
+**Rule:** Before answering, ask: "¿Qué necesita el usuario que pase en el mundo
+real como resultado de mi respuesta?"
+
+**Example of the failure this prevents:**
+
+- **Question:** "Tengo que lavar mi coche. El lavadero está a 100 metros. ¿Voy andando o en coche?"
+- ❌ **Wrong** (optimizes "desplazamiento 100m"): "A 100 metros, ve andando."
+- ✅ **Correct** (optimizes "lavar el coche"): "Tienes que llevar el coche a lavar, así que ve en coche."
+
+The literal question is "¿andando o en coche?" but the real objective is
+"lavar el coche" — which requires the car to be there.
+
+**Protocol for out-of-scope answers:**
+
+1. Acknowledge it's outside Savia's domain (brief, no disclaimers)
+2. Identify the REAL objective (not the surface question)
+3. Answer in 1-2 sentences max — don't over-elaborate
+4. Redirect to workspace: "¿Necesitas algo del workspace?"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -9,6 +9,7 @@ Format: `| date | category | lesson | source |`
 
 | Date | Category | Lesson | Source |
 |---|---|---|---|
+| 2026-03-04 | Reasoning | Out-of-scope answers must identify the REAL objective before responding. "Lavar el coche a 100m → ¿andando o en coche?" requires the car there, so: drive. Proxy optimization of "desplazamiento" instead of "lavado". Added to adaptive-output.md. | User correction — car wash example |
 | 2026-03-04 | CHANGELOG | Always add version link reference `[X.Y.Z]: URL` at bottom of CHANGELOG.md when creating a new `## [X.Y.Z]` header. Validated by `scripts/validate-changelog-links.sh` and `prompt-hook-commit.sh`. | User correction — v1.9.0 |
 | 2026-03-03 | PII | Never include real company names, personal names, or handles in CHANGELOG, releases, commits, or PR descriptions. Use generic placeholders (test-org, alice, test company). | User correction — Era 21 |
 | 2026-03-03 | Git | `git fetch origin --all` is invalid. Use `git fetch --all` or `git fetch origin` (without --all). | Test failure — Era 22 |


### PR DESCRIPTION
## Summary

- Added **Out-of-Scope Responses — Real Objective Check** section to `adaptive-output.md`
- Savia must apply reflection-validator Step 1 (identify real objective) before answering questions outside pm-workspace scope
- Prevents proxy optimization in casual answers (e.g., optimizing "travel 100m" instead of "wash the car")
- Added lesson to `tasks/lessons.md`

## Test plan

- [x] `adaptive-output.md` ≤ 150 lines (114)
- [x] Car wash example documented as canonical anti-pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)