### PR TITLE
refactor: update identity to platform-agnostic PM

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 **English** · [Versión en español](README.md)
 
-# PM-Workspace — Claude Code + Azure DevOps
+# PM-Workspace — AI-Powered Project Management for Claude Code
 
 [![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/gonzalezpazmonica/pm-workspace?logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/releases)
@@ -10,7 +10,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Contributors](https://img.shields.io/github/contributors/gonzalezpazmonica/pm-workspace)](CONTRIBUTORS.md)
 
-> 🦉 **I'm Savia**, the little owl of pm-workspace. I keep your projects flowing: I manage sprints, backlog, reports, code agents, and cloud infrastructure — all from Claude Code, in **any language**, with Scrum and Azure DevOps.
+> 🦉 **I'm Savia**, the little owl of pm-workspace. I keep your projects flowing: I manage sprints, backlog, reports, code agents, and cloud infrastructure — all from Claude Code, in **any language**. Works with Azure DevOps, Jira, or 100% Git-native via Savia Flow.
 
 > **🚀 First time here?** Check the [Adoption Guide for Consulting Firms](docs/ADOPTION_GUIDE.en.md) — step by step from Claude signup to project and team onboarding.
 
@@ -34,7 +34,7 @@ irm https://raw.githubusercontent.com/gonzalezpazmonica/pm-workspace/main/instal
 
 ## Who am I?
 
-I'm Savia — your automated PM / Scrum Master for projects on Azure DevOps. When you install me, the first thing I do is introduce myself and get to know you: your name, your role, how you work, what tools you use. I adapt to you, not the other way around.
+I'm Savia — your AI-powered automated PM. When you install me, the first thing I do is introduce myself and get to know you: your name, your role, how you work, what tools you use. I adapt to you, not the other way around. I work with Azure DevOps, Jira, or without any external PM tool — with Savia Flow I manage sprints, PBIs, and boards directly in Git.
 
 I work with 16 languages (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) and have conventions, rules, and specialized agents for each one.
 
@@ -512,4 +512,4 @@ npx claude-code-templates@latest
 
 ---
 
-*🦉 Savia — PM-Workspace, your automated PM with Claude Code + Azure DevOps for multi-language/Scrum teams*
+*🦉 Savia — PM-Workspace, your AI-powered automated PM for multi-language teams. Compatible with Azure DevOps, Jira, and Savia Flow (Git-native).*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🌐 [English version](README.en.md) · **Español**
 
-# PM-Workspace — Claude Code + Azure DevOps
+# PM-Workspace — AI-Powered Project Management for Claude Code
 
 [![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/gonzalezpazmonica/pm-workspace?logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/releases)
@@ -10,7 +10,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Contributors](https://img.shields.io/github/contributors/gonzalezpazmonica/pm-workspace)](CONTRIBUTORS.md)
 
-> 🦉 **Soy Savia**, la buhita de pm-workspace. Me encargo de que tus proyectos fluyan: gestiono sprints, backlog, informes, agentes de código e infraestructura cloud — todo desde Claude Code, en **cualquier lenguaje**, con Scrum y Azure DevOps.
+> 🦉 **Soy Savia**, la buhita de pm-workspace. Me encargo de que tus proyectos fluyan: gestiono sprints, backlog, informes, agentes de código e infraestructura cloud — todo desde Claude Code, en **cualquier lenguaje**. Funciono con Azure DevOps, Jira, o 100% Git-native con Savia Flow.
 
 > **🚀 ¿Primera vez aquí?** Consulta la [Guía de Adopción para Consultoras](docs/ADOPTION_GUIDE.md) — paso a paso desde el registro en Claude hasta la incorporación de proyectos y equipo.
 
@@ -34,7 +34,7 @@ irm https://raw.githubusercontent.com/gonzalezpazmonica/pm-workspace/main/instal
 
 ## ¿Quién soy?
 
-Soy Savia — tu PM / Scrum Master automatizada para proyectos en Azure DevOps. Cuando me instalas, lo primero que hago es presentarme y conocerte: tu nombre, tu rol, cómo trabajas, qué herramientas usas. Me adapto a ti, no al revés.
+Soy Savia — tu PM automatizada con IA. Cuando me instalas, lo primero que hago es presentarme y conocerte: tu nombre, tu rol, cómo trabajas, qué herramientas usas. Me adapto a ti, no al revés. Funciono con Azure DevOps, Jira, o sin ningún PM externo — con Savia Flow gestiono sprints, PBIs y tableros directamente en Git.
 
 Trabajo con 16 lenguajes (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) y tengo convenciones, reglas y agentes especializados para cada uno.
 
@@ -512,4 +512,4 @@ npx claude-code-templates@latest
 
 ---
 
-*🦉 Savia — PM-Workspace, tu PM automatizada con Claude Code + Azure DevOps para equipos multi-lenguaje/Scrum*
+*🦉 Savia — PM-Workspace, tu PM automatizada con IA para equipos multi-lenguaje. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).*

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -2,7 +2,7 @@
 
 # PM-Workspace Adoption Guide for Consulting Firms
 
-> From zero to AI-powered productivity in .NET project management — step by step.
+> From zero to AI-powered productivity in project management — step by step.
 
 ---
 
@@ -28,7 +28,7 @@
 
 ### What is PM-Workspace?
 
-PM-Workspace is a .NET project management system using Scrum that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager / Scrum Master**. It connects to Azure DevOps and provides 27 commands, 9 specialized skills, and 11 AI subagents covering everything from sprint planning to agent-based code implementation.
+PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 336+ commands, 25 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 industry verticals.
 
 ### Why adopt it in a consulting firm?
 
@@ -509,5 +509,5 @@ The recommended adoption is incremental. Don't try to use all features from day 
 
 ---
 
-*PM-Workspace — Claude Code + Azure DevOps for .NET/Scrum teams*
+*PM-Workspace — AI-powered project management for multi-language teams. Compatible with Azure DevOps, Jira, and Savia Flow (Git-native).*
 *[github.com/gonzalezpazmonica/pm-workspace](https://github.com/gonzalezpazmonica/pm-workspace)*

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -2,7 +2,7 @@
 
 # Guía de Adopción de PM-Workspace para Consultoras
 
-> De cero a productividad con IA en la gestión de proyectos .NET — paso a paso.
+> De cero a productividad con IA en la gestión de proyectos — paso a paso.
 
 ---
 
@@ -28,7 +28,7 @@
 
 ### ¿Qué es PM-Workspace?
 
-PM-Workspace es un sistema de gestión de proyectos .NET con Scrum que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager / Scrum Master automatizado**. Se conecta a Azure DevOps y proporciona 27 comandos, 9 skills especializadas y 11 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes.
+PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 336+ comandos, 25 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 verticales sectoriales.
 
 ### ¿Por qué adoptarlo en una consultora?
 

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -240,7 +240,7 @@
 
 ## Equipo de Subagentes Especializados
 
-El workspace incluye 24 subagentes que Claude puede invocar en paralelo o en secuencia,
+El workspace incluye 25 subagentes que Claude puede invocar en paralelo o en secuencia,
 cada uno optimizado para su tarea con el modelo LLM más adecuado:
 
 **Agentes de gestión y arquitectura:**
@@ -281,6 +281,7 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, docs de proyecto |
 | `azure-devops-operator` | Haiku 4.5 | WIQL, work items, sprint, capacity |
 | `diagram-architect` | Sonnet 4.6 | Diseño de diagramas de arquitectura, C4, flujos de datos |
+| `reflection-validator` | Opus 4.6 | Validación meta-cognitiva (System 2): supuestos, cadena causal, brechas |
 
 ### Flujo SDD con agentes en paralelo
 

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -240,7 +240,7 @@
 
 ## Specialized Agent Team
 
-The workspace includes 24 specialized agents organized in 3 groups, each optimized for its task with the most suitable LLM model:
+The workspace includes 25 specialized agents organized in 3 groups, each optimized for its task with the most suitable LLM model:
 
 ### Management & Architecture Agents
 
@@ -251,6 +251,7 @@ The workspace includes 24 specialized agents organized in 3 groups, each optimiz
 | `sdd-spec-writer` | Opus 4.6 | Generation and validation of executable SDD Specs |
 | `infrastructure-agent` | Opus 4.6 | IaC (Terraform, CloudFormation, Bicep), detect + plan multi-cloud infrastructure |
 | `diagram-architect` | Sonnet 4.6 | Architecture diagram design, C4, data flows |
+| `reflection-validator` | Opus 4.6 | Meta-cognitive validation (System 2): assumptions, causal chains, gaps |
 
 ### Language-Specific Developer Agents (16 Language Packs)
 


### PR DESCRIPTION
## Summary
- Updated title from "Claude Code + Azure DevOps" to "AI-Powered Project Management for Claude Code"
- Replaced .NET/Scrum-centric descriptions with platform-agnostic messaging (Azure DevOps, Jira, Savia Flow)
- Updated stats from "27 commands, 9 skills, 11 subagents" to "336+ commands, 25 skills, 27 subagents"
- Added reflection-validator agent to agent documentation (25th agent)

## Files changed
- `README.md` / `README.en.md` — title, Savia quote, "¿Quién soy?", footer
- `docs/ADOPTION_GUIDE.md` / `docs/ADOPTION_GUIDE.en.md` — subtitle, intro, footer
- `docs/readme/12-comandos-agentes.md` / `docs/readme_en/12-commands-agents.md` — agent count + reflection-validator

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify adoption guide intro reflects current capabilities
- [ ] Confirm agent count matches (25 in table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)