### PR TITLE
docs: comprehensive update of outdated counts and branding

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,6 +1,6 @@
 # .claude/ — Configuración de PM-Workspace
 
-Directorio de configuración de Claude Code para PM-Workspace + Azure DevOps.
+Directorio de configuración de Claude Code para PM-Workspace. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).
 
 ---
 
@@ -8,9 +8,9 @@ Directorio de configuración de Claude Code para PM-Workspace + Azure DevOps.
 
 ```
 .claude/
-├── commands/          ← 27 slash commands para flujos PM con Azure DevOps
-├── skills/            ← 9 skills especializadas en gestión de proyectos
-│   ├── azure-devops-queries/       ← Prerequisito para el resto
+├── commands/          ← 360+ slash commands para flujos PM
+├── skills/            ← 25 skills especializadas en gestión de proyectos
+│   ├── azure-devops-queries/       ← Queries a Azure DevOps
 │   ├── sprint-management/
 │   ├── capacity-planning/
 │   ├── time-tracking-report/
@@ -18,10 +18,13 @@ Directorio de configuración de Claude Code para PM-Workspace + Azure DevOps.
 │   ├── product-discovery/          ← JTBD + PRD antes de decompose
 │   ├── pbi-decomposition/
 │   ├── team-onboarding/            ← Onboarding + evaluación de competencias + RGPD
-│   └── spec-driven-development/
-├── agents/            ← 11 subagentes especializados (architect, dotnet-developer, etc.)
+│   ├── spec-driven-development/
+│   ├── architecture-intelligence/
+│   ├── voice-inbox/
+│   └── ... (25 total)
+├── agents/            ← 27 subagentes especializados (architect, dotnet-developer, etc.)
 ├── rules/             ← Reglas modulares cargadas bajo demanda
-├── mcp.json           ← Configuración MCP Azure DevOps (rellenar con datos reales)
+├── mcp.json           ← Configuración MCP (rellenar con datos reales)
 └── settings.local.json ← Permisos pre-aprobados (personalizar según entorno)
 ```
 

--- a/.claude/rules/domain/pm-config.md
+++ b/.claude/rules/domain/pm-config.md
@@ -10,7 +10,7 @@ AZURE_DEVOPS_ORG_NAME       = "MI-ORGANIZACION"
 AZURE_DEVOPS_PAT_FILE       = "$HOME/.azure/devops-pat"          # fichero con el PAT (sin comillas, sin salto de línea)
 AZURE_DEVOPS_API_VERSION    = "7.1"
 
-# ── PM / Scrum Master ────────────────────────────────────────────────────────
+# ── PM (Project Manager) ─────────────────────────────────────────────────────
 AZURE_DEVOPS_PM_USER        = "nombre.apellido@miorganizacion.com"  # email o uniqueName del PM en Azure DevOps
 AZURE_DEVOPS_PM_DISPLAY     = "Nombre Apellido"                     # nombre para mostrar en informes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 
 ## Rol
 
-**PM / Scrum Master** · multi-lenguaje · Scrum · Azure DevOps · Sprints 2 sem · Daily 09:15 · 16 lenguajes: `@.claude/rules/domain/language-packs.md`
+**PM automatizada con IA** · multi-lenguaje · Azure DevOps / Jira / Savia Flow · Sprints 2 sem · Daily 09:15 · 16 lenguajes: `@.claude/rules/domain/language-packs.md`
 
 ---
 
@@ -35,7 +35,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 ~/claude/                          ← Raíz y repositorio GitHub
 ├── .claude/
 │   ├── agents/ (27)               ← @.claude/rules/domain/agents-catalog.md
-│   ├── commands/ (327)            ← @.claude/rules/domain/pm-workflow.md
+│   ├── commands/ (360+)            ← @.claude/rules/domain/pm-workflow.md
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
 │   ├── hooks/ (14)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
@@ -54,7 +54,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 
 Inicio de sesión: `active-user.md` → voz Savia → si perfil: saludar; si no: `/profile-setup` (`@.claude/rules/domain/profile-onboarding.md`). Fragmentos por demanda: `@.claude/profiles/context-map.md`
 
-> Catálogo completo de comandos (327): `@.claude/rules/domain/pm-workflow.md`
+> Catálogo completo de comandos (360+): `@.claude/rules/domain/pm-workflow.md`
 > MCP servers se conectan bajo demanda con `/mcp-server start {nombre}`, NO al arranque.
 
 ---

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -28,7 +28,7 @@
 
 ### What is PM-Workspace?
 
-PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 336+ commands, 25 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 industry verticals.
+PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 25 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
 
 ### Why adopt it in a consulting firm?
 
@@ -74,7 +74,7 @@ Not everyone on the team needs PM-Workspace. Recommendation for a consulting fir
 
 | Role | Needs PM-Workspace? | Recommended plan |
 |------|---------------------|------------------|
-| Project Manager / Scrum Master | **Yes** — primary user | Pro ($20/mo) or Max ($100/mo) |
+| Project Manager | **Yes** — primary user | Pro ($20/mo) or Max ($100/mo) |
 | Tech Lead | **Yes** — for SDD, specs, and code review | Pro ($20/mo) |
 | Senior developers | Optional — to launch agents on specs | Pro ($20/mo) |
 | Junior developers | No — they work with Azure DevOps directly | Not needed |
@@ -201,10 +201,10 @@ After cloning, you'll find this structure:
 | Directory | Contents | Editable |
 |-----------|----------|----------|
 | `CLAUDE.md` | Claude Code entry point (global constants) | Yes |
-| `.claude/commands/` | 27 slash commands for PM workflows | Advanced |
-| `.claude/skills/` | 9 specialized skills | Advanced |
-| `.claude/agents/` | 11 AI subagents | Advanced |
-| `.claude/rules/` | Modular rules (Scrum, .NET, Git) | Advanced |
+| `.claude/commands/` | 360+ slash commands for PM workflows | Advanced |
+| `.claude/skills/` | 25 specialized skills | Advanced |
+| `.claude/agents/` | 27 AI subagents | Advanced |
+| `.claude/rules/` | Modular rules (PM, multi-language, Git) | Advanced |
 | `projects/` | Project folder (each with its own `CLAUDE.md`) | Yes |
 | `scripts/` | Auxiliary scripts (Azure DevOps, reports) | No |
 | `docs/` | Methodology documentation | Read-only |

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -28,7 +28,7 @@
 
 ### ¿Qué es PM-Workspace?
 
-PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 336+ comandos, 25 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 verticales sectoriales.
+PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 25 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
 
 ### ¿Por qué adoptarlo en una consultora?
 
@@ -74,7 +74,7 @@ No todo el equipo necesita PM-Workspace. La recomendación para una consultora:
 
 | Rol | ¿Necesita PM-Workspace? | Plan recomendado |
 |-----|------------------------|------------------|
-| Project Manager / Scrum Master | **Sí** — es el usuario principal | Pro ($20/mes) o Max ($100/mes) |
+| Project Manager | **Sí** — es el usuario principal | Pro ($20/mes) o Max ($100/mes) |
 | Tech Lead | **Sí** — para SDD, specs y code review | Pro ($20/mes) |
 | Desarrolladores senior | Opcional — para lanzar agentes sobre specs | Pro ($20/mes) |
 | Desarrolladores junior | No — trabajan con Azure DevOps directamente | No necesario |
@@ -219,10 +219,10 @@ Al clonar, encontrarás esta estructura:
 | Directorio | Contenido | Editable |
 |------------|-----------|----------|
 | `CLAUDE.md` | Punto de entrada de Claude Code (constantes globales) | Sí |
-| `.claude/commands/` | 27 slash commands para flujos PM | Avanzado |
-| `.claude/skills/` | 9 skills especializadas | Avanzado |
-| `.claude/agents/` | 11 subagentes IA | Avanzado |
-| `.claude/rules/` | Reglas modulares (Scrum, .NET, Git) | Avanzado |
+| `.claude/commands/` | 360+ slash commands para flujos PM | Avanzado |
+| `.claude/skills/` | 25 skills especializadas | Avanzado |
+| `.claude/agents/` | 27 subagentes IA | Avanzado |
+| `.claude/rules/` | Reglas modulares (PM, multi-lenguaje, Git) | Avanzado |
 | `projects/` | Carpeta de proyectos (cada uno con su `CLAUDE.md`) | Sí |
 | `scripts/` | Scripts auxiliares (Azure DevOps, informes) | No |
 | `docs/` | Documentación de metodología | Lectura |
@@ -527,5 +527,5 @@ La adopción recomendada es incremental. No intentes usar todas las funcionalida
 
 ---
 
-*PM-Workspace — Claude Code + Azure DevOps para equipos .NET/Scrum*
+*PM-Workspace — PM automatizada con IA para equipos multi-lenguaje. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).*
 *[github.com/gonzalezpazmonica/pm-workspace](https://github.com/gonzalezpazmonica/pm-workspace)*

--- a/docs/CLAUDE-GUIDE.md
+++ b/docs/CLAUDE-GUIDE.md
@@ -72,7 +72,7 @@ Añade sobre la mínima:
 ## Errores Comunes
 
 - **Copiar todas las reglas globales** → son heredadas automáticamente
-- **Listar los 336+ comandos** → referencia `pm-workflow.md`
+- **Listar los 360+ comandos** → referencia `pm-workflow.md`
 - **Incluir datos sensibles** → usar `CLAUDE.local.md` (git-ignorado)
 - **Superar 150 líneas** → dividir en ficheros referenciados con `@`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 336+ commands, 27 agents, 25 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 29 thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 25 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 29 thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -234,7 +234,7 @@ Inspired by [BullshitBench](https://github.com/petergpt/bullshit-benchmark) anal
 
 ## ✅ Era 26 — Equality Shield (v2.1.0, Mar 2026)
 
-Inspired by LLYC "Espejismo de Igualdad" (2026) audit of bias in AI systems for team management. 6 critical biases identified and mitigated with counterfactual testing. 336+ commands, 27 agents, 25 skills.
+Inspired by LLYC "Espejismo de Igualdad" (2026) audit of bias in AI systems for team management. 6 critical biases identified and mitigated with counterfactual testing. 360+ commands, 27 agents, 25 skills.
 
 - **Equality Shield Rule** — `equality-shield.md`: Framework blocking 6 biases (vocational assignment, tonal disparity, emotional labeling, experience bias, leadership exceptionalism, communication polarization). Counterfactual test obligatory before assignments/evaluations.
 - **Bias Check Command** — `/bias:check` for contrafactual audits on sprints: rewrite gender-neutral assignments, verify consistency, flag sesgos.
@@ -256,7 +256,7 @@ External audit of [claude-code-best-practice](https://github.com/shanraisshan/cl
 
 ## ✅ Era 28 — Scoring Intelligence (v2.3.0, Mar 2026)
 
-Inspired by [kimun](https://github.com/lnds/kimun) analysis. Piecewise linear scoring curves, score diffing between git refs, and Rule of Three severity classification. 336+ commands, 27 agents, 25 skills.
+Inspired by [kimun](https://github.com/lnds/kimun) analysis. Piecewise linear scoring curves, score diffing between git refs, and Rule of Three severity classification. 360+ commands, 27 agents, 25 skills.
 
 - **Scoring Curves** — `scoring-curves.md`: 6 dimension curves (PR size, context usage, file size, velocity deviation, test coverage, Brier score) with calibrated breakpoints and linear interpolation. Replaces binary pass/fail scoring. Based on SonarSource and Microsoft Code Metrics thresholds.
 - **Score Diff** — `/score:diff` command comparing workspace health between git refs. Delta tracking with regression/improvement classification. Outputs to `output/scores/`. Haiku subagent for efficient data collection.

--- a/docs/estudio-equality-shield.md
+++ b/docs/estudio-equality-shield.md
@@ -20,7 +20,7 @@ El informe **"Espejismo de Igualdad"** de LLYC (marzo 2026) auditó cerca de 10.
 
 ### 1.2 ¿Por qué esto importa para PM-Workspace y Savia Flow?
 
-PM-Workspace es un sistema donde Claude Code actúa como PM/Scrum Master automatizado para equipos .NET. Sus decisiones incluyen:
+PM-Workspace es un sistema donde Claude Code actúa como PM automatizada con IA para equipos multi-lenguaje. Sus decisiones incluyen:
 
 - **Asignación de tareas** con algoritmo de scoring (expertise × disponibilidad × balance × crecimiento)
 - **Descomposición de PBIs** y estimación de horas por miembro del equipo

--- a/docs/readme/01-introduccion.md
+++ b/docs/readme/01-introduccion.md
@@ -1,4 +1,4 @@
-# PM-Workspace — Claude Code + Azure DevOps
+# PM-Workspace — AI-Powered Project Management for Claude Code
 
 [![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/gonzalezpazmonica/pm-workspace?logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/releases)
@@ -6,7 +6,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Contributors](https://img.shields.io/github/contributors/gonzalezpazmonica/pm-workspace)](CONTRIBUTORS.md)
 
-> Sistema de gestión de proyectos **multi-lenguaje** con Scrum, impulsado por Claude Code como asistente de PM/Scrum Master con capacidad de delegar implementación técnica a agentes de IA y gestionar infraestructura cloud.
+> Plataforma de gestión de proyectos **multi-lenguaje** con IA, impulsada por Claude Code como PM automatizada con capacidad de delegar implementación técnica a agentes de IA y gestionar infraestructura cloud. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).
 
 > **🚀 ¿Primera vez aquí?** Consulta la [Guía de Adopción para Consultoras](../ADOPTION_GUIDE.md) — paso a paso desde el registro en Claude hasta la incorporación de proyectos y equipo.
 
@@ -14,7 +14,7 @@
 
 ## ¿Qué es esto?
 
-Este workspace convierte a Claude Code en un **Project Manager / Scrum Master automatizado** para proyectos de **cualquier lenguaje** en Azure DevOps. Soporta 16 lenguajes (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) con convenciones, reglas y agentes especializados para cada uno. Su característica más avanzada es el **Spec-Driven Development (SDD)**: un proceso en el que las tareas técnicas se documentan como contratos ejecutables, y Claude puede implementarlas como agente de código.
+Este workspace convierte a Claude Code en un **Project Manager automatizado con IA** para proyectos de **cualquier lenguaje**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Soporta 16 lenguajes (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) con convenciones, reglas y agentes especializados para cada uno. Su característica más avanzada es el **Spec-Driven Development (SDD)**: un proceso en el que las tareas técnicas se documentan como contratos ejecutables, y Claude puede implementarlas como agente de código.
 
 **Gestión de sprints:** seguimiento de burndown, capacity del equipo, estado del board, KPIs, reportes automáticos de retrospectiva y review en Excel/PowerPoint.
 

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Permisos de Claude Code (git-ignorado)
 │   │
-│   ├── commands/                ← 83 slash commands
+│   ├── commands/                ← 360+ slash commands
 │   │   ├── help.md              ← /help — catálogo + primeros pasos
 │   │   ├── sprint-status.md ... ← Sprint y Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI y Discovery (6)
@@ -36,7 +36,7 @@
 │   │       ├── spec-template.md
 │   │       └── ... (11 ficheros)
 │   │
-│   ├── agents/                  ← 24 subagentes especializados
+│   ├── agents/                  ← 27 subagentes especializados
 │   │   ├── business-analyst.md
 │   │   ├── architect.md
 │   │   ├── code-reviewer.md
@@ -49,7 +49,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 12 skills reutilizables
+│   ├── skills/                  ← 25 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -76,7 +76,7 @@
 │       ├── file-size-limit.md   ← Regla 150 líneas (auto-cargado)
 │       ├── readme-update.md     ← Regla 12: actualizar READMEs (auto-cargado)
 │       ├── language-packs.md    ← Tabla de 16 lenguajes (auto-cargado)
-│       ├── agents-catalog.md    ← Tabla de 24 agentes (auto-cargado)
+│       ├── agents-catalog.md    ← Tabla de 27 agentes (auto-cargado)
 │       ├── context-health.md   ← Gestión de contexto y output-first (auto-cargado)
 │       ├── domain/              ← Reglas por dominio (bajo demanda, excluidas de auto-carga)
 │       │   ├── infrastructure-as-code.md

--- a/docs/readme/03-configuracion.md
+++ b/docs/readme/03-configuracion.md
@@ -61,7 +61,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 35 comandos y las 9 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 25 skills,
 detectará el lenguaje del proyecto y cargará las convenciones y agente apropiados.
 Todas las buenas prácticas del flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 

--- a/docs/readme/13-cobertura-contribucion.md
+++ b/docs/readme/13-cobertura-contribucion.md
@@ -189,4 +189,4 @@ Las contribuciones deben ser respetuosas, técnicamente sólidas y orientadas a 
 
 ---
 
-*PM-Workspace — Estrategia Claude Code + Azure DevOps para equipos multi-lenguaje/Scrum con soporte de infraestructura cloud*
+*PM-Workspace — PM automatizada con IA para equipos multi-lenguaje. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).*

--- a/docs/readme_en/01-introduction.md
+++ b/docs/readme_en/01-introduction.md
@@ -1,8 +1,8 @@
-# PM-Workspace — Claude Code + Azure DevOps
+# PM-Workspace — AI-Powered Project Management for Claude Code
 
 ## What is this?
 
-This workspace turns Claude Code into an **automated Project Manager / Scrum Master** for projects of **any programming language** on Azure DevOps. It supports 16 languages (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) with specialized conventions, rules, and agents for each. Its most advanced feature is **Spec-Driven Development (SDD)**: a process in which technical tasks are documented as executable contracts, and Claude can implement them as a coding agent.
+This workspace turns Claude Code into an **AI-powered automated Project Manager** for projects of **any programming language**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It supports 16 languages (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) with specialized conventions, rules, and agents for each. Its most advanced feature is **Spec-Driven Development (SDD)**: a process in which technical tasks are documented as executable contracts, and Claude can implement them as a coding agent.
 
 **Sprint management:** burndown tracking, team capacity, board status, KPIs, automatic retrospective and review reports in Excel/PowerPoint.
 

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -13,7 +13,7 @@
 ├── .claude/
 │   ├── settings.local.json      ← Claude Code permissions (git-ignored)
 │   │
-│   ├── commands/                ← 83 slash commands
+│   ├── commands/                ← 360+ slash commands
 │   │   ├── help.md              ← /help — catalog + first steps
 │   │   ├── sprint-status.md ... ← Sprint & Reporting (10)
 │   │   ├── pbi-decompose.md ... ← PBI & Discovery (6)
@@ -35,7 +35,7 @@
 │   │       ├── command-catalog.md
 │   │       └── ... (11 files)
 │   │
-│   ├── agents/                  ← 24 specialized subagents
+│   ├── agents/                  ← 27 specialized subagents
 │   │   ├── business-analyst.md
 │   │   ├── architect.md
 │   │   ├── code-reviewer.md
@@ -48,7 +48,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 12 reusable skills
+│   ├── skills/                  ← 25 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/
@@ -75,7 +75,7 @@
 │       ├── file-size-limit.md   ← 150 lines rule (auto-loaded)
 │       ├── readme-update.md     ← Rule 12: update READMEs (auto-loaded)
 │       ├── language-packs.md    ← 16 supported languages table (auto-loaded)
-│       ├── agents-catalog.md    ← 24 agents table (auto-loaded)
+│       ├── agents-catalog.md    ← 27 agents table (auto-loaded)
 │       ├── context-health.md   ← Context management and output-first (auto-loaded)
 │       ├── domain/              ← Domain-specific rules (on-demand, excluded from auto-loading)
 │       │   ├── infrastructure-as-code.md

--- a/docs/readme_en/13-coverage-contributing.md
+++ b/docs/readme_en/13-coverage-contributing.md
@@ -197,4 +197,4 @@ SDD usage metrics are automatically recorded in `projects/{project}/specs/sdd-me
 
 ---
 
-*PM-Workspace — Claude Code + Azure DevOps strategy for multi-language/Scrum teams with cloud infrastructure support*
+*PM-Workspace — AI-powered automated PM for multi-language teams. Compatible with Azure DevOps, Jira, and Savia Flow (Git-native).*


### PR DESCRIPTION
## Summary
- Updated command counts across 15 files: 27/35/83/327/336+ → **360+** (actual: 361)
- Updated skills counts: 9/12/20 → **25** (actual: 25)
- Updated agent counts: 11/24 → **27** (actual: 27)
- Updated Savia's role: "PM / Scrum Master" → "PM automatizada con IA"
- Replaced "Claude Code + Azure DevOps" branding with platform-agnostic messaging
- Clarified "12 verticales" → "12 sectores regulados" (matches regulatory-compliance.md)
- Updated all footers in readme sections and adoption guides (ES + EN)

## Files changed (15)

| File | Changes |
|------|---------|
| `CLAUDE.md` | Role, command counts |
| `.claude/README.md` | Full rewrite: counts, branding, skill list |
| `.claude/rules/domain/pm-config.md` | Section header |
| `docs/ADOPTION_GUIDE.md` + `.en.md` | Counts table, role table, footer, vertical label |
| `docs/CLAUDE-GUIDE.md` | Command count |
| `docs/ROADMAP.md` | Command counts in era descriptions |
| `docs/estudio-equality-shield.md` | Role description |
| `docs/readme/01-introduccion.md` + EN | Title, quote, "What is this" section |
| `docs/readme/02-estructura.md` + EN | Commands, agents, skills counts in tree |
| `docs/readme/03-configuracion.md` | Command + skills counts |
| `docs/readme/13-cobertura-contribucion.md` + EN | Footer |

## Intentionally unchanged
- Context engineering articles (synaptic architecture ES/EN) — point-in-time publications (v0.39.0)
- CHANGELOG historical entries — accurate at time of writing
- "PM / Scrum Master" in commands/skills/rules/projects — refers to human role, not Savia's identity

## Test plan
- [ ] All updated counts verified against actual file counts (361 commands, 25 skills, 27 agents)
- [ ] Spanish/English parity verified across all paired documents
- [ ] No broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)