### PR TITLE
feat: BacklogGit — backlog version control v2.7.0 (Era 32)

### DIFF
--- a/.claude/commands/backlog-git.md
+++ b/.claude/commands/backlog-git.md
@@ -1,0 +1,118 @@
+---
+name: backlog-git
+description: "Control de versiones para backlogs de proyectos"
+model: sonnet
+context_cost: medium
+allowed_tools: ["Bash", "Read", "Write", "Edit", "Task"]
+---
+
+# /backlog-git — Versionado de backlogs
+
+> Reglas: @.claude/rules/domain/backlog-git-config.md
+> Dependencia: @.claude/rules/domain/savia-hub-config.md · @.claude/rules/domain/client-profile-config.md
+
+## Subcomandos
+
+### /backlog-git snapshot {client} {project}
+
+Captura una foto del estado actual del backlog.
+
+**Flujo:**
+1. Verificar SaviaHub + cliente + proyecto existen
+2. Detectar fuente del backlog (Azure DevOps, Jira, GitLab, Savia Flow, manual)
+3. Extraer PBIs/items con: ID, título, estado, asignado, estimación, prioridad
+4. Generar fichero markdown: `backlog-snapshots/YYYYMMDD-HHMMSS.md`
+5. Incluir frontmatter con metadatos (fuente, total items, fecha, versión)
+6. Commit en SaviaHub: `[backlog-git] snapshot: {client}/{project} ({N} items)`
+7. Si remote + no flight-mode → push
+
+**Output:**
+```
+📸 Snapshot del backlog capturado
+   Cliente: {client} · Proyecto: {project}
+   Fuente: {source}
+   Items: {N} total ({done} done, {in-progress} in-progress, {new} new)
+   Fichero: backlog-snapshots/YYYYMMDD-HHMMSS.md
+```
+
+### /backlog-git diff {client} {project} [--from REF] [--to REF]
+
+Compara dos snapshots del backlog.
+
+**Flujo:**
+1. Sin flags → comparar último snapshot con el anterior
+2. Con `--from`/`--to` → comparar snapshots específicos (fecha o índice)
+3. Calcular deltas: items añadidos, eliminados, modificados (estado/estimación/asignado)
+4. Detectar re-estimaciones (estimación original vs actual)
+5. Mostrar resumen formateado
+
+**Output:**
+```
+📊 Diff del backlog: {from} → {to}
+   Añadidos: {N} items | Eliminados: {N} | Modificados: {N}
+   Re-estimados: {N} items (Δ total: +{H}h)
+   Estado: {N} cambiaron de estado
+```
+
+### /backlog-git rollback {client} {project} {snapshot-ref}
+
+Genera un informe de restauración (NO modifica el backlog original).
+
+**Flujo:**
+1. Cargar snapshot referenciado
+2. Comparar con estado actual → generar diff inverso
+3. Listar acciones necesarias para restaurar al estado del snapshot
+4. NUNCA ejecutar automáticamente — solo informar al PM
+5. El PM decide si aplica manualmente en el PM tool
+
+**Output:**
+```
+🔄 Plan de rollback al snapshot {ref}
+   Acciones necesarias:
+   • Restaurar {N} items eliminados
+   • Revertir {N} cambios de estado
+   • Revertir {N} re-estimaciones
+   ⚠️ Revisión manual requerida antes de aplicar
+```
+
+### /backlog-git deviation-report {client} {project}
+
+Informe de desvíos acumulados entre snapshots.
+
+**Flujo:**
+1. Cargar todos los snapshots del proyecto (cronológicos)
+2. Calcular: items añadidos post-planificación, re-estimaciones totales,
+   scope creep (%), velocity real vs planificada
+3. Generar informe con gráfico ASCII de evolución
+4. Guardar en `output/` con formato estándar
+
+**Output:**
+```
+📈 Informe de desvíos — {client}/{project}
+   Período: {first-snapshot} → {last-snapshot} ({N} snapshots)
+   Scope creep: +{N} items ({%}%)
+   Re-estimación total: +{H}h ({%}%)
+   Items sin cerrar desde inicio: {N}
+```
+
+## Formato de snapshot (markdown)
+
+```yaml
+---
+source: "azure-devops"
+project: "{project-slug}"
+client: "{client-slug}"
+timestamp: "2026-03-05T10:00:00Z"
+total_items: 42
+version: 1
+---
+```
+
+Seguido de tabla con todos los items del backlog.
+
+## Errores
+
+- SaviaHub no existe → sugerir `/savia-hub init`
+- Cliente/proyecto no encontrado → sugerir `/client-create`
+- Sin snapshots → sugerir `/backlog-git snapshot`
+- PM tool no conectado → ofrecer snapshot manual

--- a/.claude/rules/domain/backlog-git-config.md
+++ b/.claude/rules/domain/backlog-git-config.md
@@ -1,0 +1,95 @@
+# Regla: Configuración BacklogGit
+# ── Versionado de backlogs con snapshots en SaviaHub ─────────────────────────
+
+> BacklogGit captura snapshots periódicos del backlog de cualquier PM tool
+> y los almacena como markdown en SaviaHub, dentro del directorio del proyecto.
+> Permite auditar cambios, detectar desvíos y restaurar estados anteriores.
+
+## Ubicación de snapshots
+
+```
+$SAVIA_HUB_PATH/clients/{client-slug}/projects/{project-slug}/
+└── backlog-snapshots/
+    ├── 20260301-090000.md    ← Snapshot ordenado por fecha
+    ├── 20260305-100000.md
+    └── ...
+```
+
+## Fuentes soportadas
+
+| Fuente | Extracción | Detección |
+|--------|-----------|-----------|
+| Azure DevOps | WIQL query via API | `AZURE_DEVOPS_ORG_URL` definida |
+| Jira | JQL query via API | `JIRA_BASE_URL` definida |
+| GitLab | Issues API | `GITLAB_URL` definida |
+| Savia Flow | Leer `projects/{name}/backlog/` | Directorio `backlog/` existe |
+| Manual | PM dicta items | Fallback si no hay tool |
+
+Detección automática: comprobar env vars en orden. Si ninguna → modo manual.
+
+## Formato de snapshot
+
+```yaml
+---
+source: "azure-devops"
+client: "acme-corp"
+project: "erp-migration"
+timestamp: "2026-03-05T10:00:00Z"
+total_items: 42
+by_state: { new: 10, active: 15, resolved: 12, closed: 5 }
+total_estimation_hours: 320
+version: 1
+---
+```
+
+### Tabla de items
+
+```markdown
+| ID | Título | Estado | Asignado | Estimación | Prioridad | Tags |
+|----|--------|--------|----------|------------|-----------|------|
+```
+
+- ID: identificador del PM tool (o secuencial si manual)
+- Estimación: en horas (convertir story points si es necesario)
+- Prioridad: 1-critical, 2-high, 3-medium, 4-low
+
+## Algoritmo de diff
+
+1. Parsear frontmatter + tabla de ambos snapshots
+2. Crear mapa ID→item para cada snapshot
+3. Calcular:
+   - **Añadidos**: IDs en `to` que no están en `from`
+   - **Eliminados**: IDs en `from` que no están en `to`
+   - **Modificados**: IDs en ambos con campos diferentes
+4. Para modificados, detectar campos cambiados: estado, asignado, estimación, prioridad
+5. Calcular métricas: scope creep %, re-estimación total, velocity delta
+
+## Deviation report
+
+Métricas calculadas sobre la serie temporal de snapshots:
+
+- **Scope creep**: `(items_final - items_inicial) / items_inicial × 100`
+- **Re-estimación**: `Σ |estimación_actual - estimación_original|` por item
+- **Completion rate**: `items_closed / items_total` por snapshot
+- **Velocity trend**: items cerrados entre snapshots consecutivos
+
+## Reglas de integridad
+
+- Snapshots son INMUTABLES una vez commiteados (append-only)
+- NUNCA modificar un snapshot existente
+- NUNCA borrar snapshots sin confirmación explícita del PM
+- Rollback genera INFORME, no modifica el backlog original
+- El PM aplica cambios manualmente en el PM tool
+
+## Frecuencia recomendada
+
+- Sprint planning → snapshot al inicio
+- Sprint review → snapshot al cierre
+- Cambios masivos al backlog → snapshot antes y después
+- Mínimo recomendado: 1 snapshot por sprint
+
+## Seguridad
+
+- Datos de negocio del cliente → SaviaHub (repo separado, datos reales OK)
+- NUNCA incluir credentials del PM tool en snapshots
+- Respetar regla PII-Free de pm-workspace para commits en el repo principal

--- a/.claude/skills/backlog-git-tracker/SKILL.md
+++ b/.claude/skills/backlog-git-tracker/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: backlog-git-tracker
+description: "Captura, comparación y auditoría de snapshots de backlog"
+context_cost: medium
+dependencies: ["savia-hub-sync", "client-profile-manager"]
+---
+
+# Skill: BacklogGit Tracker
+
+> Regla: @.claude/rules/domain/backlog-git-config.md
+> Hub: @.claude/rules/domain/savia-hub-config.md
+
+## Prerequisitos
+
+- SaviaHub inicializado: `[ -d "$SAVIA_HUB_PATH/.git" ]`
+- Cliente y proyecto existen: `[ -d "$SAVIA_HUB_PATH/clients/$CLIENT/projects/$PROJECT" ]`
+- Si no existe `backlog-snapshots/` → crear
+
+## Flujo: Snapshot
+
+1. Detectar fuente del backlog (por orden de prioridad):
+   - `AZURE_DEVOPS_ORG_URL` → Azure DevOps (WIQL query)
+   - `JIRA_BASE_URL` → Jira (JQL query)
+   - `GITLAB_URL` → GitLab (Issues API)
+   - Directorio `backlog/` en proyecto → Savia Flow
+   - Ninguno → modo manual (PM dicta items)
+2. Extraer items: ID, título, estado, asignado, estimación (horas), prioridad, tags
+3. Generar timestamp: `date -u +%Y%m%d-%H%M%S`
+4. Crear directorio si no existe: `mkdir -p backlog-snapshots/`
+5. Escribir snapshot markdown con frontmatter YAML + tabla
+6. Calcular resumen: total, por estado, estimación total
+7. Commit: `[backlog-git] snapshot: $CLIENT/$PROJECT ($TOTAL items)`
+8. Si remote + no flight-mode → push (delegar a savia-hub-sync)
+9. Mostrar banner con resumen
+
+## Flujo: Diff
+
+1. Resolver referencias:
+   - Sin flags → último vs penúltimo snapshot
+   - `--from YYYYMMDD` → buscar snapshot con prefijo
+   - Índice numérico (`-1`, `-2`) → contar desde el más reciente
+2. Parsear ambos snapshots: extraer frontmatter + tabla → mapa ID→item
+3. Calcular deltas:
+   - Añadidos: `IDs(to) - IDs(from)`
+   - Eliminados: `IDs(from) - IDs(to)`
+   - Modificados: `IDs(from) ∩ IDs(to)` con campos diferentes
+4. Para cada modificado, registrar: campo, valor anterior, valor nuevo
+5. Calcular métricas: scope change %, re-estimación total Δh
+6. Mostrar diff formateado con banner 📊
+
+## Flujo: Rollback (solo informe)
+
+1. Cargar snapshot referenciado → parsear items
+2. Obtener estado actual (último snapshot o query al PM tool)
+3. Generar diff inverso: qué acciones serían necesarias
+4. Listar acciones en formato checklist:
+   - `[ ] Restaurar item #{ID}: "{título}"`
+   - `[ ] Revertir estado de #{ID}: {actual} → {original}`
+   - `[ ] Revertir estimación de #{ID}: {actual}h → {original}h`
+5. **NUNCA ejecutar** — solo informar al PM
+6. Guardar informe en `output/` si se solicita
+
+## Flujo: Deviation Report
+
+1. Listar todos los snapshots: `ls backlog-snapshots/*.md | sort`
+2. Parsear serie temporal: para cada snapshot, extraer total, por estado, estimación
+3. Calcular métricas acumuladas:
+   - Scope creep: `(items_final - items_inicial) / items_inicial × 100`
+   - Re-estimación: `Σ deltas de estimación`
+   - Completion trend: `closed/total` por snapshot
+   - Velocity: items cerrados entre snapshots consecutivos
+4. Generar gráfico ASCII de evolución (items totales, cerrados, estimación)
+5. Guardar en `output/YYYYMMDD-deviation-{client}-{project}.md`
+6. Mostrar resumen con banner 📈
+
+## Snapshot manual
+
+Cuando no hay PM tool conectado:
+1. Pedir al PM lista de items (puede ser informal)
+2. Estructurar en tabla con IDs secuenciales (M001, M002...)
+3. Pedir confirmación antes de guardar
+4. Mismo flujo de commit/push
+
+## Errores
+
+| Error | Acción |
+|-------|--------|
+| SaviaHub no existe | Sugerir `/savia-hub init` |
+| Cliente no existe | Sugerir `/client-create` |
+| Proyecto no existe | Sugerir `/client-edit {slug}` + añadir proyecto |
+| Sin snapshots | Sugerir `/backlog-git snapshot` primero |
+| PM tool no accesible | Ofrecer snapshot manual |
+
+## Seguridad
+
+- Snapshots son append-only: NUNCA modificar uno existente
+- NUNCA ejecutar rollback automático — solo informar
+- NUNCA incluir tokens o credentials en snapshots
+- Confirmar con PM antes de push al remote

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.7.0] — 2026-03-05
+
+### Added — BacklogGit: Backlog Version Control (Era 32)
+
+- **backlog-git.md**: `/backlog-git snapshot`, `diff`, `rollback`, `deviation-report`. Captures periodic markdown snapshots of backlogs from any PM tool (Azure DevOps, Jira, GitLab, Savia Flow, manual). Diff algorithm detects added/removed/modified items with scope creep and re-estimation metrics.
+- **backlog-git-config.md**: Domain rule defining snapshot format (YAML frontmatter + items table), 5 source types with auto-detection, diff algorithm, deviation metrics, immutability rules, frequency guidance.
+- **backlog-git-tracker/SKILL.md**: Snapshot capture (9 steps), diff with flexible references, rollback (info-only, NEVER auto-execute), deviation report with temporal metrics and ASCII charts.
+- Tests: `test-backlog-git.sh` — 41 structural tests across command, rule, skill, and cross-references.
+
+---
+
 ## [2.6.0] — 2026-03-05
 
 ### Added — Client Profiles (Era 31)
@@ -237,6 +248,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.3.0...v2.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
 │   ├── hooks/ (14)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
-│   ├── skills/ (27)               ← Skills reutilizables
+│   ├── skills/ (28)               ← Skills reutilizables
 │   └── settings.json              ← Hooks + Agent Teams env
 ├── docs/ · projects/ · scripts/
 ```

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -28,7 +28,7 @@
 
 ### What is PM-Workspace?
 
-PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 27 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
+PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 28 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
 
 ### Why adopt it in a consulting firm?
 
@@ -202,7 +202,7 @@ After cloning, you'll find this structure:
 |-----------|----------|----------|
 | `CLAUDE.md` | Claude Code entry point (global constants) | Yes |
 | `.claude/commands/` | 360+ slash commands for PM workflows | Advanced |
-| `.claude/skills/` | 27 specialized skills | Advanced |
+| `.claude/skills/` | 28 specialized skills | Advanced |
 | `.claude/agents/` | 27 AI subagents | Advanced |
 | `.claude/rules/` | Modular rules (PM, multi-language, Git) | Advanced |
 | `projects/` | Project folder (each with its own `CLAUDE.md`) | Yes |

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -28,7 +28,7 @@
 
 ### ¿Qué es PM-Workspace?
 
-PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 27 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
+PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 28 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
 
 ### ¿Por qué adoptarlo en una consultora?
 
@@ -220,7 +220,7 @@ Al clonar, encontrarás esta estructura:
 |------------|-----------|----------|
 | `CLAUDE.md` | Punto de entrada de Claude Code (constantes globales) | Sí |
 | `.claude/commands/` | 360+ slash commands para flujos PM | Avanzado |
-| `.claude/skills/` | 27 skills especializadas | Avanzado |
+| `.claude/skills/` | 28 skills especializadas | Avanzado |
 | `.claude/agents/` | 27 subagentes IA | Avanzado |
 | `.claude/rules/` | Reglas modulares (PM, multi-lenguaje, Git) | Avanzado |
 | `projects/` | Carpeta de proyectos (cada uno con su `CLAUDE.md`) | Sí |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 27 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 31 thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 28 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 32 thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -291,11 +291,18 @@ First-class client entities in SaviaHub. Identity, contacts, business rules, and
 
 ---
 
-## 🟡 Eras 32–33 — Backlog & Context Intelligence (Proposed)
+## ✅ Era 32 — BacklogGit: Backlog Version Control (v2.7.0, Mar 2026)
+
+Periodic markdown snapshots of backlogs from any PM tool. Diff, rollback (info-only), and deviation reporting.
+
+- **BacklogGit** (v2.7.0) — `/backlog-git snapshot`, `diff`, `rollback`, `deviation-report`. 5 sources (Azure DevOps, Jira, GitLab, Savia Flow, manual). Scope creep detection, re-estimation tracking. Append-only immutable snapshots. 1 skill, 1 rule. 41 tests.
+
+---
+
+## 🟡 Era 33 — Context Analysis Assistant (Proposed)
 
 | Era | Version | Theme | Highlights |
 |---|---|---|---|
-| 32 — BacklogGit | v2.7.0 | Backlog versioning | `/backlog-git snapshot`, `diff`, `rollback`, `deviation-report`. Periodic markdown snapshots from any PM tool |
 | 33 — Context Assistant | v2.8.0 | Active onboarding | `/context-interview start`, `resume`, `summary`, `gaps`. 8-phase structured interview, sector-adaptive |
 
 ---

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -49,7 +49,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 27 skills reutilizables
+│   ├── skills/                  ← 28 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/docs/readme/03-configuracion.md
+++ b/docs/readme/03-configuracion.md
@@ -61,7 +61,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 27 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 28 skills,
 detectará el lenguaje del proyecto y cargará las convenciones y agente apropiados.
 Todas las buenas prácticas del flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -48,7 +48,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 27 reusable skills
+│   ├── skills/                  ← 28 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/scripts/test-backlog-git.sh
+++ b/scripts/test-backlog-git.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# test-backlog-git.sh — Structural tests for BacklogGit (Era 32 — v2.7.0)
+set -uo pipefail
+
+PASS=0; FAIL=0
+
+pass() { ((PASS+=1)) || true; echo "  ✅ $1"; }
+fail() { ((FAIL+=1)) || true; echo "  ❌ $1"; }
+check() { if eval "$2" > /dev/null 2>&1; then pass "$1"; else fail "$1"; fi; }
+
+echo "══════════════════════════════════════════"
+echo "  BacklogGit Tests (Era 32 — v2.7.0)"
+echo "══════════════════════════════════════════"
+
+# ── Section 1: Command file ────────────────────────────────────────────────
+echo ""
+echo "── Section 1: Command file ──"
+CMD=".claude/commands/backlog-git.md"
+check "Command exists" "[ -f $CMD ]"
+LINES=$(wc -l < "$CMD")
+check "Command within line limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has snapshot subcommand" "grep -q 'snapshot' $CMD"
+check "Has diff subcommand" "grep -q 'diff' $CMD"
+check "Has rollback subcommand" "grep -q 'rollback' $CMD"
+check "Has deviation-report subcommand" "grep -q 'deviation-report' $CMD"
+check "References config rule" "grep -q 'backlog-git-config' $CMD"
+check "References savia-hub" "grep -q 'savia-hub' $CMD"
+check "References client profiles" "grep -q 'client-profile' $CMD"
+check "Has snapshot format" "grep -q 'YYYYMMDD' $CMD"
+
+# ── Section 2: Domain rule ─────────────────────────────────────────────────
+echo ""
+echo "── Section 2: Domain rule ──"
+RULE=".claude/rules/domain/backlog-git-config.md"
+check "Config rule exists" "[ -f $RULE ]"
+LINES=$(wc -l < "$RULE")
+check "Config rule within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has snapshot location" "grep -q 'backlog-snapshots' $RULE"
+check "Has Azure DevOps source" "grep -q 'Azure DevOps' $RULE"
+check "Has Jira source" "grep -q 'Jira' $RULE"
+check "Has GitLab source" "grep -q 'GitLab' $RULE"
+check "Has Savia Flow source" "grep -q 'Savia Flow' $RULE"
+check "Has manual source" "grep -q 'Manual' $RULE"
+check "Has diff algorithm" "grep -q 'Algoritmo de diff' $RULE"
+check "Has scope creep metric" "grep -q 'scope creep' $RULE"
+check "Has immutability rule" "grep -q 'INMUTABLES' $RULE"
+check "Has frequency guidance" "grep -q 'Frecuencia' $RULE"
+check "Has security section" "grep -q 'Seguridad' $RULE"
+
+# ── Section 3: Skill ──────────────────────────────────────────────────────
+echo ""
+echo "── Section 3: Skill ──"
+SKILL=".claude/skills/backlog-git-tracker/SKILL.md"
+check "Skill exists" "[ -f $SKILL ]"
+LINES=$(wc -l < "$SKILL")
+check "Skill within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has correct name" "grep -q 'backlog-git-tracker' $SKILL"
+check "Has snapshot flow" "grep -q 'Flujo: Snapshot' $SKILL"
+check "Has diff flow" "grep -q 'Flujo: Diff' $SKILL"
+check "Has rollback flow" "grep -q 'Flujo: Rollback' $SKILL"
+check "Has deviation flow" "grep -q 'Flujo: Deviation' $SKILL"
+check "Has manual snapshot" "grep -q 'Snapshot manual' $SKILL"
+check "Has error handling" "grep -q 'Errores' $SKILL"
+check "Has append-only rule" "grep -q 'append-only' $SKILL"
+check "References savia-hub-sync" "grep -q 'savia-hub-sync' $SKILL"
+check "References client-profile" "grep -q 'client-profile' $SKILL"
+check "NEVER auto-rollback" "grep -q 'NUNCA ejecutar' $SKILL"
+
+# ── Section 4: Cross-references ────────────────────────────────────────────
+echo ""
+echo "── Section 4: Cross-references ──"
+HUB_CONFIG=".claude/rules/domain/savia-hub-config.md"
+check "SaviaHub mentions backlog-snapshots" "grep -q 'backlog-snapshots' $HUB_CONFIG"
+check "Skill references hub config" "grep -q 'savia-hub-config' $SKILL"
+check "Skill references backlog rule" "grep -q 'backlog-git-config' $SKILL"
+check "Command mentions output dir" "grep -q 'output/' $CMD"
+check "Rule mentions deviation metrics" "grep -q 'Re-estimación' $RULE"
+
+echo ""
+echo "══════════════════════════════════════════"
+echo "  Results: $PASS/$((PASS+FAIL)) passed, $FAIL failed"
+echo "══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- **BacklogGit**: Periodic markdown snapshots of backlogs from any PM tool
- 4 subcommands: `/backlog-git snapshot`, `diff`, `rollback`, `deviation-report`
- 5 source types: Azure DevOps, Jira, GitLab, Savia Flow, manual
- Diff algorithm: added/removed/modified items, scope creep %, re-estimation tracking
- Rollback is info-only (NEVER auto-execute) — PM applies manually
- Append-only immutable snapshots in SaviaHub
- 41/41 structural tests passing
- Updated: CHANGELOG (v2.7.0+link), ROADMAP (Era 32), docs (skills 27→28)

## New files (4)

| File | Type | Lines |
|------|------|-------|
| `.claude/commands/backlog-git.md` | Command | 118 |
| `.claude/rules/domain/backlog-git-config.md` | Rule | 95 |
| `.claude/skills/backlog-git-tracker/SKILL.md` | Skill | 99 |
| `scripts/test-backlog-git.sh` | Test | 82 |

## Test plan

- [x] `bash scripts/test-backlog-git.sh` → 41/41 passed
- [ ] PR Guardian CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)