### PR TITLE
feat: Client Profiles v2.6.0 (Era 31)

### DIFF
--- a/.claude/commands/client-profile.md
+++ b/.claude/commands/client-profile.md
@@ -1,0 +1,105 @@
+---
+name: client-profile
+description: "Gestión de perfiles de cliente en SaviaHub"
+model: sonnet
+context_cost: medium
+allowed_tools: ["Bash", "Read", "Write", "Edit", "Task"]
+---
+
+# /client-profile — Gestión de perfiles de cliente
+
+> Reglas: @.claude/rules/domain/client-profile-config.md
+> Dependencia: @.claude/rules/domain/savia-hub-config.md
+
+## Subcomandos
+
+### /client-create {nombre}
+
+Crea un nuevo directorio de cliente en SaviaHub.
+
+**Flujo:**
+1. Verificar que SaviaHub existe (`$SAVIA_HUB_PATH/.git`)
+2. Generar slug kebab-case del nombre (sin acentos, minúsculas)
+3. Verificar que `clients/{slug}/` no existe (idempotente)
+4. Crear estructura:
+   ```
+   clients/{slug}/
+   ├── profile.md      ← Identidad del cliente (frontmatter YAML + secciones)
+   ├── contacts.md     ← Personas de contacto con roles
+   ├── rules.md        ← Reglas de negocio y dominio
+   └── projects/       ← Directorio de proyectos (vacío)
+   ```
+5. Actualizar `clients/.index.md` con nueva fila
+6. Commit: `[savia-hub] client: create {slug}`
+7. Si hay remote y no flight-mode → push automático
+
+**Output:**
+```
+🏢 Cliente "{nombre}" creado en SaviaHub
+   Slug: {slug}
+   Path: $SAVIA_HUB_PATH/clients/{slug}/
+
+   Próximos pasos:
+   • Edita profile.md con los datos del cliente
+   • Añade contactos en contacts.md
+   • /client-show {slug} para verificar
+```
+
+### /client-show {slug}
+
+Muestra el perfil completo de un cliente.
+
+**Flujo:**
+1. Leer `clients/{slug}/profile.md` → extraer frontmatter
+2. Leer `clients/{slug}/contacts.md` → tabla de contactos
+3. Leer `clients/{slug}/rules.md` → resumen de reglas
+4. Listar `clients/{slug}/projects/` → proyectos asociados
+5. Mostrar resumen formateado
+
+**Output:**
+```
+🏢 {nombre} ({slug})
+   Sector: {sector} · Desde: {since}
+   Contactos: {N} personas
+   Proyectos: {N} activos
+   Reglas: {N} definidas
+   Última edición: {date}
+```
+
+### /client-edit {slug} [sección]
+
+Abre la sección indicada del perfil para edición.
+Secciones válidas: `profile`, `contacts`, `rules`.
+Sin sección → abre `profile.md` por defecto.
+
+**Flujo:**
+1. Verificar que `clients/{slug}/` existe
+2. Leer fichero de la sección
+3. Mostrar contenido actual + permitir edición
+4. Guardar cambios
+5. Commit: `[savia-hub] client: update {slug}/{section}`
+6. Si hay remote y no flight-mode → push automático
+
+### /client-list
+
+Lista todos los clientes en SaviaHub.
+
+**Flujo:**
+1. Leer `clients/.index.md`
+2. Si está desactualizado → regenerar desde directorios
+3. Mostrar tabla formateada
+
+**Output:**
+```
+🏢 Clientes en SaviaHub ({N} total)
+
+   | Slug | Nombre | Sector | Proyectos | Última edición |
+   |------|--------|--------|-----------|----------------|
+   | ...  | ...    | ...    | ...       | ...            |
+```
+
+## Errores
+
+- SaviaHub no existe → sugerir `/savia-hub init`
+- Cliente ya existe → mostrar datos actuales, sugerir `/client-show`
+- Slug no encontrado → listar clientes similares

--- a/.claude/rules/domain/client-profile-config.md
+++ b/.claude/rules/domain/client-profile-config.md
@@ -1,0 +1,106 @@
+# Regla: Configuración de Perfiles de Cliente
+# ── Estructura, campos y validación de perfiles ──────────────────────────────
+
+> Los perfiles de cliente son entidades de primera clase en SaviaHub.
+> Cada cliente tiene su directorio bajo `clients/{slug}/` con profile,
+> contacts, rules y projects.
+
+## Estructura del directorio de cliente
+
+```
+clients/{slug}/
+├── profile.md          ← Identidad y metadatos
+├── contacts.md         ← Personas de contacto
+├── rules.md            ← Reglas de negocio y dominio
+└── projects/
+    └── {project-slug}/
+        └── metadata.md ← Metadatos del proyecto
+```
+
+## Formato de profile.md
+
+```yaml
+---
+name: "Acme Corporation"
+slug: "acme-corp"
+sector: "fintech"
+since: "2026-03"
+status: "active"          # active | inactive | prospect
+sla_tier: "standard"      # basic | standard | premium
+primary_contact: "ana-garcia"
+last_updated: "2026-03-05"
+---
+```
+
+### Secciones del profile
+
+- **Descripción**: Breve descripción del cliente y su actividad
+- **Dominio**: Área de negocio, terminología específica, conceptos clave
+- **Stack tecnológico**: Lenguajes, frameworks, infraestructura
+- **Entornos**: URLs/nombres de entornos (sin secrets)
+- **Metodología**: Scrum/Kanban/Savia Flow, duración de sprint, ceremonies
+
+## Formato de contacts.md
+
+```markdown
+| Nombre | Rol | Área | Email | Notas |
+|--------|-----|------|-------|-------|
+```
+
+Reglas:
+- Email es OPCIONAL (puede estar en `.gitignore` del hub si es sensible)
+- Rol: `sponsor`, `product-owner`, `tech-lead`, `stakeholder`, `user`
+- Un contacto puede tener múltiples roles separados por `/`
+
+## Formato de rules.md
+
+```markdown
+## Reglas de negocio
+
+1. {Regla con contexto y justificación}
+
+## Restricciones técnicas
+
+1. {Restricción con impacto}
+
+## Convenciones de comunicación
+
+- Idioma:
+- Horario:
+- Canal preferido:
+```
+
+## Generación de slug (kebab-case)
+
+1. Convertir a minúsculas
+2. Reemplazar espacios y `_` por `-`
+3. Eliminar caracteres no alfanuméricos (excepto `-`)
+4. Eliminar acentos (á→a, é→e, í→i, ó→o, ú→u, ñ→n)
+5. Colapsar `-` consecutivos
+6. Trim de `-` al inicio y final
+
+Ejemplos: `Acme Corp` → `acme-corp`, `José María S.L.` → `jose-maria-sl`
+
+## Índice de clientes (.index.md)
+
+Auto-mantenido. Se regenera con cada `/client-create` o `/client-list`.
+
+```markdown
+| Slug | Nombre | Sector | Proyectos | Última edición |
+|------|--------|--------|-----------|----------------|
+```
+
+## Validaciones
+
+- Slug DEBE ser único en `clients/`
+- `name` es obligatorio en profile.md
+- `status` solo acepta: active, inactive, prospect
+- `sla_tier` solo acepta: basic, standard, premium
+- `sector` es texto libre pero se recomienda usar los mismos valores que vertical-detection
+
+## Seguridad
+
+- NUNCA incluir passwords, tokens o API keys en ningún fichero de cliente
+- contacts.md puede excluirse del remote (`.gitignore`) si contiene PII sensible
+- Regla PII-Free: sin datos personales reales en commits de pm-workspace
+  (SaviaHub es repositorio separado, allí SÍ se permiten datos reales del cliente)

--- a/.claude/skills/client-profile-manager/SKILL.md
+++ b/.claude/skills/client-profile-manager/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: client-profile-manager
+description: "Gestión CRUD de perfiles de cliente en SaviaHub"
+context_cost: medium
+dependencies: ["savia-hub-sync"]
+---
+
+# Skill: Client Profile Manager
+
+> Regla: @.claude/rules/domain/client-profile-config.md
+> Hub: @.claude/rules/domain/savia-hub-config.md
+
+## Prerequisitos
+
+SaviaHub debe existir. Verificar:
+```bash
+[ -d "$SAVIA_HUB_PATH/.git" ] || echo "ERROR: Run /savia-hub init first"
+```
+Variable `SAVIA_HUB_PATH` default: `$HOME/.savia-hub`
+
+## Flujo: Crear cliente
+
+1. Recibir nombre del cliente
+2. Generar slug: minúsculas, sin acentos, kebab-case
+3. Verificar unicidad: `[ ! -d "$SAVIA_HUB_PATH/clients/$SLUG" ]`
+4. Crear directorio: `mkdir -p "$SAVIA_HUB_PATH/clients/$SLUG/projects"`
+5. Crear `profile.md` con plantilla:
+   ```yaml
+   ---
+   name: "{nombre}"
+   slug: "{slug}"
+   sector: ""
+   since: "{YYYY-MM}"
+   status: "active"
+   sla_tier: "standard"
+   primary_contact: ""
+   last_updated: "{YYYY-MM-DD}"
+   ---
+   ## Descripción
+   (Completar con datos del cliente)
+   ## Dominio
+   (Área de negocio, terminología, conceptos clave)
+   ## Stack tecnológico
+   (Lenguajes, frameworks, infraestructura)
+   ## Metodología
+   (Scrum/Kanban/Savia Flow, sprint duration)
+   ```
+6. Crear `contacts.md` con plantilla:
+   ```markdown
+   # Contactos — {nombre}
+   | Nombre | Rol | Área | Email | Notas |
+   |--------|-----|------|-------|-------|
+   ```
+7. Crear `rules.md` con plantilla:
+   ```markdown
+   # Reglas — {nombre}
+   ## Reglas de negocio
+   (Definir reglas del dominio del cliente)
+   ## Restricciones técnicas
+   (Limitaciones de infraestructura, compatibilidad)
+   ## Convenciones de comunicación
+   - Idioma:
+   - Horario:
+   - Canal preferido:
+   ```
+8. Actualizar `.index.md`: añadir fila con slug, nombre, sector, 0 proyectos, fecha
+9. Git commit: `[savia-hub] client: create {slug}`
+10. Si remote + no flight-mode → push (delegar a savia-hub-sync skill)
+
+## Flujo: Mostrar cliente
+
+1. Verificar existencia: `[ -d "$SAVIA_HUB_PATH/clients/$SLUG" ]`
+2. Leer frontmatter de `profile.md` → extraer campos
+3. Contar líneas en `contacts.md` (excluir header) → N contactos
+4. Contar reglas en `rules.md` → N reglas
+5. Listar subdirectorios en `projects/` → N proyectos
+6. Obtener última fecha commit: `git log -1 --format=%ci -- "clients/$SLUG/"`
+7. Formatear output con banner 🏢
+
+## Flujo: Editar cliente
+
+1. Verificar existencia del slug
+2. Mapear sección al fichero: profile→profile.md, contacts→contacts.md, rules→rules.md
+3. Leer fichero actual → mostrar al PM
+4. Aplicar ediciones solicitadas
+5. Actualizar `last_updated` en profile.md si se modificó cualquier fichero
+6. Commit: `[savia-hub] client: update {slug}/{section}`
+7. Si remote + no flight-mode → push
+
+## Flujo: Listar clientes
+
+1. Leer `clients/.index.md`
+2. Verificar coherencia: comparar con directorios reales en `clients/`
+3. Si hay discrepancias → regenerar índice:
+   - Recorrer cada `clients/*/profile.md`
+   - Extraer name, sector del frontmatter
+   - Contar subdirs en projects/
+   - Obtener fecha último commit
+4. Mostrar tabla formateada con total
+
+## Flujo: Añadir proyecto a cliente
+
+1. Verificar existencia del slug del cliente
+2. Generar project-slug: kebab-case
+3. Crear `clients/{slug}/projects/{project-slug}/metadata.md`:
+   ```yaml
+   ---
+   name: "{project-name}"
+   slug: "{project-slug}"
+   status: "active"
+   stack: []
+   pm_tool: ""
+   created: "{YYYY-MM-DD}"
+   ---
+   ```
+4. Actualizar conteo en `.index.md`
+5. Commit: `[savia-hub] client: add project {slug}/{project-slug}`
+
+## Errores y recuperación
+
+| Error | Mensaje | Acción |
+|-------|---------|--------|
+| SaviaHub no existe | `❌ SaviaHub no inicializado` | Sugerir `/savia-hub init` |
+| Cliente ya existe | `⚠️ Cliente {slug} ya existe` | Mostrar `/client-show` |
+| Slug no encontrado | `❌ Cliente {slug} no encontrado` | Listar similares con fuzzy match |
+| Profile sin frontmatter | `⚠️ profile.md sin frontmatter` | Regenerar desde plantilla |
+
+## Seguridad
+
+- NUNCA escribir secrets, tokens o passwords en ficheros de cliente
+- SIEMPRE confirmar con PM antes de push al remote
+- contacts.md con PII → informar que puede añadirse a `.gitignore`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.6.0] — 2026-03-05
+
+### Added — Client Profiles (Era 31)
+
+- **client-profile.md**: `/client-create {name}`, `/client-show {slug}`, `/client-edit {slug} [section]`, `/client-list`. First-class client entities in SaviaHub with identity, contacts, business rules, and projects.
+- **client-profile-config.md**: Domain rule defining client directory structure (`profile.md`, `contacts.md`, `rules.md`, `projects/`), frontmatter schema, slug generation, status/SLA validation, security rules.
+- **client-profile-manager/SKILL.md**: CRUD orchestration skill — create (10 steps), show (7 steps), edit, list with index regeneration, add-project. Error handling with fuzzy match.
+- Tests: `test-client-profiles.sh` — 41 structural tests across command, rule, skill, cross-references, and SaviaHub integration.
+
+---
+
 ## [2.5.0] — 2026-03-05
 
 ### Added — SaviaHub: Shared Knowledge Repository (Era 30)
@@ -226,6 +237,8 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.5.0...v2.6.0
+[2.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.1.0...v2.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
 │   ├── hooks/ (14)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
-│   ├── skills/ (26)               ← Skills reutilizables
+│   ├── skills/ (27)               ← Skills reutilizables
 │   └── settings.json              ← Hooks + Agent Teams env
 ├── docs/ · projects/ · scripts/
 ```

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -28,7 +28,7 @@
 
 ### What is PM-Workspace?
 
-PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 26 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
+PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 27 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
 
 ### Why adopt it in a consulting firm?
 
@@ -202,7 +202,7 @@ After cloning, you'll find this structure:
 |-----------|----------|----------|
 | `CLAUDE.md` | Claude Code entry point (global constants) | Yes |
 | `.claude/commands/` | 360+ slash commands for PM workflows | Advanced |
-| `.claude/skills/` | 26 specialized skills | Advanced |
+| `.claude/skills/` | 27 specialized skills | Advanced |
 | `.claude/agents/` | 27 AI subagents | Advanced |
 | `.claude/rules/` | Modular rules (PM, multi-language, Git) | Advanced |
 | `projects/` | Project folder (each with its own `CLAUDE.md`) | Yes |

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -28,7 +28,7 @@
 
 ### ¿Qué es PM-Workspace?
 
-PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 26 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
+PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 27 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
 
 ### ¿Por qué adoptarlo en una consultora?
 
@@ -220,7 +220,7 @@ Al clonar, encontrarás esta estructura:
 |------------|-----------|----------|
 | `CLAUDE.md` | Punto de entrada de Claude Code (constantes globales) | Sí |
 | `.claude/commands/` | 360+ slash commands para flujos PM | Avanzado |
-| `.claude/skills/` | 26 skills especializadas | Avanzado |
+| `.claude/skills/` | 27 skills especializadas | Avanzado |
 | `.claude/agents/` | 27 subagentes IA | Avanzado |
 | `.claude/rules/` | Reglas modulares (PM, multi-lenguaje, Git) | Avanzado |
 | `projects/` | Carpeta de proyectos (cada uno con su `CLAUDE.md`) | Sí |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 26 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 30 thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 27 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 31 thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -283,11 +283,18 @@ Foundation for shared team knowledge. Git repository (local or remote) centraliz
 
 ---
 
-## 🟡 Eras 31–33 — Client Intelligence & Context (Proposed)
+## ✅ Era 31 — Client Profiles (v2.6.0, Mar 2026)
+
+First-class client entities in SaviaHub. Identity, contacts, business rules, and projects per client.
+
+- **Client Profiles** (v2.6.0) — `/client-create`, `/client-show`, `/client-edit`, `/client-list`. Profile with frontmatter (sector, SLA, status), contacts table, business rules, project subdirectories. Slug generation, index auto-maintenance. 1 skill, 1 rule. 41 tests.
+
+---
+
+## 🟡 Eras 32–33 — Backlog & Context Intelligence (Proposed)
 
 | Era | Version | Theme | Highlights |
 |---|---|---|---|
-| 31 — Client Profiles | v2.6.0 | First-class clients | `/client-create`, `/client-show`, `/client-edit`, `/client-list`. Client identity, contacts, rules, projects in SaviaHub |
 | 32 — BacklogGit | v2.7.0 | Backlog versioning | `/backlog-git snapshot`, `diff`, `rollback`, `deviation-report`. Periodic markdown snapshots from any PM tool |
 | 33 — Context Assistant | v2.8.0 | Active onboarding | `/context-interview start`, `resume`, `summary`, `gaps`. 8-phase structured interview, sector-adaptive |
 

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -49,7 +49,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 26 skills reutilizables
+│   ├── skills/                  ← 27 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/docs/readme/03-configuracion.md
+++ b/docs/readme/03-configuracion.md
@@ -61,7 +61,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 26 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 27 skills,
 detectará el lenguaje del proyecto y cargará las convenciones y agente apropiados.
 Todas las buenas prácticas del flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -48,7 +48,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 26 reusable skills
+│   ├── skills/                  ← 27 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/scripts/test-client-profiles.sh
+++ b/scripts/test-client-profiles.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test-client-profiles.sh — Structural tests for Client Profiles (Era 31 — v2.6.0)
+set -uo pipefail
+
+PASS=0; FAIL=0
+
+pass() { ((PASS+=1)) || true; echo "  ✅ $1"; }
+fail() { ((FAIL+=1)) || true; echo "  ❌ $1"; }
+check() { if eval "$2" > /dev/null 2>&1; then pass "$1"; else fail "$1"; fi; }
+
+echo "══════════════════════════════════════════"
+echo "  Client Profiles Tests (Era 31 — v2.6.0)"
+echo "══════════════════════════════════════════"
+
+# ── Section 1: Command file ────────────────────────────────────────────────
+echo ""
+echo "── Section 1: Command file ──"
+CMD=".claude/commands/client-profile.md"
+check "Command exists" "[ -f $CMD ]"
+LINES=$(wc -l < "$CMD")
+check "Command within line limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has client-create subcommand" "grep -q 'client-create' $CMD"
+check "Has client-show subcommand" "grep -q 'client-show' $CMD"
+check "Has client-edit subcommand" "grep -q 'client-edit' $CMD"
+check "Has client-list subcommand" "grep -q 'client-list' $CMD"
+check "References config rule" "grep -q 'client-profile-config' $CMD"
+check "References savia-hub config" "grep -q 'savia-hub-config' $CMD"
+
+# ── Section 2: Domain rule ─────────────────────────────────────────────────
+echo ""
+echo "── Section 2: Domain rule ──"
+RULE=".claude/rules/domain/client-profile-config.md"
+check "Config rule exists" "[ -f $RULE ]"
+LINES=$(wc -l < "$RULE")
+check "Config rule within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has profile.md format" "grep -q 'profile.md' $RULE"
+check "Has contacts.md format" "grep -q 'contacts.md' $RULE"
+check "Has rules.md format" "grep -q 'rules.md' $RULE"
+check "Has slug generation rules" "grep -q 'kebab-case' $RULE"
+check "Has status values" "grep -q 'active.*inactive.*prospect' $RULE"
+check "Has SLA tiers" "grep -q 'basic.*standard.*premium' $RULE"
+check "Has security section" "grep -q 'Seguridad' $RULE"
+check "Has frontmatter format" "grep -q 'name:' $RULE && grep -q 'sector:' $RULE"
+check "Has index format" "grep -q '.index.md' $RULE"
+
+# ── Section 3: Skill ──────────────────────────────────────────────────────
+echo ""
+echo "── Section 3: Skill ──"
+SKILL=".claude/skills/client-profile-manager/SKILL.md"
+check "Skill exists" "[ -f $SKILL ]"
+LINES=$(wc -l < "$SKILL")
+check "Skill within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has correct name" "grep -q 'client-profile-manager' $SKILL"
+check "Has create flow" "grep -q 'Crear cliente' $SKILL"
+check "Has show flow" "grep -q 'Mostrar cliente' $SKILL"
+check "Has edit flow" "grep -q 'Editar cliente' $SKILL"
+check "Has list flow" "grep -q 'Listar clientes' $SKILL"
+check "Has add project flow" "grep -q 'Añadir proyecto' $SKILL"
+check "Has error handling" "grep -q 'Errores' $SKILL"
+check "References savia-hub-sync" "grep -q 'savia-hub-sync' $SKILL"
+check "Has security rules" "grep -q 'NUNCA.*secrets' $SKILL"
+
+# ── Section 4: Cross-references ────────────────────────────────────────────
+echo ""
+echo "── Section 4: Cross-references ──"
+check "Command references profile.md" "grep -q 'profile.md' $CMD"
+check "Command references contacts.md" "grep -q 'contacts.md' $CMD"
+check "Skill references config rule" "grep -q 'client-profile-config' $SKILL"
+check "Skill references hub config" "grep -q 'savia-hub-config' $SKILL"
+check "Config mentions projects dir" "grep -q 'projects/' $RULE"
+check "Config mentions PII rules" "grep -q 'PII' $RULE"
+
+# ── Section 5: Integration with SaviaHub ───────────────────────────────────
+echo ""
+echo "── Section 5: Integration with SaviaHub ──"
+HUB_CONFIG=".claude/rules/domain/savia-hub-config.md"
+check "SaviaHub config exists" "[ -f $HUB_CONFIG ]"
+check "SaviaHub defines clients dir" "grep -q 'clients/' $HUB_CONFIG"
+check "SaviaHub defines profile.md" "grep -q 'profile.md' $HUB_CONFIG"
+check "SaviaHub defines contacts.md" "grep -q 'contacts.md' $HUB_CONFIG"
+check "Skill commit format matches hub" "grep -q 'savia-hub.*client' $SKILL"
+
+echo ""
+echo "══════════════════════════════════════════"
+echo "  Results: $PASS/$((PASS+FAIL)) passed, $FAIL failed"
+echo "══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- **Client Profiles**: First-class client entities in SaviaHub with CRUD management
- 4 subcommands: `/client-create`, `/client-show`, `/client-edit`, `/client-list`
- Client structure: `profile.md` (identity/frontmatter), `contacts.md`, `rules.md`, `projects/`
- Slug generation, status/SLA validation, index auto-maintenance
- 41/41 structural tests passing
- Also fixes: CHANGELOG v2.5.0 missing comparison link
- Updated: CHANGELOG (v2.6.0), ROADMAP (Era 31 released), docs (skills 26→27)

## New files (4)

| File | Type | Lines |
|------|------|-------|
| `.claude/commands/client-profile.md` | Command | 105 |
| `.claude/rules/domain/client-profile-config.md` | Rule | 106 |
| `.claude/skills/client-profile-manager/SKILL.md` | Skill | 132 |
| `scripts/test-client-profiles.sh` | Test | 87 |

## Test plan

- [x] `bash scripts/test-client-profiles.sh` → 41/41 passed
- [ ] PR Guardian CI gates
- [ ] Manual review of client profile structure and integration with SaviaHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)