### PR TITLE
feat: add model alias overrides to emergency mode

### DIFF
--- a/.claude/commands/emergency-mode.md
+++ b/.claude/commands/emergency-mode.md
@@ -61,11 +61,19 @@ Activa el modo emergencia:
 
 Resultado: Claude Code usará el LLM local en lugar del cloud.
 
+**Variables de modelo configuradas** (oficiales de Claude Code):
+- `ANTHROPIC_DEFAULT_OPUS_MODEL` → modelo local grande (según RAM)
+- `ANTHROPIC_DEFAULT_SONNET_MODEL` → modelo local medio
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL` → modelo local pequeño (qwen2.5:3b)
+- `CLAUDE_CODE_SUBAGENT_MODEL` → modelo para subagentes
+
+Los 27 agentes que especifican `model: opus/sonnet/haiku` resolverán a modelos locales.
+
 **Limitaciones en modo emergencia**:
 - Velocidad: más lento que Opus/Sonnet en cloud
 - Capacidad: modelos 7B son ~60-80% de la calidad de Sonnet
 - Contexto: 8K-32K tokens (vs 200K+ en cloud)
-- Agentes: subagentes pueden no funcionar correctamente
+- Agentes: funcionan pero con calidad reducida
 
 ### `/emergency-mode deactivate`
 

--- a/docs/EMERGENCY.en.md
+++ b/docs/EMERGENCY.en.md
@@ -89,7 +89,7 @@ Claude Code will now use the local LLM instead of the cloud.
 ```
 
 ### What does NOT work well in emergency
-- Specialized agents (require cloud Opus/Sonnet)
+- Specialized agents (reduced quality with local models)
 - Complex report generation (Excel/PowerPoint)
 - Azure DevOps API operations (if no internet)
 - Context >32K tokens (local models have limited window)
@@ -103,14 +103,18 @@ Claude Code will now use the local LLM instead of the cloud.
 | 32GB | qwen2.5:14b | Very good — near cloud quality |
 | NVIDIA GPU | deepseek-coder-v2 | Excellent — GPU accelerated |
 
+## Model Mapping
+
+The `opus`/`sonnet`/`haiku` aliases used by the 27 agents resolve to local models based on RAM: 8GB→`3b` for all · 16GB→`7b`/`7b`/`3b` · 32GB+→`14b`/`7b`/`3b`. Official Claude Code variables: `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` and `CLAUDE_CODE_SUBAGENT_MODEL`. Customize them in `~/.pm-workspace-emergency.env`. [Claude Code Router](https://github.com/musistudio/claude-code-router) users (community project): `CCR-SUBAGENT-MODEL` tag enables per-agent override.
+
 ## Return to normal mode
 
 When the cloud service is back online:
 
 ```bash
-unset ANTHROPIC_BASE_URL
-unset PM_EMERGENCY_MODE
-unset PM_EMERGENCY_MODEL
+unset ANTHROPIC_BASE_URL PM_EMERGENCY_MODE PM_EMERGENCY_MODEL
+unset ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL
+unset ANTHROPIC_DEFAULT_HAIKU_MODEL CLAUDE_CODE_SUBAGENT_MODEL
 ```
 
 Or simply close and open a new terminal.

--- a/docs/EMERGENCY.md
+++ b/docs/EMERGENCY.md
@@ -89,7 +89,7 @@ Ahora Claude Code usará el LLM local en lugar del cloud.
 ```
 
 ### Qué NO funciona bien en emergencia
-- Agentes especializados (requieren Opus/Sonnet cloud)
+- Agentes especializados (calidad reducida con modelos locales)
 - Generación de informes complejos (Excel/PowerPoint)
 - Operaciones con Azure DevOps API (si no hay internet)
 - Contexto >32K tokens (modelos locales tienen ventana limitada)
@@ -103,14 +103,18 @@ Ahora Claude Code usará el LLM local en lugar del cloud.
 | 32GB | qwen2.5:14b | Muy buena — casi como cloud |
 | GPU NVIDIA | deepseek-coder-v2 | Excelente — con aceleración GPU |
 
+## Mapeo de Modelos
+
+Los aliases `opus`/`sonnet`/`haiku` de los 27 agentes se resuelven a modelos locales según RAM: 8GB→`3b` para todos · 16GB→`7b`/`7b`/`3b` · 32GB+→`14b`/`7b`/`3b`. Variables oficiales de Claude Code: `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` y `CLAUDE_CODE_SUBAGENT_MODEL`. Personalízalas en `~/.pm-workspace-emergency.env`. Para usuarios de [Claude Code Router](https://github.com/musistudio/claude-code-router) (proyecto comunitario): tag `CCR-SUBAGENT-MODEL` permite override por agente.
+
 ## Volver a modo normal
 
 Cuando el servicio cloud vuelva a estar disponible:
 
 ```bash
-unset ANTHROPIC_BASE_URL
-unset PM_EMERGENCY_MODE
-unset PM_EMERGENCY_MODEL
+unset ANTHROPIC_BASE_URL PM_EMERGENCY_MODE PM_EMERGENCY_MODEL
+unset ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL
+unset ANTHROPIC_DEFAULT_HAIKU_MODEL CLAUDE_CODE_SUBAGENT_MODEL
 ```
 
 O simplemente cierra y abre una nueva terminal.

--- a/scripts/emergency-plan.ps1
+++ b/scripts/emergency-plan.ps1
@@ -81,6 +81,15 @@ if ($OllamaCmd) {
     }
 }
 
+# Download small model for haiku alias (if main model differs)
+if ($Model -ne "qwen2.5:3b" -and $OllamaCmd) {
+    $HasSmall = ollama list 2>$null | Select-String "qwen2.5:3b"
+    if (-not $HasSmall) {
+        Write-Host "  -> Modelo auxiliar qwen2.5:3b (haiku)..." -ForegroundColor Yellow
+        ollama pull "qwen2.5:3b" 2>$null
+    }
+}
+
 # ── 4. Guardar metadata y marcador ───────────────────────────────────────────
 Write-Host "`n[4/4] Guardando metadata..." -ForegroundColor Blue
 $Meta = @{ executed = (Get-Date -Format "o"); os = "Windows"; arch = $Arch; ram_gb = $RamGB; model = $Model }

--- a/scripts/emergency-plan.sh
+++ b/scripts/emergency-plan.sh
@@ -113,6 +113,11 @@ else
   echo -e "  ${YELLOW}⚠${NC} Instala Ollama primero para pre-descargar el modelo"
 fi
 
+# Download small model for haiku alias (if main model differs)
+if [[ "$MODEL" != "qwen2.5:3b" ]] && command -v ollama &>/dev/null && curl -s --max-time 3 http://localhost:11434/api/tags &>/dev/null; then
+  ollama list 2>/dev/null | grep -q "qwen2.5:3b" || { echo -e "  ${YELLOW}→${NC} Modelo auxiliar ${CYAN}qwen2.5:3b${NC} (haiku)..."; ollama pull "qwen2.5:3b" 2>/dev/null || true; }
+fi
+
 # ── 4. Guardar metadata y marcador ───────────────────────────────────────────
 echo -e "\n${BLUE}[4/4]${NC} Guardando metadata..."
 cat > "$CACHE_DIR/plan-info.json" << JSONEOF

--- a/scripts/emergency-setup.ps1
+++ b/scripts/emergency-setup.ps1
@@ -21,6 +21,11 @@ Write-Host "  OS: Windows · Arch: $Arch · RAM: ${RamGB}GB · GPU: $GpuName"
 
 if ($RamGB -lt 8 -and $Model -eq "qwen2.5:7b") { $Model = "qwen2.5:3b"; Write-Host "  WARN RAM < 8GB, modelo ajustado a $Model" -ForegroundColor Yellow }
 
+# Model alias mapping (opus/sonnet/haiku -> local models)
+if ($RamGB -ge 32) { $ModelLarge = "qwen2.5:14b"; $ModelMedium = "qwen2.5:7b"; $ModelSmall = "qwen2.5:3b" }
+elseif ($RamGB -ge 16) { $ModelLarge = "qwen2.5:7b"; $ModelMedium = "qwen2.5:7b"; $ModelSmall = "qwen2.5:3b" }
+else { $ModelLarge = "qwen2.5:3b"; $ModelMedium = "qwen2.5:3b"; $ModelSmall = "qwen2.5:3b" }
+
 $Offline = $false
 try { $null = Invoke-WebRequest -Uri "https://ollama.ai" -TimeoutSec 5 -UseBasicParsing; Write-Host "  Internet: conectado" -ForegroundColor Green }
 catch {
@@ -91,12 +96,20 @@ $EnvFile = "$env:USERPROFILE\.pm-workspace-emergency.env"
 set ANTHROPIC_BASE_URL=http://localhost:11434
 set PM_EMERGENCY_MODEL=$Model
 set PM_EMERGENCY_MODE=active
+set ANTHROPIC_DEFAULT_OPUS_MODEL=$ModelLarge
+set ANTHROPIC_DEFAULT_SONNET_MODEL=$ModelMedium
+set ANTHROPIC_DEFAULT_HAIKU_MODEL=$ModelSmall
+set CLAUDE_CODE_SUBAGENT_MODEL=$ModelMedium
 "@ | Set-Content $EnvFile
 
 # Tambien configurar variables de entorno del usuario
 [Environment]::SetEnvironmentVariable("ANTHROPIC_BASE_URL", "http://localhost:11434", "User")
 [Environment]::SetEnvironmentVariable("PM_EMERGENCY_MODEL", $Model, "User")
 [Environment]::SetEnvironmentVariable("PM_EMERGENCY_MODE", "active", "User")
+[Environment]::SetEnvironmentVariable("ANTHROPIC_DEFAULT_OPUS_MODEL", $ModelLarge, "User")
+[Environment]::SetEnvironmentVariable("ANTHROPIC_DEFAULT_SONNET_MODEL", $ModelMedium, "User")
+[Environment]::SetEnvironmentVariable("ANTHROPIC_DEFAULT_HAIKU_MODEL", $ModelSmall, "User")
+[Environment]::SetEnvironmentVariable("CLAUDE_CODE_SUBAGENT_MODEL", $ModelMedium, "User")
 
 Write-Host "  OK Variables configuradas" -ForegroundColor Green
 Write-Host "`nOK Setup completado" -ForegroundColor Green

--- a/scripts/emergency-setup.sh
+++ b/scripts/emergency-setup.sh
@@ -30,6 +30,15 @@ fi
 echo -e "  OS: ${GREEN}$OS${NC} · Arch: ${GREEN}$ARCH${NC} · RAM: ${GREEN}${RAM_GB}GB${NC}"
 [[ $RAM_GB -lt 8 ]] && echo -e "  ${YELLOW}⚠ RAM < 8GB${NC}" && [[ "$MODEL" == "$DEFAULT_MODEL" ]] && MODEL="qwen2.5:3b"
 
+# Model alias mapping (opus/sonnet/haiku → local models)
+if [[ $RAM_GB -ge 32 ]]; then
+  MODEL_LARGE="qwen2.5:14b"; MODEL_MEDIUM="qwen2.5:7b"; MODEL_SMALL="qwen2.5:3b"
+elif [[ $RAM_GB -ge 16 ]]; then
+  MODEL_LARGE="qwen2.5:7b"; MODEL_MEDIUM="qwen2.5:7b"; MODEL_SMALL="qwen2.5:3b"
+else
+  MODEL_LARGE="qwen2.5:3b"; MODEL_MEDIUM="qwen2.5:3b"; MODEL_SMALL="qwen2.5:3b"
+fi
+
 # GPU
 GPU_INFO="ninguna"
 command -v nvidia-smi &>/dev/null && GPU_INFO=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 || echo "NVIDIA")
@@ -121,6 +130,10 @@ cat > "$ENV_FILE" << ENVEOF
 export ANTHROPIC_BASE_URL="http://localhost:11434"
 export PM_EMERGENCY_MODEL="$MODEL"
 export PM_EMERGENCY_MODE="active"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="$MODEL_LARGE"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="$MODEL_MEDIUM"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="$MODEL_SMALL"
+export CLAUDE_CODE_SUBAGENT_MODEL="$MODEL_MEDIUM"
 ENVEOF
 
 echo -e "  ${GREEN}✓${NC} Variables en ${CYAN}$ENV_FILE${NC}"


### PR DESCRIPTION
## Summary
- Map `opus`/`sonnet`/`haiku` aliases to local Ollama models in emergency mode using official Claude Code variables (`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`)
- Auto-select model tiers by RAM: 8GB→`qwen2.5:3b` for all, 16GB→`7b`/`7b`/`3b`, 32GB+→`14b`/`7b`/`3b`
- Pre-download small model (`qwen2.5:3b`) in emergency-plan for haiku alias differentiation
- Document Model Mapping section in EMERGENCY docs (ES/EN) and emergency-mode command

## Files changed (7)
- `scripts/emergency-setup.sh` — model tier calc + 4 env vars
- `scripts/emergency-setup.ps1` — same for Windows
- `scripts/emergency-plan.sh` — pre-download small model
- `scripts/emergency-plan.ps1` — same for Windows
- `docs/EMERGENCY.md` — "Mapeo de Modelos" section + CCR note
- `docs/EMERGENCY.en.md` — "Model Mapping" section + CCR note
- `.claude/commands/emergency-mode.md` — document model variables

## Context
Community contribution from Cristián Rojas who identified the gap: subagents specifying `model: opus/sonnet/haiku` in frontmatter failed in emergency mode because Ollama doesn't understand those aliases. The 4 variables are officially documented by Anthropic at code.claude.com/docs/en/model-config.

## Test plan
- [ ] Run `./scripts/emergency-setup.sh` and verify `~/.pm-workspace-emergency.env` contains the 4 new variables
- [ ] Verify `ANTHROPIC_DEFAULT_HAIKU_MODEL` resolves to `qwen2.5:3b` on 16GB+ machines
- [ ] Run `bash -n` syntax check on both `.sh` scripts
- [ ] Verify all modified files are ≤150 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)