### PR TITLE
fix: add missing v2.3.0 comparison link + reinforce changelog rule

### DIFF
--- a/.claude/rules/domain/changelog-enforcement.md
+++ b/.claude/rules/domain/changelog-enforcement.md
@@ -46,7 +46,15 @@ Antes de crear un commit que incluya tag de versión:
 1. Verificar que CHANGELOG.md tiene entrada para la nueva versión
 2. Verificar que la fecha es correcta (ISO 8601)
 3. Verificar que los contadores reflejan el estado real
-4. Verificar que el link de comparación existe al final del fichero
+4. **CRITICAL — Verificar que el link de comparación existe al final del fichero**
+
+### ⚠️ Error recurrente: link de comparación olvidado
+
+Este error se ha repetido en múltiples releases. Al añadir `## [X.Y.Z]` al CHANGELOG, ir SIEMPRE al bloque de links al final del fichero y añadir:
+```
+[X.Y.Z]: https://github.com/gonzalezpazmonica/pm-workspace/compare/vAnterior...vX.Y.Z
+```
+El heading `## [X.Y.Z]` sin su link correspondiente al final genera un enlace roto en el rendered markdown.
 
 ## Consecuencia de no cumplir
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v1.9.1...v2.0.0


### PR DESCRIPTION
## Summary

- Added forgotten `[2.3.0]` comparison link at the bottom of CHANGELOG.md
- Reinforced `changelog-enforcement.md` with explicit warning about this recurring error pattern — marked as CRITICAL with concrete instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)