### PR TITLE
feat: Scoring Intelligence v2.3.0 (Era 28)

### DIFF
--- a/.claude/commands/score-diff.md
+++ b/.claude/commands/score-diff.md
@@ -1,0 +1,86 @@
+# /score:diff — Compare Workspace Metrics Between Versions
+
+## Description
+
+Compares PM-Workspace quality metrics between two git refs to track
+improvement or regression over time. Inspired by kimun's score diff.
+
+## Usage
+
+```
+/score:diff [--from <ref>] [--to <ref>] [--dimension <name>]
+```
+
+**Defaults**: `--from HEAD~5` `--to HEAD`
+
+## Process
+
+### Step 1: Collect Metrics at Each Ref
+
+For each git ref, compute:
+
+- **Files**: total count, avg lines, files over 150-line cap
+- **Rules**: domain rules count, avg lines
+- **Tests**: test count, pass rate (from last CI run if available)
+- **Agents**: count, agents with MEMORY.md
+- **Commands**: count, commands with frontmatter
+- **Context**: CLAUDE.md line count, estimated token load
+
+### Step 2: Compute Deltas
+
+For each metric, calculate:
+- Absolute delta (new - old)
+- Percentage change
+- Direction arrow (↑ improvement, ↓ regression, → stable)
+- Score using piecewise curves from `scoring-curves.md`
+
+### Step 3: Classify Changes
+
+Apply Rule of Three severity:
+- **3+ regressions** in same dimension → CRITICAL (action required)
+- **2 regressions** → WARNING (monitor)
+- **1 regression** → INFO (acceptable variance)
+- **All stable or improving** → HEALTHY
+
+### Step 4: Output
+
+```
+═══════════════════════════════════════════════════════
+  Score Diff: v2.1.0 → v2.3.0
+═══════════════════════════════════════════════════════
+
+  Dimension         Before   After   Delta   Score
+  ──────────────────────────────────────────────────
+  Rules             62       65      +3 ↑     85
+  Commands          336      339     +3 ↑     90
+  Tests             400      430     +30 ↑    95
+  CLAUDE.md lines   120      120     → 0      100
+  Avg file size     78       80      +2 →     95
+  Files > 150 ln    0        0       → 0      100
+
+  Overall: 94/100 — HEALTHY
+  Trend: ↑ Improving (3 consecutive releases)
+═══════════════════════════════════════════════════════
+```
+
+Save to: `output/scores/YYYYMMDD-score-diff.md`
+
+## Subagent Config
+
+```yaml
+model: claude-haiku-4-5-20251001
+memory: project
+permissionMode: plan
+```
+
+Use Haiku — this is a data-collection task, not reasoning.
+
+## Scheduling
+
+Recommended: run after each release or weekly.
+Can integrate with `/hub:audit` for combined health report.
+
+## References
+
+- kimun (lnds/kimun). Score diffing with git refs
+- scoring-curves.md for normalization breakpoints

--- a/.claude/rules/domain/scoring-curves.md
+++ b/.claude/rules/domain/scoring-curves.md
@@ -1,0 +1,110 @@
+# Scoring Curves — Piecewise Linear Normalization
+
+## Purpose
+
+Replace binary pass/fail scoring with calibrated piecewise linear curves
+that degrade smoothly. Inspired by kimun's normalization model and
+industry thresholds (SonarQube, Microsoft Code Metrics).
+
+## How It Works
+
+Each dimension maps a raw metric to a 0-100 score using breakpoints.
+Between breakpoints, values interpolate linearly. No cliff edges.
+
+```
+Score formula:
+  score = low_score + (high_score - low_score) × (value - low) / (high - low)
+```
+
+## Dimension Curves
+
+### PR Size (lines changed)
+
+```
+Lines    Score   Label
+≤ 50     100     XS — ideal
+100       85     S — good
+250       65     M — review carefully
+500       35     L — consider splitting
+1000      10     XL — split required
+≥ 2000     0     XXL — reject
+```
+
+### Context Usage (% of 200K window)
+
+```
+Usage%   Score   Action
+≤ 30     100     Healthy — full capacity
+50        80     Normal — monitor
+70        50     Warning — /compact recommended
+85        25     Critical — /compact required
+95         5     Emergency — subagent isolation mandatory
+≥ 100      0     Exhausted — session restart
+```
+
+### File Size (lines)
+
+```
+Lines    Score   Note
+≤ 80     100     Optimal for context loading
+120       80     Within limits
+150       50     At hard cap — split soon
+200       20     Over limit — must split
+≥ 300      0     Violates architecture
+```
+
+### Sprint Velocity Deviation (% from average)
+
+```
+Deviation%   Score   Interpretation
+≤ 10         100     Stable velocity
+20            75     Normal variance
+35            50     Investigate causes
+50            25     Team may be overloaded or blocked
+≥ 80           0     Sprint planning failure
+```
+
+### Test Coverage (%)
+
+```
+Coverage%   Score   Threshold
+≥ 90        100     Excellent
+80           80     Target (TEST_COVERAGE_MIN_PERCENT)
+65           50     Acceptable for legacy
+50           25     Risk zone
+≤ 30          0     Unacceptable
+```
+
+### Confidence Calibration (Brier score)
+
+```
+Brier    Score   Interpretation
+≤ 0.05   100     Near-perfect calibration
+0.10      80     Well calibrated
+0.15      60     Adjustment recommended
+0.20      35     Recalibration required
+0.30      10     System unreliable
+≥ 0.50     0     Broken — disable NL resolution
+```
+
+## Usage
+
+Commands that produce scores SHOULD use these curves:
+- `/code:audit` → file size, coverage, complexity
+- `/sprint:review` → velocity deviation
+- `/context:budget` → context usage
+- `/confidence-calibrate` → Brier score
+- PR Guardian Gate 7 → PR size, context impact
+
+## Extending
+
+To add a new dimension:
+1. Define 5-6 breakpoints based on published thresholds
+2. Include source (SonarQube, research paper, team consensus)
+3. Test with `scripts/test-scoring-curves.sh`
+
+## References
+
+- SonarSource (2017). "Cognitive Complexity — A new way of measuring understandability"
+- Microsoft. "Code Metrics Values" — docs.microsoft.com
+- kimun (lnds/kimun). Piecewise linear normalization for code quality

--- a/.claude/rules/domain/severity-classification.md
+++ b/.claude/rules/domain/severity-classification.md
@@ -1,0 +1,93 @@
+# Severity Classification — Rule of Three
+
+## Purpose
+
+Classify quality issues by severity using the Rule of Three pattern:
+3+ occurrences → CRITICAL, 2 → WARNING, 1 → INFO. Prevents both
+over-reaction to single events and under-reaction to systemic patterns.
+
+Inspired by kimun's duplicate severity classification and adapted
+for PM-Workspace quality dimensions.
+
+## Classification Thresholds
+
+### PR Quality
+
+```
+Metric                    CRITICAL        WARNING         INFO
+─────────────────────────────────────────────────────────────
+Files changed             > 30            15-30           < 15
+Lines changed             > 1000          500-1000        < 500
+Files over 150 lines      ≥ 3             1-2             0
+Missing tests             ≥ 3 untested    1-2 untested    0
+Commits without prefix    ≥ 3             1-2             0
+```
+
+### Sprint Health
+
+```
+Metric                    CRITICAL        WARNING         INFO
+─────────────────────────────────────────────────────────────
+Velocity deviation        > 50%           20-50%          < 20%
+Blocked items             ≥ 3             1-2             0
+Unestimated PBIs          ≥ 3             1-2             0
+Overdue tasks             ≥ 3             1-2             0
+Scope changes mid-sprint  ≥ 3             1-2             0
+```
+
+### Context Health
+
+```
+Metric                    CRITICAL        WARNING         INFO
+─────────────────────────────────────────────────────────────
+Context usage             > 85%           70-85%          < 70%
+Files loaded this session ≥ 20            10-20           < 10
+Stale memory entries      ≥ 10            5-10            < 5
+Dormant rules (0 refs)    ≥ 5             2-4             0-1
+```
+
+### Code Quality (from audits)
+
+```
+Metric                    CRITICAL        WARNING         INFO
+─────────────────────────────────────────────────────────────
+Cognitive complexity      > 25            15-25           < 15
+Duplicated blocks         ≥ 3             1-2             0
+Functions > 50 lines      ≥ 3             1-2             0
+Missing error handling    ≥ 3             1-2             0
+```
+
+## Escalation Protocol
+
+**CRITICAL** → Block action. Require human review before proceeding.
+Show in red. Include in PR Guardian digest.
+
+**WARNING** → Allow action with advisory. Show in yellow.
+Log for pattern tracking.
+
+**INFO** → Proceed normally. Track silently. Include in periodic
+reports only.
+
+## Temporal Escalation
+
+If the same WARNING appears in 3 consecutive sprints → auto-escalate
+to CRITICAL. Pattern persistence indicates systemic issue.
+
+If a CRITICAL is resolved and stays clean for 2 sprints →
+auto-downgrade to INFO.
+
+## Application
+
+Commands that SHOULD use severity classification:
+- PR Guardian (all gates)
+- `/sprint:review` and `/sprint:retro`
+- `/code:audit` and `/perf:audit`
+- `/score:diff` (regression classification)
+- `/hub:audit` (dormant rule detection)
+- `/context:budget` (context health)
+
+## References
+
+- kimun (lnds/kimun). Rule of Three for duplicate severity
+- SonarQube. Issue severity classification model
+- scoring-curves.md for normalization breakpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.3.0] — 2026-03-04
+
+### Added — Scoring Intelligence (Era 28)
+
+- **scoring-curves.md**: piecewise linear normalization for 6 dimensions (PR size, context usage, file size, velocity deviation, test coverage, Brier score). Smooth degradation with calibrated breakpoints instead of binary pass/fail. Inspired by kimun (lnds/kimun) and SonarSource/Microsoft Code Metrics.
+- **score-diff.md**: `/score:diff` command comparing workspace metrics between git refs. Delta tracking with regression/improvement classification. Haiku subagent for data collection.
+- **severity-classification.md**: Rule of Three severity system — 3+ occurrences → CRITICAL, 2 → WARNING, 1 → INFO. Temporal escalation (same WARNING × 3 sprints → auto-CRITICAL). Thresholds for PR quality, sprint health, context health, code quality.
+- Tests: `test-scoring-intelligence.sh` — 39 tests across scoring curves, score diff, severity classification, integration and cross-references.
+
+---
+
 ## [2.2.0] — 2026-03-04
 
 ### Added — Best Practices Audit & Documentation (Era 27)

--- a/README.en.md
+++ b/README.en.md
@@ -457,6 +457,7 @@ These are the rules that are never skipped — not even by me:
 
 | Version | Era | Summary |
 |---|---|---|
+| **v2.3.0** | Era 28 | Scoring Intelligence — piecewise curves, `/score:diff`, Rule of Three severity. Inspired by kimun. |
 | **v2.2.0** | Era 27 | Best Practices Audit — project CLAUDE.md guide + coverage audit |
 | **v2.1.0** | Era 26 | Equality Shield — gender bias prevention based on LLYC study |
 | **v2.0.0** | Era 25 | Quality Validation Framework: multi-judge consensus (3 judges, weighted scoring, security/GDPR veto), confidence calibration (Brier score, decay, recovery), coherence-validator (Sonnet 4.6). 98 new tests. |

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Estas son las reglas que nunca se saltan — ni yo misma:
 
 | Versión | Era | Resumen |
 |---|---|---|
+| **v2.3.0** | Era 28 | Scoring Intelligence — curvas piecewise, `/score:diff`, severidad Rule of Three. Inspirado en kimun. |
 | **v2.2.0** | Era 27 | Best Practices Audit — guía CLAUDE.md de proyecto + auditoría de cobertura |
 | **v2.1.0** | Era 26 | Equality Shield — lucha contra sesgos de género basado en estudio LLYC |
 | **v2.0.0** | Era 25 | Quality Validation Framework: consenso multi-juez (3 jueces, scoring ponderado, veto security/GDPR), calibración de confianza (Brier score, decay, recovery), coherence-validator (Sonnet 4.6). 98 tests nuevos. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 336+ commands, 27 agents, 25 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 27 thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 336+ commands, 27 agents, 25 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 28 thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -251,6 +251,17 @@ External audit of [claude-code-best-practice](https://github.com/shanraisshan/cl
 - **CLAUDE-GUIDE.md** — Template and best practices for `projects/{name}/CLAUDE.md` files (~50 line minimal, ~120 line complete)
 - **estudio-equality-shield.md** — Full implementation study with academic references for the Equality Shield
 - **Coverage audit** — Confirmed existing coverage: context-map, agent-self-memory, intelligent-hooks, source-tracking, semantic-hub-index, confidence-protocol, consensus-protocol, context-aging, command-ux-feedback, skillssh-publishing, output-first, file-size-limit
+
+---
+
+## ✅ Era 28 — Scoring Intelligence (v2.3.0, Mar 2026)
+
+Inspired by [kimun](https://github.com/lnds/kimun) analysis. Piecewise linear scoring curves, score diffing between git refs, and Rule of Three severity classification. 336+ commands, 27 agents, 25 skills.
+
+- **Scoring Curves** — `scoring-curves.md`: 6 dimension curves (PR size, context usage, file size, velocity deviation, test coverage, Brier score) with calibrated breakpoints and linear interpolation. Replaces binary pass/fail scoring. Based on SonarSource and Microsoft Code Metrics thresholds.
+- **Score Diff** — `/score:diff` command comparing workspace health between git refs. Delta tracking with regression/improvement classification. Outputs to `output/scores/`. Haiku subagent for efficient data collection.
+- **Severity Classification** — `severity-classification.md`: Rule of Three pattern (3+ → CRITICAL, 2 → WARNING, 1 → INFO). Temporal escalation: same WARNING for 3 consecutive sprints auto-escalates to CRITICAL. Thresholds for PR quality, sprint health, context health, and code quality.
+- **39 new tests** — `test-scoring-intelligence.sh` covering all 3 features + integration + cross-references.
 
 ---
 

--- a/scripts/test-scoring-intelligence.sh
+++ b/scripts/test-scoring-intelligence.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# test-scoring-intelligence.sh — Tests for Scoring Intelligence (v2.3.0)
+set -uo pipefail
+
+PASS=0; FAIL=0; TOTAL=0
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); echo "  ❌ $1"; }
+check() { if eval "$1" >/dev/null 2>&1; then pass "$2"; else fail "$2"; fi }
+
+CURVES="/home/monica/claude/.claude/rules/domain/scoring-curves.md"
+DIFF="/home/monica/claude/.claude/commands/score-diff.md"
+SEV="/home/monica/claude/.claude/rules/domain/severity-classification.md"
+CLAUDE="/home/monica/claude/CLAUDE.md"
+CHANGELOG="/home/monica/claude/CHANGELOG.md"
+
+echo "═══ Testing Scoring Intelligence (v2.3.0) ═══"
+echo ""
+
+# ─── Section 1: Scoring Curves Rule ───
+echo "Section 1: Scoring Curves (scoring-curves.md)"
+
+check "test -f $CURVES" "File exists"
+check "[ \$(wc -l < $CURVES) -le 150 ]" "File ≤ 150 lines"
+check "grep -qi 'piecewise\|breakpoint' $CURVES" "Contains piecewise/breakpoint concept"
+check "grep -qi 'PR.*size\|lines.*changed' $CURVES" "Contains PR size dimension"
+check "grep -qi 'context.*usage\|200K' $CURVES" "Contains context usage dimension"
+check "grep -qi 'file.*size\|150' $CURVES" "Contains file size dimension"
+check "grep -qi 'velocity\|sprint' $CURVES" "Contains velocity dimension"
+check "grep -qi 'coverage\|test' $CURVES" "Contains test coverage dimension"
+check "grep -qi 'brier\|confidence\|calibration' $CURVES" "Contains confidence calibration dimension"
+check "grep -qi 'SonarSource\|Microsoft\|kimun' $CURVES" "Contains references"
+check "grep -qi 'interpolat\|formula' $CURVES" "Contains interpolation formula"
+
+echo ""
+
+# ─── Section 2: Score Diff Command ───
+echo "Section 2: Score Diff Command (score-diff.md)"
+
+check "test -f $DIFF" "File exists"
+check "[ \$(wc -l < $DIFF) -le 150 ]" "File ≤ 150 lines"
+check "grep -qi 'score.diff\|/score:diff' $DIFF" "Contains command name"
+check "grep -qi 'usage\|--from\|--to' $DIFF" "Contains usage syntax"
+check "grep -qi 'delta\|regression\|improvement' $DIFF" "Contains delta tracking"
+check "grep -qi 'CRITICAL\|WARNING\|HEALTHY' $DIFF" "Contains severity classification"
+check "grep -qi 'output/' $DIFF" "Contains output path"
+check "grep -qi 'subagent\|haiku\|model' $DIFF" "Contains subagent config"
+check "grep -qi 'scoring-curves\|kimun' $DIFF" "Contains references"
+
+echo ""
+
+# ─── Section 3: Severity Classification Rule ───
+echo "Section 3: Severity Classification (severity-classification.md)"
+
+check "test -f $SEV" "File exists"
+check "[ \$(wc -l < $SEV) -le 150 ]" "File ≤ 150 lines"
+check "grep -qi 'rule of three' $SEV" "Contains Rule of Three concept"
+check "grep -qi 'CRITICAL' $SEV" "Contains CRITICAL level"
+check "grep -qi 'WARNING' $SEV" "Contains WARNING level"
+check "grep -qi 'INFO' $SEV" "Contains INFO level"
+check "grep -qi 'PR.*quality\|files.*changed' $SEV" "Contains PR quality thresholds"
+check "grep -qi 'sprint.*health\|velocity' $SEV" "Contains sprint health thresholds"
+check "grep -qi 'context.*health\|context.*usage' $SEV" "Contains context health thresholds"
+check "grep -qi 'code.*quality\|complexity' $SEV" "Contains code quality thresholds"
+check "grep -qi 'escalat' $SEV" "Contains escalation protocol"
+check "grep -qi 'temporal\|consecutive' $SEV" "Contains temporal escalation"
+check "grep -qi 'kimun\|SonarQube' $SEV" "Contains references"
+
+echo ""
+
+# ─── Section 4: Integration ───
+echo "Section 4: Integration & Documentation"
+
+check "grep -qi '2\.3\.0' $CHANGELOG" "CHANGELOG contains v2.3.0"
+check "grep -qi 'scoring\|curves\|severity' $CHANGELOG" "CHANGELOG describes scoring features"
+check "grep -qi 'kimun' $CHANGELOG" "CHANGELOG credits kimun"
+
+echo ""
+
+# ─── Section 5: Cross-references ───
+echo "Section 5: Cross-references"
+
+check "grep -qi 'scoring-curves' $DIFF" "score-diff references scoring-curves"
+check "grep -qi 'scoring-curves' $SEV" "severity references scoring-curves"
+check "grep -qi 'severity\|rule of three\|CRITICAL' $DIFF" "score-diff references severity"
+
+echo ""
+echo "═══ Scoring Intelligence: $PASS/$TOTAL passed ═══"
+
+if [ "$FAIL" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary

Adds piecewise linear scoring curves, score diffing between git refs, and Rule of Three severity classification — inspired by [kimun](https://github.com/lnds/kimun) analysis.

**New files:**
- `.claude/rules/domain/scoring-curves.md` — 6 dimension curves (PR size, context usage, file size, velocity, test coverage, Brier score) with linear interpolation between calibrated breakpoints
- `.claude/commands/score-diff.md` — `/score:diff` command for comparing workspace metrics between git refs
- `.claude/rules/domain/severity-classification.md` — Rule of Three: 3+ → CRITICAL, 2 → WARNING, 1 → INFO. Temporal escalation included
- `scripts/test-scoring-intelligence.sh` — 39 tests, all passing

**Updated:** CHANGELOG.md, ROADMAP.md, README.md, README.en.md

## Test plan

- [x] `bash scripts/test-scoring-intelligence.sh` — 39/39 passing
- [x] All files ≤ 150 lines
- [x] Cross-references validated between all 3 new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)