### PR TITLE
fix(ci): add name/description to wellbeing-guardian frontmatter

### DIFF
--- a/.claude/commands/wellbeing-guardian.md
+++ b/.claude/commands/wellbeing-guardian.md
@@ -1,4 +1,6 @@
 ---
+name: wellbeing-guardian
+description: "Proactive individual wellbeing system — break reminders, after-hours alerts, work-life balance nudges"
 allowed-tools: [Read, Glob, Grep, Write, Edit]
 argument-hint: "[status|configure|breaks|report|pause] [--reason work|personal|hydration] [--week|--month] [--summary|--detailed]"
 model: sonnet


### PR DESCRIPTION
## Resumen

- Corrige el fallo de CI añadiendo los campos `name` y `description` al frontmatter de `wellbeing-guardian.md`
- La validación de CI requiere estos campos cuando un command tiene frontmatter YAML

## What does this PR add or fix?

Fixes CI failure by adding required `name` and `description` fields to the wellbeing-guardian command frontmatter. The CI validation step checks that any command with YAML frontmatter includes both fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)