### PR TITLE
feat(wellbeing): add Wellbeing Guardian — proactive individual wellbeing (Era 34)

### DIFF
--- a/.claude/commands/wellbeing-guardian.md
+++ b/.claude/commands/wellbeing-guardian.md
@@ -1,0 +1,106 @@
+---
+allowed-tools: [Read, Glob, Grep, Write, Edit]
+argument-hint: "[status|configure|breaks|report|pause] [--reason work|personal|hydration] [--week|--month] [--summary|--detailed]"
+model: sonnet
+context_cost: low
+---
+
+# /wellbeing-guardian — Sistema proactivo de bienestar individual
+
+> Skill: @.claude/skills/wellbeing-guardian/SKILL.md
+> Config: @.claude/rules/domain/wellbeing-config.md
+> Perfil: @.claude/profiles/users/{slug}/workflow.md
+
+Savia vela por tu salud durante las sesiones de trabajo: recuerda descansos,
+alerta fuera de horario y sugiere pausas. Basado en evidencia científica
+(HBR 2026, técnica Pomodoro, regla 52-17, método 5-50).
+
+## Subcomandos
+
+### `/wellbeing-guardian status`
+
+Muestra el estado actual de bienestar en la sesión:
+- Tiempo de sesión transcurrido
+- Estrategia activa y próximo descanso
+- Breaks tomados vs esperados
+- Barra de progreso visual (🟩⬜)
+
+### `/wellbeing-guardian configure`
+
+Setup interactivo del horario y preferencias de descanso:
+1. Horario laboral (inicio, fin, comida, conciliación)
+2. Estrategia de breaks (pomodoro, 52-17, 5-50, custom)
+3. Umbrales (máximo horas diarias, silencio en fines de semana)
+
+Persiste la configuración en `workflow.md` del perfil activo.
+
+### `/wellbeing-guardian breaks [--week|--month]`
+
+Historial de pausas registradas:
+- Sin flag: breaks de la sesión actual
+- `--week`: resumen semanal
+- `--month`: resumen mensual
+
+Formato: tabla con hora, duración y razón de cada pausa.
+
+### `/wellbeing-guardian report [--summary|--detailed]`
+
+Informe de bienestar:
+- `--summary` (default): compliance %, horas totales, recomendación
+- `--detailed`: desglose por día, tiempo medio de foco, tendencias
+
+Genera `break_compliance_score` consumible por `/burnout-radar`.
+
+### `/wellbeing-guardian pause [--reason work|personal|hydration|focus-break]`
+
+Registra una pausa voluntaria:
+- Marca el momento de pausa
+- Categoriza por razón (opcional)
+- Al volver, muestra mensaje de bienvenida con duración registrada
+- Resetea el contador de foco
+
+## Estrategias disponibles
+
+| Estrategia | Foco | Descanso | Pausa larga |
+|---|---|---|---|
+| pomodoro | 25 min | 5 min | 20-30 min cada 4 ciclos |
+| 52-17 | 52 min | 17 min | — |
+| 5-50 | 50 min | 5 min analógico | 15 min cada 3 ciclos |
+| custom | configurable | configurable | configurable |
+
+## Nudges automáticos
+
+Savia sugiere descansos de forma amable y no intrusiva:
+- **Break debido** → al superar el tiempo de foco configurado
+- **Fuera de horario** → al detectar trabajo tras `work_hours_end`
+- **Fin de semana** → si `silence_weekends: true` y es sábado/domingo
+- **Hidratación** → recordatorios periódicos de agua y postura
+- **Post-descanso** → bienvenida al volver de una pausa
+
+Máximo 1 nudge por interacción. Sin bloqueo. El usuario decide siempre.
+
+## Integración
+
+- **burnout-radar**: alimenta `break_compliance_score` individual
+- **sustainable-pace**: mejora `wellbeing_factor` con adherencia real
+- **daily-routine**: complementa con micro-pausas (no duplica)
+
+## Ejemplo de uso
+
+```
+PM: /wellbeing-guardian status
+Savia:
+⏱️ Sesión actual: 47min
+🎯 Estrategia: pomodoro (25min foco / 5min descanso)
+📊 Breaks hoy: 1 de 2 esperados
+⏭️ Próximo descanso: en 3min
+🟩🟩🟩🟩⬜ Progreso hacia próximo break
+
+💡 Llevas 22min de foco continuo. En 3min tu Pomodoro
+   sugiere una pausa de 5min. ¿Buen momento?
+```
+
+## Primera vez
+
+Si el perfil no tiene campos wellbeing configurados, Savia sugiere
+automáticamente `/wellbeing-guardian configure` para el setup inicial.

--- a/.claude/rules/domain/session-init-priority.md
+++ b/.claude/rules/domain/session-init-priority.md
@@ -40,6 +40,7 @@ paths: []
 |---|---|---|
 | Backup reminder | ~12 | Sin backup o >24h |
 | Emergency plan | ~12 | No ejecutado nunca |
+| Wellbeing context | ~25 | wellbeing configurado en workflow.md |
 
 ### Baja (probabilística)
 

--- a/.claude/rules/domain/wellbeing-config.md
+++ b/.claude/rules/domain/wellbeing-config.md
@@ -1,0 +1,102 @@
+# Regla: Configuración del Wellbeing Guardian
+# ── Sistema proactivo de bienestar individual para usuarios de Savia ──
+
+> Basado en: "AI Doesn't Reduce Work—It Intensifies It" (HBR, Feb 2026, Berkeley Haas)
+> La IA intensifica el trabajo de 3 formas: expansión de tareas, difuminación
+> de límites trabajo-vida, y multitasking cognitivo. Soluciones: pausas
+> intencionales, secuenciación del trabajo, y tiempo de conexión humana.
+
+## Estrategias de descanso
+
+| Estrategia | Foco (min) | Descanso (min) | Pausa larga | Ideal para |
+|---|---|---|---|---|
+| `pomodoro` | 25 | 5 | 20-30 cada 4 ciclos | Tareas variadas |
+| `52-17` | 52 | 17 | — | Deep work / coding |
+| `5-50` | 50 | 5 (analógico) | 15 cada 3 ciclos | Trabajo con IA |
+| `custom` | configurable | configurable | configurable | Preferencias personales |
+
+Complementarias (siempre activas):
+- **Regla 20-20-20**: cada 20min, mirar a 6m durante 20s (fatiga visual)
+- **INSST España**: pausa 10-15min por cada 60-90min de pantalla
+- **Pausas activas**: estiramientos y cambio de postura reducen molestias un 30%
+
+## Schema de horario en workflow.md
+
+Campos opcionales (backward-compatible) a añadir en `workflow.md` del perfil:
+
+```yaml
+# Wellbeing
+work_hours_start: "09:00"        # Hora local inicio jornada
+work_hours_end: "18:00"          # Hora local fin jornada
+lunch_break: "13:00-14:00"       # Franja de comida
+conciliation: ""                 # Ej: "17:00-18:00" (conciliación)
+break_strategy: "pomodoro"       # pomodoro | 52-17 | 5-50 | custom
+custom_focus_min: 25             # Solo si strategy=custom
+custom_break_min: 5              # Solo si strategy=custom
+max_daily_hours: 10              # Alerta si se supera
+silence_weekends: true           # Nudge de desconexión en fin de semana
+```
+
+Nota: `timezone` se obtiene de `preferences.md` → no duplicar.
+
+## Plantillas de nudge
+
+### Break debido
+```
+⏸️ Llevas {elapsed}min de foco continuo. Tu estrategia {strategy}
+sugiere un descanso de {break_min}min. ¿Buen momento para parar?
+```
+
+### Fuera de horario
+```
+🌙 Son las {hora_actual}. Tu jornada termina a las {work_hours_end}.
+¿Necesitas continuar o prefieres dejarlo para mañana?
+```
+
+### Fin de semana
+```
+📅 Hoy es {día_semana}. Recuerda que desconectar es parte del rendimiento.
+¿Hay algo urgente que requiera tu atención ahora?
+```
+
+### Hidratación y postura
+```
+💧 Llevas {elapsed}min en esta sesión. Buen momento para hidratarte,
+estirar y aplicar la regla 20-20-20 (mira a 6m durante 20s).
+```
+
+### Post-descanso
+```
+✅ ¡Bienvenido/a de vuelta! Pausa de {break_duration}min registrada.
+Llevas {breaks_today} descansos hoy. ¡Buen ritmo!
+```
+
+## Reglas de conducción
+
+- **Una sugerencia, no una orden** — el usuario decide siempre
+- **Sin bloqueo** — los nudges son informativos, nunca interrumpen
+- **Frecuencia máxima** — máximo 1 nudge cada 25min (evitar fatiga)
+- **Escalado amable** — si el usuario ignora 3 nudges seguidos, reducir frecuencia
+- **Fuera de horario** — máximo 1 aviso al inicio, luego silencio salvo que pidan
+- **Privacidad** — datos de horario son locales, nunca en commits públicos
+
+## Integración con sistemas existentes
+
+### burnout-radar
+- Wellbeing Guardian exporta `break_compliance_score`: (breaks_tomados / esperados) × 100
+- Radar lo consume como señal individual para el heat map del equipo
+
+### sustainable-pace
+- El `wellbeing_factor` de la fórmula se alimenta de la adherencia real a descansos
+- Factor = break_compliance_score / 100 (normalizado 0-1)
+
+### daily-routine
+- Wellbeing integra work_hours para ajustar sugerencias de horario
+- No duplica la rutina diaria; la complementa con micro-pausas
+
+## Seguridad y privacidad
+
+- Datos de horario → perfil local del usuario, nunca en SaviaHub público
+- Historial de breaks → log local (git-ignorado si se implementa)
+- NUNCA registrar contenido de trabajo en logs de bienestar
+- Respetar preferencia `silence_weekends` sin excepciones

--- a/.claude/skills/wellbeing-guardian/SKILL.md
+++ b/.claude/skills/wellbeing-guardian/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: wellbeing-guardian
+description: "Sistema proactivo de bienestar individual"
+context_cost: low
+dependencies: []
+---
+
+# Skill: Wellbeing Guardian
+
+> Regla: @.claude/rules/domain/wellbeing-config.md
+> Perfiles: @.claude/profiles/users/{slug}/workflow.md + preferences.md
+
+## Prerequisitos
+
+- Perfil de usuario con campos wellbeing configurados en `workflow.md`
+- Timezone definido en `preferences.md`
+
+## Flujo: Inicio de sesión
+
+1. Leer `workflow.md` → extraer work_hours_start, work_hours_end, break_strategy
+2. Leer `preferences.md` → extraer timezone
+3. Calcular hora local actual
+4. Si fuera de horario → nudge "Fuera de horario" (una vez)
+5. Si fin de semana y silence_weekends → nudge "Fin de semana" (una vez)
+6. Calcular próximo break según estrategia:
+   - pomodoro: 25min desde inicio sesión
+   - 52-17: 52min desde inicio sesión
+   - 5-50: 50min desde inicio sesión
+   - custom: custom_focus_min desde inicio sesión
+7. Retornar contexto compacto (~25 tokens):
+   `⏱️ Horario: {start}-{end} {tz} | Break: {strategy} {focus}/{break} | Próximo: tras {N}min`
+
+## Flujo: Check periódico
+
+Durante la conversación, verificar periódicamente (máximo cada 25min):
+
+1. Calcular tiempo transcurrido desde último break o inicio
+2. Si elapsed ≥ duración_foco de la estrategia:
+   - Insertar nudge "Break debido" al final de la respuesta actual
+   - Tono amable, nunca imperativo
+3. Si hora_actual > work_hours_end (primera vez):
+   - Insertar nudge "Fuera de horario"
+   - No repetir salvo que el usuario pida continuar explícitamente
+4. Si hora_actual entre lunch_break:
+   - Sugerir pausa para comer si el usuario sigue activo
+
+Reglas:
+- **Máximo 1 nudge por interacción** — no saturar
+- **Escalado**: si usuario ignora 3 nudges → reducir a 1 cada 45min
+- **Reset**: `/wellbeing-guardian pause` resetea el contador
+
+## Flujo: Configure
+
+1. Preguntar horario laboral:
+   - "¿A qué hora empiezas normalmente?" → work_hours_start
+   - "¿A qué hora terminas?" → work_hours_end
+   - "¿Tienes franja de comida?" → lunch_break
+   - "¿Algún horario de conciliación?" → conciliation
+2. Presentar estrategias con tabla comparativa (de wellbeing-config.md)
+3. Dejar que el usuario elija o configure custom
+4. Preguntar umbrales: max_daily_hours, silence_weekends
+5. Persistir todo en workflow.md (preservar campos existentes)
+6. Confirmar: "✅ Wellbeing Guardian configurado. Tu estrategia: {strategy}"
+
+## Flujo: Status
+
+1. Leer configuración actual de workflow.md
+2. Calcular tiempo de sesión actual
+3. Calcular breaks tomados (del contexto de sesión)
+4. Mostrar:
+   ```
+   ⏱️ Sesión actual: {elapsed}min
+   🎯 Estrategia: {strategy} ({focus}min foco / {break}min descanso)
+   📊 Breaks hoy: {count} de {expected} esperados
+   ⏭️ Próximo descanso: en {remaining}min
+   🟩🟩🟩⬜⬜ Progreso hacia próximo break
+   ```
+
+## Flujo: Pause
+
+1. Registrar momento de pausa
+2. Si --reason proporcionado → categorizar (work, personal, hydration, focus-break)
+3. Mostrar nudge "Post-descanso" cuando el usuario vuelva
+4. Resetear contador de foco
+
+## Flujo: Breaks (historial)
+
+1. Mostrar breaks registrados en la sesión actual
+2. Si --week: agregar breaks de la semana (si hay log persistente)
+3. Formato tabla: hora, duración, razón
+4. Calcular break_compliance_score: (tomados / esperados) × 100
+
+## Flujo: Report
+
+1. Leer historial de sesiones (contexto actual + log si existe)
+2. Calcular métricas:
+   - Horas totales de trabajo
+   - Breaks tomados vs esperados (compliance %)
+   - Tiempo medio de foco continuo
+   - Incidencias fuera de horario
+3. Generar break_compliance_score para burnout-radar
+4. Presentar resumen + 1-2 recomendaciones personalizadas
+5. Si compliance < 60% → sugerir estrategia alternativa
+
+## Errores
+
+| Error | Acción |
+|-------|--------|
+| Perfil sin wellbeing config | Sugerir `/wellbeing-guardian configure` |
+| Timezone no definido | Pedir timezone o asumir UTC |
+| Estrategia desconocida | Fallback a pomodoro |
+| Sin historial de breaks | Mostrar solo sesión actual |
+
+## Seguridad
+
+- NUNCA registrar contenido de trabajo en logs de bienestar
+- Datos de horario → perfil local, nunca en commits públicos
+- Respetar `silence_weekends` sin excepciones
+- No enviar datos de bienestar a sistemas externos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.9.0] — 2026-03-05
+
+### Added — Wellbeing Guardian: Proactive Individual Wellbeing (Era 34)
+
+- **wellbeing-guardian.md**: `/wellbeing-guardian status`, `configure`, `breaks`, `report`, `pause`. Proactive nudge system for individual work-life balance — break reminders, after-hours alerts, weekend disconnection suggestions. 5 break strategies (Pomodoro, 52-17, 5-50, custom, 20-20-20 eye rule). Non-blocking philosophy: suggestions, never interruptions.
+- **wellbeing-config.md**: Domain rule with break science reference (HBR Feb 2026 research on AI-intensified work), strategy definitions, 5 nudge template categories, work schedule schema for user profiles, integration points with burnout-radar and sustainable-pace.
+- **wellbeing-guardian/SKILL.md**: Orchestration — session start (load schedule, detect after-hours), periodic check (time-based nudges), configure (interactive setup), status, pause, breaks history, weekly report with break_compliance_score.
+- **session-init-priority.md**: Added Wellbeing context entry (Media priority, ~25 tokens) for ambient work schedule awareness.
+- Tests: `test-wellbeing-guardian.sh` — 50 structural tests across command, rule, skill, and cross-references.
+
+---
+
 ## [2.8.1] — 2026-03-05
 
 Emergency mode model alias overrides — subagents now resolve in offline mode.
@@ -274,6 +286,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.6.0...v2.7.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
 │   ├── hooks/ (14)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
-│   ├── skills/ (29)               ← Skills reutilizables
+│   ├── skills/ (30)               ← Skills reutilizables
 │   └── settings.json              ← Hooks + Agent Teams env
 ├── docs/ · projects/ · scripts/
 ```

--- a/README.en.md
+++ b/README.en.md
@@ -187,7 +187,7 @@ I've organized all documentation into sections so you can quickly find what you 
 
 ## Quick Command Reference
 
-> 329+ commands · 27 agents · 25 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
+> 360+ commands · 27 agents · 30 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
 
 ### User Profile, Updates and Community
 ```

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ He organizado toda la documentación en secciones para que encuentres rápido lo
 
 ## Referencia rápida de comandos
 
-> 329+ comandos · 27 agentes · 25 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
+> 360+ comandos · 27 agentes · 30 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
 
 ### Perfil de Usuario, Actualización y Comunidad
 ```

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -28,7 +28,7 @@
 
 ### What is PM-Workspace?
 
-PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 29 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
+PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 30 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
 
 ### Why adopt it in a consulting firm?
 
@@ -202,7 +202,7 @@ After cloning, you'll find this structure:
 |-----------|----------|----------|
 | `CLAUDE.md` | Claude Code entry point (global constants) | Yes |
 | `.claude/commands/` | 360+ slash commands for PM workflows | Advanced |
-| `.claude/skills/` | 29 specialized skills | Advanced |
+| `.claude/skills/` | 30 specialized skills | Advanced |
 | `.claude/agents/` | 27 AI subagents | Advanced |
 | `.claude/rules/` | Modular rules (PM, multi-language, Git) | Advanced |
 | `projects/` | Project folder (each with its own `CLAUDE.md`) | Yes |

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -28,7 +28,7 @@
 
 ### ¿Qué es PM-Workspace?
 
-PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 29 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
+PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 30 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
 
 ### ¿Por qué adoptarlo en una consultora?
 
@@ -220,7 +220,7 @@ Al clonar, encontrarás esta estructura:
 |------------|-----------|----------|
 | `CLAUDE.md` | Punto de entrada de Claude Code (constantes globales) | Sí |
 | `.claude/commands/` | 360+ slash commands para flujos PM | Avanzado |
-| `.claude/skills/` | 29 skills especializadas | Avanzado |
+| `.claude/skills/` | 30 skills especializadas | Avanzado |
 | `.claude/agents/` | 27 subagentes IA | Avanzado |
 | `.claude/rules/` | Reglas modulares (PM, multi-lenguaje, Git) | Avanzado |
 | `projects/` | Carpeta de proyectos (cada uno con su `CLAUDE.md`) | Sí |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 29 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 33 thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 30 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 34 thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -304,6 +304,14 @@ Periodic markdown snapshots of backlogs from any PM tool. Diff, rollback (info-o
 Proactive onboarding interview for new clients and projects. 8-phase structured questionnaire with sector-adaptive compliance.
 
 - **Context Assistant** (v2.8.0) — `/context-interview start`, `resume`, `summary`, `gaps`. 8 phases: Domain, Stakeholders, Stack, Constraints, Business Rules, Compliance (sector-adaptive), Timeline, Summary. Gap detection. One-question-at-a-time. 1 skill, 1 rule. 49 tests.
+
+---
+
+## ✅ Era 34 — Wellbeing Guardian: Proactive Individual Wellbeing (v2.9.0, Mar 2026)
+
+Proactive nudge system for individual work-life balance. Based on HBR research "AI Doesn't Reduce Work—It Intensifies It" (Feb 2026, Berkeley Haas). Break science: Pomodoro, 52-17, 5-50 method, 20-20-20 eye rule, INSST Spain guidelines.
+
+- **Wellbeing Guardian** (v2.9.0) — `/wellbeing-guardian status`, `configure`, `breaks`, `report`, `pause`. Work schedule in user profile (start/end hours, lunch, conciliation). 5 break strategies. Non-blocking nudges (after-hours alerts, break reminders, weekend disconnection). Integration with burnout-radar (break_compliance_score) and sustainable-pace (wellbeing_factor). Session-init context (~25 tokens). 1 skill, 1 rule. 50 tests.
 
 ---
 

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -49,7 +49,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 29 skills reutilizables
+│   ├── skills/                  ← 30 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/docs/readme/03-configuracion.md
+++ b/docs/readme/03-configuracion.md
@@ -61,7 +61,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 29 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 30 skills,
 detectará el lenguaje del proyecto y cargará las convenciones y agente apropiados.
 Todas las buenas prácticas del flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -48,7 +48,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 29 reusable skills
+│   ├── skills/                  ← 30 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/scripts/test-wellbeing-guardian.sh
+++ b/scripts/test-wellbeing-guardian.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test-wellbeing-guardian.sh — Structural tests for Wellbeing Guardian (Era 34 — v2.9.0)
+set -uo pipefail
+
+PASS=0; FAIL=0
+
+pass() { ((PASS+=1)) || true; echo "  ✅ $1"; }
+fail() { ((FAIL+=1)) || true; echo "  ❌ $1"; }
+check() { if eval "$2" > /dev/null 2>&1; then pass "$1"; else fail "$1"; fi; }
+
+echo "══════════════════════════════════════════"
+echo "  Wellbeing Guardian Tests (Era 34 — v2.9.0)"
+echo "══════════════════════════════════════════"
+
+# ── Section 1: Command file ────────────────────────────────────────────────
+echo ""
+echo "── Section 1: Command file ──"
+CMD=".claude/commands/wellbeing-guardian.md"
+check "Command exists" "[ -f $CMD ]"
+LINES=$(wc -l < "$CMD")
+check "Command within line limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has status subcommand" "grep -q 'wellbeing-guardian status' $CMD"
+check "Has configure subcommand" "grep -q 'wellbeing-guardian configure' $CMD"
+check "Has breaks subcommand" "grep -q 'wellbeing-guardian breaks' $CMD"
+check "Has report subcommand" "grep -q 'wellbeing-guardian report' $CMD"
+check "Has pause subcommand" "grep -q 'wellbeing-guardian pause' $CMD"
+check "References skill" "grep -q 'wellbeing-guardian/SKILL.md' $CMD"
+check "References config rule" "grep -q 'wellbeing-config' $CMD"
+check "Has strategy table" "grep -q 'pomodoro' $CMD && grep -q '52-17' $CMD && grep -q '5-50' $CMD"
+
+# ── Section 2: Domain rule ─────────────────────────────────────────────────
+echo ""
+echo "── Section 2: Domain rule ──"
+RULE=".claude/rules/domain/wellbeing-config.md"
+check "Config rule exists" "[ -f $RULE ]"
+LINES=$(wc -l < "$RULE")
+check "Config rule within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has HBR reference" "grep -q 'HBR' $RULE"
+check "Has pomodoro strategy" "grep -q 'pomodoro' $RULE"
+check "Has 52-17 strategy" "grep -q '52-17' $RULE"
+check "Has 5-50 strategy" "grep -q '5-50' $RULE"
+check "Has 20-20-20 eye rule" "grep -q '20-20-20' $RULE"
+check "Has INSST reference" "grep -q 'INSST' $RULE"
+check "Has break nudge template" "grep -q 'Break debido' $RULE"
+check "Has after-hours nudge" "grep -q 'Fuera de horario' $RULE"
+check "Has weekend nudge" "grep -q 'Fin de semana' $RULE"
+check "Has hydration nudge" "grep -q 'Hidratación' $RULE"
+check "Has post-break nudge" "grep -q 'Post-descanso' $RULE"
+check "Has schema section" "grep -q 'Schema de horario' $RULE"
+check "Has work_hours_start field" "grep -q 'work_hours_start' $RULE"
+check "Has break_strategy field" "grep -q 'break_strategy' $RULE"
+check "Has burnout-radar integration" "grep -q 'burnout-radar' $RULE"
+check "Has sustainable-pace integration" "grep -q 'sustainable-pace' $RULE"
+check "Has privacy section" "grep -q 'privacidad' $RULE || grep -q 'Privacidad' $RULE || grep -q 'Seguridad' $RULE"
+
+# ── Section 3: Skill ──────────────────────────────────────────────────────
+echo ""
+echo "── Section 3: Skill ──"
+SKILL=".claude/skills/wellbeing-guardian/SKILL.md"
+check "Skill exists" "[ -f $SKILL ]"
+LINES=$(wc -l < "$SKILL")
+check "Skill within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has correct name" "grep -q 'wellbeing-guardian' $SKILL"
+check "Has session start flow" "grep -q 'Inicio de sesión' $SKILL"
+check "Has periodic check flow" "grep -q 'Check periódico' $SKILL"
+check "Has configure flow" "grep -q 'Configure' $SKILL"
+check "Has status flow" "grep -q 'Status' $SKILL"
+check "Has pause flow" "grep -q 'Pause' $SKILL"
+check "Has breaks flow" "grep -q 'Breaks' $SKILL"
+check "Has report flow" "grep -q 'Report' $SKILL"
+check "Has break_compliance_score" "grep -q 'break_compliance_score' $SKILL"
+check "Has escalation rule" "grep -q 'ignora.*nudge' $SKILL || grep -q 'Escalado' $SKILL"
+check "Has max 1 nudge rule" "grep -q '1 nudge' $SKILL"
+check "References workflow.md" "grep -q 'workflow.md' $SKILL"
+check "References preferences.md" "grep -q 'preferences.md' $SKILL"
+
+# ── Section 4: Cross-references ────────────────────────────────────────────
+echo ""
+echo "── Section 4: Cross-references ──"
+check "Skill references config rule" "grep -q 'wellbeing-config' $SKILL"
+check "Command references skill" "grep -q 'wellbeing-guardian/SKILL.md' $CMD"
+check "Command references config rule" "grep -q 'wellbeing-config' $CMD"
+check "Rule references burnout-radar" "grep -q 'burnout-radar' $RULE"
+check "Rule references sustainable-pace" "grep -q 'sustainable-pace' $RULE"
+check "Skill references burnout-radar" "grep -q 'burnout-radar' $SKILL"
+
+echo ""
+echo "══════════════════════════════════════════"
+echo "  Results: $PASS/$((PASS+FAIL)) passed, $FAIL failed"
+echo "══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Resumen

- Nuevo sistema proactivo de bienestar individual basado en investigación HBR sobre intensificación del trabajo con IA
- Comando `/wellbeing-guardian` con 5 subcomandos: status, configure, breaks, report, pause
- 5 estrategias de descanso (Pomodoro, 52-17, 5-50, custom, regla 20-20-20) con nudges no intrusivos
- Integración con session-init (~25 tokens) para conciencia ambiental del horario laboral
- 50 tests estructurales pasan correctamente

## What does this PR add or fix?

Adds the Wellbeing Guardian system (Era 34, v2.9.0) — a proactive individual wellbeing nudge system based on the HBR Feb 2026 research "AI Doesn't Reduce Work—It Intensifies It". Includes break reminders, after-hours alerts, weekend disconnection suggestions, and 5 configurable break strategies. Non-blocking philosophy: all nudges are gentle suggestions, never interruptions. Integrates with burnout-radar (break_compliance_score) and sustainable-pace (wellbeing_factor).

## Type of contribution

- [x] New skill
- [x] New slash command
- [x] New domain rule
- [x] Test suite addition

## Context impact

- [x] This PR modifies context files — estimated impact: ~25 tokens added to session-init (Media priority)
- [x] CLAUDE.md stays within 120 lines limit

## Files added / modified

- `.claude/commands/wellbeing-guardian.md` — Command with 5 subcommands (status, configure, breaks, report, pause)
- `.claude/rules/domain/wellbeing-config.md` — Break science, strategies, nudge templates, schedule schema
- `.claude/skills/wellbeing-guardian/SKILL.md` — Orchestration: session start, periodic check, configure, report
- `.claude/rules/domain/session-init-priority.md` — Added Wellbeing context entry (Media priority)
- `scripts/test-wellbeing-guardian.sh` — 50 structural tests
- `CHANGELOG.md` — v2.9.0 entry with comparison link
- `docs/ROADMAP.md` — Era 34
- `CLAUDE.md`, `README.md`, `README.en.md`, docs — Skills count 29→30

## How to test this

1. Run `bash scripts/test-wellbeing-guardian.sh` — expect 50/50 passed
2. Verify all 3 new files are ≤150 lines
3. Review nudge templates in wellbeing-config.md for tone and completeness

## Test suite

- [x] `test-wellbeing-guardian.sh` passes 50/50
- [x] I added tests for new files

## Checklist

- [x] PR title follows conventional commits: `feat(wellbeing): description`
- [x] Command/skill name follows existing conventions (kebab-case)
- [x] I tested this in a real Claude Code conversation at least once
- [x] No real PATs, org URLs, project names, or client data included
- [x] Documentation in the file is sufficient for a PM to understand it without reading this PR
- [x] `CHANGELOG.md` updated under `[2.9.0]`