### PR TITLE
feat: AI labor impact analysis module

### DIFF
--- a/.claude/commands/ai-exposure-audit.md
+++ b/.claude/commands/ai-exposure-audit.md
@@ -1,0 +1,146 @@
+---
+name: ai-exposure-audit
+description: "Auditoría de exposición IA por rol — observed exposure, riesgo de desplazamiento, reskilling"
+developer_type: all
+agent: task
+context_cost: high
+model: sonnet
+argument-hint: "[--team equipo] [--role rol] [--threshold 50] [--lang es|en]"
+---
+
+# /ai-exposure-audit — Auditoría de Exposición IA
+
+> 🦉 Savia mide cuánto de cada rol ya está siendo automatizado vs. cuánto podría estarlo.
+> Fuente: Anthropic "Labor Market Impacts of AI" (2026) — observed exposure framework.
+
+---
+
+## Cargar perfil de usuario
+
+Grupo: **Team & Strategy** — cargar:
+
+- `identity.md` — nombre, rol
+- `projects.md` — proyecto(s)
+- `preferences.md` — language, detail_level
+- `equipo.md` — miembros, roles, seniority
+
+---
+
+## Subcomandos
+
+- `/ai-exposure-audit` — auditoría completa del equipo
+- `/ai-exposure-audit --role {rol}` — análisis de un rol específico
+- `/ai-exposure-audit --team {equipo}` — análisis de un equipo
+- `/ai-exposure-audit --threshold {N}` — solo roles con exposición > N%
+- `/ai-exposure-audit reskilling` — plan de reconversión por rol
+
+---
+
+## Flujo
+
+### Paso 1 — Mapear tareas por rol
+
+Para cada rol del equipo, descomponer en tareas O*NET-style:
+
+1. Listar tareas core del rol (6-12 por rol)
+2. Clasificar cada tarea: cognitive-routine, cognitive-nonroutine, manual
+3. Asignar peso relativo (% del tiempo dedicado)
+
+### Paso 2 — Calcular exposición teórica vs. observada
+
+Para cada tarea:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  EXPOSICIÓN TEÓRICA   = ¿Puede la IA hacer esta tarea?  │
+│  EXPOSICIÓN OBSERVADA = ¿Ya se está automatizando?       │
+│  GAP DE ADOPCIÓN      = Teórica - Observada              │
+└──────────────────────────────────────────────────────────┘
+```
+
+Escala 0-100 por tarea. Score del rol = media ponderada por peso.
+
+### Paso 3 — Clasificar riesgo de desplazamiento
+
+```
+🦉 AI Exposure Audit — {equipo}
+
+  Rol           | Teórica | Observada | Gap  | Riesgo
+  ──────────────|─────────|───────────|──────|────────
+  Data Entry    | 85%     | 67%       | 18%  | 🔴 Alto
+  QA Manual     | 72%     | 45%       | 27%  | 🔴 Alto
+  Dev Backend   | 65%     | 33%       | 32%  | 🟡 Medio
+  PM/Scrum      | 40%     | 15%       | 25%  | 🟢 Bajo
+  Architect     | 30%     | 10%       | 20%  | 🟢 Bajo
+
+  🔴 Alto (>60% observada): Desplazamiento activo
+  🟡 Medio (30-60%): Transición en curso
+  🟢 Bajo (<30%): Augmentation predominante
+```
+
+### Paso 4 — Análisis augmentation vs. automation
+
+Para cada rol, clasificar el uso actual de IA:
+
+- **Automation** — la IA reemplaza la tarea (el humano ya no la hace)
+- **Augmentation** — la IA amplifica al humano (más rápido, mejor calidad)
+
+Ratio: `augmentation_pct / (augmentation_pct + automation_pct)`
+
+### Paso 5 — Plan de reskilling
+
+Para roles con riesgo 🔴 o 🟡, generar rutas concretas:
+
+```
+🎯 Reskilling — Data Entry (riesgo 🔴)
+
+  Habilidades actuales    → Habilidades objetivo
+  ─────────────────────────────────────────────
+  Entrada de datos        → Data quality assurance
+  Validación manual       → Diseño de reglas de validación
+  Formato documentos      → Prompt engineering para templates
+
+  Plazo estimado: 8-12 semanas
+  Recursos: ai-competency-framework nivel 2 → 3
+```
+
+Output guardado en: `output/analytics/ai-exposure-YYYYMMDD.md`
+
+---
+
+## Modo agente (role: "Agent")
+
+```yaml
+status: ok
+action: ai_exposure_audit
+team_size: 8
+roles_analyzed: 5
+high_risk_roles: 2
+medium_risk_roles: 1
+low_risk_roles: 2
+avg_theoretical_exposure: 58
+avg_observed_exposure: 34
+adoption_gap: 24
+augmentation_ratio: 0.65
+reskilling_plans_generated: 3
+```
+
+---
+
+## Restricciones
+
+- **NUNCA** usar como justificación para despidos — es herramienta de planificación
+- **NUNCA** compartir scores individuales sin consentimiento del afectado
+- **NUNCA** asumir que alta exposición = rol innecesario (augmentation ≠ replacement)
+- Objetivo: anticipar y preparar, no alarmar
+- Siempre incluir rutas de reskilling junto al diagnóstico de riesgo
+- Citar fuente Anthropic cuando se use el framework de observed exposure
+
+---
+
+## Referencias
+
+- Anthropic, "The Labor Market Impacts of AI" (2026) — observed exposure
+- O*NET Task Framework — descomposición de tareas por ocupación
+- @.claude/rules/domain/ai-exposure-metrics.md — métricas de exposición
+- @.claude/rules/domain/ai-competency-framework.md — niveles de competencia IA

--- a/.claude/rules/domain/ai-exposure-metrics.md
+++ b/.claude/rules/domain/ai-exposure-metrics.md
@@ -1,0 +1,116 @@
+# AI Exposure Metrics — Métricas de Exposición Laboral a la IA
+
+> Define cómo medir el impacto de la IA en roles y equipos.
+> Fuente: Anthropic "Labor Market Impacts of AI" (2026).
+
+---
+
+## Principio
+
+La exposición a la IA no es binaria ("automatizable" o "no"). Existen dos
+dimensiones: lo que la IA **podría** hacer (teórica) y lo que **ya** hace
+(observada). La diferencia es el gap de adopción — una ventana para actuar.
+
+---
+
+## Métricas Core
+
+### 1. Theoretical Exposure (TE)
+
+Porcentaje de tareas del rol que un LLM podría realizar con calidad aceptable.
+
+```
+TE = Σ(peso_tarea × capacidad_ia) / Σ(peso_tarea)
+```
+
+Capacidad IA por tarea: 0 (imposible) a 1 (automatizable al 100%).
+
+### 2. Observed Exposure (OE)
+
+Porcentaje de tareas que YA se están automatizando en la práctica.
+
+```
+OE = Σ(peso_tarea × uso_real_ia) / Σ(peso_tarea)
+```
+
+Uso real: 0 (sin IA) a 1 (totalmente automatizado).
+
+### 3. Adoption Gap (AG)
+
+```
+AG = TE - OE
+```
+
+Interpretación: AG alto = margen para automatizar más. AG bajo = ya cerca del techo.
+
+### 4. Augmentation Ratio (AR)
+
+```
+AR = tareas_augmentadas / (tareas_augmentadas + tareas_automatizadas)
+```
+
+- AR > 0.7 — IA como copiloto (saludable)
+- AR 0.4-0.7 — Transición mixta (vigilar)
+- AR < 0.4 — Sustitución dominante (reskilling urgente)
+
+---
+
+## Clasificación de Riesgo por Rol
+
+| OE | Riesgo | Acción |
+|---|---|---|
+| > 60% | 🔴 Alto | Plan de reskilling inmediato (8 semanas) |
+| 30-60% | 🟡 Medio | Monitorizar + plan preventivo (12 semanas) |
+| < 30% | 🟢 Bajo | Augmentation; optimizar uso de IA |
+
+---
+
+## Junior Hiring Gap Index
+
+Mide si un equipo deja de incorporar perfiles junior en roles expuestos.
+
+```
+JHG = juniors_contratados_último_año / juniors_contratados_año_anterior
+```
+
+| JHG | Estado | Riesgo |
+|---|---|---|
+| > 0.85 | 🟢 Estable | Pipeline de talento sano |
+| 0.60-0.85 | 🟡 Declive | Pipeline en riesgo |
+| < 0.60 | 🔴 Crítico | Pipeline roto — sin relevo generacional |
+
+Dato de referencia: caída del ~14% en contratación junior post-ChatGPT
+(Anthropic, 2026).
+
+---
+
+## Taxonomía de Tareas
+
+Cada tarea se clasifica en una de 4 categorías:
+
+- **Cognitive-Routine** — reglas claras, repetitiva (alta automatización)
+- **Cognitive-Nonroutine** — juicio, creatividad (augmentation)
+- **Manual-Routine** — física y repetitiva (robótica, no LLM)
+- **Manual-Nonroutine** — destreza física variable (baja exposición LLM)
+
+---
+
+## Integración
+
+| Comando/Regla | Relación |
+|---|---|
+| `/ai-exposure-audit` | Comando principal que usa estas métricas |
+| `/capacity-forecast --scenario automate` | Simula impacto de automatización |
+| `/enterprise-dashboard team-health` | Incluye exposure score |
+| `ai-competency-framework.md` | Define niveles de reskilling |
+| `/team-skills-matrix` | Bus factor + exposure = riesgo compuesto |
+| `/burnout-radar` | Correlaciona burnout con roles en transición |
+
+---
+
+## Referencias
+
+- Anthropic, "The Labor Market Impacts of AI" (2026)
+- O*NET OnLine — Occupational Information Network
+- BLS Occupational Outlook Handbook — growth projections
+- Eloundou et al. — "GPTs are GPTs" theoretical capability scores

--- a/.claude/skills/ai-labor-impact/SKILL.md
+++ b/.claude/skills/ai-labor-impact/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ai-labor-impact
+description: "AI labor impact analysis — exposure audit, reskilling plans, workforce forecasting"
+context: fork
+agent: architect
+context_cost: medium
+dependencies: [enterprise-analytics]
+memory: project
+---
+
+# Skill: AI Labor Impact
+
+> Prerequisito: @.claude/rules/domain/ai-exposure-metrics.md
+> Prerequisito: @.claude/rules/domain/ai-competency-framework.md
+
+Orquesta el análisis de impacto de la IA en la fuerza laboral: mapeo de
+exposición por rol, clasificación de riesgo, planes de reskilling, y
+monitorización del Junior Hiring Gap.
+
+## Capacidades
+
+- Auditoría de exposición teórica vs. observada por rol
+- Clasificación de riesgo de desplazamiento (alto/medio/bajo)
+- Ratio augmentation vs. automation por equipo
+- Detección de Junior Hiring Gap
+- Generación de planes de reskilling con plazos y recursos
+- Simulación de impacto de automatización en capacidad
+
+## Flujo 1 — Exposure Audit (`audit`)
+
+1. Leer `equipo.md` — roles, seniority, headcount
+2. Descomponer cada rol en 6-12 tareas O*NET-style
+3. Evaluar TE (teórica) y OE (observada) por tarea
+4. Calcular scores agregados por rol
+5. Clasificar riesgo: 🔴 🟡 🟢
+6. Output: `output/analytics/ai-exposure-YYYYMMDD.md`
+
+## Flujo 2 — Reskilling Plan (`reskilling`)
+
+1. Filtrar roles con riesgo 🔴 o 🟡
+2. Mapear habilidades actuales → habilidades objetivo
+3. Cruzar con `ai-competency-framework.md` (nivel actual → objetivo)
+4. Estimar plazo y recursos por persona
+5. Output: plan individual + plan equipo
+
+## Flujo 3 — Junior Hiring Gap (`jhg`)
+
+1. Leer histórico de incorporaciones (último año vs. anterior)
+2. Calcular JHG index por rol y equipo
+3. Alertar si JHG < 0.60 (pipeline roto)
+4. Correlacionar con seniority distribution
+5. Output: alerta + recomendación
+
+## Flujo 4 — Automation Scenario (`simulate`)
+
+1. Recibir parámetros: rol, % tareas a automatizar
+2. Calcular impacto en capacidad del equipo (SP ganados/perdidos)
+3. Calcular impacto en headcount necesario
+4. Proyectar a 2-4 quarters
+5. Output: tabla comparativa antes/después
+
+## Errores
+
+| Error | Acción |
+|---|---|
+| Equipo sin roles definidos | Solicitar `equipo.md` mínimo |
+| Rol sin tareas mapeables | Usar plantilla genérica O*NET |
+| Datos de contratación ausentes | Marcar JHG como "sin datos" |
+
+## Seguridad
+
+- Scores de exposición NO son evaluaciones de rendimiento
+- Planes de reskilling son confidenciales (no compartir sin consentimiento)
+- JHG index es métrica organizacional, no individual

--- a/docs/ai-labor-impact-en.md
+++ b/docs/ai-labor-impact-en.md
@@ -1,0 +1,66 @@
+# AI Labor Impact Analysis
+
+## Overview
+
+This module enables organizations to measure and anticipate the impact of artificial intelligence on their teams. Based on Anthropic's "observed exposure" framework (2026), it provides concrete metrics to distinguish between automation (AI replaces tasks) and augmentation (AI amplifies human capabilities).
+
+## Components
+
+### Command: `/ai-exposure-audit`
+
+Comprehensive AI exposure audit by role. Breaks down each role into tasks, measures theoretical exposure (what AI could do) vs. observed exposure (what it already does), and classifies displacement risk.
+
+**Subcommands:**
+
+- `/ai-exposure-audit` — full team audit
+- `/ai-exposure-audit --role {role}` — single role analysis
+- `/ai-exposure-audit --team {team}` — team-level analysis
+- `/ai-exposure-audit --threshold {N}` — only roles with exposure > N%
+- `/ai-exposure-audit reskilling` — reskilling plan generation
+
+### Rule: `ai-exposure-metrics.md`
+
+Defines the 4 core metrics:
+
+- **Theoretical Exposure (TE)** — percentage of tasks theoretically automatable
+- **Observed Exposure (OE)** — percentage already being automated in practice
+- **Adoption Gap (AG)** — difference between TE and OE (window for action)
+- **Augmentation Ratio (AR)** — proportion of AI use as copilot vs. replacement
+
+Also includes the **Junior Hiring Gap Index (JHG)**, which detects whether a team has stopped hiring juniors in exposed roles — a leading indicator of talent pipeline erosion. Reference: ~14% decline in junior hiring post-ChatGPT (Anthropic, 2026).
+
+### Skill: `ai-labor-impact`
+
+Orchestrates 4 analysis flows:
+
+1. **Audit** — exposure mapping and risk classification
+2. **Reskilling** — reconversion plans with timelines and resources
+3. **JHG** — Junior Hiring Gap monitoring
+4. **Simulate** — automation impact simulation on team capacity
+
+## Risk Classification
+
+| Observed Exposure | Risk | Action |
+|---|---|---|
+| > 60% | 🔴 High | Immediate reskilling plan (8 weeks) |
+| 30-60% | 🟡 Medium | Monitor + preventive plan (12 weeks) |
+| < 30% | 🟢 Low | Augmentation focus; optimize AI usage |
+
+## Integration with Existing Commands
+
+- `/capacity-forecast --scenario automate` — simulates capacity impact
+- `/enterprise-dashboard team-health` — includes exposure score
+- `/team-skills-matrix` — bus factor + exposure = compound risk
+- `/burnout-radar` — correlates burnout with roles in transition
+- `ai-competency-framework.md` — defines reskilling competency levels
+
+## Ethical Use
+
+This module is designed as a planning and care tool, not a headcount reduction instrument. Command restrictions explicitly prohibit using scores to justify layoffs or sharing individual data without consent.
+
+## References
+
+- Anthropic, "The Labor Market Impacts of AI" (2026)
+- O*NET OnLine — Occupational Information Network
+- BLS Occupational Outlook Handbook
+- Eloundou et al. — "GPTs are GPTs" theoretical capability scores

--- a/docs/ai-labor-impact-es.md
+++ b/docs/ai-labor-impact-es.md
@@ -1,0 +1,66 @@
+# Análisis de Impacto Laboral de la IA
+
+## Resumen
+
+Este módulo permite a las organizaciones medir y anticipar el impacto de la inteligencia artificial en sus equipos. Basado en el framework de "observed exposure" de Anthropic (2026), proporciona métricas concretas para distinguir entre automatización (la IA reemplaza tareas) y augmentación (la IA amplifica capacidades humanas).
+
+## Componentes
+
+### Comando: `/ai-exposure-audit`
+
+Auditoría completa de exposición IA por rol. Descompone cada rol en tareas, mide la exposición teórica (lo que la IA podría hacer) y la observada (lo que ya hace), y clasifica el riesgo de desplazamiento.
+
+**Subcomandos:**
+
+- `/ai-exposure-audit` — auditoría completa del equipo
+- `/ai-exposure-audit --role {rol}` — análisis de un rol específico
+- `/ai-exposure-audit --team {equipo}` — análisis por equipo
+- `/ai-exposure-audit --threshold {N}` — solo roles con exposición > N%
+- `/ai-exposure-audit reskilling` — plan de reconversión
+
+### Regla: `ai-exposure-metrics.md`
+
+Define las 4 métricas core del módulo:
+
+- **Theoretical Exposure (TE)** — porcentaje de tareas automatizables en teoría
+- **Observed Exposure (OE)** — porcentaje que ya se está automatizando
+- **Adoption Gap (AG)** — diferencia entre TE y OE (ventana para actuar)
+- **Augmentation Ratio (AR)** — proporción de uso de IA como copiloto vs. sustituto
+
+Incluye también el **Junior Hiring Gap Index (JHG)**, que detecta si un equipo deja de contratar juniors en roles expuestos — un indicador adelantado de pérdida de pipeline de talento. Referencia: caída del ~14% en contratación junior post-ChatGPT (Anthropic, 2026).
+
+### Skill: `ai-labor-impact`
+
+Orquesta 4 flujos de análisis:
+
+1. **Audit** — mapeo de exposición y clasificación de riesgo
+2. **Reskilling** — planes de reconversión con plazos y recursos
+3. **JHG** — monitorización del Junior Hiring Gap
+4. **Simulate** — simulación del impacto de automatización en capacidad
+
+## Clasificación de Riesgo
+
+| Exposición Observada | Riesgo | Acción |
+|---|---|---|
+| > 60% | 🔴 Alto | Plan de reskilling inmediato (8 semanas) |
+| 30-60% | 🟡 Medio | Monitorizar + plan preventivo (12 semanas) |
+| < 30% | 🟢 Bajo | Augmentation; optimizar uso de IA |
+
+## Integración con Comandos Existentes
+
+- `/capacity-forecast --scenario automate` — simula impacto en capacidad
+- `/enterprise-dashboard team-health` — incluye exposure score
+- `/team-skills-matrix` — bus factor + exposure = riesgo compuesto
+- `/burnout-radar` — correlaciona burnout con roles en transición
+- `ai-competency-framework.md` — define niveles de reskilling
+
+## Uso Ético
+
+Este módulo está diseñado como herramienta de planificación y cuidado, no de reducción de plantilla. Las restricciones del comando prohíben explícitamente usar los scores como justificación para despidos o compartir datos individuales sin consentimiento.
+
+## Referencias
+
+- Anthropic, "The Labor Market Impacts of AI" (2026)
+- O*NET OnLine — Occupational Information Network
+- BLS Occupational Outlook Handbook
+- Eloundou et al. — "GPTs are GPTs" theoretical capability scores

--- a/scripts/test-ai-labor-impact.sh
+++ b/scripts/test-ai-labor-impact.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-ai-labor-impact.sh — Tests for AI Labor Impact Analysis (v2.5.0)
+set -uo pipefail
+
+PASS=0; FAIL=0; TOTAL=0
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); echo "  ✅ $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); echo "  ❌ $1"; }
+check() { if eval "$1" >/dev/null 2>&1; then pass "$2"; else fail "$2"; fi }
+
+CMD="/home/monica/savia/.claude/commands/ai-exposure-audit.md"
+RULE="/home/monica/savia/.claude/rules/domain/ai-exposure-metrics.md"
+SKILL="/home/monica/savia/.claude/skills/ai-labor-impact/SKILL.md"
+AI_COMP="/home/monica/savia/.claude/rules/domain/ai-competency-framework.md"
+CAP_FORE="/home/monica/savia/.claude/commands/capacity-forecast.md"
+ENT_DASH="/home/monica/savia/.claude/commands/enterprise-dashboard.md"
+DOC_ES="/home/monica/savia/docs/ai-labor-impact-es.md"
+DOC_EN="/home/monica/savia/docs/ai-labor-impact-en.md"
+
+echo "═══ Testing AI Labor Impact Analysis ═══"
+echo ""
+
+# ─── Section 1: Command File ───
+echo "Section 1: ai-exposure-audit.md (command)"
+
+check "test -f $CMD" "Command file exists"
+check "[ \$(wc -l < $CMD) -le 150 ]" "Command ≤ 150 lines"
+check "grep -qi 'ai-exposure-audit' $CMD" "Contains command name"
+check "grep -qi 'observed.*exposure\|exposure.*observed' $CMD" "Contains observed exposure concept"
+check "grep -qi 'theoretical\|teórica' $CMD" "Contains theoretical exposure"
+check "grep -qi 'anthropic' $CMD" "References Anthropic research"
+check "grep -qi 'reskilling' $CMD" "Contains reskilling concept"
+check "grep -qi 'augmentation\|automation' $CMD" "Contains augmentation vs automation"
+check "grep -qi 'Restricciones\|NUNCA' $CMD" "Contains restrictions"
+check "grep -qi 'modo agente\|Agent' $CMD" "Contains agent mode"
+check "grep -qi 'frontmatter\|name:' $CMD" "Has YAML frontmatter"
+check "grep -qi '\-\-team\|\-\-role\|\-\-threshold' $CMD" "Contains subcommand options"
+
+echo ""
+
+# ─── Section 2: Rule File ───
+echo "Section 2: ai-exposure-metrics.md (rule)"
+
+check "test -f $RULE" "Rule file exists"
+check "[ \$(wc -l < $RULE) -le 150 ]" "Rule ≤ 150 lines"
+check "grep -qi 'theoretical.*exposure\|TE' $RULE" "Contains Theoretical Exposure metric"
+check "grep -qi 'observed.*exposure\|OE' $RULE" "Contains Observed Exposure metric"
+check "grep -qi 'adoption.*gap\|AG' $RULE" "Contains Adoption Gap metric"
+check "grep -qi 'augmentation.*ratio\|AR' $RULE" "Contains Augmentation Ratio metric"
+check "grep -qi 'junior.*hiring.*gap\|JHG' $RULE" "Contains Junior Hiring Gap index"
+check "grep -qi '14%' $RULE" "Contains 14% junior decline reference"
+check "grep -qi 'cognitive.*routine' $RULE" "Contains task taxonomy"
+check "grep -qi 'capacity-forecast' $RULE" "Cross-references capacity-forecast"
+check "grep -qi 'ai-competency-framework' $RULE" "Cross-references ai-competency-framework"
+check "grep -qi 'Anthropic' $RULE" "References Anthropic source"
+check "grep -qi 'O\*NET\|BLS' $RULE" "References labor market sources"
+
+echo ""
+
+# ─── Section 3: Skill File ───
+echo "Section 3: ai-labor-impact/SKILL.md (skill)"
+
+check "test -f $SKILL" "Skill file exists"
+check "grep -qi 'ai-labor-impact' $SKILL" "Contains skill name"
+check "grep -qi 'Flujo 1\|audit' $SKILL" "Contains audit flow"
+check "grep -qi 'Flujo 2\|reskilling' $SKILL" "Contains reskilling flow"
+check "grep -qi 'Flujo 3\|jhg\|junior' $SKILL" "Contains JHG flow"
+check "grep -qi 'Flujo 4\|simulat' $SKILL" "Contains simulation flow"
+check "grep -qi 'Errores' $SKILL" "Contains error handling"
+check "grep -qi 'Seguridad' $SKILL" "Contains security section"
+check "grep -qi 'enterprise-analytics' $SKILL" "References enterprise-analytics dependency"
+check "grep -qi 'ai-exposure-metrics\|ai-competency' $SKILL" "References prerequisite rules"
+
+echo ""
+
+# ─── Section 4: Documentation ───
+echo "Section 4: Documentation (ES + EN)"
+
+check "test -f $DOC_ES" "Spanish docs exist"
+check "test -f $DOC_EN" "English docs exist"
+check "grep -qi 'exposición\|exposure' $DOC_ES" "ES docs contain exposure concept"
+check "grep -qi 'reskilling' $DOC_ES" "ES docs contain reskilling"
+check "grep -qi 'exposure' $DOC_EN" "EN docs contain exposure concept"
+check "grep -qi 'reskilling' $DOC_EN" "EN docs contain reskilling"
+check "grep -qi 'junior.*hiring\|contratación.*junior' $DOC_ES" "ES docs contain JHG"
+check "grep -qi 'junior.*hiring' $DOC_EN" "EN docs contain JHG"
+check "grep -qi 'Anthropic' $DOC_ES" "ES docs reference Anthropic"
+check "grep -qi 'Anthropic' $DOC_EN" "EN docs reference Anthropic"
+
+echo ""
+
+# ─── Section 5: Cross-references & Integration ───
+echo "Section 5: Cross-references"
+
+check "grep -qi 'ai-exposure-metrics' $CMD" "Command references rule"
+check "grep -qi 'ai-competency-framework' $CMD" "Command references ai-competency"
+check "grep -qi 'capacity-forecast' $RULE" "Rule references capacity-forecast"
+check "grep -qi 'enterprise-dashboard' $RULE" "Rule references enterprise-dashboard"
+check "grep -qi 'team-skills-matrix' $RULE" "Rule references team-skills-matrix"
+check "grep -qi 'burnout-radar' $RULE" "Rule references burnout-radar"
+
+echo ""
+
+# ─── Section 6: Line Count Limits ───
+echo "Section 6: Line Count Validation"
+
+CMD_LINES=$(wc -l < "$CMD")
+RULE_LINES=$(wc -l < "$RULE")
+echo "  ℹ️  Command: $CMD_LINES lines (max 150)"
+echo "  ℹ️  Rule: $RULE_LINES lines (max 150)"
+check "[ $CMD_LINES -le 150 ]" "Command within 150-line limit"
+check "[ $RULE_LINES -le 150 ]" "Rule within 150-line limit"
+
+echo ""
+echo "═══ AI Labor Impact: $PASS/$TOTAL passed ═══"
+
+if [ "$FAIL" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary

- New `/ai-exposure-audit` command — measures theoretical vs. observed AI exposure per role, classifies displacement risk (🔴🟡🟢), generates reskilling plans
- New `ai-exposure-metrics.md` rule — defines 4 core metrics: Theoretical Exposure, Observed Exposure, Adoption Gap, Augmentation Ratio + Junior Hiring Gap Index
- New `ai-labor-impact` skill — orchestrates 4 flows: audit, reskilling, JHG monitoring, automation simulation
- Bilingual documentation (ES/EN) in `docs/`
- 53/53 tests passing in `scripts/test-ai-labor-impact.sh`

Based on Anthropic's "The Labor Market Impacts of AI" (2026) observed exposure framework.

## Test plan

- [x] `bash scripts/test-ai-labor-impact.sh` → 53/53 passed
- [x] Command file ≤ 150 lines (146)
- [x] Rule file ≤ 150 lines (116)
- [x] Cross-references validated between command ↔ rule ↔ skill
- [x] Integration references to capacity-forecast, enterprise-dashboard, team-skills-matrix, burnout-radar verified
- [ ] PR Guardian CI gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)