### PR TITLE
fix(ci): PR Guardian digest shows empty sections

### DIFF
--- a/.github/workflows/pr-guardian.yml
+++ b/.github/workflows/pr-guardian.yml
@@ -413,18 +413,15 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const { execSync } = require('child_process');
 
-            // Get file stats
-            const filesRaw = execSync(
-              'git diff --stat origin/main...HEAD 2>/dev/null || true',
-              { encoding: 'utf8' }
-            ).trim();
-
-            const diffNames = execSync(
-              'git diff --name-only origin/main...HEAD 2>/dev/null || true',
-              { encoding: 'utf8' }
-            ).trim().split('\n').filter(Boolean);
+            // Get changed files via GitHub API (reliable, unlike git diff in PR merge context)
+            const filesResponse = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+            const diffNames = filesResponse.data.map(f => f.filename);
 
             // Classify changes
             const categories = {


### PR DESCRIPTION
## Summary
- Gate 8 PR Digest was posting comments with empty "¿Qué trae esta PR?" and "Componentes tocados" sections (Ficheros: 0)
- Root cause: `git diff --name-only origin/main...HEAD` returns empty in GitHub Actions PR merge ref context
- Fix: replaced with `github.rest.pulls.listFiles()` API which is reliable and canonical

## Test plan
- [ ] Open a test PR and verify the digest comment shows correct file counts and categories
- [ ] Verify risk assessment works correctly with API-sourced file list

🤖 Generated with [Claude Code](https://claude.com/claude-code)