### PR TITLE
fix(emergency): connectivity check, idempotency and offline verification

### DIFF
--- a/scripts/emergency-plan.ps1
+++ b/scripts/emergency-plan.ps1
@@ -18,8 +18,18 @@ if ($Check) {
 Write-Host "`nPM-Workspace - Emergency Plan (Windows)" -ForegroundColor Cyan
 Write-Host "Pre-descarga de recursos para instalacion offline.`n"
 
+# ── 0. Check de conectividad ──────────────────────────────────────────────────
+try {
+    $null = Invoke-WebRequest -Uri "https://ollama.com" -TimeoutSec 5 -UseBasicParsing
+} catch {
+    Write-Host "X Sin conexion a internet." -ForegroundColor Red
+    Write-Host "  Este script necesita internet para descargar recursos."
+    Write-Host "  Si ya ejecutaste el plan, usa: .\scripts\emergency-setup.ps1" -ForegroundColor Cyan
+    exit 1
+}
+
 # ── 1. Detectar hardware ─────────────────────────────────────────────────────
-Write-Host "[1/4] Detectando hardware..." -ForegroundColor Blue
+Write-Host "[1/5] Detectando hardware..." -ForegroundColor Blue
 $Arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "x86" }
 $RamGB = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB)
 $GpuName = (Get-CimInstance Win32_VideoController | Select-Object -First 1).Name
@@ -34,7 +44,7 @@ if (-not $Model) {
 New-Item -ItemType Directory -Force -Path $CacheDir | Out-Null
 
 # ── 2. Descargar Ollama ──────────────────────────────────────────────────────
-Write-Host "`n[2/4] Descargando Ollama para Windows..." -ForegroundColor Blue
+Write-Host "`n[2/5] Descargando Ollama para Windows..." -ForegroundColor Blue
 $InstallerPath = "$CacheDir\OllamaSetup.exe"
 
 if (Test-Path $InstallerPath) {
@@ -51,7 +61,7 @@ if (Test-Path $InstallerPath) {
 }
 
 # ── 3. Pre-descargar modelo LLM ──────────────────────────────────────────────
-Write-Host "`n[3/4] Pre-descargando modelo $Model..." -ForegroundColor Blue
+Write-Host "`n[3/5] Pre-descargando modelo $Model..." -ForegroundColor Blue
 $OllamaCmd = Get-Command ollama -ErrorAction SilentlyContinue
 
 if ($OllamaCmd) {
@@ -69,8 +79,13 @@ if ($OllamaCmd) {
         Write-Host "  -> Iniciando Ollama para descargar modelo..." -ForegroundColor Yellow
         Start-Process ollama -ArgumentList "serve" -WindowStyle Hidden
         Start-Sleep -Seconds 4
-        ollama pull $Model 2>$null
-        Write-Host "  OK Modelo pre-descargado" -ForegroundColor Green
+        $ModelsAfterServe = ollama list 2>$null
+        if ($ModelsAfterServe -match [regex]::Escape($Model)) {
+            Write-Host "  OK Modelo ya disponible" -ForegroundColor Green
+        } else {
+            ollama pull $Model 2>$null
+            Write-Host "  OK Modelo pre-descargado" -ForegroundColor Green
+        }
     }
 } else {
     if (Test-Path $InstallerPath) {
@@ -91,10 +106,35 @@ if ($Model -ne "qwen2.5:3b" -and $OllamaCmd) {
 }
 
 # ── 4. Guardar metadata y marcador ───────────────────────────────────────────
-Write-Host "`n[4/4] Guardando metadata..." -ForegroundColor Blue
+Write-Host "`n[4/5] Guardando metadata..." -ForegroundColor Blue
 $Meta = @{ executed = (Get-Date -Format "o"); os = "Windows"; arch = $Arch; ram_gb = $RamGB; model = $Model }
 $Meta | ConvertTo-Json | Set-Content "$CacheDir\plan-info.json"
 Get-Date -Format "o" | Set-Content $MarkerFile
+
+# ── 5. Verificacion final de cache offline ────────────────────────────────────
+Write-Host "`n[5/5] Verificando cache offline..." -ForegroundColor Blue
+if (Test-Path $InstallerPath) {
+    Write-Host "  OK Instalador Ollama cacheado" -ForegroundColor Green
+} elseif ($OllamaCmd) {
+    Write-Host "  OK Ollama instalado en PATH" -ForegroundColor Green
+} else {
+    Write-Host "  WARN Ollama no disponible" -ForegroundColor Yellow
+}
+if ($OllamaCmd) {
+    $VerifyModels = ollama list 2>$null
+    if ($VerifyModels -match [regex]::Escape($Model)) {
+        Write-Host "  OK Modelo $Model cacheado" -ForegroundColor Green
+    } else {
+        Write-Host "  WARN Modelo $Model no verificado" -ForegroundColor Yellow
+    }
+    if ($Model -ne "qwen2.5:3b") {
+        if ($VerifyModels -match "qwen2\.5:3b") {
+            Write-Host "  OK Modelo auxiliar qwen2.5:3b cacheado" -ForegroundColor Green
+        } else {
+            Write-Host "  WARN Modelo auxiliar qwen2.5:3b no verificado" -ForegroundColor Yellow
+        }
+    }
+}
 
 Write-Host "`nOK Emergency Plan completado" -ForegroundColor Green
 Write-Host "Cache: $CacheDir · Modelo: $Model" -ForegroundColor Cyan

--- a/scripts/emergency-plan.sh
+++ b/scripts/emergency-plan.sh
@@ -14,14 +14,9 @@ iso_date() { date -Iseconds 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%S+00:00"; }
 show_help() {
   echo -e "${BOLD}PM-Workspace Emergency Plan${NC} — Pre-descarga Ollama + LLM para offline"
   echo "Uso: $0 [--model MODEL] [--check] [--help]"
-  echo "  --model MODEL  Modelo (default: auto según RAM). --check  Verifica si ya se ejecutó"
-  echo "Soporta: Linux, macOS, Windows (usar .ps1). Modelos: 8GB→3b | 16GB→7b | 32GB+→14b"
-  exit 0
-}
-
+  echo "Modelos: 8GB→3b | 16GB→7b | 32GB+→14b. Windows: usar .ps1"; exit 0; }
 check_plan() {
-  [[ -f "$MARKER_FILE" ]] && { echo -e "${GREEN}✓${NC} Emergency plan ejecutado ($(cat "$MARKER_FILE"))"; exit 0; } || exit 1
-}
+  [[ -f "$MARKER_FILE" ]] && { echo -e "${GREEN}✓${NC} Emergency plan ejecutado ($(cat "$MARKER_FILE"))"; exit 0; } || exit 1; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -32,102 +27,106 @@ done
 echo -e "\n${BOLD}${CYAN}PM-Workspace · Emergency Plan${NC}"
 echo -e "Pre-descarga de recursos para instalación offline.\n"
 
-# ── 1. Detectar hardware y elegir modelo ─────────────────────────────────────
-echo -e "${BLUE}[1/4]${NC} Detectando hardware..."
+# ── 0. Check de conectividad ───────────────────────────────────────────────
+if ! curl -s --max-time 5 https://ollama.com >/dev/null 2>&1; then
+  echo -e "${RED}✗${NC} Sin conexión a internet. Se necesita para descargar recursos."
+  echo -e "  Si ya ejecutaste el plan, usa: ${CYAN}./scripts/emergency-setup.sh${NC}"; exit 1
+fi
+
+# ── 1. Detectar hardware y elegir modelo ───────────────────────────────────
+echo -e "${BLUE}[1/5]${NC} Detectando hardware..."
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
-if [[ "$OS" == "Darwin" ]]; then
-  RAM_BYTES=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
-  RAM_GB=$((RAM_BYTES / 1024 / 1024 / 1024))
-else
-  RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo 0)
-  RAM_GB=$((RAM_KB / 1024 / 1024))
-fi
+if [[ "$OS" == "Darwin" ]]; then RAM_GB=$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1024 / 1024 / 1024 ))
+else RAM_GB=$(( $(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo 0) / 1024 / 1024 )); fi
 echo -e "  OS: ${GREEN}$OS${NC} · Arch: ${GREEN}$ARCH${NC} · RAM: ${GREEN}${RAM_GB}GB${NC}"
 
 if [[ -z "$MODEL" ]]; then
-  if [[ $RAM_GB -ge 32 ]]; then MODEL="qwen2.5:14b"
-  elif [[ $RAM_GB -ge 16 ]]; then MODEL="qwen2.5:7b"
-  else MODEL="qwen2.5:3b"; fi
+  [[ $RAM_GB -ge 32 ]] && MODEL="qwen2.5:14b" || { [[ $RAM_GB -ge 16 ]] && MODEL="qwen2.5:7b" || MODEL="qwen2.5:3b"; }
   echo -e "  Modelo: ${CYAN}$MODEL${NC} (auto)"
-fi
-mkdir -p "$CACHE_DIR"
+fi; mkdir -p "$CACHE_DIR"
 
-# ── 2. Descargar Ollama según OS ─────────────────────────────────────────────
-echo -e "\n${BLUE}[2/4]${NC} Descargando Ollama para ${GREEN}$OS${NC}..."
+# ── 2. Descargar Ollama según OS ────────────────────────────────────────────
+echo -e "\n${BLUE}[2/5]${NC} Descargando Ollama para ${GREEN}$OS${NC}..."
 OLLAMA_BIN="$CACHE_DIR/ollama-bin"
-
-if [[ -f "$OLLAMA_BIN" ]]; then
-  echo -e "  ${GREEN}✓${NC} Binario Ollama ya en caché"
+_extract_ollama() { # usage: _extract_ollama <archive> <tar_flags>
+  local arc="$1"; shift; TMP_EX="$CACHE_DIR/_extract"; mkdir -p "$TMP_EX"
+  tar "$@" -xf "$arc" -C "$TMP_EX" 2>/dev/null
+  local found; found=$(find "$TMP_EX" -name "ollama" -type f | head -1)
+  [[ -n "$found" ]] && cp "$found" "$OLLAMA_BIN" && chmod +x "$OLLAMA_BIN" || OLLAMA_BIN=""
+  rm -rf "$TMP_EX" "$arc"
+}
+if [[ -f "$OLLAMA_BIN" ]]; then echo -e "  ${GREEN}✓${NC} Binario Ollama ya en caché"
 elif [[ "$OS" == "Linux" ]]; then
-  # Linux: tar.zst con binario en bin/ollama
   DL_ARCH="$ARCH"; [[ "$ARCH" == "x86_64" ]] && DL_ARCH="amd64"; [[ "$ARCH" == "aarch64" ]] && DL_ARCH="arm64"
   curl -fsSL https://ollama.ai/install.sh -o "$CACHE_DIR/ollama-install.sh" && chmod +x "$CACHE_DIR/ollama-install.sh"
   TMP_TAR="$CACHE_DIR/ollama.tar.zst"
   echo -e "  ${YELLOW}→${NC} Descargando ollama-linux-${DL_ARCH}.tar.zst..."
   curl -fSL "https://ollama.com/download/ollama-linux-${DL_ARCH}.tar.zst" -o "$TMP_TAR" && {
-    TMP_EX="$CACHE_DIR/_extract"; mkdir -p "$TMP_EX"
-    tar --zstd -xf "$TMP_TAR" -C "$TMP_EX" 2>/dev/null
-    FOUND=$(find "$TMP_EX" -name "ollama" -type f | head -1)
-    [[ -n "$FOUND" ]] && cp "$FOUND" "$OLLAMA_BIN" && chmod +x "$OLLAMA_BIN" || OLLAMA_BIN=""
-    rm -rf "$TMP_EX" "$TMP_TAR"
-    echo -e "  ${GREEN}✓${NC} Binario Linux extraído y cacheado"
+    _extract_ollama "$TMP_TAR" --zstd; echo -e "  ${GREEN}✓${NC} Binario Linux extraído y cacheado"
   } || { echo -e "  ${YELLOW}⚠${NC} Descarga falló. Se usará script de instalación."; rm -f "$TMP_TAR"; OLLAMA_BIN=""; }
 elif [[ "$OS" == "Darwin" ]]; then
-  # macOS: tgz con binario ollama en raíz (~70MB)
   TMP_TGZ="$CACHE_DIR/ollama-darwin.tgz"
   echo -e "  ${YELLOW}→${NC} Descargando ollama-darwin.tgz..."
   curl -fSL "https://ollama.com/download/ollama-darwin.tgz" -o "$TMP_TGZ" && {
-    TMP_EX="$CACHE_DIR/_extract"; mkdir -p "$TMP_EX"
-    tar xzf "$TMP_TGZ" -C "$TMP_EX" 2>/dev/null
-    [[ -f "$TMP_EX/ollama" ]] && cp "$TMP_EX/ollama" "$OLLAMA_BIN" && chmod +x "$OLLAMA_BIN" || OLLAMA_BIN=""
-    rm -rf "$TMP_EX" "$TMP_TGZ"
-    echo -e "  ${GREEN}✓${NC} Binario macOS extraído y cacheado"
+    _extract_ollama "$TMP_TGZ" -z; echo -e "  ${GREEN}✓${NC} Binario macOS extraído y cacheado"
   } || { echo -e "  ${YELLOW}⚠${NC} Descarga falló. Instala desde https://ollama.com/download"; rm -f "$TMP_TGZ"; OLLAMA_BIN=""; }
-else
-  echo -e "  ${YELLOW}⚠${NC} SO no soportado por este script. En Windows usa: ${CYAN}scripts/emergency-plan.ps1${NC}"
-fi
+else echo -e "  ${YELLOW}⚠${NC} SO no soportado. En Windows usa: ${CYAN}scripts/emergency-plan.ps1${NC}"; fi
 
 # ── 3. Pre-descargar modelo LLM ─────────────────────────────────────────────
-echo -e "\n${BLUE}[3/4]${NC} Pre-descargando modelo ${CYAN}$MODEL${NC}..."
+echo -e "\n${BLUE}[3/5]${NC} Pre-descargando modelo ${CYAN}$MODEL${NC}..."
+MODEL_OK=false; SMALL_OK=false; OLLAMA_OK=false
+_pull_small() { # Pull qwen2.5:3b if not present, using $1 as ollama binary
+  [[ "$MODEL" == "qwen2.5:3b" ]] && return
+  "$1" list 2>/dev/null | grep -q "qwen2.5:3b" && SMALL_OK=true || {
+    echo -e "  ${YELLOW}→${NC} Modelo auxiliar ${CYAN}qwen2.5:3b${NC} (haiku)..."
+    "$1" pull "qwen2.5:3b" 2>/dev/null && SMALL_OK=true || true; }
+}
 if command -v ollama &>/dev/null; then
+  OLLAMA_OK=true
   if curl -s --max-time 3 http://localhost:11434/api/tags &>/dev/null; then
-    ollama list 2>/dev/null | grep -q "$MODEL" && echo -e "  ${GREEN}✓${NC} Modelo ya disponible" || {
-      echo -e "  ${YELLOW}→${NC} Descargando modelo..."; ollama pull "$MODEL"; echo -e "  ${GREEN}✓${NC} Modelo descargado"; }
+    ollama list 2>/dev/null | grep -q "$MODEL" && { echo -e "  ${GREEN}✓${NC} Modelo ya disponible"; MODEL_OK=true; } || {
+      echo -e "  ${YELLOW}→${NC} Descargando modelo..."; ollama pull "$MODEL" && MODEL_OK=true; echo -e "  ${GREEN}✓${NC} Modelo descargado"; }
+    _pull_small ollama
   else
     echo -e "  ${YELLOW}→${NC} Iniciando Ollama para descargar modelo..."
     ollama serve &>/dev/null & OLLAMA_PID=$!; sleep 3
-    ollama pull "$MODEL" 2>/dev/null || echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo ahora"
-    kill "$OLLAMA_PID" 2>/dev/null || true
+    ollama pull "$MODEL" 2>/dev/null && MODEL_OK=true || echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo ahora"
+    _pull_small ollama; kill "$OLLAMA_PID" 2>/dev/null || true
   fi
 elif [[ -f "${OLLAMA_BIN:-}" ]]; then
+  OLLAMA_OK=true
   echo -e "  ${YELLOW}→${NC} Usando binario cacheado para descargar modelo..."
   "$OLLAMA_BIN" serve &>/dev/null & OLLAMA_PID=$!; sleep 4
-  "$OLLAMA_BIN" pull "$MODEL" 2>/dev/null || {
-    echo -e "  ${YELLOW}⚠${NC} No se pudo descargar modelo. Se hará en emergency-setup."
-    kill "$OLLAMA_PID" 2>/dev/null || true; }
-  echo -e "  ${GREEN}✓${NC} Modelo pre-descargado"
-  # Download small model for haiku alias while server is still running
-  if [[ "$MODEL" != "qwen2.5:3b" ]]; then
-    "$OLLAMA_BIN" list 2>/dev/null | grep -q "qwen2.5:3b" || { echo -e "  ${YELLOW}→${NC} Modelo auxiliar ${CYAN}qwen2.5:3b${NC} (haiku)..."; "$OLLAMA_BIN" pull "qwen2.5:3b" 2>/dev/null || true; }
+  if "$OLLAMA_BIN" list 2>/dev/null | grep -q "$MODEL"; then
+    echo -e "  ${GREEN}✓${NC} Modelo $MODEL ya disponible"; MODEL_OK=true
+  else
+    "$OLLAMA_BIN" pull "$MODEL" 2>/dev/null && MODEL_OK=true || {
+      echo -e "  ${YELLOW}⚠${NC} No se pudo descargar. Se hará en emergency-setup."; }
+    $MODEL_OK && echo -e "  ${GREEN}✓${NC} Modelo pre-descargado"
   fi
-  kill "$OLLAMA_PID" 2>/dev/null || true
-else
-  echo -e "  ${YELLOW}⚠${NC} Instala Ollama primero para pre-descargar el modelo"
-fi
-
-# Download small model for haiku alias (if ollama is in PATH)
-if [[ "$MODEL" != "qwen2.5:3b" ]] && command -v ollama &>/dev/null && curl -s --max-time 3 http://localhost:11434/api/tags &>/dev/null; then
-  ollama list 2>/dev/null | grep -q "qwen2.5:3b" || { echo -e "  ${YELLOW}→${NC} Modelo auxiliar ${CYAN}qwen2.5:3b${NC} (haiku)..."; ollama pull "qwen2.5:3b" 2>/dev/null || true; }
-fi
+  _pull_small "$OLLAMA_BIN"; kill "$OLLAMA_PID" 2>/dev/null || true
+else echo -e "  ${YELLOW}⚠${NC} Instala Ollama primero para pre-descargar el modelo"; fi
 
 # ── 4. Guardar metadata y marcador ───────────────────────────────────────────
-echo -e "\n${BLUE}[4/4]${NC} Guardando metadata..."
+echo -e "\n${BLUE}[4/5]${NC} Guardando metadata..."
 cat > "$CACHE_DIR/plan-info.json" << JSONEOF
 {"executed":"$(iso_date)","os":"$OS","arch":"$ARCH","ram_gb":$RAM_GB,"model":"$MODEL"}
 JSONEOF
 iso_date > "$MARKER_FILE"
+
+# ── 5. Verificación final de caché offline ────────────────────────────────────
+echo -e "\n${BLUE}[5/5]${NC} Verificando caché offline..."
+if [[ -f "$OLLAMA_BIN" ]]; then echo -e "  ${GREEN}✓${NC} Binario Ollama cacheado"
+elif $OLLAMA_OK; then echo -e "  ${GREEN}✓${NC} Ollama instalado en PATH"
+else echo -e "  ${YELLOW}⚠${NC} Binario Ollama no disponible"; fi
+$MODEL_OK && echo -e "  ${GREEN}✓${NC} Modelo $MODEL cacheado" \
+  || echo -e "  ${YELLOW}⚠${NC} Modelo $MODEL no verificado"
+if [[ "$MODEL" != "qwen2.5:3b" ]]; then
+  $SMALL_OK && echo -e "  ${GREEN}✓${NC} Modelo auxiliar qwen2.5:3b cacheado" \
+    || echo -e "  ${YELLOW}⚠${NC} Modelo auxiliar qwen2.5:3b no verificado"
+fi
 
 echo -e "\n${GREEN}${BOLD}✓ Emergency Plan completado${NC}"
 echo -e "Caché: ${CYAN}$CACHE_DIR${NC} · Modelo: ${CYAN}$MODEL${NC}"


### PR DESCRIPTION
## Summary
- **Step 0**: Connectivity check at startup — fails fast with clear message if no internet, pointing to `emergency-setup.sh` for offline use
- **Idempotency**: Cached binary path now checks `ollama list` before `pull` (both `.sh` and `.ps1`), matching the `command -v ollama` path behavior
- **Step 5**: New verification step reports what's cached and ready for offline (binary, main model, auxiliary model)
- **Refactor**: Extracted `_extract_ollama()` and `_pull_small()` helpers to reduce duplication in `.sh`

## Test plan
- [ ] Run `./scripts/emergency-plan.sh` with internet — all 5 steps complete
- [ ] Re-run immediately — everything reports "ya en caché" / "ya disponible" (idempotency)
- [ ] Step 5 shows green checkmarks for all cached resources
- [ ] `./scripts/emergency-plan.sh --check` confirms marker exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)