### PR TITLE
fix: PR digest in Spanish — add Resumen section convention

### DIFF
--- a/.claude/rules/domain/github-flow.md
+++ b/.claude/rules/domain/github-flow.md
@@ -86,8 +86,8 @@ Ejemplos inválidos: `feature/rama1`, `fix/cosas`, `feature/12345-algo` (falta e
 ## Pull Request
 
 1. **Abrir PR** desde la feature branch hacia `main`
-2. **Título**: igual que el commit principal (convencional)
-3. **Descripción**: qué cambia y por qué; si cierra un PBI incluir `Closes #N`
+2. **Título**: igual que el commit principal (convencional, en inglés)
+3. **Descripción**: qué cambia y por qué; si cierra un PBI incluir `Closes #N`. Incluir **dos secciones de resumen**: `## Resumen` (español, para el digest que recibe la PM por email) y `## Summary` (inglés, para la comunidad internacional). El digest de PR Guardian prioriza `## Resumen`
 4. **Reviewer asignado por tarea**: si la tarea de DevOps que originó el cambio tiene un programador humano asignado (`System.AssignedTo`), ese programador se añade automáticamente como reviewer del PR. Esto garantiza que quien conoce el contexto de la tarea valide el código
 5. **Revisión**: al menos una aprobación antes de mergear. **NUNCA auto-aprobar** (`gh pr review --approve` sobre PR propio) — GitHub lo bloquea y es mala práctica. Si no hay reviewer humano, el PR espera
 6. **Merge**: Squash merge para commits pequeños, Merge commit para features completas. **NUNCA** usar `--admin` para bypass de branch protection

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,12 @@
+## Resumen
+
+<!-- Resumen en español (2-5 bullets). PR Guardian lo incluye en el email de digest. -->
+
+-
+
 ## What does this PR add or fix?
 
-<!-- 2-3 sentence summary. Must be >50 characters. -->
+<!-- 2-3 sentence summary in English for the international community. Must be >50 characters. -->
 
 ## Type of contribution
 

--- a/.github/workflows/pr-guardian.yml
+++ b/.github/workflows/pr-guardian.yml
@@ -475,13 +475,16 @@ jobs:
             if (risks.some(r => r.startsWith('🟡'))) riskLevel = '🟡 Medio';
             if (risks.some(r => r.startsWith('🔴'))) riskLevel = '🔴 Alto';
 
-            // Extract natural language summary from PR body
+            // Extract natural language summary from PR body (prefer Spanish)
             let nlSummary = '';
             if (pr.body) {
-              // Try to extract Summary section first
+              // Priority 1: Spanish "## Resumen" section
+              const resumenMatch = pr.body.match(/## Resumen\s*\n([\s\S]*?)(?=\n## |\n---|\n🤖|$)/);
+              // Priority 2: English "## Summary" section (legacy)
               const summaryMatch = pr.body.match(/## Summary\s*\n([\s\S]*?)(?=\n## |\n---|\n🤖|$)/);
-              if (summaryMatch) {
-                nlSummary = summaryMatch[1].trim()
+              const match = resumenMatch || summaryMatch;
+              if (match) {
+                nlSummary = match[1].trim()
                   .split('\n')
                   .filter(l => l.trim().length > 0)
                   .slice(0, 6)


### PR DESCRIPTION
## Resumen

- El digest de PR Guardian ahora busca primero `## Resumen` (español) antes de `## Summary` (inglés)
- El PR template incluye una sección `## Resumen` al inicio para que el email llegue en español
- La regla `github-flow.md` documenta la convención de incluir ambas secciones
- Las PRs siguen en inglés para la comunidad, pero Mónica recibe el digest en español

## Summary

- PR Guardian workflow now prioritizes `## Resumen` (Spanish) over `## Summary` (English) for digest extraction
- PR template adds a `## Resumen` section at the top for Spanish email digest
- `github-flow.md` rule updated to require both summary sections in PR descriptions
- PRs remain in English for international collaboration; Spanish digest is for the PM's email

## Test plan

- [x] YAML validation passes
- [ ] Next PR will verify the Spanish digest in the email notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)