### PR TITLE
docs: align AI labor impact docs with project reality

### DIFF
--- a/docs/ai-labor-impact-en.md
+++ b/docs/ai-labor-impact-en.md
@@ -2,13 +2,15 @@
 
 ## Overview
 
-This module enables organizations to measure and anticipate the impact of artificial intelligence on their teams. Based on Anthropic's "observed exposure" framework (2026), it provides concrete metrics to distinguish between automation (AI replaces tasks) and augmentation (AI amplifies human capabilities).
+pm-workspace includes a labor impact analysis module that enables organizations to measure and anticipate how artificial intelligence affects their teams. Based on Anthropic's "observed exposure" framework (2026), Savia provides concrete metrics to distinguish between automation (AI replaces tasks) and augmentation (AI amplifies human capabilities), with integrated reskilling plans.
+
+Compatible with Azure DevOps, Jira, and Savia Flow (Git-native).
 
 ## Components
 
 ### Command: `/ai-exposure-audit`
 
-Comprehensive AI exposure audit by role. Breaks down each role into tasks, measures theoretical exposure (what AI could do) vs. observed exposure (what it already does), and classifies displacement risk.
+Comprehensive AI exposure audit by role. Breaks down each role into tasks (O*NET taxonomy), measures theoretical exposure (what AI could do) vs. observed exposure (what it already does), and classifies displacement risk with action plans.
 
 **Subcommands:**
 
@@ -16,27 +18,29 @@ Comprehensive AI exposure audit by role. Breaks down each role into tasks, measu
 - `/ai-exposure-audit --role {role}` — single role analysis
 - `/ai-exposure-audit --team {team}` — team-level analysis
 - `/ai-exposure-audit --threshold {N}` — only roles with exposure > N%
-- `/ai-exposure-audit reskilling` — reskilling plan generation
+- `/ai-exposure-audit reskilling` — per-role reskilling plan
+
+Reports generated at `output/analytics/ai-exposure-YYYYMMDD.md`.
 
 ### Rule: `ai-exposure-metrics.md`
 
-Defines the 4 core metrics:
+Defines the 4 core metrics and a talent pipeline index:
 
 - **Theoretical Exposure (TE)** — percentage of tasks theoretically automatable
 - **Observed Exposure (OE)** — percentage already being automated in practice
 - **Adoption Gap (AG)** — difference between TE and OE (window for action)
 - **Augmentation Ratio (AR)** — proportion of AI use as copilot vs. replacement
 
-Also includes the **Junior Hiring Gap Index (JHG)**, which detects whether a team has stopped hiring juniors in exposed roles — a leading indicator of talent pipeline erosion. Reference: ~14% decline in junior hiring post-ChatGPT (Anthropic, 2026).
+Also includes the **Junior Hiring Gap Index (JHG)**, which detects whether a team has stopped hiring juniors in exposed roles — a leading indicator of talent pipeline erosion. Reference: ~14% decline in junior hiring post-ChatGPT (Anthropic, 2026). JHG can be fed from the SaviaHub member directory (`/savia-directory`) to compute historical onboarding rates.
 
 ### Skill: `ai-labor-impact`
 
-Orchestrates 4 analysis flows:
+Orchestrates 4 analysis flows in isolated context (subagent):
 
 1. **Audit** — exposure mapping and risk classification
-2. **Reskilling** — reconversion plans with timelines and resources
-3. **JHG** — Junior Hiring Gap monitoring
-4. **Simulate** — automation impact simulation on team capacity
+2. **Reskilling** — reskilling plans with timelines, resources, and ai-competency-framework levels
+3. **JHG** — Junior Hiring Gap monitoring using team data or SaviaHub
+4. **Simulate** — automation impact simulation on team capacity (connects to `/capacity-forecast`)
 
 ## Risk Classification
 
@@ -46,17 +50,19 @@ Orchestrates 4 analysis flows:
 | 30-60% | 🟡 Medium | Monitor + preventive plan (12 weeks) |
 | < 30% | 🟢 Low | Augmentation focus; optimize AI usage |
 
-## Integration with Existing Commands
+## Integration with pm-workspace
 
-- `/capacity-forecast --scenario automate` — simulates capacity impact
-- `/enterprise-dashboard team-health` — includes exposure score
-- `/team-skills-matrix` — bus factor + exposure = compound risk
-- `/burnout-radar` — correlates burnout with roles in transition
-- `ai-competency-framework.md` — defines reskilling competency levels
+- `/capacity-forecast --scenario automate` — simulates capacity impact on team
+- `/enterprise-dashboard team-health` — includes exposure score in SPACE radar
+- `/team-skills-matrix` — bus factor + exposure = compound risk per module
+- `/burnout-radar` — correlates burnout with roles in AI transition
+- `/daily-routine` — role definitions feed task decomposition
+- `/savia-directory` — onboarding data for JHG computation
+- `ai-competency-framework.md` — defines 6 AI competency levels for reskilling paths
 
 ## Ethical Use
 
-This module is designed as a planning and care tool, not a headcount reduction instrument. Command restrictions explicitly prohibit using scores to justify layoffs or sharing individual data without consent.
+Savia treats this module as a planning and care tool, not a headcount reduction instrument. Command restrictions explicitly prohibit using scores to justify layoffs or sharing individual data without consent. Aligned with `equality-shield.md` (mandatory counterfactual test in evaluations).
 
 ## References
 

--- a/docs/ai-labor-impact-es.md
+++ b/docs/ai-labor-impact-es.md
@@ -2,13 +2,15 @@
 
 ## Resumen
 
-Este módulo permite a las organizaciones medir y anticipar el impacto de la inteligencia artificial en sus equipos. Basado en el framework de "observed exposure" de Anthropic (2026), proporciona métricas concretas para distinguir entre automatización (la IA reemplaza tareas) y augmentación (la IA amplifica capacidades humanas).
+pm-workspace incluye un módulo de análisis de impacto laboral que permite a las organizaciones medir y anticipar cómo la inteligencia artificial afecta a sus equipos. Basado en el framework de "observed exposure" de Anthropic (2026), Savia proporciona métricas concretas para distinguir entre automatización (la IA reemplaza tareas) y augmentación (la IA amplifica capacidades humanas), con planes de reskilling integrados.
+
+Compatible con Azure DevOps, Jira y Savia Flow (Git-native).
 
 ## Componentes
 
 ### Comando: `/ai-exposure-audit`
 
-Auditoría completa de exposición IA por rol. Descompone cada rol en tareas, mide la exposición teórica (lo que la IA podría hacer) y la observada (lo que ya hace), y clasifica el riesgo de desplazamiento.
+Auditoría completa de exposición IA por rol. Descompone cada rol en tareas (taxonomía O*NET), mide la exposición teórica (lo que la IA podría hacer) y la observada (lo que ya hace), y clasifica el riesgo de desplazamiento con planes de acción.
 
 **Subcomandos:**
 
@@ -16,27 +18,29 @@ Auditoría completa de exposición IA por rol. Descompone cada rol en tareas, mi
 - `/ai-exposure-audit --role {rol}` — análisis de un rol específico
 - `/ai-exposure-audit --team {equipo}` — análisis por equipo
 - `/ai-exposure-audit --threshold {N}` — solo roles con exposición > N%
-- `/ai-exposure-audit reskilling` — plan de reconversión
+- `/ai-exposure-audit reskilling` — plan de reconversión por rol
+
+Informes generados en `output/analytics/ai-exposure-YYYYMMDD.md`.
 
 ### Regla: `ai-exposure-metrics.md`
 
-Define las 4 métricas core del módulo:
+Define las 4 métricas core y el índice de pipeline de talento:
 
 - **Theoretical Exposure (TE)** — porcentaje de tareas automatizables en teoría
 - **Observed Exposure (OE)** — porcentaje que ya se está automatizando
 - **Adoption Gap (AG)** — diferencia entre TE y OE (ventana para actuar)
 - **Augmentation Ratio (AR)** — proporción de uso de IA como copiloto vs. sustituto
 
-Incluye también el **Junior Hiring Gap Index (JHG)**, que detecta si un equipo deja de contratar juniors en roles expuestos — un indicador adelantado de pérdida de pipeline de talento. Referencia: caída del ~14% en contratación junior post-ChatGPT (Anthropic, 2026).
+Incluye el **Junior Hiring Gap Index (JHG)**, que detecta si un equipo deja de contratar juniors en roles expuestos — un indicador adelantado de pérdida de pipeline de talento. Referencia: caída del ~14% en contratación junior post-ChatGPT (Anthropic, 2026). El JHG puede alimentarse del directorio de miembros de SaviaHub (`/savia-directory`) para calcular incorporaciones históricas.
 
 ### Skill: `ai-labor-impact`
 
-Orquesta 4 flujos de análisis:
+Orquesta 4 flujos de análisis con contexto aislado (subagente):
 
 1. **Audit** — mapeo de exposición y clasificación de riesgo
-2. **Reskilling** — planes de reconversión con plazos y recursos
-3. **JHG** — monitorización del Junior Hiring Gap
-4. **Simulate** — simulación del impacto de automatización en capacidad
+2. **Reskilling** — planes de reconversión con plazos, recursos y nivel ai-competency-framework
+3. **JHG** — monitorización del Junior Hiring Gap con datos de equipo o SaviaHub
+4. **Simulate** — simulación del impacto de automatización en capacidad (conecta con `/capacity-forecast`)
 
 ## Clasificación de Riesgo
 
@@ -46,17 +50,19 @@ Orquesta 4 flujos de análisis:
 | 30-60% | 🟡 Medio | Monitorizar + plan preventivo (12 semanas) |
 | < 30% | 🟢 Bajo | Augmentation; optimizar uso de IA |
 
-## Integración con Comandos Existentes
+## Integración con pm-workspace
 
-- `/capacity-forecast --scenario automate` — simula impacto en capacidad
-- `/enterprise-dashboard team-health` — incluye exposure score
-- `/team-skills-matrix` — bus factor + exposure = riesgo compuesto
-- `/burnout-radar` — correlaciona burnout con roles en transición
-- `ai-competency-framework.md` — define niveles de reskilling
+- `/capacity-forecast --scenario automate` — simula impacto en capacidad del equipo
+- `/enterprise-dashboard team-health` — incluye exposure score en el radar SPACE
+- `/team-skills-matrix` — bus factor + exposure = riesgo compuesto por módulo
+- `/burnout-radar` — correlaciona burnout con roles en transición IA
+- `/daily-routine` — los roles del daily alimentan la descomposición de tareas
+- `/savia-directory` — datos de incorporaciones para calcular JHG
+- `ai-competency-framework.md` — define los 6 niveles de competencia IA para reskilling
 
 ## Uso Ético
 
-Este módulo está diseñado como herramienta de planificación y cuidado, no de reducción de plantilla. Las restricciones del comando prohíben explícitamente usar los scores como justificación para despidos o compartir datos individuales sin consentimiento.
+Savia trata este módulo como herramienta de planificación y cuidado, no de reducción de plantilla. Las restricciones del comando prohíben explícitamente usar los scores como justificación para despidos o compartir datos individuales sin consentimiento. Alineado con `equality-shield.md` (test contrafactual obligatorio en evaluaciones).
 
 ## Referencias
 


### PR DESCRIPTION
## Summary

- Adds Savia identity and pm-workspace context to both ES/EN docs
- Adds compatibility note for Azure DevOps, Jira, and Savia Flow
- Adds SaviaHub `/savia-directory` integration for JHG computation
- Adds `/daily-routine` cross-reference for task decomposition
- Adds `equality-shield.md` cross-reference for ethical use
- Adds output path convention (`output/analytics/`)
- Fixes EN "reconversion" hispanicism → proper "reskilling"

## Test plan

- [x] `bash scripts/test-ai-labor-impact.sh` → 53/53 passed
- [x] Both docs reference pm-workspace, Savia, SaviaHub
- [x] ES/EN content parity verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)