### PR TITLE
feat(sovereignty): add Cognitive Sovereignty audit (Era 35)

### DIFF
--- a/.claude/commands/sovereignty-audit.md
+++ b/.claude/commands/sovereignty-audit.md
@@ -1,0 +1,103 @@
+---
+name: sovereignty-audit
+description: "Cognitive sovereignty audit — diagnose AI vendor lock-in risk and data portability"
+allowed-tools: [Read, Glob, Grep, Write, Edit]
+argument-hint: "[scan|report|exit-plan|recommend] [--format md|pdf] [--dimension d1|d2|d3|d4|d5]"
+model: sonnet
+context_cost: medium
+---
+
+# /sovereignty-audit — Auditoría de soberanía cognitiva
+
+> Skill: @.claude/skills/sovereignty-auditor/SKILL.md
+> Config: @.claude/rules/domain/cognitive-sovereignty.md
+> Complementa: @.claude/commands/governance-audit.md
+
+Diagnostica y cuantifica el nivel de independencia de tu organización respecto
+a proveedores de IA. Basado en "La Trampa Cognitiva" (De Nicolás, 2026):
+cuando la IA entiende tu organización mejor que tú, el coste de cambiar de
+proveedor ya no es técnico — es estratégico.
+
+## Subcomandos
+
+### `/sovereignty-audit scan`
+
+Escanea el workspace y calcula el Sovereignty Score (0-100):
+
+**5 dimensiones analizadas:**
+1. **D1 — Portabilidad de datos** (25%): formatos abiertos, SaviaHub, BacklogGit
+2. **D2 — Independencia LLM** (25%): Emergency Mode, multi-modelo, prompts portables
+3. **D3 — Protección del grafo** (20%): cifrado, PII gate, datos sensibles
+4. **D4 — Gobernanza del consumo** (15%): políticas, audit trail, tracking
+5. **D5 — Opcionalidad de salida** (15%): documentación, exit plan, backups
+
+Output: score por dimensión + score global + clasificación + gráfico ASCII.
+Resultado guardado en `output/sovereignty-scan-YYYYMMDD.md`.
+
+### `/sovereignty-audit report [--format md|pdf]`
+
+Informe ejecutivo de soberanía para CTO/CIO/comité de dirección:
+- Score global + tendencia temporal (si hay scans anteriores)
+- Desglose por dimensión con evidencia concreta
+- Benchmarks contra configuración ideal de pm-workspace
+- Riesgos priorizados con impacto estimado
+- Recomendaciones top-3
+
+### `/sovereignty-audit exit-plan`
+
+Plan de salida concreto y documentado:
+- Inventario de datos organizacionales (SaviaHub, perfiles, memorias, backlogs)
+- Dependencias del proveedor actual (APIs, integraciones, MCP servers)
+- Estimación de esfuerzo de migración por categoría
+- Timeline realista (72h mínimo viables vs plan completo)
+- Alternativas de proveedor disponibles
+
+### `/sovereignty-audit recommend`
+
+Recomendaciones accionables para mejorar el Sovereignty Score:
+- Ordenadas por impacto/esfuerzo (quick wins primero)
+- Con comandos concretos de pm-workspace
+- Ejemplo: "Emergency Mode no configurado → `/emergency-mode setup`"
+- Solo dimensiones con score < 70
+
+## Clasificación del Sovereignty Score
+
+| Rango | Nivel | Significado |
+|---|---|---|
+| 90-100 | Soberanía plena | Migración trivial |
+| 70-89 | Soberanía alta | Migración viable con esfuerzo moderado |
+| 50-69 | Riesgo medio | Dependencias significativas |
+| 30-49 | Riesgo alto | Lock-in cognitivo en progreso |
+| 0-29 | Lock-in crítico | Migración prácticamente inviable |
+
+## Integración
+
+- **governance-audit**: cumplimiento normativo (NIST, EU AI Act, AEPD)
+- **sovereignty-audit**: independencia del proveedor (5 dimensiones)
+- Ambos se complementan: cumplir la ley ≠ ser independiente
+
+## Ejemplo de output (scan)
+
+```
+══════════════════════════════════════════
+  Sovereignty Score: 78/100 — Soberanía alta
+══════════════════════════════════════════
+
+  D1 Portabilidad     ████████████████████░░░░░  82
+  D2 Independencia    ██████████████████░░░░░░░  72
+  D3 Grafo org.       █████████████████████░░░░  85
+  D4 Gobernanza       ██████████████░░░░░░░░░░░  58
+  D5 Salida           ████████████████████░░░░░  80
+
+  ⚠️ D4 bajo 70 → Ejecuta /governance-policy create
+  ✅ Migración viable con esfuerzo moderado
+```
+
+## Señales de alarma
+
+El scan detecta automáticamente estas señales:
+- No hay exit plan documentado
+- Emergency Mode no configurado
+- Datos sensibles en commits públicos
+- Sin governance policy ni audit trail
+- Documentación dispersa o incompleta

--- a/.claude/rules/domain/cognitive-sovereignty.md
+++ b/.claude/rules/domain/cognitive-sovereignty.md
@@ -1,0 +1,119 @@
+# Regla: Soberanía Cognitiva — Protección contra el Lock-in de IA
+# ── Diagnóstico y cuantificación de dependencia de proveedores IA ──
+
+> Basado en: "La Trampa Cognitiva" (Álvaro de Nicolás, LinkedIn, Mar 2026)
+> Complementa: @.claude/rules/domain/ai-governance.md (cumplimiento normativo)
+> "En los 90 el lock-in era técnico. En los 2000 contractual. En los 2010 de
+> procesos. En 2026 es cognitivo." — Cuando la IA entiende tu organización
+> mejor que tú, el coste de cambiar de proveedor ya no es técnico.
+
+## Evolución del lock-in empresarial
+
+| Década | Tipo | Mecanismo | Coste de salida |
+|---|---|---|---|
+| 1990s | Técnico | Formatos propietarios, hardware específico | Migración de datos |
+| 2000s | Contractual | Licencias, penalizaciones, volumen mínimo | Legal + financiero |
+| 2010s | De procesos | Workflows integrados, APIs acopladas | Reingeniería |
+| 2026+ | **Cognitivo** | IA aprende patrones org., grafo decisional | **Estratégico** |
+
+## Las 5 dimensiones del Sovereignty Score
+
+### D1 — Portabilidad de datos (peso: 25%)
+
+¿El conocimiento organizacional es exportable sin la herramienta?
+
+| Indicador | Score alto (80-100) | Score bajo (0-30) |
+|---|---|---|
+| Formato de datos | Markdown, CSV, JSON en Git | APIs propietarias, DBs cerradas |
+| SaviaHub | Configurado con company/clients/users | Sin repo de conocimiento |
+| Memoria de agentes | MEMORY.md en Git | Solo en cloud del proveedor |
+| Backlogs | BacklogGit (snapshots md) | Solo en API del PM tool |
+
+### D2 — Independencia de proveedor LLM (peso: 25%)
+
+¿Se puede operar sin el proveedor LLM actual?
+
+| Indicador | Score alto | Score bajo |
+|---|---|---|
+| Emergency Mode | Configurado + modelo descargado | No configurado |
+| Multi-modelo | Smart frontmatter (haiku/sonnet/opus) | Single model hardcoded |
+| Prompts | Portables, sin features exclusivas | Dependientes de API específica |
+| Fallback local | Ollama + modelo 7B+ disponible | Sin alternativa offline |
+
+### D3 — Protección del grafo organizacional (peso: 20%)
+
+¿Quién accede a la estructura de decisiones y relaciones?
+
+| Indicador | Score alto | Score bajo |
+|---|---|---|
+| Datos sensibles | Git-ignorados, cifrados | En commits públicos |
+| Company Savia | RSA-4096 + AES-256-CBC | Sin cifrado |
+| Perfiles de cliente | Locales en SaviaHub | En cloud de terceros |
+| PII scanning | hook-pii-gate activo | Sin protección |
+
+### D4 — Gobernanza del consumo (peso: 15%)
+
+¿Se controla y mide el uso de IA?
+
+| Indicador | Score alto | Score bajo |
+|---|---|---|
+| Governance policy | Documentada y revisada | Inexistente |
+| Audit trail | Trazas de agentes activas | Sin registro |
+| Token tracking | Medición por sesión/sprint | Sin medición |
+| Governance audit | Ejecutada trimestralmente | Nunca ejecutada |
+
+### D5 — Opcionalidad de salida (peso: 15%)
+
+¿Se puede migrar a otro proveedor en <72h?
+
+| Indicador | Score alto | Score bajo |
+|---|---|---|
+| Documentación | Completa en markdown | Dispersa o ausente |
+| Exit plan | Documentado y actualizado | Inexistente |
+| Datos separados | Empresa ≠ herramienta | Acoplados |
+| Backups | Cifrados y verificados | Sin backups |
+
+## Cálculo del Sovereignty Score
+
+```
+Score = D1×0.25 + D2×0.25 + D3×0.20 + D4×0.15 + D5×0.15
+```
+
+| Rango | Nivel | Significado |
+|---|---|---|
+| 90-100 | Soberanía plena | Migración trivial |
+| 70-89 | Soberanía alta | Migración viable, esfuerzo moderado |
+| 50-69 | Riesgo medio | Dependencias significativas |
+| 30-49 | Riesgo alto | Lock-in cognitivo en progreso |
+| 0-29 | Lock-in crítico | Migración prácticamente inviable |
+
+## Vendor Risk Matrix
+
+| Proveedor | Riesgo lock-in | Mitigación pm-workspace |
+|---|---|---|
+| LLM (Claude/GPT) | ALTO — aprende patrones org. | Emergency Mode + multi-modelo |
+| PM Tool (Azure/Jira) | MEDIO — workflows acoplados | BacklogGit + Savia Flow Git-native |
+| Cloud (AWS/Azure/GCP) | MEDIO — infra dependiente | Scripts portables, sin cloud-lock |
+| Data store | BAJO si Git, ALTO si SaaS | Todo en Git markdown |
+
+## Señales de alarma
+
+Indicadores de que el lock-in cognitivo está avanzando:
+1. No puedes explicar tu proceso de decisión sin la herramienta IA
+2. El proveedor sube precios y no hay alternativa viable (<6 meses migración)
+3. Los nuevos empleados necesitan la IA para entender los procesos existentes
+4. La documentación organizacional solo existe dentro del sistema IA
+5. No hay exit plan actualizado ni se ha probado una migración de prueba
+
+## Integración
+
+- **governance-audit**: audita cumplimiento normativo (NIST, EU AI Act, AEPD)
+- **sovereignty-audit**: audita independencia del proveedor (5 dimensiones)
+- Ambos se complementan: cumplir la ley ≠ ser independiente
+
+## Referencias
+
+- De Nicolás, Á. (2026). "La Trampa Cognitiva". LinkedIn Pulse.
+- Gartner (2025). "35% of countries will adopt region-specific AI platforms by 2027"
+- AEPD (2026). "Orientaciones sobre IA Agéntica y Protección de Datos"
+- EU AI Act (2024). Reglamento (UE) 2024/1689

--- a/.claude/skills/sovereignty-auditor/SKILL.md
+++ b/.claude/skills/sovereignty-auditor/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: sovereignty-auditor
+description: "Auditoría de soberanía cognitiva — diagnóstico de lock-in de IA"
+context_cost: medium
+dependencies: []
+---
+
+# Skill: Sovereignty Auditor
+
+> Regla: @.claude/rules/domain/cognitive-sovereignty.md
+> Complementa: @.claude/commands/governance-audit.md (cumplimiento normativo)
+
+## Prerequisitos
+
+- Workspace pm-workspace inicializado
+- Para scan completo: acceso a `.claude/`, `scripts/`, `docs/`
+
+## Flujo: Scan
+
+Calcula el Sovereignty Score analizando 5 dimensiones:
+
+### Paso 1 — D1: Portabilidad de datos (25%)
+1. Contar ficheros en formatos abiertos (md, csv, json, yaml) vs propietarios
+2. Verificar SaviaHub existente (`savia-hub/` o `$SAVIA_HUB_PATH`)
+3. Detectar MEMORY.md en `.claude/agent-memory/` (memoria portable)
+4. Verificar BacklogGit configurado (snapshots en markdown)
+5. Score: % datos en formatos abiertos × presencia de SaviaHub/BacklogGit
+
+### Paso 2 — D2: Independencia LLM (25%)
+1. Verificar `scripts/emergency-setup.sh` existe
+2. Comprobar si Ollama está mencionado en configuración
+3. Analizar smart-frontmatter: ¿hay variedad de modelos? (haiku/sonnet/opus)
+4. Buscar dependencias Claude-específicas en prompts
+5. Score: emergency_mode_ready × multi_model_usage × prompt_portability
+
+### Paso 3 — D3: Protección del grafo (20%)
+1. Verificar `.gitignore` excluye datos sensibles (PAT, credenciales, PII)
+2. Detectar Company Savia con cifrado (RSA-4096, AES-256)
+3. Comprobar perfiles de cliente en local (no cloud)
+4. Verificar hook-pii-gate activo en settings.json
+5. Score: gitignore_coverage × encryption_present × pii_protection
+
+### Paso 4 — D4: Gobernanza del consumo (15%)
+1. Verificar `company/policies.md` existe (governance policy)
+2. Detectar audit-trail configurado (action-log, agent-trace-log)
+3. Buscar trazas de ejecución de governance-audit
+4. Verificar token tracking (context-budget, scoring-curves)
+5. Score: policy_exists × audit_active × tracking_present
+
+### Paso 5 — D5: Opcionalidad de salida (15%)
+1. Verificar documentación completa (README, guides, rules en markdown)
+2. Buscar exit plan documentado
+3. Comprobar backups configurados (backup-encrypt, backup-verify)
+4. Verificar datos de empresa separados de herramienta
+5. Score: docs_complete × exit_plan × backups × data_separation
+
+### Paso 6 — Score global
+1. Calcular: `Score = D1×0.25 + D2×0.25 + D3×0.20 + D4×0.15 + D5×0.15`
+2. Clasificar nivel (plena/alta/medio/alto/crítico)
+3. Generar gráfico ASCII de barras por dimensión
+4. Guardar en `output/sovereignty-scan-YYYYMMDD.md`
+
+## Flujo: Report
+
+1. Cargar último scan de `output/sovereignty-scan-*.md`
+2. Si no existe → ejecutar scan primero
+3. Cargar scans anteriores para tendencia (si hay)
+4. Generar informe ejecutivo:
+   - Score global + clasificación
+   - Desglose por dimensión con evidencia concreta
+   - Tendencia temporal (mejora/empeora/estable)
+   - Riesgos priorizados
+   - Benchmarks: comparación con configuración ideal
+5. Formato: markdown (default) o delegado a skill PDF si --format pdf
+
+## Flujo: Exit Plan
+
+1. Inventariar datos organizacionales:
+   - SaviaHub: company/, clients/, users/ (tamaño, items)
+   - Perfiles: `.claude/profiles/` (users, teams)
+   - Memorias: `.claude/agent-memory/` (MEMORY.md por agente)
+   - Backlogs: snapshots en BacklogGit
+   - Specs, decisiones, playbooks
+2. Listar dependencias del proveedor actual:
+   - API Anthropic (Claude Code)
+   - Azure DevOps / Jira (si configurado)
+   - MCP servers activos
+3. Estimar esfuerzo de migración por categoría
+4. Generar timeline realista (72h/1 semana/1 mes)
+5. Listar alternativas: otros LLMs, herramientas PM, plataformas
+6. Output: `output/exit-plan-YYYYMMDD.md`
+
+## Flujo: Recommend
+
+1. Leer último scan
+2. Identificar dimensiones con score < 70
+3. Para cada gap, mapear a acción concreta:
+   - D1 bajo → "Configura SaviaHub: `/savia-hub init`"
+   - D2 bajo → "Configura Emergency Mode: `/emergency-mode setup`"
+   - D3 bajo → "Activa PII gate: revisa `.claude/settings.json`"
+   - D4 bajo → "Crea governance policy: `/governance-policy create`"
+   - D5 bajo → "Genera exit plan: `/sovereignty-audit exit-plan`"
+4. Ordenar por impacto/esfuerzo (quick wins primero)
+5. Presentar como checklist accionable con prioridad
+
+## Errores
+
+| Error | Acción |
+|-------|--------|
+| Workspace no inicializado | Sugerir `git init` + setup básico |
+| Sin datos para scan | Ejecutar scan con defaults (score bajo) |
+| Sin scans anteriores | Report sin tendencia, solo snapshot actual |
+| Fichero de scan corrupto | Re-ejecutar scan |
+
+## Seguridad
+
+- El scan NUNCA envía datos organizacionales a APIs externas
+- Los resultados se guardan localmente en `output/`
+- El exit plan no ejecuta ninguna migración, solo documenta
+- Las recomendaciones son informativas, no ejecutan comandos automáticamente

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.10.0] — 2026-03-06
+
+### Added — Cognitive Sovereignty: AI Vendor Lock-in Audit (Era 35)
+
+- **sovereignty-audit.md**: `/sovereignty-audit scan`, `report`, `exit-plan`, `recommend`. Diagnoses and quantifies organizational independence from AI providers. 5-dimension Sovereignty Score (0-100): data portability, LLM independence, organizational graph protection, consumption governance, exit optionality. Based on "La Trampa Cognitiva" (De Nicolás, 2026) — cognitive lock-in as the new enterprise dependency.
+- **cognitive-sovereignty.md**: Domain rule with lock-in evolution framework (technical→contractual→process→cognitive), 5 dimensions with weighted scoring, vendor risk matrix, alarm signals, integration with governance-audit.
+- **sovereignty-auditor/SKILL.md**: Scan orchestration (workspace analysis, score calculation), executive report generation, concrete exit plan with migration timeline, actionable recommendations mapped to pm-workspace commands.
+- Tests: `test-sovereignty-audit.sh` — 50 structural tests across command, rule, skill, and cross-references.
+
+---
+
 ## [2.9.0] — 2026-03-05
 
 ### Added — Wellbeing Guardian: Proactive Individual Wellbeing (Era 34)
@@ -296,6 +307,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.10.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.8.2...v2.9.0
 [2.8.2]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.8.0...v2.8.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
 │   ├── hooks/ (14)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
-│   ├── skills/ (30)               ← Skills reutilizables
+│   ├── skills/ (31)               ← Skills reutilizables
 │   └── settings.json              ← Hooks + Agent Teams env
 ├── docs/ · projects/ · scripts/
 ```

--- a/README.en.md
+++ b/README.en.md
@@ -187,7 +187,7 @@ I've organized all documentation into sections so you can quickly find what you 
 
 ## Quick Command Reference
 
-> 360+ commands · 27 agents · 30 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
+> 360+ commands · 27 agents · 31 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
 
 ### User Profile, Updates and Community
 ```

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ He organizado toda la documentación en secciones para que encuentres rápido lo
 
 ## Referencia rápida de comandos
 
-> 360+ comandos · 27 agentes · 30 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
+> 360+ comandos · 27 agentes · 31 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
 
 ### Perfil de Usuario, Actualización y Comunidad
 ```

--- a/docs/ADOPTION_GUIDE.en.md
+++ b/docs/ADOPTION_GUIDE.en.md
@@ -28,7 +28,7 @@
 
 ### What is PM-Workspace?
 
-PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 30 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
+PM-Workspace is an AI-powered project management platform that turns Claude Code (Anthropic's AI coding tool) into an **automated Project Manager**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It provides 360+ commands, 31 specialized skills, and 27 AI subagents covering everything from sprint planning to agent-based code implementation, with support for 16 languages and 12 regulated sectors.
 
 ### Why adopt it in a consulting firm?
 
@@ -202,7 +202,7 @@ After cloning, you'll find this structure:
 |-----------|----------|----------|
 | `CLAUDE.md` | Claude Code entry point (global constants) | Yes |
 | `.claude/commands/` | 360+ slash commands for PM workflows | Advanced |
-| `.claude/skills/` | 30 specialized skills | Advanced |
+| `.claude/skills/` | 31 specialized skills | Advanced |
 | `.claude/agents/` | 27 AI subagents | Advanced |
 | `.claude/rules/` | Modular rules (PM, multi-language, Git) | Advanced |
 | `projects/` | Project folder (each with its own `CLAUDE.md`) | Yes |

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -28,7 +28,7 @@
 
 ### ¿Qué es PM-Workspace?
 
-PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 30 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
+PM-Workspace es una plataforma de gestión de proyectos con IA que convierte a Claude Code (la herramienta de programación con IA de Anthropic) en un **Project Manager automatizado**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Proporciona 360+ comandos, 31 skills especializadas y 27 subagentes de IA que cubren desde el sprint planning hasta la implementación de código por agentes, con soporte para 16 lenguajes y 12 sectores regulados.
 
 ### ¿Por qué adoptarlo en una consultora?
 
@@ -220,7 +220,7 @@ Al clonar, encontrarás esta estructura:
 |------------|-----------|----------|
 | `CLAUDE.md` | Punto de entrada de Claude Code (constantes globales) | Sí |
 | `.claude/commands/` | 360+ slash commands para flujos PM | Avanzado |
-| `.claude/skills/` | 30 skills especializadas | Avanzado |
+| `.claude/skills/` | 31 skills especializadas | Avanzado |
 | `.claude/agents/` | 27 subagentes IA | Avanzado |
 | `.claude/rules/` | Reglas modulares (PM, multi-lenguaje, Git) | Avanzado |
 | `projects/` | Carpeta de proyectos (cada uno con su `CLAUDE.md`) | Sí |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 30 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 34 thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 360+ commands, 27 agents, 31 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into 35 thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -312,6 +312,14 @@ Proactive onboarding interview for new clients and projects. 8-phase structured 
 Proactive nudge system for individual work-life balance. Based on HBR research "AI Doesn't Reduce Work—It Intensifies It" (Feb 2026, Berkeley Haas). Break science: Pomodoro, 52-17, 5-50 method, 20-20-20 eye rule, INSST Spain guidelines.
 
 - **Wellbeing Guardian** (v2.9.0) — `/wellbeing-guardian status`, `configure`, `breaks`, `report`, `pause`. Work schedule in user profile (start/end hours, lunch, conciliation). 5 break strategies. Non-blocking nudges (after-hours alerts, break reminders, weekend disconnection). Integration with burnout-radar (break_compliance_score) and sustainable-pace (wellbeing_factor). Session-init context (~25 tokens). 1 skill, 1 rule. 50 tests.
+
+---
+
+## ✅ Era 35 — Cognitive Sovereignty: AI Vendor Lock-in Audit (v2.10.0, Mar 2026)
+
+Diagnose and quantify organizational independence from AI providers. Based on "La Trampa Cognitiva" (De Nicolás, 2026) — cognitive lock-in as the new enterprise dependency when AI learns organizational patterns.
+
+- **Cognitive Sovereignty** (v2.10.0) — `/sovereignty-audit scan`, `report`, `exit-plan`, `recommend`. 5-dimension Sovereignty Score (0-100): data portability, LLM independence, organizational graph protection, consumption governance, exit optionality. Vendor risk matrix. Alarm signals detection. Integration with governance-audit. 1 skill, 1 rule. 50 tests.
 
 ---
 

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -49,7 +49,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 developers por lenguaje
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 30 skills reutilizables
+│   ├── skills/                  ← 31 skills reutilizables
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/docs/readme/03-configuracion.md
+++ b/docs/readme/03-configuracion.md
@@ -61,7 +61,7 @@ cd ~/claude    # o el directorio donde hayas clonado el repositorio
 claude
 ```
 
-Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 30 skills,
+Claude Code cargará `CLAUDE.md` automáticamente, activará los 360+ comandos y las 31 skills,
 detectará el lenguaje del proyecto y cargará las convenciones y agente apropiados.
 Todas las buenas prácticas del flujo Explorar → Planificar → Implementar → Commit están preconfiguradas.
 

--- a/docs/readme_en/02-structure.md
+++ b/docs/readme_en/02-structure.md
@@ -48,7 +48,7 @@
 │   │   ├── dotnet-developer.md  ← + 10 language-specific developers
 │   │   └── ...
 │   │
-│   ├── skills/                  ← 30 reusable skills
+│   ├── skills/                  ← 31 reusable skills
 │   │   ├── azure-devops-queries/
 │   │   ├── sprint-management/
 │   │   ├── capacity-planning/

--- a/scripts/test-sovereignty-audit.sh
+++ b/scripts/test-sovereignty-audit.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test-sovereignty-audit.sh — Structural tests for Cognitive Sovereignty (Era 35 — v2.10.0)
+set -uo pipefail
+
+PASS=0; FAIL=0
+
+pass() { ((PASS+=1)) || true; echo "  ✅ $1"; }
+fail() { ((FAIL+=1)) || true; echo "  ❌ $1"; }
+check() { if eval "$2" > /dev/null 2>&1; then pass "$1"; else fail "$1"; fi; }
+
+echo "══════════════════════════════════════════"
+echo "  Cognitive Sovereignty Tests (Era 35 — v2.10.0)"
+echo "══════════════════════════════════════════"
+
+# ── Section 1: Command file ────────────────────────────────────────────────
+echo ""
+echo "── Section 1: Command file ──"
+CMD=".claude/commands/sovereignty-audit.md"
+check "Command exists" "[ -f $CMD ]"
+LINES=$(wc -l < "$CMD")
+check "Command within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has name in frontmatter" "grep -q '^name:' $CMD"
+check "Has description in frontmatter" "grep -q '^description:' $CMD"
+check "Has scan subcommand" "grep -q 'sovereignty-audit scan' $CMD"
+check "Has report subcommand" "grep -q 'sovereignty-audit report' $CMD"
+check "Has exit-plan subcommand" "grep -q 'sovereignty-audit exit-plan' $CMD"
+check "Has recommend subcommand" "grep -q 'sovereignty-audit recommend' $CMD"
+check "References skill" "grep -q 'sovereignty-auditor/SKILL.md' $CMD"
+check "References config rule" "grep -q 'cognitive-sovereignty' $CMD"
+
+# ── Section 2: Domain rule ─────────────────────────────────────────────────
+echo ""
+echo "── Section 2: Domain rule ──"
+RULE=".claude/rules/domain/cognitive-sovereignty.md"
+check "Config rule exists" "[ -f $RULE ]"
+LINES=$(wc -l < "$RULE")
+check "Config rule within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has De Nicolás reference" "grep -q 'Nicolás' $RULE"
+check "Has D1 Portabilidad" "grep -q 'Portabilidad' $RULE"
+check "Has D2 Independencia" "grep -q 'Independencia' $RULE"
+check "Has D3 Grafo" "grep -q 'grafo' $RULE"
+check "Has D4 Gobernanza" "grep -q 'Gobernanza' $RULE"
+check "Has D5 Opcionalidad" "grep -q 'Opcionalidad' $RULE"
+check "Has scoring formula" "grep -q 'Score.*D1.*D2' $RULE || grep -q '0.25.*0.25.*0.20' $RULE"
+check "Has lock-in evolution table" "grep -q 'Cognitivo' $RULE"
+check "Has vendor risk matrix" "grep -q 'Vendor Risk' $RULE"
+check "Has alarm signals" "grep -q 'alarma' $RULE || grep -q 'Señales' $RULE"
+check "Has sovereignty levels" "grep -q 'Soberanía plena' $RULE"
+check "Has governance-audit integration" "grep -q 'governance-audit' $RULE"
+check "Has AEPD reference" "grep -q 'AEPD' $RULE"
+check "Has EU AI Act reference" "grep -q 'EU AI Act' $RULE"
+check "Has Gartner reference" "grep -q 'Gartner' $RULE"
+
+# ── Section 3: Skill ──────────────────────────────────────────────────────
+echo ""
+echo "── Section 3: Skill ──"
+SKILL=".claude/skills/sovereignty-auditor/SKILL.md"
+check "Skill exists" "[ -f $SKILL ]"
+LINES=$(wc -l < "$SKILL")
+check "Skill within limit ($LINES/150 lines)" "[ $LINES -le 150 ]"
+check "Has correct name" "grep -q 'sovereignty-auditor' $SKILL"
+check "Has scan flow" "grep -q 'Flujo: Scan' $SKILL"
+check "Has report flow" "grep -q 'Flujo: Report' $SKILL"
+check "Has exit-plan flow" "grep -q 'Flujo: Exit Plan' $SKILL"
+check "Has recommend flow" "grep -q 'Flujo: Recommend' $SKILL"
+check "Has D1 analysis" "grep -q 'Portabilidad' $SKILL"
+check "Has D2 analysis" "grep -q 'Independencia' $SKILL"
+check "Has D3 analysis" "grep -q 'grafo' $SKILL || grep -q 'Protección' $SKILL"
+check "Has D4 analysis" "grep -q 'Gobernanza' $SKILL"
+check "Has D5 analysis" "grep -q 'Opcionalidad\|salida' $SKILL"
+check "Has scoring calculation" "grep -q 'Score.*D1\|0.25.*0.25' $SKILL"
+check "Has output path" "grep -q 'output/sovereignty' $SKILL"
+check "References config rule" "grep -q 'cognitive-sovereignty' $SKILL"
+check "Has emergency mode check" "grep -q 'emergency' $SKILL || grep -q 'Emergency' $SKILL"
+check "Has SaviaHub check" "grep -q 'SaviaHub\|savia-hub\|savia_hub' $SKILL"
+
+# ── Section 4: Cross-references ────────────────────────────────────────────
+echo ""
+echo "── Section 4: Cross-references ──"
+check "Skill references config rule" "grep -q 'cognitive-sovereignty' $SKILL"
+check "Command references skill" "grep -q 'sovereignty-auditor' $CMD"
+check "Command references config rule" "grep -q 'cognitive-sovereignty' $CMD"
+check "Rule references governance-audit" "grep -q 'governance-audit' $RULE"
+check "Command references governance-audit" "grep -q 'governance-audit' $CMD"
+check "Skill references governance-audit" "grep -q 'governance-audit' $SKILL"
+
+echo ""
+echo "══════════════════════════════════════════"
+echo "  Results: $PASS/$((PASS+FAIL)) passed, $FAIL failed"
+echo "══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Resumen

- Nuevo sistema de auditoría de soberanía cognitiva basado en "La Trampa Cognitiva" (Álvaro de Nicolás, 2026)
- Comando `/sovereignty-audit` con 4 subcomandos: scan, report, exit-plan, recommend
- Sovereignty Score (0-100) con 5 dimensiones: portabilidad datos, independencia LLM, protección del grafo organizacional, gobernanza del consumo, opcionalidad de salida
- Vendor Risk Matrix y señales de alarma de lock-in cognitivo
- 50 tests estructurales pasan correctamente

## What does this PR add or fix?

Adds the Cognitive Sovereignty audit system (Era 35, v2.10.0). Diagnoses and quantifies AI vendor lock-in risk using a 5-dimension Sovereignty Score (0-100): data portability, LLM independence, organizational graph protection, consumption governance, and exit optionality. Based on the evolution of enterprise lock-in from technical (90s) to contractual (2000s) to process (2010s) to cognitive (2026). Complements existing governance-audit (compliance) with independence assessment.

## Type of contribution

- [x] New skill
- [x] New slash command
- [x] New domain rule
- [x] Test suite addition

## Context impact

- [x] CLAUDE.md stays within 120 lines limit
- [x] No session-init impact (sovereignty-audit is on-demand only)

## How to test this

1. Run `bash scripts/test-sovereignty-audit.sh` — expect 50/50 passed
2. Verify all 3 new files are ≤150 lines

## Test suite

- [x] `test-sovereignty-audit.sh` passes 50/50

## Checklist

- [x] PR title follows conventional commits
- [x] Command has `name` and `description` in frontmatter (CI requirement)
- [x] CHANGELOG updated with comparison link
- [x] Skills count updated 30→31 across all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)