### PR TITLE
docs: bilingual guide system — 11 EN translations + indexes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -156,16 +156,19 @@ I've organized all documentation into sections so you can quickly find what you 
 
 | Guide | Scenario |
 |---|---|
-| [Consultancy + Azure DevOps](docs/guides/guide-azure-devops.md) | Scrum team with Azure DevOps, CI/CD, SDD |
-| [Consultancy + Jira](docs/guides/guide-jira.md) | Jira ↔ Savia sync, hybrid workflow |
-| [Savia Only / Savia Flow](docs/guides/guide-savia-standalone.md) | No external tool, everything in Git |
-| [Educational Center](docs/guides/guide-education.md) | Savia School: projects, evaluations, GDPR |
-| [Hardware Lab](docs/guides/guide-hardware-lab.md) | PCB, firmware, BOM, certifications |
-| [Research Laboratory](docs/guides/guide-research-lab.md) | Papers, experiments, datasets, grants |
-| [Startup](docs/guides/guide-startup.md) | MVP, lean, rapid iteration, OKRs |
-| [Non-profit / NGO](docs/guides/guide-nonprofit.md) | Grants, volunteers, social impact |
-| [Legal Firm](docs/guides/guide-legal-firm.md) | Cases, legal deadlines, time billing |
-| [Healthcare Organization](docs/guides/guide-healthcare.md) | Quality improvement, protocols, compliance |
+| [Consultancy + Azure DevOps](docs/guides_en/guide-azure-devops.md) | Scrum team with Azure DevOps, CI/CD, SDD |
+| [Consultancy + Jira](docs/guides_en/guide-jira.md) | Jira ↔ Savia sync, hybrid workflow |
+| [Savia Only / Savia Flow](docs/guides_en/guide-savia-standalone.md) | No external tool, everything in Git |
+| [Educational Center](docs/guides_en/guide-education.md) | Savia School: projects, evaluations, GDPR |
+| [Hardware Lab](docs/guides_en/guide-hardware-lab.md) | PCB, firmware, BOM, certifications |
+| [Research Laboratory](docs/guides_en/guide-research-lab.md) | Papers, experiments, datasets, grants |
+| [Startup](docs/guides_en/guide-startup.md) | MVP, lean, rapid iteration, OKRs |
+| [Non-profit / NGO](docs/guides_en/guide-nonprofit.md) | Grants, volunteers, social impact |
+| [Legal Firm](docs/guides_en/guide-legal-firm.md) | Cases, legal deadlines, time billing |
+| [Healthcare Organization](docs/guides_en/guide-healthcare.md) | Quality improvement, protocols, compliance |
+| [Cognitive Sovereignty Audit](docs/guides_en/guide-sovereignty.md) | Cognitive lock-in, Sovereignty Score, exit plan |
+
+> 📚 [Full guide index (English)](docs/guides_en/README.md) · [Índice completo de guías (Español)](docs/guides/README.md)
 
 ### Other Documents
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ He organizado toda la documentación en secciones para que encuentres rápido lo
 | [ONG](docs/guides/guide-nonprofit.md) | Subvenciones, voluntarios, impacto social |
 | [Bufete de abogados](docs/guides/guide-legal-firm.md) | Casos, plazos legales, facturación por horas |
 | [Organización sanitaria](docs/guides/guide-healthcare.md) | Mejora continua, protocolos, compliance |
+| [Auditoría de soberanía cognitiva](docs/guides/guide-sovereignty.md) | Lock-in cognitivo, Sovereignty Score, exit plan |
+
+> 📚 [Índice completo de guías](docs/guides/README.md) · [Full guide index (English)](docs/guides_en/README.md)
 
 ### Otros documentos
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,35 @@
+# Guías de uso por escenario
+
+> Cada guía explica cómo configurar y usar Savia (pm-workspace) para un tipo de organización o escenario concreto. Incluye roles, comandos principales, flujos de trabajo y consejos prácticos.
+
+🌐 [English version](../guides_en/README.md)
+
+---
+
+## Guías disponibles
+
+| Guía | Escenario | Roles principales |
+|---|---|---|
+| [Consultora + Azure DevOps](guide-azure-devops.md) | Equipo Scrum con Azure DevOps, CI/CD, SDD | PM, Dev Lead, Devs |
+| [Consultora + Jira](guide-jira.md) | Sincronización Jira ↔ Savia, workflow híbrido | PM, Scrum Master, Devs |
+| [Solo Savia / Savia Flow](guide-savia-standalone.md) | Sin herramienta externa, todo en Git | PM, Devs, cualquier equipo |
+| [Centro de estudios](guide-education.md) | Savia School: proyectos, evaluaciones, RGPD | Dirección, Profesores, TIC |
+| [Laboratorio de hardware](guide-hardware-lab.md) | PCB, firmware, BOM, certificaciones | HW Lead, FW Dev, QA |
+| [Laboratorio de investigación](guide-research-lab.md) | Papers, experimentos, datasets, financiación | IP, Investigadores, Postdocs |
+| [Startup](guide-startup.md) | MVP, lean, iteración rápida, OKRs | Founder, CTO, Fullstack |
+| [ONG](guide-nonprofit.md) | Subvenciones, voluntarios, impacto social | Director, Coordinador, Voluntarios |
+| [Bufete de abogados](guide-legal-firm.md) | Casos, plazos legales, facturación por horas | Socio, Abogado, Paralegal |
+| [Organización sanitaria](guide-healthcare.md) | Mejora continua, protocolos, compliance | Dir. Calidad, Responsable TIC |
+| [Auditoría de soberanía cognitiva](guide-sovereignty.md) | Lock-in cognitivo, Sovereignty Score, exit plan | CTO, PM, Compliance |
+
+---
+
+## ¿Por dónde empezar?
+
+1. **Lee la guía de tu escenario** — cada una incluye un setup rápido (10-15 minutos)
+2. **Instala pm-workspace** — `git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude`
+3. **Preséntate a Savia** — dile tu rol, equipo y contexto. Ella se adapta.
+
+## ¿Tu escenario no está aquí?
+
+Savia es agnóstica al sector. Si ninguna guía encaja exactamente, la de [Solo Savia / Savia Flow](guide-savia-standalone.md) es un buen punto de partida universal.

--- a/docs/guides_en/README.md
+++ b/docs/guides_en/README.md
@@ -1,0 +1,35 @@
+# Usage Guides by Scenario
+
+> Each guide explains how to configure and use Savia (pm-workspace) for a specific type of organization or scenario. Includes roles, key commands, workflows, and practical tips.
+
+🌐 [Versión en español](../guides/README.md)
+
+---
+
+## Available Guides
+
+| Guide | Scenario | Key Roles |
+|---|---|---|
+| [Consultancy + Azure DevOps](guide-azure-devops.md) | Scrum team with Azure DevOps, CI/CD, SDD | PM, Dev Lead, Devs |
+| [Consultancy + Jira](guide-jira.md) | Jira ↔ Savia sync, hybrid workflow | PM, Scrum Master, Devs |
+| [Savia Only / Savia Flow](guide-savia-standalone.md) | No external tool, everything in Git | PM, Devs, any team |
+| [Educational Center](guide-education.md) | Savia School: projects, evaluations, GDPR | Management, Teachers, IT |
+| [Hardware Lab](guide-hardware-lab.md) | PCB, firmware, BOM, certifications | HW Lead, FW Dev, QA |
+| [Research Laboratory](guide-research-lab.md) | Papers, experiments, datasets, grants | PI, Researchers, Postdocs |
+| [Startup](guide-startup.md) | MVP, lean, rapid iteration, OKRs | Founder, CTO, Fullstack |
+| [Non-profit / NGO](guide-nonprofit.md) | Grants, volunteers, social impact | Director, Coordinator, Volunteers |
+| [Legal Firm](guide-legal-firm.md) | Cases, legal deadlines, time billing | Partner, Lawyer, Paralegal |
+| [Healthcare Organization](guide-healthcare.md) | Quality improvement, protocols, compliance | Quality Dir., IT Manager |
+| [Cognitive Sovereignty Audit](guide-sovereignty.md) | Cognitive lock-in, Sovereignty Score, exit plan | CTO, PM, Compliance |
+
+---
+
+## Where to Start?
+
+1. **Read the guide for your scenario** — each includes a quick setup (10-15 minutes)
+2. **Install pm-workspace** — `git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude`
+3. **Introduce yourself to Savia** — tell her your role, team, and context. She adapts.
+
+## Your Scenario Isn't Listed?
+
+Savia is sector-agnostic. If no guide matches exactly, the [Savia Only / Savia Flow](guide-savia-standalone.md) guide is a good universal starting point.

--- a/docs/guides_en/guide-azure-devops.md
+++ b/docs/guides_en/guide-azure-devops.md
@@ -1,0 +1,188 @@
+# Guide: Software Consultancy with Azure DevOps
+
+> Scenario: team of 4–15 people at a consulting firm delivering projects to customers using Azure DevOps for management and CI/CD.
+
+---
+
+## Your team
+
+| Role | Who they are | What they need from Savia |
+|---|---|---|
+| **PM / Scrum Master** | Coordinates sprints, reports to client | `/sprint-status`, `/report-executive`, `/ceo-report` |
+| **Tech Lead** | Technical decisions, code review | `/arch-health`, `/tech-radar`, `/pr-review` |
+| **Developers** (3–8) | Implementation | `/my-sprint`, `/my-focus`, `/spec-implement` |
+| **QA** | Testing, validation | `/qa-dashboard`, `/testplan-generate` |
+| **Product Owner** | Backlog, prioritization | `/value-stream-map`, `/feature-impact` |
+
+---
+
+## Initial setup (day 1)
+
+### 1. Install pm-workspace
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+```
+
+### 2. Configure Azure DevOps
+
+Edit `CLAUDE.md` with your organization:
+
+```
+AZURE_DEVOPS_ORG_URL = "https://dev.azure.com/your-organization"
+AZURE_DEVOPS_PAT_FILE = "$HOME/.azure/devops-pat"
+```
+
+Save your PAT in the specified file (never in the repo).
+
+### 3. First contact with Savia
+
+Open Claude Code and say:
+
+> "Hi, I'm Ana, PM at a software consulting firm. We use Azure DevOps."
+
+Savia will introduce herself and guide you through `/profile-setup` to get to know you: your name, role, projects, schedules, communication preferences.
+
+### 4. Connect your project
+
+> "Connect the sala-reservas project from Azure DevOps"
+
+Savia will run `/devops-validate` to audit the configuration: process template, states, fields, iterations. If there are incompatibilities, it will propose a remediation plan.
+
+### 5. Team onboarding
+
+For each member:
+
+> "Onboard carlos as a senior developer to the sala-reservas project"
+
+Savia will use `/team-onboarding` to create their profile, assess competencies, and assign permissions.
+
+---
+
+## PM's day to day
+
+### Monday — Planning
+
+```
+/daily-routine                     → Savia proposes your day's routine
+/sprint-status                     → Current sprint status
+/backlog-groom --top 10            → Review top 10 items
+/pbi-decompose {id}                → Decompose PBI into tasks
+/sprint-plan                       → Plan the sprint
+```
+
+**Typical conversation:**
+
+> "Savia, how's the current sprint going?"
+
+Savia responds with burndown, remaining capacity, at-risk items and suggestions.
+
+> "Decompose PBI 1234 into tasks and assign them to the team"
+
+Savia analyzes the PBI, generates tasks with hour estimates, and proposes assignments using scoring (expertise × availability × balance × growth).
+
+### Daily standup (09:15)
+
+> "Savia, prepare today's standup"
+
+Savia collects: items moved yesterday, detected blockers, items at risk due to SLA. Generates an executive summary to share in the daily.
+
+### Friday — Review + Retro
+
+```
+/sprint-review                     → Summary of deliverables
+/sprint-retro                      → Structured retrospective
+/report-executive                  → Report for the client
+/kpi-dashboard                     → Sprint metrics
+```
+
+---
+
+## Developer's day to day
+
+### Starting the day
+
+> "Savia, what should I be working on today?"
+
+Savia runs `/my-focus` and shows you your highest priority item with all context loaded.
+
+### Implementing an SDD spec
+
+```
+/spec-generate {task-id}           → Generate spec from task
+/spec-design {spec}                → Design the solution
+/spec-implement {spec}             → Implement (human or agent)
+/spec-review {file}                → Code review
+/spec-verify {spec}                → Final verification
+```
+
+**Typical conversation:**
+
+> "Savia, generate the spec for task 5678"
+
+Savia creates an executable spec with: context, requirements, acceptance criteria, expected tests, and files to modify. If you're a human developer, use it as a guide. If you delegate to a Claude agent, it executes it automatically.
+
+### PRs and code review
+
+> "Savia, review PR #42"
+
+Savia runs `/pr-review` analyzing: project conventions, tests, security, performance, and generates constructive comments.
+
+---
+
+## Tech Lead's day to day
+
+```
+/arch-health --drift               → Detect architectural drift
+/tech-radar                        → Status of technology stack
+/team-skills-matrix --bus-factor   → Knowledge risks
+/incident-postmortem               → Blameless postmortem
+/debt-analyze                      → Technical debt hotspots
+```
+
+**Typical conversation:**
+
+> "Savia, is there drift in the architecture of the project?"
+
+Savia analyzes the code against detected patterns (Clean, DDD, CQRS...) and reports deviations with prioritized suggestions.
+
+---
+
+## Complete flow: PBI to production
+
+1. **PO creates PBI** in Azure DevOps → Savia detects it with `/backlog-capture`
+2. **PM decomposes** → `/pbi-decompose` generates tasks with hours
+3. **PM assigns** → `/pbi-assign` with intelligent scoring
+4. **Dev generates spec** → `/spec-generate` creates SDD spec
+5. **Architect reviews** → `/spec-design` validates the solution
+6. **Security review** → `/security-review` analyzes OWASP
+7. **Dev implements** → `/spec-implement` (human or agent)
+8. **QA validates** → `/testplan-generate` + `/qa-regression-plan`
+9. **PR + merge** → `/pr-review` + PR Guardian (automatic CI)
+10. **Release** → `/sprint-release-notes` generates notes
+
+---
+
+## Reports for the client
+
+```
+/report-executive                  → Weekly report
+/ceo-report --format pptx          → Presentation for leadership
+/kpi-dora                          → DORA metrics
+/velocity-trend                    → Velocity trend
+```
+
+> "Savia, generate this week's report for the client in PowerPoint"
+
+Savia creates a `.pptx` with: sprint summary, burndown, completed items, risks, and next steps. All based on real Azure DevOps data.
+
+---
+
+## Tips specific to Azure DevOps
+
+- Savia automatically validates that your project complies with the "ideal Agile" when you connect it
+- CI hooks (`pr-guardian.yml`) integrate with Azure Pipelines
+- `/pipeline-status` and `/pipeline-run` operate directly against Azure Pipelines
+- Connection strings and secrets never go to the repo — use `config.local/`
+- Savia detects whether your process template is Agile, Scrum, or CMMI and adapts

--- a/docs/guides_en/guide-education.md
+++ b/docs/guides_en/guide-education.md
@@ -1,0 +1,192 @@
+# Guide: Education Center (Savia School)
+
+> Scenario: educational institution (secondary school, university, academy, bootcamp) that wants to manage student projects, evaluations and academic progress with Savia School.
+
+---
+
+## Your center
+
+| Role | Who it is | What they use |
+|---|---|---|
+| **Teacher** | Creates projects, evaluates, tracks progress | `/school-setup`, `/school-evaluate`, `/school-analytics` |
+| **Student** | Submits projects, checks progress | `/school-submit`, `/school-progress`, `/school-portfolio` |
+| **Coordinator** | Overall view of the course | `/school-analytics`, `/school-export` |
+
+---
+
+## Center setup (the teacher)
+
+### 1. Install pm-workspace
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+### 2. Create the classroom
+
+> "Savia, set up a classroom for the Web Development course, 2nd DAW"
+
+```
+/school-setup "IES Example" "2DAW-WebDevelopment"
+```
+
+Savia creates the structure: folders per student, rubrics, and project templates. Everything in Git, no database.
+
+### 3. Enroll students
+
+> "Savia, enroll the students in the course"
+
+```
+/school-enroll student01
+/school-enroll student02
+/school-enroll student03
+```
+
+Savia School uses **aliases** instead of real names. The teacher chooses the aliases and they do not contain personal data (GDPR compliance). The mapping between alias and real identity is kept outside the system, in the institution's records.
+
+### 4. Create evaluation rubrics
+
+> "Savia, create a rubric for web projects"
+
+```
+/school-rubric create
+```
+
+Savia guides you to define criteria (functionality, design, clean code, documentation, tests) with levels and weights.
+
+---
+
+## Teacher's day-to-day
+
+### Assign a project
+
+> "Savia, create an online store project for student01"
+
+```
+/school-project student01 "online-store"
+```
+
+Savia creates the project structure with: assignment statement, evaluation criteria, delivery date, and submission space for the student.
+
+### Receive submissions
+
+Students submit with:
+
+```
+/school-submit student01 "online-store"
+```
+
+The teacher sees pending submissions:
+
+> "Savia, who has submitted?"
+
+### Evaluate
+
+> "Savia, evaluate student01's online-store project"
+
+```
+/school-evaluate student01 "online-store"
+```
+
+Savia applies the defined rubric. The teacher reviews, adjusts scores and adds comments. The evaluation is encrypted with AES-256 (only the teacher and student can view it).
+
+### View course analytics
+
+```
+/school-analytics                    → Global course metrics
+/school-progress --class             → Progress of all students
+```
+
+---
+
+## Student's day-to-day
+
+### Check assigned projects
+
+> "Savia, what projects do I have?"
+
+### Submit a project
+
+> "Savia, I'm submitting my online-store project"
+
+```
+/school-submit student01 "online-store"
+```
+
+### View my progress
+
+```
+/school-progress student01            → Grades and feedback
+/school-portfolio student01           → Full portfolio
+```
+
+### Check my learning diary
+
+```
+/school-diary student01               → Progress diary
+```
+
+---
+
+## Privacy and GDPR
+
+Savia School complies with GDPR for minors:
+
+- **Art. 8**: Parental consent for under-14s (in Spain). The institution manages consents outside the system.
+- **Art. 15**: Right of access. `/school-portfolio` gives the student complete access.
+- **Art. 17**: Right to be forgotten. `/school-forget student01` deletes all student data.
+- **Encrypted evaluations**: AES-256-CBC, accessible only by teacher and student.
+- **No PII in repo**: only aliases, never names, IDs or emails.
+
+---
+
+## Data export
+
+At the end of the course:
+
+```
+/school-export student01              → Export student data
+/school-export --class                → Export entire course
+```
+
+Generates files with evaluations, progress and portfolio for the institution's official records.
+
+---
+
+## Extended use cases
+
+### Programming bootcamp
+
+Savia School works especially well for bootcamps:
+
+- Short projects with frequent deliveries
+- Continuous evaluation with predefined rubrics
+- Portfolio that the student can show to employers
+- Progress analytics to identify at-risk students
+
+### University — Final Projects (Thesis)
+
+For final degree/master projects:
+
+- Single project per student, long duration
+- Intermediate milestones with `/school-project` for each milestone
+- Research diary with `/school-diary`
+- Evaluation by panel applying shared rubric
+
+### Internal company training
+
+For corporate training courses:
+
+- Alias = employee code (no names)
+- Practical projects evaluated with rubric
+- Competency report for HR with `/school-export`
+
+---
+
+## Tips
+
+- Aliases should be consistent and not reveal identity (use codes, not initials)
+- Run `/school-analytics` weekly to identify students falling behind
+- Rubrics can be reused across courses with `/school-rubric edit`
+- The Git repository acts as an immutable historical record of evaluations
+- For large groups (>30 students), consider dividing into sections with separate `/school-setup`

--- a/docs/guides_en/guide-hardware-lab.md
+++ b/docs/guides_en/guide-hardware-lab.md
@@ -1,0 +1,175 @@
+# Guide: Hardware Projects Laboratory
+
+> Scenario: team of 3–12 people that designs, prototypes and manufactures hardware (electronics, IoT, robotics, medical devices). Combines firmware, mechanics, PCB and embedded software.
+
+---
+
+## Your laboratory
+
+| Role | What they do | Main commands |
+|---|---|---|
+| **Project Lead** | Coordinates product, sprints, deliveries | `/savia-sprint`, `/savia-board`, `/report-executive` |
+| **Hardware Engineer** | PCB design, schematics, BOM | `/savia-pbi`, `/flow-task-*`, `/flow-timesheet` |
+| **Firmware Developer** | Embedded code (C/C++, Rust) | `/spec-generate`, `/spec-implement`, `/my-focus` |
+| **Mechanical Engineer** | CAD, enclosures, tolerances | `/flow-task-*`, `/savia-send` |
+| **QA / Testing** | Functional validation, EMC, certifications | `/qa-dashboard`, `/testplan-generate` |
+
+---
+
+## Why Savia for hardware?
+
+Hardware projects have particularities that Savia handles well:
+
+- **Long iterations**: a 2-week firmware sprint plus a 6–8 week PCB cycle. Savia Flow allows sprints of different duration per team.
+- **BOM (Bill of Materials)**: component tracking files, suppliers and costs that live in Git alongside code.
+- **Certifications**: tracking regulatory requirements (CE, FCC, UL, RoHS) as PBIs.
+- **Firmware + Software**: Savia supports C/C++, Rust, Python and all languages you need.
+- **Technical documentation**: specs, datasheets, design notes — all versioned in Git.
+
+---
+
+## Setup from scratch
+
+### 1. Install and create the company repo
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+> "Savia, create an enterprise repository for the laboratory"
+
+```
+/company-repo
+```
+
+### 2. Create the hardware project
+
+> "Savia, create a project called sensor-iot for the hardware team"
+
+### 3. Structure the backlog by discipline
+
+```
+/savia-pbi create "Design sensor schematic" --project sensor-iot --tag hw
+/savia-pbi create "PCB Layout v1" --project sensor-iot --tag hw
+/savia-pbi create "Firmware: I2C driver for sensor" --project sensor-iot --tag fw
+/savia-pbi create "3D Enclosure: IP67 housing" --project sensor-iot --tag mech
+/savia-pbi create "BLE Configuration App" --project sensor-iot --tag sw
+/savia-pbi create "CE Certification: EMC documentation" --project sensor-iot --tag cert
+```
+
+Use tags (`hw`, `fw`, `mech`, `sw`, `cert`) to filter by discipline on the board.
+
+---
+
+## Hardware development cycle
+
+### Phase 1 — Concept (weeks 1–2)
+
+```
+/savia-sprint start --project sensor-iot --goal "Define system architecture"
+```
+
+**Conversation with Savia:**
+
+> "Savia, I need to break down the sensor design into tasks for hardware and firmware"
+
+Savia generates parallel tasks: schematic (HW), driver (FW), 3D model (MECH), each with estimation and dependencies.
+
+**Architectural decisions:**
+
+> "Savia, record that we're using ESP32-S3 for its integrated BLE 5.0 + WiFi"
+
+```
+/adr-create sensor-iot "MCU Selection: ESP32-S3"
+```
+
+### Phase 2 — Prototype (weeks 3–8)
+
+The board reflects the actual state:
+
+```
+/savia-board sensor-iot
+```
+
+```
+┌──────────┬───────────┬─────────────┬────────┬────────┐
+│ Backlog  │ To Do     │ In Progress │ Review │ Done   │
+├──────────┼───────────┼─────────────┼────────┼────────┤
+│ App BLE  │ PCB v1    │ Driver I2C  │ Schem. │        │
+│ Cert CE  │ Housing   │             │        │        │
+└──────────┴───────────┴─────────────┴────────┴────────┘
+```
+
+**Cross-team communication:**
+
+> "Savia, tell @mech that the USB-C connector needs 5mm extra clearance for the antenna"
+
+```
+/savia-send @mech "The USB-C connector needs 5mm extra clearance for the BLE antenna. See datasheet p.23."
+```
+
+### Phase 3 — Validation (weeks 9–12)
+
+```
+/testplan-generate --project sensor-iot    → Functional test plan
+/qa-dashboard sensor-iot                    → Quality status
+```
+
+**Tracking certifications as PBIs:**
+
+```
+/flow-task-create cert "Prepare EMC documentation for CE"
+/flow-task-create cert "Conducted emissions test"
+/flow-task-create cert "ESD immunity test"
+```
+
+---
+
+## BOM management
+
+For component tracking, create a `bom.md` or `bom.csv` file in the project:
+
+> "Savia, record that we've selected the BME280 sensor from Bosch, Mouser reference 262-BME280"
+
+Savia can create and maintain PBIs associated with component procurement:
+
+```
+/savia-pbi create "Procure BME280 x50 units (Mouser)" --project sensor-iot --tag procurement
+```
+
+---
+
+## Timesheet by discipline
+
+```
+/flow-timesheet TASK-001 6            → 6h in PCB design
+/flow-timesheet TASK-003 4            → 4h in firmware I2C
+/flow-timesheet-report --monthly      → Report of hours by person and discipline
+```
+
+Useful for: justification of R&D projects, reporting to investors, cost control.
+
+---
+
+## Gaps identified and proposals
+
+In writing this guide, needs not currently covered were identified:
+
+| Gap | Description | Proposal |
+|---|---|---|
+| **BOM management** | No specific command for BOM management | `/hw-bom {add\|list\|cost\|export}` |
+| **Revision tracking** | Hardware has revisions (Rev A, Rev B) different from software versions | `/hw-revision {create\|compare\|history}` |
+| **Compliance matrix** | Tracking regulatory requirements vs. evidence | `/compliance-matrix {standard\|status\|export}` |
+| **Cross-discipline dependencies** | HW↔FW↔MECH dependencies not well modeled with linear tasks | Dependency graph with improved `/dependency-map` |
+
+These gaps are added to the roadmap as proposals for future eras.
+
+---
+
+## Tips
+
+- Hardware projects typically have longer sprints for HW (4 weeks) and shorter for FW (2 weeks). Savia supports sprints of different duration.
+- Version design files (Gerber, STEP, STL) in Git LFS, not directly in the company repo.
+- Use ADRs (`/adr-create`) to document component decisions — the "why" is forgotten quickly.
+- `/savia-send` is ideal for cross-discipline technical communication — it's recorded and searchable.
+- For regulated projects (medical devices, automotive), combine with `/compliance-scan` for requirements tracking.

--- a/docs/guides_en/guide-healthcare.md
+++ b/docs/guides_en/guide-healthcare.md
@@ -1,0 +1,201 @@
+# Guide: Healthcare Organization
+
+> Scenario: hospital, clinic or health center that manages improvement projects, clinical protocols, regulatory compliance and coordination of multidisciplinary teams.
+
+**Note**: Savia is NOT a patient management system (HIS/HCE). It's a project management tool that helps healthcare teams coordinate improvement initiatives, implement protocols and meet regulations.
+
+---
+
+## Your organization
+
+| Role | What you manage with Savia | Main commands |
+|---|---|---|
+| **Quality Director** | Improvement projects, audits, indicators | `/ceo-report`, `/compliance-scan`, `/portfolio-overview` |
+| **Service Chief** | Service coordination, protocols | `/savia-sprint`, `/savia-board`, `/savia-pbi` |
+| **IT Manager** | Systems, integrations, cybersecurity | `/security-audit`, `/arch-health`, `/spec-implement` |
+| **Nursing Coordinator** | Shifts, training, procedures | `/flow-task-*`, `/savia-send`, `/school-*` |
+| **Quality Technician** | Indicators, non-conformities, corrective actions | `/flow-task-*`, `/flow-timesheet`, `/qa-dashboard` |
+
+---
+
+## Why Savia in healthcare
+
+- **Regulatory compliance**: tracking HIPAA, healthcare GDPR, JCI/EFQM accreditations.
+- **Improvement project management**: PDCA cycles as sprints.
+- **Staff training**: Savia School for mandatory courses and refresher training.
+- **Extreme confidentiality**: E2E encryption for communications about incidents.
+- **Traceability**: each decision and action is versioned — essential for audits.
+- **No patient data**: Savia manages PROJECTS, not medical records.
+
+---
+
+## Use cases
+
+### 1. Continuous improvement project (PDCA)
+
+Each PDCA cycle is a sprint:
+
+```
+/savia-sprint start --project improve-emergency --goal "Reduce triage time by 15%"
+```
+
+**Plan:**
+```
+/flow-task-create plan "Map current triage flow"
+/flow-task-create plan "Identify bottlenecks"
+/flow-task-create plan "Design new protocol"
+```
+
+**Do:**
+```
+/flow-task-create do "Pilot new protocol (1 week)"
+/flow-task-create do "Training for triage team"
+```
+
+**Check:**
+```
+/flow-task-create check "Measure times with new protocol"
+/flow-task-create check "Staff satisfaction survey"
+```
+
+**Act:**
+```
+/flow-task-create act "Adjust protocol based on results"
+/flow-task-create act "Document and standardize"
+```
+
+### 2. Implementation of new IT system
+
+> "Savia, we're going to implement a new online appointment system"
+
+```
+/savia-pbi create "Selection of online appointment provider" --project appointment-system
+/savia-pbi create "Integration with existing HIS" --project appointment-system
+/savia-pbi create "Training for admission staff" --project appointment-system
+/savia-pbi create "User acceptance tests" --project appointment-system
+/savia-pbi create "Go-live + post-implementation support" --project appointment-system
+```
+
+For the technical part, SDD works normally:
+
+```
+/spec-generate {task-id}             → Integration spec
+/spec-implement {spec}               → Implementation
+/security-review {spec}              → OWASP review (critical in healthcare)
+```
+
+### 3. Regulatory compliance
+
+```
+/compliance-scan                     → Compliance scan
+```
+
+Savia detects healthcare sector requirements: health data protection, access control, encryption in transit and at rest, audit logs.
+
+**Tracking corrective actions:**
+
+```
+/flow-task-create compliance "NC-001: Update password policy"
+/flow-task-create compliance "NC-002: Encrypt test server backups"
+/flow-task-create compliance "NC-003: Review HIS access permissions"
+```
+
+### 4. Mandatory training (Savia School)
+
+For continuing education courses:
+
+```
+/school-setup "Hospital Example" "CPR-Training-2026"
+/school-enroll healthcare-worker01
+/school-enroll healthcare-worker02
+```
+
+```
+/school-project healthcare-worker01 "cpr-simulation"
+/school-evaluate healthcare-worker01 "cpr-simulation"
+```
+
+Evaluations are encrypted. Training records are exported for center accreditation.
+
+---
+
+## A quality director's day
+
+### Morning
+
+> "Savia, how are the improvement projects going?"
+
+```
+/portfolio-overview                  → View of all projects
+/ceo-alerts                          → Alerts requiring decision
+```
+
+### Prepare quality committee
+
+```
+/ceo-report --format md              → Report for committee
+/savia-board improve-emergency       → Main project board
+```
+
+### Audit
+
+```
+/compliance-scan                     → Compliance status
+```
+
+---
+
+## Confidential communication
+
+### On a patient safety incident
+
+```
+/savia-send @service-chief "Incident ISPA-2026-015: notification to safety committee. Urgent meeting tomorrow 08:00."
+```
+
+E2E encrypted. No patient data in the message — only incident code reference.
+
+### Shift coordination
+
+```
+/savia-announce "Shift change 15-Mar: Dr. A covers Dr. B (night shift)"
+```
+
+---
+
+## Privacy — Golden rule
+
+**NEVER patient data in Savia.** Not names, not medical records, not patient codes.
+
+Savia manages:
+- Improvement projects (processes, not patients)
+- Protocols and procedures
+- Staff training
+- Regulatory compliance
+- Team coordination
+
+Patient management systems (HIS, EHR) are separate tools.
+
+---
+
+## Detected gaps and proposals
+
+| Gap | Description | Proposal |
+|---|---|---|
+| **PDCA native** | No PDCA cycle as native entity | `/pdca-cycle {plan\|do\|check\|act}` with metrics |
+| **Incident tracking** | Patient safety incidents have their own flows | `/incident-register {classify\|investigate\|action}` |
+| **Accreditation tracking** | Tracking JCI/EFQM/ISO 9001 standards | `/accreditation-track {standard\|evidence\|gap}` |
+| **Training compliance** | Control mandatory training completed/pending by professional | `/training-compliance {status\|expired\|plan}` |
+| **Indicator dashboard** | Healthcare KPIs (wait times, infection rate, readmissions) | `/health-kpi {define\|measure\|trend}` |
+
+---
+
+## Tips
+
+- Improvement projects work very well as sprints — PDCA cycle maps naturally
+- Never, under any circumstances, introduce patient data in Savia
+- E2E encryption is especially relevant for incident communications
+- `/compliance-scan` automatically detects healthcare sector requirements
+- Savia School is ideal for mandatory continuing education
+- Hour reports (`/flow-timesheet-report`) justify dedication to improvement projects
+- For centers with multiple services, each service can be a "team" in Company Savia

--- a/docs/guides_en/guide-jira.md
+++ b/docs/guides_en/guide-jira.md
@@ -1,0 +1,144 @@
+# Guide: Software Consultancy with Jira
+
+> Scenario: development team that uses Jira as a project management tool, possibly combined with GitHub/GitLab for code and CI/CD.
+
+---
+
+## Your team
+
+| Role | What they need from Savia |
+|---|---|
+| **PM / Scrum Master** | Jira ↔ Savia synchronization, reports, sprint management |
+| **Tech Lead** | Architecture, code review, technical debt |
+| **Developers** | Daily focus, SDD specs, implementation |
+| **Product Owner** | Backlog grooming, prioritization, value metrics |
+
+---
+
+## Initial setup
+
+### 1. Install pm-workspace
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+### 2. Connect Jira
+
+> "Savia, connect my Jira project"
+
+Savia will run `/jira-connect` which guides you through:
+
+- URL of your Jira instance (Cloud or Server)
+- API token (saved in local file, never in repo)
+- Project to synchronize
+- State mapping (To Do → New, In Progress → Active, Done → Closed)
+
+### 3. Bidirectional synchronization
+
+```
+/jira-sync                         → Synchronize Jira items ↔ Savia
+/jira-connect map                  → Review/adjust field mapping
+```
+
+Synchronization is bidirectional: changes in Jira are reflected in Savia and vice versa. Savia maintains its own data model for advanced analysis without depending on the Jira API on every operation.
+
+---
+
+## Hybrid mode: Jira + Savia
+
+The most common pattern is to use Jira as the "single source of truth" for the client/stakeholders and Savia as an internal tool for the technical team:
+
+**In Jira** (visible to the client):
+- Epics, Stories, Bugs
+- Sprint board
+- Releases
+
+**In Savia** (internal power):
+- Intelligent PBI decomposition → `/pbi-decompose`
+- Executable SDD specs → `/spec-generate`
+- Automated code review → `/pr-review`
+- Predictive metrics → `/sprint-forecast`
+- Technical debt → `/debt-analyze`
+
+### Typical flow
+
+1. PO creates Story in Jira
+2. `/jira-sync` brings the item to Savia
+3. PM decomposes with `/pbi-decompose` → tasks stay in Savia
+4. Dev implements with SDD → `/spec-generate` + `/spec-implement`
+5. PR + merge → automatic quality hooks
+6. `/jira-sync` updates the status in Jira
+7. Client sees progress on their Jira board
+
+---
+
+## PM's day to day
+
+### Morning
+
+> "Savia, sync Jira and give me sprint status"
+
+```
+/jira-sync                         → Bring in changes from Jira
+/sprint-status                     → Status with fresh data
+/daily-routine                     → Daily routine based on your role
+```
+
+### Standup
+
+> "Savia, prepare data for the daily"
+
+Savia combines Jira data (states, assignments) with its own metrics (velocity, burndown, detected blockers) to give you a complete summary.
+
+### End of sprint
+
+```
+/sprint-review                     → Delivery summary
+/sprint-retro                      → Retrospective
+/report-executive                  → Report for stakeholders
+/jira-sync                         → Ensure Jira reflects everything
+```
+
+---
+
+## Developer's day to day
+
+> "Savia, what do I have assigned today?"
+
+```
+/my-sprint                         → Your personal view
+/my-focus                          → Highest priority item
+```
+
+### SDD implementation
+
+The SDD flow works the same as with Azure DevOps — the spec is agnostic to the project management tool:
+
+1. `/spec-generate {jira-key}` → generate spec from the Jira issue
+2. `/spec-implement {spec}` → implement
+3. `/pr-review` → automated code review
+4. When done, `/jira-sync` updates the status in Jira
+
+---
+
+## Differences from Azure DevOps
+
+| Aspect | Azure DevOps | Jira |
+|---|---|---|
+| Connection | Native (REST API) | Via `/jira-connect` + sync |
+| Pipelines | `/pipeline-*` direct | GitHub Actions / GitLab CI separate |
+| Work items | WIQL queries | JQL queries via sync |
+| State mapping | Automatic (Agile template) | Configurable with `/jira-connect map` |
+| Board | Azure Boards | Jira Board + `/savia-board` local |
+
+---
+
+## Tips specific to Jira
+
+- Sync frequently (`/jira-sync`) to keep data fresh
+- Jira custom fields map to Savia fields in the configuration
+- If using Jira Cloud, the API is faster than Jira Server
+- Savia can work with multiple Jira projects simultaneously
+- Savia reports (`/report-executive`, `/kpi-dashboard`) are richer than native Jira ones because they combine code, PR, and flow metrics data
+- If your client only wants to see Jira, use Savia as an internal tool and sync results

--- a/docs/guides_en/guide-legal-firm.md
+++ b/docs/guides_en/guide-legal-firm.md
@@ -1,0 +1,231 @@
+# Guide: Law Firm / Legal Practice
+
+> Scenario: law practice with 3–20 professionals managing cases, files, legal deadlines and voluminous documentation. Requires extreme confidentiality and traceability.
+
+---
+
+## Your practice
+
+| Role | Needs | Main commands |
+|---|---|---|
+| **Senior Partner/Director** | Global vision, billing, reporting | `/ceo-report`, `/portfolio-overview`, `/flow-timesheet-report` |
+| **Senior Attorney** | Manage cases, supervise juniors | `/savia-sprint`, `/savia-board`, `/savia-pbi` |
+| **Junior Attorney** | Execute tasks, research, drafting | `/my-focus`, `/flow-task-move`, `/flow-timesheet` |
+| **Paralegal** | Documentation, filing, deadlines | `/flow-task-*`, `/savia-inbox` |
+| **Secretary / Admin** | Schedule, billing, communications | `/flow-timesheet-report`, `/excel-report` |
+
+---
+
+## Why Savia for a law firm
+
+- **Confidentiality**: E2E encryption (RSA-4096 + AES-256-CBC) for internal communications about cases.
+- **Timesheet for billing**: time tracking by case/task, essential for hourly billing.
+- **Traceability**: each document, decision and communication is versioned in Git.
+- **Deadline management**: legal deadlines modeled as tasks with critical dates.
+- **Offline**: Travel Mode for courts, client visits, areas without coverage.
+
+---
+
+## Practice setup
+
+### 1. Install and create repo
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+> "Savia, create a repository for the practice"
+
+### 2. Structure by practice areas
+
+Each area is a "team" and each case a "project":
+
+```
+/savia-team init --name commercial
+/savia-team init --name labor
+/savia-team init --name criminal
+```
+
+### 3. Create a case
+
+> "Savia, create a new case in the commercial area"
+
+```
+/savia-pbi create "Case: claim for payment — file 2026-M-0042" --project commercial
+```
+
+**Case tasks:**
+
+```
+/flow-task-create investigation "Analysis of documents provided by client"
+/flow-task-create drafting "Drafting of claim"
+/flow-task-create filing "Electronic filing with court"
+/flow-task-create hearing "Preparation of hearing"
+/flow-task-create deadline "DEADLINE: response to claim — 20 business days"
+```
+
+---
+
+## Case management as sprints
+
+Each case has its own pace. Use flexible sprints:
+
+### Quick case (demand, claim)
+
+```
+/savia-sprint start --project case-2026-M-0042 --goal "Claim filed on time"
+```
+
+Sprint of 2–4 weeks with fixed deadline.
+
+### Long case (litigation, insolvency)
+
+Divide into phases as sprints:
+
+```
+Sprint 1: "Pleading phase"
+Sprint 2: "Evidence phase"
+Sprint 3: "Closing arguments + hearing"
+Sprint 4: "Judgment + appeal"
+```
+
+### The case board
+
+```
+/savia-board case-2026-M-0042
+```
+
+```
+┌──────────┬───────────┬─────────────┬────────┬────────┐
+│ Pending  │ In progress│ In review  │ Filing │ Done   │
+├──────────┼───────────┼─────────────┼────────┼────────┤
+│ Evidence │ Claim    │ Analysis   │        │ Docs   │
+│ Hearing  │           │ doc.       │        │ client │
+└──────────┴───────────┴─────────────┴────────┴────────┘
+```
+
+---
+
+## Timesheet and billing
+
+**Time tracking is the heart of a law practice's business.**
+
+### Log hours
+
+```
+/flow-timesheet TASK-001 2.5         → 2.5h on drafting claim
+/flow-timesheet TASK-002 1           → 1h reviewing documentation
+/flow-timesheet TASK-003 0.5         → 30min on client call
+```
+
+### Billing reports
+
+```
+/flow-timesheet-report --monthly     → Hours by attorney/case/month
+/excel-report time-tracking          → Excel for accounting
+```
+
+> "Savia, generate the hours report for case 2026-M-0042 to bill the client"
+
+Savia produces a breakdown: date, attorney, task, hours, description — ready to attach to invoice.
+
+---
+
+## Confidential communication
+
+### On a sensitive case
+
+```
+/savia-send @senior1 "Case 0042: expert confirms client's version. Attached report in case branch."
+```
+
+All E2E encrypted. Even a repo administrator cannot read messages without private keys.
+
+### Practice coordination
+
+```
+/savia-announce "Partners meeting Friday at 13:00. Agenda in governance board."
+/savia-broadcast "Reminder: close timesheet on the 30th"
+```
+
+---
+
+## Deadline control
+
+Legal deadlines are non-negotiable. Model them as tasks with maximum priority:
+
+```
+/flow-task-create deadline "FATAL DEADLINE: appeal — 20 days"
+```
+
+> "Savia, what deadlines do we have this week?"
+
+Savia filters deadline-type tasks and displays them sorted by urgency.
+
+---
+
+## A junior attorney's day
+
+### Morning
+
+> "Savia, what do I have for today?"
+
+```
+/my-focus                            → Most priority task
+/savia-inbox                         → Instructions from senior
+```
+
+### During the day
+
+```
+/flow-task-move TASK-005 in-progress → Start research
+/flow-timesheet TASK-005 3           → 3h research
+/flow-task-move TASK-005 review      → Pass to senior for review
+```
+
+### End of day
+
+```
+/savia-send @senior1 "Finished analysis of TASK-005. Found 3 favorable Supreme Court judgments."
+```
+
+---
+
+## Reporting for partners
+
+### Practice workload
+
+```
+/portfolio-overview                  → All active cases
+/ceo-alerts                          → Only critical alerts (deadlines, blockers)
+```
+
+### Productivity metrics
+
+```
+/ceo-report                          → Executive summary
+/velocity-trend                      → Case resolution trend
+```
+
+---
+
+## Detected gaps and proposals
+
+| Gap | Description | Proposal |
+|---|---|---|
+| **Deadline management** | No native "legal deadline" entity with alarms | `/legal-deadline {set\|list\|alert}` with notifications |
+| **Court calendar** | Integration with court calendars | `/court-calendar {import\|sync}` |
+| **Conflict check** | Verify conflicts of interest before accepting case | `/conflict-check {client\|matter}` |
+| **Document templates** | Templates for judicial documents | `/legal-template {claim\|response\|appeal}` |
+| **Billing rates** | Hourly rates differentiated by attorney/type | `/billing-rate {set\|calculate\|invoice}` |
+
+---
+
+## Tips
+
+- Each case is a separate project — never mix files
+- Log hours immediately, not at end of day — precision is money
+- Use `/savia-send` for instructions on cases — recorded and encrypted
+- Legal deadlines ALWAYS as maximum priority tasks
+- E2E encryption is especially important here: professional secrecy is a deontological obligation
+- For multi-office practices, Company Savia enables secure collaboration without VPN

--- a/docs/guides_en/guide-nonprofit.md
+++ b/docs/guides_en/guide-nonprofit.md
@@ -1,0 +1,193 @@
+# Guide: NGO / Non-Profit Organization
+
+> Scenario: NGO of 5–30 people with volunteers, social impact projects, grant management and need for reporting to donors. Limited budget for tools.
+
+---
+
+## Your organization
+
+| Role | What they need | Main commands |
+|---|---|---|
+| **Director** | Overall vision, reporting to board and donors | `/ceo-report`, `/portfolio-overview`, `/ceo-alerts` |
+| **Project Coordinator** | Manages teams and deliveries | `/savia-sprint`, `/savia-board`, `/report-executive` |
+| **Volunteer Manager** | Onboarding, assignment, tracking | `/team-onboarding`, `/savia-directory` |
+| **Field Technician** | Executes activities, reports progress | `/flow-task-move`, `/flow-timesheet`, `/savia-send` |
+| **Admin / Finance** | Grant justification, hours | `/flow-timesheet-report`, `/excel-report` |
+
+---
+
+## Why Savia for an NGO?
+
+- **Zero cost**: no licenses. Git + Claude Code is all you need.
+- **Hours justification**: `/flow-timesheet` generates reports for grants (essential for public funds).
+- **Privacy**: beneficiary data never in the repo (PII-Free rule + E2E encryption).
+- **Offline fieldwork**: Travel Mode for areas without connectivity.
+- **Multi-project**: manages multiple programs and grants simultaneously.
+
+---
+
+## Organization setup
+
+### 1. Install and create repo
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+> "Savia, create an enterprise repository for our NGO"
+
+### 2. Define programs as projects
+
+Each program or grant is an independent project:
+
+```
+/savia-pbi create "Digital literacy training for seniors" --project programa-digital
+/savia-pbi create "Q1 Food distribution" --project banco-alimentos
+/savia-pbi create "Annual report for donors" --project gobernanza
+```
+
+### 3. Add team and volunteers
+
+> "Savia, add vol01 as a volunteer in the digital training program"
+
+For volunteers: use aliases (not real names) to protect their privacy.
+
+---
+
+## Program management
+
+### Sprint planning adapted for NGOs
+
+NGOs don't have "software sprints" but activity cycles. Savia adapts:
+
+> "Savia, start a 4-week cycle for the digital training program"
+
+```
+/savia-sprint start --project programa-digital --goal "10 workshops across 4 centers"
+```
+
+**Tasks for a social program:**
+
+```
+/flow-task-create activity "Workshop 1: smartphone introduction (North Center)"
+/flow-task-create activity "Workshop 2: WhatsApp and video calls (North Center)"
+/flow-task-create logistics "Prepare materials for 40 participants"
+/flow-task-create admin "Register attendance workshop 1"
+/flow-task-create reporting "Partial report for the funder"
+```
+
+### Daily tracking
+
+> "Savia, how is the digital training program going?"
+
+```
+/savia-board programa-digital        → Visual board
+/flow-burndown                       → Progress vs. planned
+```
+
+### Hours registration (grant justification)
+
+```
+/flow-timesheet TALLER-001 3         → 3h teaching workshop
+/flow-timesheet TALLER-001 1         → 1h preparation
+/flow-timesheet-report --monthly     → Monthly report by person
+```
+
+**This is critical**: many public grants require detailed hours justification by activity and person. Savia generates these reports automatically.
+
+---
+
+## Team communication
+
+### Coordination with volunteers
+
+```
+/savia-send @vol01 "Remember tomorrow's workshop at 10:00 am at North Center"
+/savia-broadcast "Coordination meeting Friday at 5:00 pm"
+/savia-announce "Thursday workshop cancelled due to local holiday"
+```
+
+### Field reports
+
+Field technicians report progress directly:
+
+> "Savia, tell the coordinator: workshop completed, 12 attendees, 2 need follow-up"
+
+End-to-end encrypted messaging protects sensitive information about beneficiaries.
+
+---
+
+## Reporting to donors and board
+
+### Executive report
+
+> "Savia, generate the quarterly report for the board"
+
+```
+/ceo-report --format md              → Multi-project report
+/portfolio-overview                  → Global view of all programs
+```
+
+### Impact report
+
+```
+/report-executive --project programa-digital
+```
+
+Savia generates: activities completed, people served (as metric, no personal data), hours invested, progress vs. objectives.
+
+### Grant data
+
+```
+/excel-report time-tracking          → Excel with hours by project/person
+/flow-timesheet-report --monthly     → Monthly breakdown
+```
+
+---
+
+## Fieldwork (offline)
+
+For rural areas or countries without stable connectivity:
+
+```
+/savia-travel-pack                   → Prepare portable package
+```
+
+In the field, everything works offline. Upon returning to an area with internet:
+
+```
+/savia-travel-init                   → Sync changes
+```
+
+---
+
+## Beneficiary privacy
+
+**Fundamental rule**: beneficiary data NEVER goes in the repo.
+
+- Use aggregate metrics: "12 attendees", not names
+- Beneficiary identifiers are managed in external systems (NGO databases)
+- Internal communication about cases uses aliases or codes
+- `/hook-pii-gate.sh` detects personal data before commit
+
+---
+
+## Gaps identified and proposals
+
+| Gap | Description | Proposal |
+|---|---|---|
+| **Impact metrics** | No native tracking of social impact metrics | `/impact-metric {define\|log\|report}` |
+| **Volunteer management** | Onboarding doesn't distinguish between permanent staff and volunteers | `/volunteer-manage {register\|availability\|hours}` |
+| **Grant lifecycle** | Grants have their own cycles (application → award → execution → justification) | `/grant-track {apply\|awarded\|execute\|justify}` |
+| **Donor reporting templates** | Donors request specific formats | Report templates by donor type |
+
+---
+
+## Tips
+
+- Each grant should be a separate project — facilitates hours justification
+- Register hours daily, not at month-end — precision matters for audits
+- Use `/savia-broadcast` for general team communications
+- The Kanban board (`/savia-board`) works very well in weekly coordination meetings
+- For volunteers with little technical experience, the coordinator can log their hours for them
+- Travel Mode is especially valuable for international cooperation projects

--- a/docs/guides_en/guide-research-lab.md
+++ b/docs/guides_en/guide-research-lab.md
@@ -1,0 +1,225 @@
+# Guide: Research Laboratory
+
+> Scenario: research group at university or R&D center. Manages papers, experiments, datasets, funding proposals and multi-institutional collaborations.
+
+---
+
+## Your group
+
+| Role | What they do | Main commands |
+|---|---|---|
+| **PI (Principal Investigator)** | Coordinates research lines, manages funding | `/ceo-report`, `/savia-sprint`, `/report-executive` |
+| **Postdoc / Senior** | Leads experiments, supervises juniors | `/savia-pbi`, `/savia-board`, `/flow-spec-create` |
+| **PhD Student** | Executes experiments, writes papers | `/my-focus`, `/flow-task-move`, `/flow-timesheet` |
+| **Lab Technician** | Maintains equipment, processes samples | `/flow-task-*`, `/savia-inbox` |
+| **External Collaborator** | Participates in shared projects | `/savia-send`, `/savia-directory` |
+
+---
+
+## Why Savia for research?
+
+- **Traceability**: every decision, experiment and result is versioned in Git.
+- **Reproducibility**: SDD specs document reproducible experimental procedures.
+- **Secure collaboration**: end-to-end encrypted messaging for sensitive data.
+- **No cloud dependency**: works offline (Travel Mode) — ideal for fieldwork.
+- **Multi-project**: manages multiple research lines simultaneously.
+
+---
+
+## Group setup
+
+### 1. Create the group repository
+
+> "Savia, create an enterprise repository for the research group"
+
+```
+/company-repo
+```
+
+### 2. Define research lines as projects
+
+```
+/savia-pbi create "Paper: effect of X under conditions Y" --project linea-alpha
+/savia-pbi create "H2020 Proposal: call ABC" --project financing
+/savia-pbi create "Dataset: field sample collection" --project linea-beta
+```
+
+### 3. Incorporate researchers
+
+```
+/school-enroll inv01                 → For PhD students (privacy via aliases)
+```
+
+Or with full profiles for permanent staff:
+
+> "Savia, add @postdoc1 as senior researcher"
+
+---
+
+## Research cycle with Savia
+
+### 1. Research proposal → "Exploration" sprint
+
+> "Savia, start an exploration sprint for the alpha line"
+
+```
+/savia-sprint start --project linea-alpha --goal "Literature review + hypothesis"
+```
+
+**Typical tasks:**
+
+```
+/flow-task-create research "Systematic review: effect X"
+/flow-task-create research "Define hypotheses H1, H2, H3"
+/flow-task-create research "Experimental design: variables, controls"
+/flow-task-create research "Ethics protocol (if applicable)"
+```
+
+### 2. Experimentation → "Execution" sprint
+
+```
+/savia-sprint start --project linea-alpha --goal "Execute experiments batch 1"
+```
+
+**Each experiment as spec:**
+
+> "Savia, create a spec for the sensor calibration experiment at 25°C"
+
+```
+/flow-spec-create "Experiment: sensor calibration 25°C"
+```
+
+The SDD spec adapted to research includes: hypothesis, materials, step-by-step procedure, expected data, success/failure criteria. This ensures reproducibility.
+
+### 3. Analysis → "Analysis" sprint
+
+```
+/flow-task-create analysis "Statistical processing batch 1"
+/flow-task-create analysis "Results visualization"
+/flow-task-create analysis "Cross-validation with external dataset"
+```
+
+### 4. Publication → "Writing" sprint
+
+```
+/flow-task-create writing "Paper draft: introduction + methods"
+/flow-task-create writing "Results + discussion"
+/flow-task-create writing "Group internal review"
+/flow-task-create writing "Journal submission"
+```
+
+---
+
+## PI's day-to-day
+
+### Monday — Group meeting
+
+> "Savia, give me the status of all research lines"
+
+```
+/portfolio-overview                  → Global view of all projects
+/savia-board linea-alpha             → Alpha line board
+/savia-board linea-beta              → Beta line board
+```
+
+### Funding management
+
+Funding proposals are projects with their own sprints:
+
+```
+/savia-pbi create "Write technical proposal" --project h2020-call
+/savia-pbi create "Budget and cost justification" --project h2020-call
+/savia-pbi create "Support letter: partner university" --project h2020-call
+```
+
+**Timesheet for hours justification:**
+
+```
+/flow-timesheet-report --monthly     → Hours per researcher and project
+```
+
+Essential for justifying dedication in funded projects (H2020, National Plan, etc.).
+
+### Department report
+
+```
+/report-executive --project linea-alpha
+/ceo-report --format md
+```
+
+---
+
+## PhD student's day-to-day
+
+### Start of day
+
+> "Savia, what do I have pending?"
+
+```
+/my-focus                            → Your most priority task
+/savia-inbox                         → Messages from supervisor
+```
+
+### Register experimental work
+
+```
+/flow-task-move EXP-003 in-progress  → Start experiment
+/flow-timesheet EXP-003 5            → 5 hours of lab
+/flow-task-move EXP-003 done         → Completed
+```
+
+### Communicate results
+
+> "Savia, send @pi the results from batch 1: all samples above threshold"
+
+```
+/savia-send @pi "Batch 1 results: 23/25 samples exceed threshold (92%). Data in linea-alpha:resultados/batch1.csv"
+```
+
+---
+
+## Digital lab notebook
+
+The lab notebook is fundamental in research. Use `/school-diary` adapted:
+
+```
+/school-diary inv01                  → PhD student diary entries
+```
+
+Each entry records: date, experiment, observations, data, conclusions. Immutable because it's in Git — valid as evidence for patents and publications.
+
+---
+
+## Multi-institutional collaborations
+
+For projects with researchers from other institutions:
+
+1. The company repo is shared (private GitHub/GitLab)
+2. Each collaborator has their `user/{handle}` branch
+3. End-to-end encrypted messaging protects sensitive data
+4. `/savia-directory` lists all participants
+
+> "Savia, send @collab-univ-b the anonymized data from the pilot study"
+
+---
+
+## Gaps identified and proposals
+
+| Gap | Description | Proposal |
+|---|---|---|
+| **Experiment tracking** | No native "experiment" entity with metadata (hypothesis, variables, results) | `/experiment-log {create\|run\|result\|compare}` |
+| **Literature management** | No tracking of bibliographic references | `/biblio-add {doi\|bibtex}`, `/biblio-search` |
+| **Dataset versioning** | Large datasets don't fit in Git | Integration with DVC (Data Version Control) or Git LFS |
+| **Grant lifecycle** | Funding proposals have their own cycles (draft → submitted → review → awarded) | `/grant-track {submit\|status\|report}` |
+| **Ethics/IRB tracking** | Ethics protocols not managed as standard PBIs | `/ethics-protocol {create\|status\|expire}` |
+
+---
+
+## Tips
+
+- Use long sprints (4 weeks) for research — cycles are slower than software
+- SDD specs are perfect for documenting reproducible experimental protocols
+- `/flow-timesheet` is essential for hours justification in funded projects
+- The lab notebook in Git has legal value for intellectual property disputes
+- For sensitive data (patients, biological samples), end-to-end encrypted messaging protects communication
+- ADRs (`/adr-create`) document methodological decisions that are forgotten in 6 months

--- a/docs/guides_en/guide-savia-standalone.md
+++ b/docs/guides_en/guide-savia-standalone.md
@@ -1,0 +1,210 @@
+# Guide: Savia Only + Savia Flow (no external tool)
+
+> Scenario: small team (2–8 people) that wants to manage their software project using exclusively Savia and Git, without Azure DevOps, Jira, or other external PM tool.
+
+---
+
+## Why choose Savia standalone?
+
+- **Zero external dependencies**: everything lives in Git. No licenses, no APIs, no mandatory internet.
+- **Total portability**: the repository IS your management tool. Clone and work.
+- **End-to-end encryption**: internal messaging with RSA-4096 + AES-256-CBC.
+- **Travel mode**: carry it on a USB and work offline.
+- **Zero cost**: you only need Git and Claude Code.
+
+---
+
+## Your team
+
+| Role | Main Commands |
+|---|---|
+| **Lead / PM** | `/savia-pbi`, `/savia-sprint`, `/savia-board`, `/savia-team` |
+| **Developers** | `/flow-task-move`, `/flow-timesheet`, `/my-focus` |
+| **Everyone** | `/savia-send`, `/savia-inbox`, `/savia-directory` |
+
+---
+
+## Setup from scratch
+
+### 1. Install pm-workspace
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+### 2. Create the shared company repository
+
+> "Savia, create a company repository for my team"
+
+Savia runs `/company-repo` and asks you for:
+
+- Company name (generic for the repo, e.g. "my-team")
+- Basic info (sector, size)
+
+This creates a Git repo with orphan branches:
+
+- `main` — configuration, rules, pubkeys (admin only)
+- `user/{handle}` — personal space for each member
+- `team/{name}` — projects and team data
+- `exchange` — encrypted messaging bus
+
+### 3. Onboard the team
+
+For each person:
+
+> "Savia, onboard @carlos as a developer"
+
+Savia generates RSA-4096 keys for encryption, creates the `user/carlos` branch, publishes the public key in `main:pubkeys/carlos.pem`, and registers the profile.
+
+### 4. Create your first project
+
+> "Savia, create a project called app-mobile in the dev team"
+
+```
+/savia-pbi create "Login screen design" --project app-mobile
+/savia-pbi create "Authentication API" --project app-mobile
+/savia-pbi create "Login flow E2E tests" --project app-mobile
+```
+
+---
+
+## Day to day
+
+### The Lead / PM
+
+**Monday — Sprint planning:**
+
+> "Savia, start a 2-week sprint for app-mobile"
+
+```
+/savia-sprint start --project app-mobile --goal "Login MVP"
+/savia-board app-mobile              → ASCII Kanban board with 5 columns
+```
+
+**Assigning tasks:**
+
+```
+/flow-task-create story "Login screen"
+/flow-task-assign TASK-001 @carlos
+/flow-task-assign TASK-002 @elena
+```
+
+**Seeing daily progress:**
+
+> "Savia, how's the sprint going?"
+
+```
+/savia-board app-mobile              → Visual board
+/flow-burndown                       → Burndown chart
+/flow-velocity                       → Team velocity
+```
+
+**Sprint closure:**
+
+```
+/savia-sprint close --project app-mobile
+/flow-timesheet-report --monthly     → Hours report
+```
+
+### The Developers
+
+**Starting the day:**
+
+> "Savia, what do I have pending?"
+
+Savia shows your assigned tasks ordered by priority.
+
+**Moving tasks:**
+
+```
+/flow-task-move TASK-001 in-progress  → Starting work
+/flow-task-move TASK-001 review       → Requesting review
+/flow-task-move TASK-001 done         → Completed
+```
+
+**Logging hours:**
+
+```
+/flow-timesheet TASK-001 4           → 4 hours on this task
+```
+
+### Internal communication
+
+**Send a direct message:**
+
+> "Savia, tell @carlos that the auth endpoint needs token validation"
+
+```
+/savia-send @carlos "The auth endpoint needs JWT token validation"
+```
+
+**Check your inbox:**
+
+```
+/savia-inbox                         → See pending messages
+/savia-reply {msg-id} "Got it, I'll look at it this afternoon"
+```
+
+**Team announcement:**
+
+```
+/savia-announce "Sprint review tomorrow at 10:00"
+```
+
+---
+
+## SDD flow without external tool
+
+You can use the complete SDD cycle even without Azure DevOps:
+
+1. `/savia-pbi create` — create the PBI in Git
+2. `/pbi-decompose` — Savia decomposes into tasks
+3. `/flow-spec-create` — generates an SDD spec
+4. Implement (you or a Claude agent)
+5. `/pr-review` — automated review
+6. `/flow-task-move {id} done` — mark as done
+
+---
+
+## Offline work and Travel Mode
+
+### Prepare for travel
+
+> "Savia, prepare a portable pack for me"
+
+```
+/savia-travel-pack                   → Creates package for USB
+```
+
+Generates: shallow clone + manifest + AES-256-CBC encrypted backup.
+
+### On the new machine
+
+```
+/savia-travel-init                   → Complete bootstrap
+```
+
+Detects OS, verifies dependencies, restores profile and configuration.
+
+---
+
+## Comparison: when to choose standalone?
+
+| Criterion | Standalone | + Azure DevOps | + Jira |
+|---|---|---|---|
+| Small team (<8) | Ideal | Overkill | Overkill |
+| No budget for licenses | Perfect | Requires licenses | Requires licenses |
+| Frequent offline work | Native | Limited | Limited |
+| Client needs management portal | No web portal | Azure Boards | Jira Board |
+| Advanced metrics | Savia Flow metrics | Complete | Via sync |
+| CI/CD | GitHub Actions | Azure Pipelines | GitHub/GitLab CI |
+
+---
+
+## Tips
+
+- Do `git push` frequently so the whole team sees changes
+- Use `/savia-board` in the daily as a shared visual board
+- End-to-end encrypted messages guarantee privacy even in shared repos
+- `/index-rebuild` reconstructs indexes if something gets out of sync
+- The company repo can be hosted on GitHub, GitLab, Bitbucket, or even your own server

--- a/docs/guides_en/guide-sovereignty.md
+++ b/docs/guides_en/guide-sovereignty.md
@@ -1,0 +1,161 @@
+# Guide: Cognitive Sovereignty Audit
+
+> Scenario: your company uses AI in project management and wants to ensure you're not creating strategic dependence on the provider. This guide explains how to use `/sovereignty-audit` to diagnose, measure and reduce the risk of cognitive lock-in.
+
+---
+
+## What is cognitive lock-in?
+
+Lock-in has evolved: in the 90s it was technical (proprietary formats), in the 2000s contractual (licenses), in the 2010s process-based (coupled workflows). In 2026 it is **cognitive** — when AI learns your organization's decision patterns, internal relationships and knowledge flow, switching providers stops being a technical problem and becomes a strategic one.
+
+Reference: "The Cognitive Trap" (Álvaro de Nicolás, 2026).
+
+---
+
+## Who should use `/sovereignty-audit`?
+
+| Role | For what | Frequency |
+|---|---|---|
+| **CTO / CIO** | Report for board | Quarterly |
+| **Project Manager** | Verify projects don't create dependencies | When incorporating new provider |
+| **Compliance Officer** | Align with EU AI Act and AEPD | Semi-annual |
+| **Architect** | Verify architecture portability | Before stack decisions |
+
+---
+
+## Step 1: Your first scan
+
+```
+/sovereignty-audit scan
+```
+
+Savia analyzes your workspace and calculates a **Sovereignty Score (0-100)** with 5 dimensions:
+
+1. **Data portability** (25%) — Are your data in Git/markdown or trapped in APIs?
+2. **LLM independence** (25%) — Can you operate without Claude? Do you have Emergency Mode?
+3. **Organization graph protection** (20%) — Are sensitive data encrypted and local?
+4. **Consumption governance** (15%) — Do you control and measure AI usage?
+5. **Exit optionality** (15%) — Can you migrate to another provider in <72h?
+
+The result is saved in `output/sovereignty-scan-YYYYMMDD.md`.
+
+---
+
+## Step 2: Interpret the score
+
+| Range | Level | What to do |
+|---|---|---|
+| 90-100 | Full sovereignty | Maintain. Review every 6 months. |
+| 70-89 | High sovereignty | Well positioned. Improve weak dimensions. |
+| 50-69 | Medium risk | Action required. Execute `/sovereignty-audit recommend`. |
+| 30-49 | High risk | Urgent mitigation plan. Escalate to leadership. |
+| 0-29 | Critical lock-in | Strategic risk. Prepare immediate exit plan. |
+
+---
+
+## Step 3: Get recommendations
+
+```
+/sovereignty-audit recommend
+```
+
+Savia identifies dimensions with score < 70 and gives concrete actions, ordered by impact/effort. Example:
+
+```
+🔴 D2 LLM Independence: 35/100
+   → Action: Configure Emergency Mode to operate offline
+   → Command: /emergency-mode setup
+   → Effort: 15 minutes
+   → Impact: +35 points in D2
+
+🟡 D4 Consumption Governance: 58/100
+   → Action: Create AI governance policy
+   → Command: /governance-policy create
+   → Effort: 30 minutes
+   → Impact: +20 points in D4
+```
+
+---
+
+## Step 4: Generate report for leadership
+
+```
+/sovereignty-audit report
+```
+
+Generates an executive report with: overall score, trend (if previous scans exist), breakdown by dimension, prioritized risks and top-3 recommendations. Format designed for board presentation or inclusion in compliance reports.
+
+---
+
+## Step 5: Prepare an exit plan
+
+```
+/sovereignty-audit exit-plan
+```
+
+Generates a documented exit plan: data inventory, provider dependencies, migration effort estimation, timeline and alternatives. Does not execute any migration — only documents how it would be done.
+
+Useful for: contract renewals with providers, compliance audits, due diligence.
+
+---
+
+## When to execute each subcommand
+
+| Situation | Subcommand |
+|---|---|
+| Quarterly IT review | `scan` + `report` |
+| Before signing contract with AI provider | `scan` + `exit-plan` |
+| After implementing improvements | `scan` (compare with previous) |
+| Someone asks "what if Claude disappears tomorrow?" | `exit-plan` |
+| Score < 70 in any dimension | `recommend` |
+| EU AI Act compliance audit | `report` + `exit-plan` |
+
+---
+
+## Relationship with other commands
+
+`/sovereignty-audit` complements the existing governance system:
+
+| Command | What it audits | Focus |
+|---|---|---|
+| `/governance-audit` | Regulatory compliance (NIST, EU AI Act) | Do you comply with law? |
+| `/aepd-compliance` | Data protection (AEPD, GDPR) | Do you protect data? |
+| `/sovereignty-audit` | Provider independence | Are you free to change? |
+
+The three complement each other: **complying with law is not the same as being independent**.
+
+---
+
+## Real example: consulting firm with Azure DevOps + Claude
+
+A 15-person consulting firm, 3 active projects, using pm-workspace for 4 months:
+
+```
+/sovereignty-audit scan
+
+Sovereignty Score: 78/100 — High sovereignty
+
+D1 Portability     82  ████████████████░░░░  SaviaHub + BacklogGit active
+D2 Independence    72  ██████████████░░░░░░  Emergency Mode configured
+D3 Org. graph      85  █████████████████░░░  Encryption active, PII gate ON
+D4 Governance      58  ████████████░░░░░░░░  No formal governance policy
+D5 Exit            80  ████████████████░░░░  Complete docs, backups OK
+
+⚠️ D4 below 70 → /governance-policy create
+```
+
+The consulting firm has a high score because pm-workspace stores everything in Git by design. The weak point is formal governance (they don't have a documented policy). With `/sovereignty-audit recommend`, they get the specific action to gain 20 points.
+
+---
+
+## Why pm-workspace protects against lock-in
+
+pm-workspace is designed from its foundation to prevent the cognitive trap:
+
+- **Everything is text in Git** — markdown, YAML, JSON. No proprietary databases.
+- **SaviaHub** stores organizational knowledge in local files.
+- **Emergency Mode** allows operating with local LLMs (Ollama) without internet.
+- **Agent Memory** (MEMORY.md) is portable — not dependent on any provider's APIs.
+- **BacklogGit** versions backlogs in markdown, not in Jira/Azure APIs.
+
+Álvaro de Nicolás's question — "Who owns the intelligence?" — has a clear answer with pm-workspace: **you do**.

--- a/docs/guides_en/guide-startup.md
+++ b/docs/guides_en/guide-startup.md
@@ -1,0 +1,139 @@
+# Guide: Early-Stage Startup
+
+> Scenario: team of 2–6 people building an MVP. Prioritizes speed, rapid iteration, and validation with real users. No budget for enterprise tools.
+
+---
+
+## Your startup
+
+| Role | Who (sometimes the same person) | Main Commands |
+|---|---|---|
+| **Founder / CEO** | Vision, prioritization, stakeholders | `/ceo-report`, `/value-stream-map`, `/okr-track` |
+| **CTO / Lead Dev** | Architecture, implementation, tech debt | `/arch-detect`, `/debt-analyze`, `/spec-implement` |
+| **Fullstack Dev** | Code, features, bugs | `/my-focus`, `/flow-task-move`, `/pr-review` |
+| **Product / Design** | UX, discovery, metrics | `/pbi-jtbd`, `/feature-impact`, `/stakeholder-report` |
+
+---
+
+## Why Savia for a startup?
+
+- **Zero cost**: Git + Claude Code. No Jira, Asana, or Linear licenses.
+- **Speed**: from idea to executable spec in minutes with SDD.
+- **One repo for everything**: code, management, docs, communication.
+- **Scales with you**: start with Savia Flow standalone, add Azure DevOps/Jira as you grow.
+- **Metrics from day 1**: velocity, DORA, burndown — don't wait to have 50 people to measure.
+
+---
+
+## Setup in 10 minutes
+
+### 1. Clone pm-workspace
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+```
+
+### 2. Introduce yourself to Savia
+
+> "Hi Savia, I'm the CTO of a startup. We're 3 people building a SaaS inventory management system. We use React + Node.js."
+
+Savia guides you through `/profile-setup` and adapts suggestions to your stack and context.
+
+### 3. Define OKRs (optional but recommended)
+
+> "Savia, define this quarter's OKRs"
+
+```
+/okr-define
+```
+
+Example:
+- **O1**: Launch functional MVP
+  - KR1: 5 core features implemented
+  - KR2: 10 active beta users
+  - KR3: <3s load time
+
+---
+
+## The lean cycle with Savia
+
+### Discovery → PBI
+
+> "Savia, analyze this feature idea with Jobs-to-Be-Done"
+
+```
+/pbi-jtbd "Low stock alerts by email"
+```
+
+Savia generates: job statement, outcome expectations, and value criteria. This becomes a prioritized PBI.
+
+### PBI → Spec → Implementation
+
+```
+/savia-pbi create "Low stock alert by email" --project mvp
+/pbi-decompose {id}                  → Tasks with estimation
+/spec-generate {task-id}             → Executable SDD spec
+/spec-implement {spec}               → Implement (you or Claude agent)
+```
+
+**The power of SDD for a startup**: you can delegate implementation to a Claude agent while you talk to customers. The spec guarantees the agent does exactly what you need.
+
+### Validate → Iterate
+
+```
+/feature-impact --roi                → Does this feature move the needle?
+/okr-track                           → Are we advancing toward our OKRs?
+```
+
+---
+
+## Day to day (everyone does everything)
+
+### Morning — 15 min
+
+> "Savia, what's most important today?"
+
+```
+/my-focus                            → Your highest priority item
+/savia-board mvp                     → Project board
+```
+
+### During the day
+
+```
+/flow-task-move TASK-005 in-progress → Starting
+/spec-implement {spec}               → Implement or delegate to agent
+/pr-review                           → Quick review
+/flow-task-move TASK-005 done        → Done
+```
+
+### Friday — Demo + metrics
+
+> "Savia, generate this week's metrics for retro"
+
+```
+/sprint-review                       → What was delivered
+/velocity-trend                      → Are we getting faster or slower?
+/debt-analyze                        → Are we accumulating debt?
+```
+
+---
+
+## When to scale
+
+| Signal | Action |
+|---|---|
+| >6 people on the team | Add `/jira-connect` or Azure DevOps |
+| Investor asks for formal metrics | `/ceo-report --format pptx` |
+| Need serious CI/CD | Integrate GitHub Actions + PR Guardian |
+| Remote team grows | Enable Company Savia for encrypted communication |
+
+---
+
+## Tips for startups
+
+- Don't over-process. Savia adapts to your pace — if a 1-week sprint works, use it
+- Use `/spec-implement` with Claude agents to multiply your development capacity
+- Run `/debt-analyze` every 2 weeks to avoid surprises when you need to scale
+- Measure from day 1 even if you're 2 people — accumulated data has enormous value
+- `/pbi-jtbd` before each new feature — avoid building things nobody needs


### PR DESCRIPTION
## Summary

- Translate all 11 usage guides from Spanish to English in `docs/guides_en/`
- Create guide index files (`README.md`) for both `docs/guides/` and `docs/guides_en/` with cross-language links
- Add missing sovereignty guide to both README.md guide tables
- Update English README to link to English guide versions (previously linked to Spanish)

## Files

- **11 new English guides** in `docs/guides_en/`
- **2 new index files**: `docs/guides/README.md` + `docs/guides_en/README.md`
- **2 updated READMEs**: sovereignty guide row + index links

## Test plan

- [ ] Verify all 11 English guide links resolve correctly
- [ ] Verify both index files have correct relative links
- [ ] Verify cross-language links work (ES→EN, EN→ES)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)