### PR TITLE
docs: Savia-led documentation overhaul with role-based quick-starts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,523 +2,147 @@
 
 **English** · [Versión en español](README.md)
 
-# PM-Workspace — AI-Powered Project Management for Claude Code
+# PM-Workspace
 
 [![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/gonzalezpazmonica/pm-workspace?logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Contributors](https://img.shields.io/github/contributors/gonzalezpazmonica/pm-workspace)](CONTRIBUTORS.md)
 
-> 🦉 **I'm Savia**, the little owl of pm-workspace. I keep your projects flowing: I manage sprints, backlog, reports, code agents, and cloud infrastructure — all from Claude Code, in **any language**. Works with Azure DevOps, Jira, or 100% Git-native via Savia Flow.
+## Hi, I'm Savia 🦉
 
-> **🚀 First time here?** Check the [Adoption Guide for Consulting Firms](docs/ADOPTION_GUIDE.en.md) — step by step from Claude signup to project and team onboarding.
+I'm Savia, the little owl that lives inside pm-workspace. My job is to keep your projects flowing: I manage sprints, break down backlogs, coordinate code agents, handle billing, generate executive reports, and watch over technical debt — all from Claude Code, in whatever language you use. I work with Azure DevOps, Jira, or 100% Git-native via Savia Flow. When you arrive for the first time, I introduce myself and get to know you. I adapt to you, not the other way around.
 
-### Quick Install
+---
+
+## Who are you?
+
+Depending on your role, your experience with me will be different. Pick your quick-start:
+
+| Role | What I do for you | Quick-start |
+|---|---|---|
+| **PM / Scrum Master** | Sprints, dailies, capacity, reporting | [→ quick-start-pm](docs/quick-starts_en/quick-start-pm.md) |
+| **Tech Lead** | Architecture, tech debt, tech radar, PRs | [→ quick-start-tech-lead](docs/quick-starts_en/quick-start-tech-lead.md) |
+| **Developer** | Specs, implementation, tests, my sprint | [→ quick-start-developer](docs/quick-starts_en/quick-start-developer.md) |
+| **QA** | Test plans, coverage, regression, quality gates | [→ quick-start-qa](docs/quick-starts_en/quick-start-qa.md) |
+| **Product Owner** | KPIs, backlog, feature impact, stakeholders | [→ quick-start-po](docs/quick-starts_en/quick-start-po.md) |
+| **CEO / CTO** | Portfolio, DORA, governance, AI exposure | [→ quick-start-ceo](docs/quick-starts_en/quick-start-ceo.md) |
+
+---
+
+## How information flows
+
+Everything in pm-workspace is connected. When your team logs hours, that feeds into costs; costs generate invoices; invoices show up in executive reports. Nothing is lost, nothing is duplicated.
+
+```
+Hours (timesheet)  ──→  Costs (cost-mgmt)  ──→  Invoices  ──→  CEO Report
+       ↓                                                            ↑
+Sprint items  ──→  Velocity trend  ──→  Capacity forecast  ──→  Executive alerts
+       ↓
+Spec (SDD)  ──→  Agent implements  ──→  Code review  ──→  Tests  ──→  DORA metrics
+       ↓
+Memory  ──→  Entity recall  ──→  Context load  ──→  Cross-session continuity
+```
+
+More detail in the [Data flow guide](docs/data-flow-guide-en.md).
+
+---
+
+## Where everything lives
+
+```
+pm-workspace/
+├── .claude/
+│   ├── commands/       ← 360+ commands (what you can ask me)
+│   ├── agents/         ← 27 specialized agents
+│   ├── skills/         ← 38 skills with domain knowledge
+│   ├── hooks/          ← 14 hooks that enforce rules automatically
+│   └── rules/          ← context, language, and domain rules
+├── docs/
+│   ├── quick-starts/   ← role-based guides (PM, Dev, QA, PO, TL, CEO)
+│   ├── readme/         ← detailed documentation (13 sections)
+│   ├── guides/         ← 13 scenario guides (Azure, Jira, startup...)
+│   └── savia-flow/     ← Git-native system docs
+├── scripts/            ← validation, CI, utilities
+├── output/             ← generated files (reports, specs, exports)
+└── CLAUDE.md           ← my identity and core rules
+```
+
+Every command has YAML frontmatter with metadata (model, context cost, description). Rules auto-load by file type or domain. Skills activate on demand.
+
+---
+
+## What I can do
+
+**Project management** — Sprints, burndown, capacity, KPIs, dailies, retros. Automated reports in Excel and PowerPoint. Sprint completion prediction with Monte Carlo.
+
+**Spec-Driven Development** — Tasks become executable specs. I implement handlers, tests, and repositories in 16 languages. Agents work in isolated worktrees to avoid conflicts.
+
+**Code intelligence** — I detect architecture patterns (Clean, Hexagonal, DDD, CQRS, Microservices), measure architectural health with fitness functions, and prioritize tech debt by business impact.
+
+**Security & compliance** — SAST against OWASP Top 10, SBOM, credential scanning, regulatory compliance across 12 sectors, and AI governance with model cards and EU AI Act.
+
+**Infrastructure** — Multi-cloud (Azure, AWS, GCP) with auto-detection, minimum tier by default, and scaling only with your approval. Configurable CI/CD pipelines.
+
+**Memory & context** — Persistent memory store (JSONL), entity recall for stakeholders and components, progressive disclosure by context cost, and cross-session continuity.
+
+**Executive reporting** — Multi-project CEO report, executive alerts, portfolio overview, DORA metrics, value stream mapping.
+
+**Collaboration** — Company Savia (shared repo with E2E encrypted messaging), Savia Flow (Git-native PM), Travel Mode, encrypted backup, and Savia School for educational centers. Full reference: [360+ commands · 27 agents · 38 skills](docs/readme/12-comandos-agentes.md)
+
+---
+
+## Installation
 
 **macOS / Linux:**
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gonzalezpazmonica/pm-workspace/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
-
 ```powershell
 irm https://raw.githubusercontent.com/gonzalezpazmonica/pm-workspace/main/install.ps1 | iex
 ```
 
-> Installs Claude Code + clones pm-workspace + dependencies + smoke test. Configurable via `SAVIA_HOME`, `--skip-tests`. Details: `install.sh --help`
-
----
-
-## Who am I?
-
-I'm Savia — your AI-powered automated PM. When you install me, the first thing I do is introduce myself and get to know you: your name, your role, how you work, what tools you use. I adapt to you, not the other way around. I work with Azure DevOps, Jira, or without any external PM tool — with Savia Flow I manage sprints, PBIs, and boards directly in Git.
-
-I work with 16 languages (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) and have conventions, rules, and specialized agents for each one.
-
-**Sprint management** — I track burndown, team capacity, board status, KPIs, and generate automatic reports in Excel and PowerPoint.
-
-**PBI decomposition** — I analyze the backlog, break PBIs into tasks with estimates, detect workload issues, and propose assignments using scoring (expertise × availability × balance × growth).
-
-**Spec-Driven Development (SDD)** — Tasks become executable specs. A "developer" can be a human or a Claude agent. I implement handlers, repositories, and unit tests in the project's language.
-
-**Infrastructure as Code** — I manage multi-cloud (Azure, AWS, GCP) with automatic resource detection, creation at the lowest tier, and scaling only with your approval.
-
-**Multi-environment** — Support for DEV/PRE/PRO (configurable) with secrets protection — connection strings never go into the repository.
-
-**Intelligent memory system** — I have language rules with auto-loading by file type, persistent auto memory per project, support for external projects via symlinks and `--add-dir`. My memory store (JSONL) features full-text search, hash-based deduplication, topic_key for evolving decisions, `<private>` tag filtering, and automatic context injection after compaction. My skills and agents use progressive disclosure with `context_cost` metadata to optimize context consumption.
-
-**Programmatic hooks** — 14 hooks that enforce critical rules automatically: force push blocking, secrets detection, destructive infrastructure operation prevention, auto-lint after edits, quality gates before finishing, scope guard that detects files modified outside the SDD spec's declared scope, persistent memory injection after compaction, semantic commit validation and pre-merge quality gates.
-
-**Agents with advanced capabilities** — Each subagent has persistent memory, preloaded skills, appropriate permission mode, and developer agents use `isolation: worktree` for parallel implementation without conflicts. Experimental support for Agent Teams (lead + teammates).
-
-**Multi-agent coordination** — Agent-notes system for persistent inter-agent memory, TDD gate that blocks implementation without prior tests, pre-implementation security review (OWASP on the spec, not just code), Architecture Decision Records (ADR) for traceable decisions, and scope serialization rules for safe parallel sessions.
-
-**Automated code review** — Pre-commit hook that analyzes staged files against domain rules (REJECT/REQUIRE/PREFER), with SHA256 cache to skip re-reviewing unchanged files. Guardian angel integrated into the commit flow.
-
-**Security and compliance** — SAST analysis against OWASP Top 10, dependency vulnerability auditing, SBOM generation (CycloneDX), git history credential scanning, and enhanced leak detection (AWS, GitHub, OpenAI, Azure, JWT patterns).
-
-**Azure DevOps validation** — When you connect a project, I automatically audit the configuration against my "ideal Agile": process template, work item types, states, fields, backlog hierarchy, and iterations. If incompatibilities are found, I generate a remediation plan for your approval.
-
-**Validation and CI/CD** — Plan gate that warns when implementing without an approved spec, file size validation (≤150 lines), frontmatter and settings.json schema validation, and CI pipeline with automated checks on every PR.
-
-**Predictive analytics** — Sprint completion forecasting with Monte Carlo simulation, Value Stream Mapping with E2E Lead Time and Flow Efficiency, velocity trending with anomaly detection, and WIP aging alerts. Data-driven metrics, not gut feelings.
-
-**Agent observability** — Execution traces with token consumption, duration and outcome, cost estimation per model (Opus/Sonnet/Haiku), and efficiency metrics (success rate, re-work, first-pass). Automatic hook logs every subagent invocation.
-
-**Developer Experience** — Adapted DX Core 4 surveys, automated dashboard with feedback loops and cognitive load proxy, and friction point analysis with actionable recommendations. I measure team experience, not just speed.
-
-**AI governance and compliance** — Model cards documenting agents and models, risk assessment per EU AI Act categories, audit logs with full traceability, and governance rules with quarterly compliance checklist.
-
-**Technical debt intelligence** — Automated hotspot analysis, temporal coupling and code smell detection, business impact prioritization with scoring model, and per-sprint debt budget with velocity impact projection.
-
-**Architecture Intelligence** — I detect architecture patterns (Clean, Hexagonal, DDD, CQRS, MVC/MVVM, Microservices, Event-Driven) in repositories of any language, suggest improvements prioritized by impact, recommend architectures for new projects, verify integrity with fitness functions, and compare patterns for decision-making.
-
-**Emergency mode (local LLM)** — Contingency plan for operating without cloud connection. Automatic Ollama setup scripts with hardware detection, recommended model download (Qwen 2.5), and transparent Claude Code configuration. Offline PM operations without LLM. Emergency documentation in English and Spanish.
-
-**Regulatory Compliance Intelligence** — Automated compliance scanning across 12 regulated sectors. 5-phase calibrated sector auto-detection algorithm. I detect HIPAA/PCI violations, data retention failures, audit trail gaps, weak encryption, misconfigured access control. Auto-fix with post-fix re-verification.
-
-**Performance Audit** — Static performance analysis without code execution. I detect heavy functions by cyclomatic + cognitive complexity, language-specific async anti-patterns, hotspots with O() estimation and N+1 query detection. Test-first workflow: I create characterization tests before optimizing.
-
-**User profiles and agent mode** — When you arrive for the first time, I introduce myself and get to know you through a natural conversation. I store your fragmented profile (identity, workflow, tools, projects, preferences, tone) and load only what's needed for each operation. I also communicate with external agents (OpenClaw and similar) in machine-to-machine mode: structured YAML/JSON output, no narrative, just data and status codes.
-
-**Community and collaboration** — I encourage you to contribute improvements, report bugs, or propose ideas. With `/contribute` you can create PRs directly to the repository, and with `/feedback` you can open issues. Before sending anything, I validate that no private data is included (PATs, corporate emails, project names, IPs) — your privacy comes first.
-
-**Encrypted cloud backup** — With `/backup` I encrypt your profiles, configurations, and PATs with AES-256-CBC (PBKDF2, 100k iterations) before uploading to NextCloud or Google Drive. Automatic rotation of 7 backups. If you lose your machine, a single command restores everything after a fresh clone.
-
-**Adaptive daily routine** — With `/daily-routine` I suggest the day's routine based on your role (PM, Tech Lead, QA, Product Owner, Developer, CEO/CTO). Each role sees the most relevant commands in the right order. You can also use `/health-dashboard` for a project health dashboard adapted to your perspective, with composite scoring and prioritized alerts.
-
-**Context optimization** — With `/context-optimize` I analyze how you use pm-workspace and suggest optimizations to the context-map. With `/context-age` I compress and archive old decisions using semantic aging (episodic → compressed → archived). With `/context-benchmark` I empirically verify that critical information is well-positioned in the context. With `/hub-audit` I audit the dependency topology between rules, commands, and agents to detect critical hubs and orphan rules.
-
-**Executive reports** — With `/ceo-report` I generate multi-project reports for leadership with portfolio traffic lights, key metrics, and recommendations. With `/ceo-alerts` I filter only alerts requiring C-level decisions. With `/portfolio-overview` I show a bird's-eye view of all projects with dependencies.
-
-**QA Toolkit** — With `/qa-dashboard` I provide a quality panel with coverage, flaky tests, bugs, and escape rate. With `/qa-regression-plan` I analyze change impact and recommend which tests to run. With `/qa-bug-triage` I help classify bugs by severity and detect duplicates. With `/testplan-generate` I generate test plans from SDD specs or PBIs.
-
-**Developer productivity** — With `/my-sprint` I show your personal sprint view with assigned items and cycle time. With `/my-focus` I identify your top priority item and load all its context. With `/my-learning` I detect improvement opportunities by analyzing your code. With `/code-patterns` I document project patterns with real code examples.
-
-**Tech Lead intelligence** — With `\`/tech-radar\`` I map the tech stack with adopt/trial/hold/retire categorization. With `\`/team-skills-matrix\`` I build the team skills matrix with bus factor and pair programming suggestions. With `\`/arch-health\`` I measure architectural health with fitness functions, drift detection, and coupling metrics. With `\`/incident-postmortem\`` I structure blameless postmortems with timeline and root cause analysis.
-
-**Product Owner Analytics** — With `/value-stream-map` I map the end-to-end value flow detecting bottlenecks. With `/feature-impact` I analyze feature impact on ROI, engagement, and technical load. With `/stakeholder-report` I generate executive reports for stakeholders with delivery metrics and objective alignment. With `/release-readiness` I verify release readiness: technical capacity, risks mitigated, communications prepared.
-
-**Vertical detection** — I automatically detect if your project belongs to a non-software sector (healthcare, legal, industrial, agriculture, education, finance...) using a calibrated 5-phase scoring algorithm. If the score is sufficient, I propose creating specialized extensions with rules, workflows, and domain entities for your sector.
-
-**Company Savia — Shared repository** — With `/company-repo` you create a shared Git repository for your company: org chart, rules, holidays, conventions. Each employee gets a personal folder with public profile, documents, and message inbox. With `/savia-send` you send direct messages using @handle, `/savia-inbox` checks your inbox, `/savia-reply` replies with threading, `/savia-announce` publishes company announcements, `/savia-directory` lists members, and `/savia-broadcast` sends to everyone. E2E encryption with RSA-4096 + AES-256-CBC (openssl only), pre-push privacy validation, and zero external dependencies.
-
-**Savia Flow — Git-based project management** — With `/savia-pbi` you create and manage PBIs as markdown files in the company repo, with a state machine (new/ready/in-progress/review/done). With `/savia-sprint` you manage the sprint lifecycle (start/close). With `/savia-board` you display a 5-column ASCII Kanban board. With `/savia-timesheet` you log hours per PBI with monthly reports. With `/savia-team` you manage teams with capacity, ceremonies, and velocity. Everything stored in Git — no Azure DevOps dependency.
-
-**Travel Mode** — With `/savia-travel-pack` you create a portable pm-workspace package for USB or cloud (shallow clone + manifest + encrypted backup). With `/savia-travel-init` you bootstrap pm-workspace on a new machine: detects OS, verifies dependencies, installs Claude Code, and restores profile.
-
-**SaviaHub — Shared knowledge repository** — With `/savia-hub init` you create a local Git repository (or clone a remote) that centralizes your company's knowledge: identity, org chart, clients, users, and projects. With `/savia-hub push` and `/savia-hub pull` you sync with the remote whenever you want. With `/savia-hub flight-mode on` you work 100% offline — writes are queued and synced when you reconnect. Everything is optional: works locally without a remote, and syncs when one exists.
+Configurable with `SAVIA_HOME`, `--skip-tests`. Details: `install.sh --help`
 
 ---
 
 ## Documentation
 
-I've organized all documentation into sections so you can quickly find what you need:
-
-### Getting Started
-
 | Section | Description |
 |---|---|
-| [Introduction and quick example](docs/readme_en/01-introduction.md) | First 5 minutes with the workspace |
-| [Workspace structure](docs/readme_en/02-structure.md) | Directories, files, and organization |
-| [Initial setup](docs/readme_en/03-setup.md) | PAT, constants, dependencies, verification |
+| **Getting started** | |
+| [Introduction & example](docs/readme_en/01-introduccion.md) | First 5 minutes |
+| [Workspace structure](docs/readme_en/02-estructura.md) | Directories and layout |
+| [Initial configuration](docs/readme_en/03-configuracion.md) | PAT, constants, verification |
 | [Adoption guide](docs/ADOPTION_GUIDE.en.md) | Step by step for consulting firms |
-
-### Daily Use
-
-| Section | Description |
-|---|---|
-| [Sprints and reports](docs/readme_en/04-usage-sprint-reports.md) | Sprint management, reporting, workload, KPIs |
-| [Spec-Driven Development](docs/readme_en/05-sdd.md) | Full SDD: specs, agents, team patterns |
-| [Advanced configuration](docs/readme_en/06-advanced-config.md) | Assignment weights, SDD config per project |
-
-### Infrastructure and Deployment
-
-| Section | Description |
-|---|---|
-| [Project infrastructure](docs/readme_en/07-infrastructure.md) | Define compute, databases, API gateways, storage |
-| [Pipelines (PR and CI/CD)](docs/readme_en/08-pipelines.md) | Define validation and deployment pipelines |
-
-### Reference
-
-| Section | Description |
-|---|---|
-| [Test project](docs/readme_en/09-test-project.md) | `sala-reservas`: tests, mock data, validation |
-| [KPIs, rules, and roadmap](docs/readme_en/10-kpis-rules.md) | Metrics, critical rules, adoption plan |
-| [Onboarding new team members](docs/readme_en/11-onboarding.md) | 5-phase onboarding, competency evaluation, GDPR |
-| [Commands and agents](docs/readme_en/12-commands-agents.md) | 271 commands + 25 specialized agents |
-| [Coverage and contributing](docs/readme_en/13-coverage-contributing.md) | What's covered, what's not, how to contribute |
-
-### Usage Guides by Scenario
-
-| Guide | Scenario |
-|---|---|
-| [Consultancy + Azure DevOps](docs/guides_en/guide-azure-devops.md) | Scrum team with Azure DevOps, CI/CD, SDD |
-| [Consultancy + Jira](docs/guides_en/guide-jira.md) | Jira ↔ Savia sync, hybrid workflow |
-| [Savia Only / Savia Flow](docs/guides_en/guide-savia-standalone.md) | No external tool, everything in Git |
-| [Educational Center](docs/guides_en/guide-education.md) | Savia School: projects, evaluations, GDPR |
-| [Hardware Lab](docs/guides_en/guide-hardware-lab.md) | PCB, firmware, BOM, certifications |
-| [Research Laboratory](docs/guides_en/guide-research-lab.md) | Papers, experiments, datasets, grants |
-| [Startup](docs/guides_en/guide-startup.md) | MVP, lean, rapid iteration, OKRs |
-| [Non-profit / NGO](docs/guides_en/guide-nonprofit.md) | Grants, volunteers, social impact |
-| [Legal Firm](docs/guides_en/guide-legal-firm.md) | Cases, legal deadlines, time billing |
-| [Healthcare Organization](docs/guides_en/guide-healthcare.md) | Quality improvement, protocols, compliance |
-| [Cognitive Sovereignty Audit](docs/guides_en/guide-sovereignty.md) | Cognitive lock-in, Sovereignty Score, exit plan |
-| [Large Technology Consultancy](docs/guides_en/guide-enterprise-consultancy.md) | 500-5000 employees, multi-project, sovereignty |
-| [Gap Analysis — Large Consultancy](docs/guides_en/guide-enterprise-gap-analysis.md) | 10 operational gaps and how Savia solves them |
-
-> 📚 [Full guide index (English)](docs/guides_en/README.md) · [Índice completo de guías (Español)](docs/guides/README.md)
-
-### Other Documents
-
-| Document | Description |
-|---|---|
-| [Best practices Claude Code](docs/best-practices-claude-code.md) | Usage best practices |
-| [Language incorporation guide](docs/guia-incorporacion-lenguajes.md) | How to add support for new languages |
-| [Scrum rules](docs/reglas-scrum.md) | Workspace Scrum management rules |
-| [Estimation policy](docs/politica-estimacion.md) | Estimation criteria |
-| [Team KPIs](docs/kpis-equipo.md) | KPI definitions |
-| [Report templates](docs/plantillas-informes.md) | Reporting templates |
-| [Workflow](docs/flujo-trabajo.md) | Complete workflow |
-| [Memory system](docs/memory-system.md) | Auto-loading, auto memory, symlinks, `--add-dir` |
-| [Agent Teams SDD](docs/agent-teams-sdd.md) | Parallel implementation with lead + teammates |
-| [Agent Notes Protocol](docs/agent-notes-protocol.md) | Inter-agent memory, handoffs, traceability |
-| [Emergency guide](docs/EMERGENCY.en.md) | Offline mode with local LLM, contingency scripts |
+| **Daily use** | |
+| [Sprints & reports](docs/readme_en/04-uso-sprint-informes.md) | Sprint, reporting, KPIs |
+| [Spec-Driven Development](docs/readme_en/05-sdd.md) | SDD: specs, agents, patterns |
+| [Data flow](docs/data-flow-guide-en.md) | How the parts connect |
+| **Reference** | |
+| [Commands & agents](docs/readme/12-comandos-agentes.md) | 360+ commands + 27 agents |
+| [Scenario guides](docs/guides_en/README.md) | Azure, Jira, startup, healthcare... |
+| [AI Augmentation](docs/ai-augmentation-opportunities-en.md) | Opportunities by sector |
+| [Context Engineering](docs/context-engineering-en.md) | Context & AI improvements |
 
 ---
 
-## Quick Command Reference
+## Rules that are never skipped
 
-> 360+ commands · 27 agents · 38 skills — full reference at [docs/readme_en/12-commands-agents.md](docs/readme_en/12-commands-agents.md)
-
-### User Profile, Updates and Community
-```
-/profile-setup    /profile-edit    /profile-switch    /profile-show
-/update {check|install|auto-on|auto-off|status}
-/contribute {pr|idea|bug|status}    /feedback {bug|idea|improve|list|search}
-/vertical-propose {name}    /vertical-finance    /vertical-healthcare    /vertical-legal    /vertical-education
-/banking-detect    /banking-bian    /banking-eda-validate    /banking-data-governance    /banking-mlops-audit
-/flow-setup    /flow-board    /flow-intake    /flow-metrics    /flow-spec
-/review-community {pending|review|merge|release|summary}
-/backup {now|restore|auto-on|auto-off|status}
-/daily-routine    /health-dashboard {project|all|trend}
-/context-optimize {stats|reset|apply}
-/context-age {status|apply}    /context-benchmark {quick|history}
-/hub-audit {quick|update}
-/ceo-report {project|--format md|pdf|pptx}
-/ceo-alerts {project|--history}    /portfolio-overview {--compact|--deps}
-/qa-dashboard {project|--trend}    /qa-regression-plan {branch|--pr}
-/qa-bug-triage {bug-id|--backlog}    /testplan-generate {spec|--pbi|--sprint}
-
-### Developer Productivity
-```
-/my-sprint {--all|--history}    /my-focus {--next|--list}
-/my-learning {--quick|--topic}    /code-patterns {pattern|--new}
-```
-
-### Tech Lead Intelligence
-```
-/tech-radar {project|--outdated}    /team-skills-matrix {--bus-factor|--pairs}
-/arch-health {--drift|--coupling}    /incident-postmortem {desc|--from-alert|--list}
-```
-
-### Product Owner Analytics
-```
-/value-stream-map {--bottlenecks}    /feature-impact {--roi}
-/stakeholder-report    /release-readiness
-```
-
-### Intelligent Backlog Management
-```
-/backlog-groom {--top N|--duplicates|--incomplete}    /backlog-prioritize {--method|--strategy-aligned}
-/outcome-track {--release vX.Y.Z|--register}    /stakeholder-align {--items|--scenario}
-```
-
-### Ceremony Intelligence
-```
-/async-standup {--compile|--start|--deadline HH:MM|--list}    /retro-patterns {--sprints N|--method|--action-items}
-/ceremony-health {--sprints N|--ceremony type|--metric}    /meeting-agenda {--type|--sprint|--duration}
-```
-
-### Cross-Project Intelligence
-```
-/portfolio-deps {--critical}    /backlog-patterns
-/org-metrics {--trend 6}    /cross-project-search {query}
-```
-
-### AI-Powered Planning
-```
-/sprint-autoplan {--conservative}    /risk-predict {--sprint N}
-/meeting-summarize {--type daily}    /capacity-forecast {--sprints 6}
-```
-
-### Integration Hub
-```
-/mcp-server {start|stop}    /nl-query {question}
-/webhook-config {add|list}    /integration-status {--check}
-```
-
-### Multi-Platform
-```
-/jira-connect {setup|sync|map}    /github-projects {connect|board}
-/linear-sync {setup|pull|push}    /platform-migrate {plan|execute}
-```
-
-### Company Intelligence
-```
-/company-setup {--quick}    /company-edit {section}
-/company-show {--gaps}    /company-vertical {detect|configure}
-```
-
-### OKR & Strategy
-```
-/okr-define {--template|--import}    /okr-track {--objective|--trend}
-/okr-align {--gaps|--project}    /strategy-map {--initiative|--dependencies}
-```
-
-### Technical Debt Intelligence
-```
-/debt-analyze    /debt-prioritize    /debt-budget
-```
-
-### AI Governance and Compliance
-```
-/ai-safety-config    /ai-confidence    /ai-boundary    /ai-incident
-/ai-model-card    /ai-risk-assessment    /ai-audit-log
-/aepd-compliance {project} [--agent name] [--full] [--fix]
-/governance-audit    /governance-report    /governance-certify
-```
-
-### AI Adoption Companion
-```
-/adoption-assess    /adoption-plan    /adoption-sandbox    /adoption-track
-```
-
-### Sprint and Reporting
-```
-/sprint-status    /sprint-plan    /sprint-review    /sprint-retro
-/sprint-release-notes    /report-hours    /report-executive    /report-capacity
-/team-workload    /board-flow    /kpi-dashboard    /kpi-dora
-/sprint-forecast    /flow-metrics    /velocity-trend
-```
-
-### PBI and SDD
-```
-/pbi-decompose {id}    /pbi-decompose-batch {ids}    /pbi-assign {id}
-/pbi-plan-sprint    /pbi-jtbd {id}    /pbi-prd {id}
-/spec-generate {id}    /spec-explore {id}    /spec-design {spec}
-/spec-implement {spec}    /spec-review {file}    /spec-verify {spec}
-/spec-status    /agent-run {file}
-```
-
-### Repositories, PRs and Pipelines
-```
-/repos-list    /repos-branches {repo}    /repos-search {query}
-/repos-pr-create    /repos-pr-list    /repos-pr-review {pr}
-/pr-review [PR]    /pr-pending
-/pipeline-status    /pipeline-run {pipe}    /pipeline-logs {id}
-/pipeline-artifacts {id}    /pipeline-create {repo}
-```
-
-### Infrastructure and Environments
-```
-/infra-detect {proj} {env}    /infra-plan {proj} {env}    /infra-estimate {proj}
-/infra-scale {resource}    /infra-status {proj}
-/env-setup {proj}    /env-promote {proj} {source} {dest}
-```
-
-### Projects and Planning
-```
-/project-kickoff {name}    /project-assign {name}    /project-audit {name}
-/project-roadmap {name}    /project-release-plan {name}
-/epic-plan {proj}    /backlog-capture    /retro-actions
-/rpi-start {feature}    /rpi-status [feature] [--all]
-```
-
-### Memory and Context
-```
-/memory-sync    /memory-save    /memory-search    /memory-context
-/memory-recall {index|timeline|detail}    /memory-stats    /memory-consolidate
-/context-load    /session-save    /help [filter]
-/agent-memory {list|show|clear}    /savia-recall {query}    /savia-forget {topic|--all}
-/nl-query {question}    /nl-query --explain    /nl-query --learn {phrase} → {cmd}
-/entity-recall {entity}    /entity-recall --list    /entity-recall --save {entity}
-/eval-output {file}    /eval-output --compare {A} {B}    /eval-output --type {type}
-```
-
-### Security and Auditing
-```
-/security-review {spec}    /security-audit    /security-alerts
-/credential-scan    /dependencies-audit    /sbom-generate
-```
-
-### Quality and Validation
-```
-/changelog-update    /evaluate-repo [URL]    /validate-filesize
-/validate-schema    /review-cache-stats    /review-cache-clear
-/testplan-status    /testplan-results {id}    /devops-validate {proj}
-/excel-report {capacity|ceo|time-tracking|custom}
-/savia-gallery [--role pm|techlead|qa|po|dev|ceo] [--vertical name]
-/mcp-recommend [--stack dotnet|python|node] [--role pm|dev|qa]
-```
-
-### Developer Experience
-```
-/dx-survey    /dx-dashboard    /dx-recommendations
-```
-
-### Agent Observability
-```
-/agent-trace    /agent-cost    /agent-efficiency
-```
-
-### Team and Onboarding
-```
-/team-onboarding {name}    /team-evaluate {name}    /team-privacy-notice {name}
-/onboard --role {dev|pm|qa} [--project name]
-```
-
-### Architecture Intelligence
-```
-/arch-detect {repo|path}    /arch-suggest {repo|path}    /arch-recommend {reqs}
-/arch-fitness {repo|path}    /arch-compare {pattern1} {pattern2}
-```
-
-### Architecture and Diagrams
-```
-/adr-create {proj} {title}    /agent-notes-archive {proj}
-/diagram-generate {proj}    /diagram-import {file}
-/diagram-config    /diagram-status
-/debt-track    /dependency-map    /legacy-assess    /risk-log
-```
-
-### Regulatory Compliance Intelligence
-```
-/compliance-scan {repo|path}    /compliance-fix {repo|path}    /compliance-report {repo|path}
-```
-
-### Performance Audit
-```
-/perf-audit {path}              /perf-fix {PA-NNN}              /perf-report {path}
-```
-
-### Savia Flow (Git-based PM)
-```
-/savia-pbi {create|view|list}    /savia-sprint {start|close|plan}
-/savia-board {project}    /savia-timesheet {log|view}    /savia-team {init|members|velocity}
-```
-
-### Travel Mode
-```
-/travel-pack    /travel-unpack    /travel-sync    /travel-verify    /travel-clean
-/savia-travel-pack    /savia-travel-init
-```
-
-### Git Persistence Engine
-```
-/index-rebuild {--all|--profiles|--messages|--projects|--specs|--timesheets}
-/index-status {--detailed}    /index-compact
-```
-
-### Savia Flow Git-Native Tasks
-```
-/flow-task-create {type} {title}    /flow-task-move {task-id} {status}
-/flow-task-assign {task-id} {handle}    /flow-sprint-create {goal}
-/flow-sprint-close {sprint-id}    /flow-sprint-board
-/flow-timesheet {task-id} {hours}    /flow-timesheet-report {--monthly|--weekly}
-/flow-burndown    /flow-velocity    /flow-spec-create {title}
-/flow-backlog-groom {--top N}
-```
-
-### Savia School (Education Vertical)
-```
-/school-setup {school} {course}    /school-enroll {alias}
-/school-project {alias} {name}    /school-submit {alias} {project}
-/school-evaluate {alias} {project}    /school-progress {alias|--class}
-/school-portfolio {alias}    /school-diary {alias}
-/school-export {alias}    /school-forget {alias}
-/school-analytics    /school-rubric {create|edit}
-```
-
-### Emergency
-```
-/emergency-plan [--model MODEL]    /emergency-mode {setup|status|activate|deactivate|test}
-```
-
-### External Integrations
-```
-/jira-sync    /linear-sync    /notion-sync    /confluence-publish
-/wiki-publish    /wiki-sync    /slack-search    /notify-slack
-/notify-whatsapp    /whatsapp-search    /notify-nctalk    /nctalk-search
-/figma-extract    /gdrive-upload    /github-activity    /github-issues
-/sentry-bugs    /sentry-health    /inbox-check    /inbox-start
-/worktree-setup {spec}
-```
+Not even I skip them: no hardcoding PATs, confirm before writing to Azure DevOps, read the project's CLAUDE.md before acting, no launching agents without an approved spec, no secrets in the repo, no `terraform apply` in PRO without approval, always branch + PR. Full detail in [KPIs & rules](docs/readme_en/10-kpis-reglas.md).
 
 ---
 
-## Critical Rules
+## Contributing
 
-These are the rules that are never skipped — not even by me:
+Use `/contribute` to create PRs directly. Use `/feedback` to open issues. Before sending anything, I validate there's no private data. Your privacy comes first.
 
-1. **NEVER hardcode the PAT** — always `$(cat $PAT_FILE)`
-2. **Confirm before writing** to Azure DevOps — I ask before modifying data
-3. **Read the project's CLAUDE.md** before acting on it
-4. **SDD**: NEVER launch agent without approved Spec; Code Review ALWAYS human
-5. **Secrets**: NEVER connection strings, API keys, or passwords in the repository
-6. **Infrastructure**: NEVER `terraform apply` in PRE/PRO without human approval; always minimum tier
-7. **Git**: NEVER commit directly to `main` — always branch + PR
-8. **Commands**: validate with `scripts/validate-commands.sh` before committing
-9. **Parallel**: verify scope overlap before launching Agent Teams; serialize if conflict
+Special thanks to [claude-code-templates](https://github.com/davila7/claude-code-templates) by [Daniel Avila](https://github.com/davila7) — the largest marketplace of Claude Code components (5,788+ components, 21K+ stars).
+
+> Full changelog in [CHANGELOG.md](CHANGELOG.md) · Releases at [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
 
 ---
 
-## Version History
-
-> Full changelog at [CHANGELOG.md](CHANGELOG.md) · All releases at [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
-
-| Version | Era | Summary |
-|---|---|---|
-| **v2.4.0** | Era 29 | One-Line Installer — `curl \| bash` / `irm \| iex` to install Savia with a single command |
-| **v2.3.0** | Era 28 | Scoring Intelligence — piecewise curves, `/score:diff`, Rule of Three severity. Inspired by kimun. |
-| **v2.2.0** | Era 27 | Best Practices Audit — project CLAUDE.md guide + coverage audit |
-| **v2.1.0** | Era 26 | Equality Shield — gender bias prevention based on LLYC study |
-| **v2.0.0** | Era 25 | Quality Validation Framework: multi-judge consensus (3 judges, weighted scoring, security/GDPR veto), confidence calibration (Brier score, decay, recovery), coherence-validator (Sonnet 4.6). 98 new tests. |
-| **v1.9.1** | Era 24 | Reflection Validator: System 2 agent (Opus 4.6) + meta-cognitive validation skill. 65 new tests. |
-| **v1.9.0** | Era 24 | Memory & NL: concepts dimension, 3-layer progressive disclosure, token economics, session consolidation, auto-capture hook, hybrid search with scoring. NL→command: intent catalog (60+ patterns), `/nl-query` rewritten, NL resolution rule. 32 new tests. |
-| **v1.8.0** | Era 23 | 10 usage guides by scenario (Azure DevOps, Jira, Savia standalone, education, hardware, research, startup, nonprofit, legal, healthcare). README restructured. 20 gap proposals detected. |
-| **v1.7.0** | Era 22 | Company Savia v3: orphan branch isolation, quality framework (rules #21-#22), Agent Self-Memory, PII gate, drift detection. 120 Savia tests. |
-| **v1.6.0** | — | Company Savia v2: directory restructure, TSV indexes, simplified user paths. |
-| **v0.99–v1.5.1** | Era 21 | Savia Everywhere: Company Savia, Git Persistence Engine, Savia Flow, Travel Mode, Savia School, E2E encryption. |
-| **v0.91–v0.98** | Era 20 | Persistent Intelligence: agent memory, smart frontmatter, RPI workflow, PR Guardian, 3 output modes. |
-| **v0.90** | Era 19 | Open Source Synergy: claude-code-templates integration, `/mcp-browse`, `/component-search`. |
-| **v0.84–v0.89** | Era 18 | Compliance & Hooks: `/aepd-compliance`, Excel reports, Savia Gallery, intelligent hooks. |
-| **v0.71–v0.72** | Era 17 | Observability & Traces: `/obs-connect`, `/trace-search`, `/error-investigate`. |
-
----
-
-## Special Acknowledgment
-
-This project thrives on the open source ecosystem of Claude Code tools. We want to give special thanks to:
-
-### [claude-code-templates](https://github.com/davila7/claude-code-templates)
-
-Created by [Daniel Avila](https://github.com/davila7), claude-code-templates is the largest component marketplace for Claude Code: **5,788+ components** (agents, commands, hooks, MCPs, settings, skills), a **CLI installer** (`npx claude-code-templates@latest`), a **web catalog** at [aitmpl.com](https://aitmpl.com), and a **dashboard** at [app.aitmpl.com](https://app.aitmpl.com). With 21K+ stars, it's an essential reference for any team working with Claude Code.
-
-pm-workspace integrates components from this ecosystem and contributes back with enterprise hooks, PM/Scrum agents, and specialized skills. If you're looking for free tools for Claude Code, start there.
-
-```bash
-# Install components from the marketplace
-npx claude-code-templates@latest
-
-# Explore from pm-workspace
-/mcp-browse
-/component-search {term}
-```
-
----
-
-*🦉 Savia — PM-Workspace, your AI-powered automated PM for multi-language teams. Compatible with Azure DevOps, Jira, and Savia Flow (Git-native).*
+*🦉 Savia — your AI-powered PM. Compatible with Azure DevOps, Jira, and Savia Flow.*

--- a/README.md
+++ b/README.md
@@ -2,523 +2,147 @@
 
 🌐 [English version](README.en.md) · **Español**
 
-# PM-Workspace — AI-Powered Project Management for Claude Code
+# PM-Workspace
 
 [![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/gonzalezpazmonica/pm-workspace?logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Contributors](https://img.shields.io/github/contributors/gonzalezpazmonica/pm-workspace)](CONTRIBUTORS.md)
 
-> 🦉 **Soy Savia**, la buhita de pm-workspace. Me encargo de que tus proyectos fluyan: gestiono sprints, backlog, informes, agentes de código e infraestructura cloud — todo desde Claude Code, en **cualquier lenguaje**. Funciono con Azure DevOps, Jira, o 100% Git-native con Savia Flow.
+## Hola, soy Savia 🦉
 
-> **🚀 ¿Primera vez aquí?** Consulta la [Guía de Adopción para Consultoras](docs/ADOPTION_GUIDE.md) — paso a paso desde el registro en Claude hasta la incorporación de proyectos y equipo.
+Soy Savia, la buhita que vive dentro de pm-workspace. Mi trabajo es que tus proyectos fluyan: gestiono sprints, descompongo backlog, coordino agentes de código, llevo la facturación, genero informes para dirección y vigilo la deuda técnica — todo desde Claude Code, en el lenguaje que uses. Funciono con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Cuando llegas por primera vez, me presento y te conozco. Me adapto a ti, no al revés.
 
-### Instalación rápida
+---
+
+## ¿Quién eres?
+
+Según tu rol, tu experiencia conmigo será diferente. Elige tu quick-start:
+
+| Rol | Qué hago por ti | Quick-start |
+|---|---|---|
+| **PM / Scrum Master** | Sprints, dailies, capacity, reporting | [→ quick-start-pm](docs/quick-starts/quick-start-pm.md) |
+| **Tech Lead** | Arquitectura, deuda técnica, tech radar, PRs | [→ quick-start-tech-lead](docs/quick-starts/quick-start-tech-lead.md) |
+| **Developer** | Specs, implementación, tests, mi sprint | [→ quick-start-developer](docs/quick-starts/quick-start-developer.md) |
+| **QA** | Testplan, cobertura, regresión, quality gates | [→ quick-start-qa](docs/quick-starts/quick-start-qa.md) |
+| **Product Owner** | KPIs, backlog, feature impact, stakeholders | [→ quick-start-po](docs/quick-starts/quick-start-po.md) |
+| **CEO / CTO** | Portfolio, DORA, governance, AI exposure | [→ quick-start-ceo](docs/quick-starts/quick-start-ceo.md) |
+
+---
+
+## Cómo fluye la información
+
+Todo en pm-workspace está conectado. Cuando tu equipo imputa horas, eso alimenta los costes; los costes generan facturas; las facturas aparecen en los informes de dirección. Nada se pierde, nada se duplica.
+
+```
+Horas (timesheet)  ──→  Costes (cost-mgmt)  ──→  Facturas  ──→  Informe CEO
+       ↓                                                              ↑
+Sprint items  ──→  Velocity trend  ──→  Capacity forecast  ──→  Alertas directivas
+       ↓
+Spec (SDD)  ──→  Agente implementa  ──→  Code review  ──→  Tests  ──→  DORA metrics
+       ↓
+Memoria  ──→  Entity recall  ──→  Context load  ──→  Continuidad entre sesiones
+```
+
+Más detalle en la [Guía de flujo de datos](docs/data-flow-guide-es.md).
+
+---
+
+## Dónde vive todo
+
+```
+pm-workspace/
+├── .claude/
+│   ├── commands/       ← 360+ comandos (lo que me puedes pedir)
+│   ├── agents/         ← 27 agentes especializados
+│   ├── skills/         ← 38 skills con conocimiento de dominio
+│   ├── hooks/          ← 14 hooks que refuerzan reglas automáticamente
+│   └── rules/          ← reglas de contexto, lenguaje, dominio
+├── docs/
+│   ├── quick-starts/   ← guías por rol (PM, Dev, QA, PO, TL, CEO)
+│   ├── readme/         ← documentación detallada (13 secciones)
+│   ├── guides/         ← 13 guías por escenario (Azure, Jira, startup...)
+│   └── savia-flow/     ← docs del sistema Git-native
+├── scripts/            ← validación, CI, utilidades
+├── output/             ← ficheros generados (informes, specs, exports)
+└── CLAUDE.md           ← mi identidad y reglas fundamentales
+```
+
+Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, descripción). Las reglas se auto-cargan por tipo de fichero o dominio. Los skills se activan por demanda.
+
+---
+
+## Qué puedo hacer
+
+**Gestión de proyectos** — Sprints, burndown, capacity, KPIs, dailies, retros. Informes automáticos en Excel y PowerPoint. Predicción de completitud con Monte Carlo.
+
+**Spec-Driven Development** — Las tasks se convierten en specs ejecutables. Implemento handlers, tests y repositorios en 16 lenguajes. Los agentes trabajan en worktrees aislados para evitar conflictos.
+
+**Inteligencia de código** — Detecto patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, Microservices), mido salud arquitectónica con fitness functions, y priorizo deuda técnica por impacto de negocio.
+
+**Seguridad y compliance** — SAST contra OWASP Top 10, SBOM, escaneo de credenciales, compliance regulatorio en 12 sectores, y gobernanza IA con model cards y EU AI Act.
+
+**Infraestructura** — Multi-cloud (Azure, AWS, GCP) con detección automática, tier mínimo por defecto, y escalado solo con tu aprobación. Pipelines CI/CD configurables.
+
+**Memoria y contexto** — Memory store persistente (JSONL), entity recall para stakeholders y componentes, progressive disclosure por coste de contexto, y continuidad entre sesiones.
+
+**Informes ejecutivos** — CEO report multi-proyecto, alertas de dirección, portfolio overview, DORA metrics, value stream mapping.
+
+**Colaboración** — Company Savia (repo compartido con mensajería E2E cifrada), Savia Flow (PM Git-native), Travel Mode, backup cifrado, y Savia School para centros educativos. Referencia completa: [360+ comandos · 27 agentes · 38 skills](docs/readme/12-comandos-agentes.md)
+
+---
+
+## Instalación
 
 **macOS / Linux:**
-
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gonzalezpazmonica/pm-workspace/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
-
 ```powershell
 irm https://raw.githubusercontent.com/gonzalezpazmonica/pm-workspace/main/install.ps1 | iex
 ```
 
-> Instala Claude Code + clona pm-workspace + dependencias + smoke test. Configurable con `SAVIA_HOME`, `--skip-tests`. Detalles: `install.sh --help`
-
----
-
-## ¿Quién soy?
-
-Soy Savia — tu PM automatizada con IA. Cuando me instalas, lo primero que hago es presentarme y conocerte: tu nombre, tu rol, cómo trabajas, qué herramientas usas. Me adapto a ti, no al revés. Funciono con Azure DevOps, Jira, o sin ningún PM externo — con Savia Flow gestiono sprints, PBIs y tableros directamente en Git.
-
-Trabajo con 16 lenguajes (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) y tengo convenciones, reglas y agentes especializados para cada uno.
-
-**Gestión de sprints** — Llevo el control del burndown, la capacity del equipo, el estado del board, los KPIs, y genero informes automáticos en Excel y PowerPoint.
-
-**Descomposición de PBIs** — Analizo el backlog, descompongo PBIs en tasks con estimación, detecto problemas de carga y propongo asignaciones con scoring (expertise × disponibilidad × balance × crecimiento).
-
-**Spec-Driven Development (SDD)** — Las tasks se convierten en specs ejecutables. Un "developer" puede ser humano o agente Claude. Implemento handlers, repositorios y unit tests en el lenguaje del proyecto.
-
-**Infraestructura como Código** — Gestiono multi-cloud (Azure, AWS, GCP) con detección automática de recursos, creación al tier más bajo, y escalado solo con tu aprobación.
-
-**Multi-entorno** — Soporte para DEV/PRE/PRO (configurable) con protección de secrets — las connection strings nunca van al repositorio.
-
-**Sistema de memoria inteligente** — Tengo reglas de lenguaje con auto-carga por tipo de fichero, auto memory persistente por proyecto, soporte para proyectos externos vía symlinks y `--add-dir`. Mi memory store (JSONL) tiene búsqueda, deduplicación por hash, topic_key para decisiones que evolucionan, filtrado de `<private>` tags, e inyección automática de contexto tras compactación. Mis skills y agentes usan progressive disclosure con metadata `context_cost` para optimizar el consumo de contexto.
-
-**Hooks programáticos** — 14 hooks que refuerzan reglas críticas automáticamente: bloqueo de force push, detección de secrets, prevención de operaciones destructivas de infra, auto-lint tras edición, quality gates antes de finalizar, scope guard que detecta ficheros modificados fuera del alcance de la spec SDD, inyección de memoria persistente tras compactación, validación semántica de commits y quality gate pre-merge.
-
-**Agentes con capacidades avanzadas** — Cada subagente tiene memoria persistente, skills precargados, modo de permisos apropiado, y los developer agents usan `isolation: worktree` para implementación paralela sin conflictos. Soporte experimental para Agent Teams (lead + teammates).
-
-**Coordinación multi-agente** — Sistema de agent-notes para memoria inter-agente persistente, TDD gate que bloquea implementación sin tests previos, security review pre-implementación (OWASP en la spec, no solo en el código), Architecture Decision Records (ADR) para decisiones trazables, y reglas de serialización de scope para sesiones paralelas seguras.
-
-**Code Review automatizado** — Hook pre-commit que analiza ficheros staged contra reglas de dominio (REJECT/REQUIRE/PREFER), con caché SHA256 que evita re-revisar ficheros sin cambios. Guardian angel integrado en el flujo de commit.
-
-**Seguridad y compliance** — Análisis SAST contra OWASP Top 10, auditoría de vulnerabilidades en dependencias, generación de SBOM (CycloneDX), escaneo de credenciales en historial git, y detección mejorada de leaks (AWS, GitHub, OpenAI, Azure, JWT).
-
-**Validación de Azure DevOps** — Cuando conectas un proyecto, audito automáticamente la configuración contra mi "Agile ideal": process template, tipos de work item, estados, campos, jerarquía de backlog e iteraciones. Si hay incompatibilidades, genero un plan de remediación para que tú lo apruebes.
-
-**Validación y CI/CD** — Plan gate que avisa si se implementa sin spec aprobada, validación de tamaño de ficheros (≤150 líneas), schema de frontmatter y settings.json, y pipeline CI con checks automáticos en cada PR.
-
-**Analítica predictiva** — Predicción de completitud de sprint con Monte Carlo, Value Stream Mapping con Lead Time E2E y Flow Efficiency, tendencia de velocity con detección de anomalías, y WIP aging con alertas. Métricas basadas en datos, no en sensaciones.
-
-**Observabilidad de agentes** — Trazas de ejecución con tokens consumidos, duración y resultado, estimación de costes por modelo (Opus/Sonnet/Haiku), y métricas de eficiencia (success rate, re-work, first-pass). Hook automático que registra cada invocación de subagente.
-
-**Developer Experience** — Encuestas DX Core 4 adaptadas, dashboard automatizado con feedback loops y cognitive load proxy, y análisis de friction points con recomendaciones accionables. Mido la experiencia del equipo, no solo la velocidad.
-
-**Gobernanza IA y compliance** — Model cards documentando agentes y modelos, evaluación de riesgo según EU AI Act, logs de auditoría con trazabilidad completa, y reglas de gobernanza con checklist de compliance trimestral.
-
-**Inteligencia de deuda técnica** — Análisis automático de hotspots, coupling temporal y code smells, priorización por impacto de negocio con modelo de scoring, y presupuesto de deuda por sprint con proyección de impacto en velocity.
-
-**Architecture Intelligence** — Detecto patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, MVC/MVVM, Microservices, Event-Driven) en repositorios de cualquier lenguaje, sugiero mejoras priorizadas por impacto, recomiendo arquitectura para proyectos nuevos, verifico integridad con fitness functions, y comparo patrones para toma de decisiones.
-
-**Modo emergencia (LLM local)** — Plan de contingencia para operar sin conexión cloud. Scripts de setup automático de Ollama con detección de hardware, descarga de modelo recomendado (Qwen 2.5), y configuración transparente de Claude Code. Operaciones PM offline sin LLM. Documentación de emergencia en español e inglés.
-
-**Inteligencia de Compliance Regulatorio** — Escaneo automatizado de cumplimiento normativo en 12 sectores regulados. Algoritmo de auto-detección de sector en 5 fases calibradas. Detecto violaciones HIPAA/PCI, fallos de retención, auditoría incompleta, cifrado débil, acceso mal configurado. Auto-fix con re-verificación post-aplicación.
-
-**Auditoría de Rendimiento** — Análisis estático de rendimiento sin ejecución de código. Detecto funciones pesadas por complejidad ciclomática + cognitiva, anti-patrones de async por lenguaje, hotspots con estimación de O() y N+1 queries. Workflow test-first: creo characterization tests antes de optimizar.
-
-**Perfiles de usuario y modo agente** — Cuando llegas por primera vez, me presento y te conozco en una conversación natural. Guardo tu perfil fragmentado (identidad, workflow, herramientas, proyectos, preferencias, tono) y cargo solo lo necesario en cada operación. También hablo con agentes externos (OpenClaw y similares) en modo máquina-a-máquina: output estructurado YAML/JSON, sin narrativa, solo datos y códigos de estado.
-
-**Comunidad y colaboración** — Te animo a contribuir mejoras, reportar bugs o proponer ideas. Con `/contribute` puedes crear PRs directamente al repositorio, y con `/feedback` abrir issues. Antes de enviar cualquier cosa, valido que no haya datos privados (PATs, emails corporativos, nombres de proyecto, IPs) — tu privacidad es lo primero.
-
-**Backup cifrado en la nube** — Con `/backup` cifro tus perfiles, configuraciones y PATs con AES-256-CBC (PBKDF2, 100k iteraciones) antes de subirlos a NextCloud o Google Drive. Rotación automática de 7 backups. Si pierdes tu máquina, un solo comando restaura todo tras un clone fresco.
-
-**Rutina diaria adaptativa** — Con `/daily-routine` te propongo la rutina del día según tu rol (PM, Tech Lead, QA, Product Owner, Developer, CEO/CTO). Cada rol ve los comandos más relevantes en el orden correcto. También puedes usar `/health-dashboard` para ver un dashboard de salud del proyecto adaptado a tu perspectiva, con scoring compuesto y alertas priorizadas.
-
-**Optimización de contexto** — Con `/context-optimize` analizo cómo usas pm-workspace y te sugiero optimizaciones al context-map. Con `/context-age` comprimo y archivo decisiones antiguas aplicando envejecimiento semántico (episódico → comprimido → archivado). Con `/context-benchmark` verifico empíricamente que la información crítica está bien posicionada en el contexto. Con `/hub-audit` audito la topología de dependencias entre reglas, comandos y agentes para detectar hubs críticos y reglas huérfanas.
-
-**Informes ejecutivos** — Con `/ceo-report` genero informes multi-proyecto para dirección con semáforo de portfolio, métricas clave y recomendaciones. Con `/ceo-alerts` filtro solo las alertas que requieren decisión de nivel directivo. Con `/portfolio-overview` muestro una vista bird's-eye de todos los proyectos con dependencias.
-
-**Toolkit QA** — Con `/qa-dashboard` tengo un panel de calidad con cobertura, tests flaky, bugs y escape rate. Con `/qa-regression-plan` analizo el impacto de cambios y recomiendo qué tests ejecutar. Con `/qa-bug-triage` ayudo a clasificar bugs por severidad y detectar duplicados. Con `/testplan-generate` genero planes de pruebas desde specs SDD o PBIs.
-
-**Productividad del desarrollador** — Con `/my-sprint` muestro tu vista personal del sprint con items asignados y cycle time. Con `/my-focus` identifico tu item más prioritario y cargo todo su contexto. Con `/my-learning` detecto oportunidades de mejora analizando tu código. Con `/code-patterns` documento los patterns del proyecto con ejemplos reales.
-
-**Inteligencia para Tech Lead** — Con `\`/tech-radar\`` mapeo el stack tecnológico con categorización adopt/trial/hold/retire. Con `\`/team-skills-matrix\`` construyo la matriz de competencias del equipo con bus factor y sugerencias de pair programming. Con `\`/arch-health\`` mido la salud arquitectónica con fitness functions, drift detection y métricas de acoplamiento. Con `\`/incident-postmortem\`` estructuro postmortems blameless con timeline y root cause analysis.
-
-**Product Owner Analytics** — Con `/value-stream-map` mapeo el flujo de valor end-to-end detectando cuellos de botella. Con `/feature-impact` analizo el impacto de features en ROI, engagement y carga técnica. Con `/stakeholder-report` genero reportes ejecutivos para stakeholders con métricas de entrega y alineación de objetivos. Con `/release-readiness` verifico que una release está lista: capacidad técnica, riesgos mitigados, comunicación preparada.
-
-**Detección de verticales** — Detecto automáticamente si tu proyecto pertenece a un sector no-software (sanidad, legal, industrial, agrícola, educación, finanzas...) usando un algoritmo de 5 fases con scoring calibrado. Si el score es suficiente, te propongo crear extensiones especializadas con reglas, flujos y entidades de dominio para tu sector.
-
-**Company Savia — Repositorio compartido** — Con `/company-repo` creas un repositorio Git compartido para tu empresa: organigrama, reglas, festivos, convenciones. Cada empleado tiene su carpeta personal con perfil público, documentos y buzón de mensajes. Con `/savia-send` envías mensajes directos con @handle, `/savia-inbox` revisa tu bandeja, `/savia-reply` responde con threading, `/savia-announce` publica anuncios corporativos, `/savia-directory` lista miembros y `/savia-broadcast` envía a todos. Cifrado E2E con RSA-4096 + AES-256-CBC (openssl only), validación de privacidad pre-push, y cero dependencias externas.
-
-**Savia Flow — Gestión de proyectos Git-based** — Con `/savia-pbi` creas y gestionas PBIs como ficheros markdown en el company repo, con state machine (new/ready/in-progress/review/done). Con `/savia-sprint` gestionas el ciclo de sprint (start/close). Con `/savia-board` muestras un tablero Kanban ASCII de 5 columnas. Con `/savia-timesheet` registras horas por PBI con informes mensuales. Con `/savia-team` gestionas equipos con capacity, ceremonies y velocity. Todo almacenado en Git — sin dependencia de Azure DevOps.
-
-**Travel Mode** — Con `/savia-travel-pack` creas un paquete portable de pm-workspace para USB o cloud (shallow clone + manifest + backup cifrado). Con `/savia-travel-init` bootstrapeas pm-workspace en una máquina nueva: detecta OS, verifica dependencias, instala Claude Code, y restaura perfil.
-
-**SaviaHub — Repositorio de conocimiento compartido** — Con `/savia-hub init` creas un repositorio Git local (o clonas un remoto) que centraliza el conocimiento de tu empresa: identidad, organigrama, clientes, usuarios y proyectos. Con `/savia-hub push` y `/savia-hub pull` sincronizas con el remoto cuando quieras. Con `/savia-hub flight-mode on` trabajas 100% offline — las escrituras se encolan y se sincronizan cuando reconectes. Todo es opcional: funciona local sin remote, y si existe remote, sincroniza.
+Configurable con `SAVIA_HOME`, `--skip-tests`. Detalles: `install.sh --help`
 
 ---
 
 ## Documentación
 
-He organizado toda la documentación en secciones para que encuentres rápido lo que necesitas:
-
-### Empezar
-
 | Sección | Descripción |
 |---|---|
-| [Introducción y ejemplo rápido](docs/readme/01-introduccion.md) | Primeros 5 minutos con el workspace |
-| [Estructura del workspace](docs/readme/02-estructura.md) | Directorios, ficheros y organización |
-| [Configuración inicial](docs/readme/03-configuracion.md) | PAT, constantes, dependencias, verificación |
+| **Empezar** | |
+| [Introducción y ejemplo](docs/readme/01-introduccion.md) | Primeros 5 minutos |
+| [Estructura del workspace](docs/readme/02-estructura.md) | Directorios y organización |
+| [Configuración inicial](docs/readme/03-configuracion.md) | PAT, constantes, verificación |
 | [Guía de adopción](docs/ADOPTION_GUIDE.md) | Paso a paso para consultoras |
-
-### Uso diario
-
-| Sección | Descripción |
-|---|---|
-| [Sprints e informes](docs/readme/04-uso-sprint-informes.md) | Gestión de sprint, reporting, workload, KPIs |
-| [Spec-Driven Development](docs/readme/05-sdd.md) | SDD completo: specs, agentes, patrones de equipo |
-| [Configuración avanzada](docs/readme/06-configuracion-avanzada.md) | Pesos de asignación, config SDD por proyecto |
-
-### Infraestructura y despliegue
-
-| Sección | Descripción |
-|---|---|
-| [Infraestructura del proyecto](docs/readme/07-infraestructura.md) | Definir compute, bases de datos, API gateways, storage |
-| [Pipelines (PR y CI/CD)](docs/readme/08-pipelines.md) | Definir pipelines de validación y despliegue |
-
-### Referencia
-
-| Sección | Descripción |
-|---|---|
-| [Proyecto de test](docs/readme/09-proyecto-test.md) | `sala-reservas`: tests, datos mock, validación |
-| [KPIs, reglas y roadmap](docs/readme/10-kpis-reglas.md) | Métricas, reglas críticas, plan de adopción |
-| [Onboarding de nuevos miembros](docs/readme/11-onboarding.md) | Incorporación en 5 fases, evaluación de competencias, RGPD |
-| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 271 comandos + 27 agentes especializados |
-| [Cobertura y contribución](docs/readme/13-cobertura-contribucion.md) | Qué cubre, qué no, cómo contribuir |
-
-### Guías de uso por escenario
-
-| Guía | Escenario |
-|---|---|
-| [Consultora + Azure DevOps](docs/guides/guide-azure-devops.md) | Equipo Scrum con Azure DevOps, CI/CD, SDD |
-| [Consultora + Jira](docs/guides/guide-jira.md) | Sincronización Jira ↔ Savia, workflow híbrido |
-| [Solo Savia / Savia Flow](docs/guides/guide-savia-standalone.md) | Sin herramienta externa, todo en Git |
-| [Centro de estudios](docs/guides/guide-education.md) | Savia School: proyectos, evaluaciones, RGPD |
-| [Laboratorio de hardware](docs/guides/guide-hardware-lab.md) | PCB, firmware, BOM, certificaciones |
-| [Laboratorio de investigación](docs/guides/guide-research-lab.md) | Papers, experimentos, datasets, financiación |
-| [Startup](docs/guides/guide-startup.md) | MVP, lean, iteración rápida, OKRs |
-| [ONG](docs/guides/guide-nonprofit.md) | Subvenciones, voluntarios, impacto social |
-| [Bufete de abogados](docs/guides/guide-legal-firm.md) | Casos, plazos legales, facturación por horas |
-| [Organización sanitaria](docs/guides/guide-healthcare.md) | Mejora continua, protocolos, compliance |
-| [Auditoría de soberanía cognitiva](docs/guides/guide-sovereignty.md) | Lock-in cognitivo, Sovereignty Score, exit plan |
-| [Gran consultora tecnológica](docs/guides/guide-enterprise-consultancy.md) | 500-5000 empleados, multi-proyecto, soberanía |
-| [Análisis de gaps — Gran consultora](docs/guides/guide-enterprise-gap-analysis.md) | 10 gaps operativos y cómo los resuelve Savia |
-
-> 📚 [Índice completo de guías](docs/guides/README.md) · [Full guide index (English)](docs/guides_en/README.md)
-
-### Otros documentos
-
-| Documento | Descripción |
-|---|---|
-| [Best practices Claude Code](docs/best-practices-claude-code.md) | Buenas prácticas de uso |
-| [Guía incorporación de lenguajes](docs/guia-incorporacion-lenguajes.md) | Cómo añadir soporte para nuevos lenguajes |
-| [Reglas Scrum](docs/reglas-scrum.md) | Reglas de gestión Scrum del workspace |
-| [Política de estimación](docs/politica-estimacion.md) | Criterios de estimación |
-| [KPIs de equipo](docs/kpis-equipo.md) | Definición de KPIs |
-| [Plantillas de informes](docs/plantillas-informes.md) | Templates para reporting |
-| [Flujo de trabajo](docs/flujo-trabajo.md) | Workflow completo |
-| [Sistema de memoria](docs/memory-system.md) | Auto-carga, auto memory, symlinks, `--add-dir` |
-| [Agent Teams SDD](docs/agent-teams-sdd.md) | Implementación paralela con lead + teammates |
-| [Agent Notes Protocol](docs/agent-notes-protocol.md) | Memoria inter-agente, handoffs, trazabilidad |
-| [Guía de emergencia](docs/EMERGENCY.md) | Modo offline con LLM local, scripts de contingencia |
+| **Uso diario** | |
+| [Sprints e informes](docs/readme/04-uso-sprint-informes.md) | Sprint, reporting, KPIs |
+| [Spec-Driven Development](docs/readme/05-sdd.md) | SDD: specs, agentes, patrones |
+| [Flujo de datos](docs/data-flow-guide-es.md) | Cómo se conectan las partes |
+| **Referencia** | |
+| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 360+ comandos + 27 agentes |
+| [Guías por escenario](docs/guides/README.md) | Azure, Jira, startup, sanidad... |
+| [AI Augmentation](docs/ai-augmentation-opportunities-es.md) | Oportunidades por sector |
+| [Context Engineering](docs/context-engineering-es.md) | Mejoras de contexto e IA |
 
 ---
 
-## Referencia rápida de comandos
+## Reglas que nunca se saltan
 
-> 360+ comandos · 27 agentes · 38 skills — referencia completa en [docs/readme/12-comandos-agentes.md](docs/readme/12-comandos-agentes.md)
-
-### Perfil de Usuario, Actualización y Comunidad
-```
-/profile-setup    /profile-edit    /profile-switch    /profile-show
-/update {check|install|auto-on|auto-off|status}
-/contribute {pr|idea|bug|status}    /feedback {bug|idea|improve|list|search}
-/vertical-propose {nombre}    /vertical-finance    /vertical-healthcare    /vertical-legal    /vertical-education
-/banking-detect    /banking-bian    /banking-eda-validate    /banking-data-governance    /banking-mlops-audit
-/flow-setup    /flow-board    /flow-intake    /flow-metrics    /flow-spec
-/review-community {pending|review|merge|release|summary}
-/backup {now|restore|auto-on|auto-off|status}
-/daily-routine    /health-dashboard {proyecto|all|trend}
-/context-optimize {stats|reset|apply}
-/context-age {status|apply}    /context-benchmark {quick|history}
-/hub-audit {quick|update}
-/ceo-report {proyecto|--format md|pdf|pptx}
-/ceo-alerts {proyecto|--history}    /portfolio-overview {--compact|--deps}
-/qa-dashboard {proyecto|--trend}    /qa-regression-plan {branch|--pr}
-/qa-bug-triage {bug-id|--backlog}    /testplan-generate {spec|--pbi|--sprint}
-
-### Productividad del Desarrollador
-```
-/my-sprint {--all|--history}    /my-focus {--next|--list}
-/my-learning {--quick|--topic}    /code-patterns {pattern|--new}
-```
-
-### Inteligencia para Tech Lead
-```
-/tech-radar {proyecto|--outdated}    /team-skills-matrix {--bus-factor|--pairs}
-/arch-health {--drift|--coupling}    /incident-postmortem {desc|--from-alert|--list}
-```
-
-### Product Owner Analytics
-```
-/value-stream-map {--bottlenecks}    /feature-impact {--roi}
-/stakeholder-report    /release-readiness
-```
-
-### Intelligent Backlog Management
-```
-/backlog-groom {--top N|--duplicates|--incomplete}    /backlog-prioritize {--method|--strategy-aligned}
-/outcome-track {--release vX.Y.Z|--register}    /stakeholder-align {--items|--scenario}
-```
-
-### Ceremony Intelligence
-```
-/async-standup {--compile|--start|--deadline HH:MM|--list}    /retro-patterns {--sprints N|--method|--action-items}
-/ceremony-health {--sprints N|--ceremony type|--metric}    /meeting-agenda {--type|--sprint|--duration}
-```
-
-### Cross-Project Intelligence
-```
-/portfolio-deps {--critical}    /backlog-patterns
-/org-metrics {--trend 6}    /cross-project-search {query}
-```
-
-### AI-Powered Planning
-```
-/sprint-autoplan {--conservative}    /risk-predict {--sprint N}
-/meeting-summarize {--type daily}    /capacity-forecast {--sprints 6}
-```
-
-### Integration Hub
-```
-/mcp-server {start|stop}    /nl-query {pregunta}
-/webhook-config {add|list}    /integration-status {--check}
-```
-
-### Multi-Platform
-```
-/jira-connect {setup|sync|map}    /github-projects {connect|board}
-/linear-sync {setup|pull|push}    /platform-migrate {plan|execute}
-```
-
-### Company Intelligence
-```
-/company-setup {--quick}    /company-edit {section}
-/company-show {--gaps}    /company-vertical {detect|configure}
-```
-
-### OKR & Strategy
-```
-/okr-define {--template|--import}    /okr-track {--objective|--trend}
-/okr-align {--gaps|--project}    /strategy-map {--initiative|--dependencies}
-```
-
-### Inteligencia de Deuda Técnica
-```
-/debt-analyze    /debt-prioritize    /debt-budget
-```
-
-### Gobernanza IA y Compliance
-```
-/ai-safety-config    /ai-confidence    /ai-boundary    /ai-incident
-/ai-model-card    /ai-risk-assessment    /ai-audit-log
-/aepd-compliance {proyecto} [--agent nombre] [--full] [--fix]
-/governance-audit    /governance-report    /governance-certify
-```
-
-### AI Adoption Companion
-```
-/adoption-assess    /adoption-plan    /adoption-sandbox    /adoption-track
-```
-
-### Sprint y Reporting
-```
-/sprint-status    /sprint-plan    /sprint-review    /sprint-retro
-/sprint-release-notes    /report-hours    /report-executive    /report-capacity
-/team-workload    /board-flow    /kpi-dashboard    /kpi-dora
-/sprint-forecast    /flow-metrics    /velocity-trend
-```
-
-### PBI y SDD
-```
-/pbi-decompose {id}    /pbi-decompose-batch {ids}    /pbi-assign {id}
-/pbi-plan-sprint    /pbi-jtbd {id}    /pbi-prd {id}
-/spec-generate {id}    /spec-explore {id}    /spec-design {spec}
-/spec-implement {spec}    /spec-review {file}    /spec-verify {spec}
-/spec-status    /agent-run {file}
-```
-
-### Repositorios, PRs y Pipelines
-```
-/repos-list    /repos-branches {repo}    /repos-search {query}
-/repos-pr-create    /repos-pr-list    /repos-pr-review {pr}
-/pr-review [PR]    /pr-pending
-/pipeline-status    /pipeline-run {pipe}    /pipeline-logs {id}
-/pipeline-artifacts {id}    /pipeline-create {repo}
-```
-
-### Infraestructura y Entornos
-```
-/infra-detect {proy} {env}    /infra-plan {proy} {env}    /infra-estimate {proy}
-/infra-scale {recurso}    /infra-status {proy}
-/env-setup {proy}    /env-promote {proy} {origen} {destino}
-```
-
-### Proyectos y Planificación
-```
-/project-kickoff {nombre}    /project-assign {nombre}    /project-audit {nombre}
-/project-roadmap {nombre}    /project-release-plan {nombre}
-/epic-plan {proy}    /backlog-capture    /retro-actions
-/rpi-start {feature}    /rpi-status [feature] [--all]
-```
-
-### Memoria, Contexto y Agent Memory
-```
-/memory-sync    /memory-save    /memory-search    /memory-context
-/memory-recall {index|timeline|detail}    /memory-stats    /memory-consolidate
-/context-load    /session-save    /help [filtro]
-/agent-memory {list|show|clear}    /savia-recall {query}    /savia-forget {topic|--all}
-/nl-query {pregunta}    /nl-query --explain    /nl-query --learn {frase} → {cmd}
-/entity-recall {entidad}    /entity-recall --list    /entity-recall --save {entidad}
-/eval-output {fichero}    /eval-output --compare {A} {B}    /eval-output --type {tipo}
-```
-
-### Seguridad y Auditoría
-```
-/security-review {spec}    /security-audit    /security-alerts
-/credential-scan    /dependencies-audit    /sbom-generate
-```
-
-### Calidad y Validación
-```
-/changelog-update    /evaluate-repo [URL]    /validate-filesize
-/validate-schema    /review-cache-stats    /review-cache-clear
-/testplan-status    /testplan-results {id}    /devops-validate {proy}
-/excel-report {capacity|ceo|time-tracking|custom}
-/savia-gallery [--role pm|techlead|qa|po|dev|ceo] [--vertical name]
-/mcp-recommend [--stack dotnet|python|node] [--role pm|dev|qa]
-```
-
-### Developer Experience
-```
-/dx-survey    /dx-dashboard    /dx-recommendations
-```
-
-### Observabilidad de Agentes
-```
-/agent-trace    /agent-cost    /agent-efficiency
-```
-
-### Equipo y Onboarding
-```
-/team-onboarding {nombre}    /team-evaluate {nombre}    /team-privacy-notice {nombre}
-/onboard --role {dev|pm|qa} [--project nombre]
-```
-
-### Architecture Intelligence
-```
-/arch-detect {repo|path}    /arch-suggest {repo|path}    /arch-recommend {reqs}
-/arch-fitness {repo|path}    /arch-compare {patrón1} {patrón2}
-```
-
-### Arquitectura y Diagramas
-```
-/adr-create {proy} {título}    /agent-notes-archive {proy}
-/diagram-generate {proy}    /diagram-import {fichero}
-/diagram-config    /diagram-status
-/debt-track    /dependency-map    /legacy-assess    /risk-log
-```
-
-### Inteligencia de Compliance Regulatorio
-```
-/compliance-scan {repo|path}       /compliance-fix {repo|path}       /compliance-report {repo|path}
-```
-
-### Auditoría de Rendimiento
-```
-/perf-audit {path}                 /perf-fix {PA-NNN}                 /perf-report {path}
-```
-
-### Savia Flow (Git-based PM)
-```
-/savia-pbi {create|view|list}    /savia-sprint {start|close|plan}
-/savia-board {project}    /savia-timesheet {log|view}    /savia-team {init|members|velocity}
-```
-
-### Travel Mode
-```
-/travel-pack    /travel-unpack    /travel-sync    /travel-verify    /travel-clean
-/savia-travel-pack    /savia-travel-init
-```
-
-### Git Persistence Engine
-```
-/index-rebuild {--all|--profiles|--messages|--projects|--specs|--timesheets}
-/index-status {--detailed}    /index-compact
-```
-
-### Savia Flow Git-Native Tasks
-```
-/flow-task-create {type} {title}    /flow-task-move {task-id} {status}
-/flow-task-assign {task-id} {handle}    /flow-sprint-create {goal}
-/flow-sprint-close {sprint-id}    /flow-sprint-board
-/flow-timesheet {task-id} {hours}    /flow-timesheet-report {--monthly|--weekly}
-/flow-burndown    /flow-velocity    /flow-spec-create {title}
-/flow-backlog-groom {--top N}
-```
-
-### Savia School (Vertical Educativa)
-```
-/school-setup {centro} {curso}    /school-enroll {alias}
-/school-project {alias} {nombre}    /school-submit {alias} {proyecto}
-/school-evaluate {alias} {proyecto}    /school-progress {alias|--class}
-/school-portfolio {alias}    /school-diary {alias}
-/school-export {alias}    /school-forget {alias}
-/school-analytics    /school-rubric {create|edit}
-```
-
-### Emergencia
-```
-/emergency-plan [--model MODEL]    /emergency-mode {setup|status|activate|deactivate|test}
-```
-
-### Integraciones Externas
-```
-/jira-sync    /linear-sync    /notion-sync    /confluence-publish
-/wiki-publish    /wiki-sync    /slack-search    /notify-slack
-/notify-whatsapp    /whatsapp-search    /notify-nctalk    /nctalk-search
-/figma-extract    /gdrive-upload    /github-activity    /github-issues
-/sentry-bugs    /sentry-health    /inbox-check    /inbox-start
-/worktree-setup {spec}
-```
+Ni yo misma las salto: no hardcodear PATs, confirmar antes de escribir en Azure DevOps, leer CLAUDE.md del proyecto antes de actuar, no lanzar agente sin spec aprobada, no subir secrets al repo, no `terraform apply` en PRO sin aprobación, siempre rama + PR. Detalle completo en [KPIs y reglas](docs/readme/10-kpis-reglas.md).
 
 ---
 
-## Reglas Críticas
+## Contribuir
 
-Estas son las reglas que nunca se saltan — ni yo misma:
+Con `/contribute` puedes crear PRs directamente. Con `/feedback` abrir issues. Antes de enviar, valido que no haya datos privados. Tu privacidad es lo primero.
 
-1. **NUNCA hardcodear el PAT** — siempre `$(cat $PAT_FILE)`
-2. **Confirmar antes de escribir** en Azure DevOps — pregunto antes de modificar datos
-3. **Leer CLAUDE.md del proyecto** antes de actuar sobre él
-4. **SDD**: NUNCA lanzar agente sin Spec aprobada; Code Review SIEMPRE humano
-5. **Secrets**: NUNCA connection strings, API keys o passwords en el repositorio
-6. **Infraestructura**: NUNCA `terraform apply` en PRE/PRO sin aprobación humana; siempre tier mínimo
-7. **Git**: NUNCA commit directo en `main` — siempre rama + PR
-8. **Comandos**: validar con `scripts/validate-commands.sh` antes de commit
-9. **Paralelo**: verificar solapamiento de scope antes de lanzar Agent Teams; serializar si hay conflicto
+Agradecimiento especial a [claude-code-templates](https://github.com/davila7/claude-code-templates) de [Daniel Avila](https://github.com/davila7) — el mayor marketplace de componentes para Claude Code (5.788+ componentes, 21K+ stars).
+
+> Changelog completo en [CHANGELOG.md](CHANGELOG.md) · Releases en [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
 
 ---
 
-## Historial de versiones
-
-> Changelog completo en [CHANGELOG.md](CHANGELOG.md) · Todas las releases en [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
-
-| Versión | Era | Resumen |
-|---|---|---|
-| **v2.4.0** | Era 29 | One-Line Installer — `curl \| bash` / `irm \| iex` para instalar Savia con un solo comando |
-| **v2.3.0** | Era 28 | Scoring Intelligence — curvas piecewise, `/score:diff`, severidad Rule of Three. Inspirado en kimun. |
-| **v2.2.0** | Era 27 | Best Practices Audit — guía CLAUDE.md de proyecto + auditoría de cobertura |
-| **v2.1.0** | Era 26 | Equality Shield — lucha contra sesgos de género basado en estudio LLYC |
-| **v2.0.0** | Era 25 | Quality Validation Framework: consenso multi-juez (3 jueces, scoring ponderado, veto security/GDPR), calibración de confianza (Brier score, decay, recovery), coherence-validator (Sonnet 4.6). 98 tests nuevos. |
-| **v1.9.1** | Era 24 | Reflection Validator: agente System 2 (Opus 4.6) + skill de validación meta-cognitiva. 65 tests nuevos. |
-| **v1.9.0** | Era 24 | Memory & NL: dimensión concepts, progressive disclosure 3 capas, token economics, session consolidation, auto-capture hook, hybrid search con scoring. NL→comando: intent catalog (60+ patrones), `/nl-query` reescrito, regla de resolución NL. 32 tests nuevos. |
-| **v1.8.0** | Era 23 | 10 guías de uso por escenario (Azure DevOps, Jira, Savia standalone, educación, hardware, investigación, startup, ONG, legal, sanidad). README reestructurado. 20 propuestas de gaps detectados. |
-| **v1.7.0** | Era 22 | Company Savia v3: aislamiento por ramas orphan, quality framework (reglas #21-#22), Agent Self-Memory, PII gate, drift detection. 120 tests Savia. |
-| **v1.6.0** | — | Company Savia v2: reestructuración de directorios, índices TSV, simplificación de rutas de usuario. |
-| **v0.99–v1.5.1** | Era 21 | Savia Everywhere: Company Savia, Git Persistence Engine, Savia Flow, Travel Mode, Savia School, cifrado E2E. |
-| **v0.91–v0.98** | Era 20 | Persistent Intelligence: agent memory, frontmatter inteligente, RPI workflow, PR Guardian, 3 modos output. |
-| **v0.90** | Era 19 | Open Source Synergy: integración con claude-code-templates, `/mcp-browse`, `/component-search`. |
-| **v0.84–v0.89** | Era 18 | Compliance & Hooks: `/aepd-compliance`, Excel reports, Savia Gallery, intelligent hooks. |
-| **v0.71–v0.72** | Era 17 | Observability & Traces: `/obs-connect`, `/trace-search`, `/error-investigate`. |
-
----
-
-## Agradecimiento especial
-
-Este proyecto se nutre del ecosistema open source de herramientas para Claude Code. Queremos dar un agradecimiento especial a:
-
-### [claude-code-templates](https://github.com/davila7/claude-code-templates)
-
-Creado por [Daniel Avila](https://github.com/davila7), claude-code-templates es el mayor marketplace de componentes para Claude Code: **5.788+ componentes** (agents, commands, hooks, MCPs, settings, skills), una **CLI para instalación** (`npx claude-code-templates@latest`), un **catálogo web** en [aitmpl.com](https://aitmpl.com) y un **dashboard** en [app.aitmpl.com](https://app.aitmpl.com). Con 21K+ stars, es referencia imprescindible para cualquier equipo que trabaje con Claude Code.
-
-pm-workspace integra componentes de este ecosistema y contribuye de vuelta con hooks enterprise, agentes de PM/Scrum y skills especializados. Si buscas herramientas libres para Claude Code, empieza por ahí.
-
-```bash
-# Instalar componentes del marketplace
-npx claude-code-templates@latest
-
-# Explorar desde pm-workspace
-/mcp-browse
-/component-search {término}
-```
-
----
-
-*🦉 Savia — PM-Workspace, tu PM automatizada con IA para equipos multi-lenguaje. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).*
+*🦉 Savia — tu PM automatizada con IA. Compatible con Azure DevOps, Jira y Savia Flow.*

--- a/docs/ai-augmentation-opportunities-en.md
+++ b/docs/ai-augmentation-opportunities-en.md
@@ -1,0 +1,82 @@
+# AI Augmentation Opportunities by Sector
+
+> 🦉 I'm Savia. This analysis identifies sectors where AI has the highest theoretical capability but the lowest real adoption — and how pm-workspace can help close that gap.
+
+---
+
+## The concept: AI Augmented Donut
+
+The "AI Augmented Donut" model (Anthropic, analyzed by Miguel Luengo-Oroz) compares two dimensions for each occupation: theoretical AI exposure (how much of that work could AI do) and observed adoption (how much is actually being used). The gap between them is the augmentation opportunity.
+
+Sectors with the largest gap would benefit most from well-designed AI tools — but are using them the least today.
+
+---
+
+## Sectors with the greatest opportunity
+
+| Sector | Theoretical capability | Real adoption | Gap | pm-workspace today |
+|---|---|---|---|---|
+| Healthcare (practitioners) | High | Low | Large | guide-healthcare.md |
+| Education & library | High | Low | Large | guide-education.md |
+| Social services | High | Very low | Very large | Does not exist |
+| Sales | High | Low | Large | Does not exist |
+| Legal | High | Medium-low | Large | guide-legal-firm.md |
+| Arts & media | High | Low | Large | Does not exist |
+| Business & finance | High | Medium | Medium | Partial (enterprise) |
+
+---
+
+## How pm-workspace already covers them
+
+**Healthcare** — The `guide-healthcare.md` adapts pm-workspace for healthcare organizations: continuous improvement protocols, HIPAA compliance, shift management, and clinical indicator tracking. Sprint and reporting commands apply to PDCA improvement cycles.
+
+**Education** — The `guide-education.md` and Savia School cover educational project management, competency assessment, student portfolios, and GDPR compliance for minors. Timesheets track teaching dedication.
+
+**Legal** — The `guide-legal-firm.md` adapts the workspace for law firms: case management as PBIs, legal deadlines as sprints, hourly billing integrated with cost-management, and sector compliance.
+
+---
+
+## Identified gaps
+
+### Social services (very large gap)
+
+**Opportunity:** Social case management, multi-agency coordination, beneficiary tracking, impact reporting for funders.
+
+**Applicable pm-workspace workflows:** Sprint management for intervention cycles, capacity planning for caseload distribution, time tracking for grant justification, executive reporting for activity reports.
+
+**Extension needed:** Domain entities (beneficiary, case, intervention), custom states (assessment → plan → follow-up → closure), social impact metrics.
+
+### Sales (large gap)
+
+**Opportunity:** Commercial pipeline management, sales forecasting, campaign coordination, performance reporting.
+
+**Applicable workflows:** Backlog management for pipeline (leads as PBIs), sprint for campaign cycles, velocity for conversion rate, stakeholder reports for sales leadership.
+
+**Extension needed:** Domain entities (lead, opportunity, account), funnel stages, commercial metrics (CAC, LTV, churn).
+
+### Arts & media (large gap)
+
+**Opportunity:** Creative production management, multidisciplinary team coordination, deliverable and review tracking, production budgets.
+
+**Applicable workflows:** Sprint for production cycles, spec-driven for creative briefs, code review adapted for content review, time tracking for production budgets.
+
+**Extension needed:** Domain entities (piece, campaign, brief), review states (draft → review → approval → publication), production metrics.
+
+---
+
+## Relationship with `/ai-exposure-audit`
+
+The `/ai-exposure-audit` command already calculates each role's AI exposure using O*NET data. It could be extended to show not just exposure but the augmentation gap: how much that role could benefit from tools like pm-workspace, comparing theoretical capability vs real adoption.
+
+This would transform the audit from a risk analysis ("Will AI replace me?") into an opportunity analysis ("Where can I multiply my impact with AI?").
+
+---
+
+## Next steps
+
+1. Create `guide-social-services.md` for the social services vertical
+2. Create `guide-sales.md` for the sales vertical
+3. Create `guide-arts-media.md` for the arts & media vertical
+4. Extend `/ai-exposure-audit` with the augmentation gap dimension
+
+> Source: Analysis based on Anthropic's "AI Augmented Donut" model, reviewed by Miguel Luengo-Oroz (2025).

--- a/docs/ai-augmentation-opportunities-es.md
+++ b/docs/ai-augmentation-opportunities-es.md
@@ -1,0 +1,82 @@
+# Oportunidades de AI Augmentation por sector
+
+> 🦉 Soy Savia. Este análisis identifica los sectores donde la IA tiene mayor capacidad teórica pero menor adopción real — y cómo pm-workspace puede ayudar a cerrar esa brecha.
+
+---
+
+## El concepto: AI Augmented Donut
+
+El modelo "AI Augmented Donut" (Anthropic, analizado por Miguel Luengo-Oroz) compara dos dimensiones para cada ocupación: la exposición teórica a la IA (cuánto de ese trabajo podría hacer una IA) y la adopción observada (cuánto se usa realmente). La brecha entre ambas es la oportunidad de augmentation.
+
+Los sectores con mayor brecha son los que más se beneficiarían de herramientas de IA bien diseñadas — pero donde menos se están usando hoy.
+
+---
+
+## Sectores con mayor oportunidad
+
+| Sector | Capacidad teórica | Adopción real | Brecha | pm-workspace hoy |
+|---|---|---|---|---|
+| Healthcare (profesionales) | Alta | Baja | Grande | guide-healthcare.md |
+| Educación y biblioteca | Alta | Baja | Grande | guide-education.md |
+| Servicios sociales | Alta | Muy baja | Muy grande | No existe |
+| Ventas | Alta | Baja | Grande | No existe |
+| Legal | Alta | Media-baja | Grande | guide-legal-firm.md |
+| Artes y medios | Alta | Baja | Grande | No existe |
+| Business y finanzas | Alta | Media | Media | Parcial (enterprise) |
+
+---
+
+## Cómo pm-workspace ya los cubre
+
+**Healthcare** — La guía `guide-healthcare.md` adapta pm-workspace para organizaciones sanitarias: protocolos de mejora continua, compliance HIPAA, gestión de turnos y seguimiento de indicadores clínicos. Los comandos de sprint y reporting se aplican a ciclos de mejora PDCA.
+
+**Educación** — La guía `guide-education.md` y Savia School cubren gestión de proyectos educativos, evaluación de competencias, portfolios de estudiantes y cumplimiento RGPD para menores. Los timesheets trackean dedicación docente.
+
+**Legal** — La guía `guide-legal-firm.md` adapta el workspace a bufetes: gestión de casos como PBIs, plazos legales como sprints, facturación por horas integrada con cost-management, y compliance sectorial.
+
+---
+
+## Gaps identificados
+
+### Servicios sociales (brecha muy grande)
+
+**Oportunidad:** Gestión de casos sociales, coordinación multi-agencia, seguimiento de beneficiarios, reporting de impacto para financiadores.
+
+**Workflows de pm-workspace aplicables:** Sprint management para ciclos de intervención, capacity planning para distribución de caseload, time tracking para justificación de subvenciones, executive reporting para memorias de actividad.
+
+**Extensión necesaria:** Entidades de dominio (beneficiario, caso, intervención), estados personalizados (valoración → plan → seguimiento → cierre), métricas de impacto social.
+
+### Ventas (brecha grande)
+
+**Oportunidad:** Gestión de pipeline comercial, forecasting de ventas, coordinación de campañas, reporting de performance.
+
+**Workflows aplicables:** Backlog management para el pipeline (leads como PBIs), sprint para ciclos de campaña, velocity para conversion rate, stakeholder reports para dirección comercial.
+
+**Extensión necesaria:** Entidades de dominio (lead, oportunidad, cuenta), funnel stages, métricas comerciales (CAC, LTV, churn).
+
+### Artes y medios (brecha grande)
+
+**Oportunidad:** Gestión de producción creativa, coordinación de equipos multidisciplinares, tracking de entregas y revisiones, presupuestos de producción.
+
+**Workflows aplicables:** Sprint para ciclos de producción, spec-driven para briefs creativos, code review adaptado a revisión de contenidos, time tracking para presupuestos de producción.
+
+**Extensión necesaria:** Entidades de dominio (pieza, campaña, brief), estados de revisión (draft → review → aprobación → publicación), métricas de producción.
+
+---
+
+## Relación con `/ai-exposure-audit`
+
+El comando `/ai-exposure-audit` ya calcula la exposición de cada rol a la IA usando datos O*NET. Se podría extender para mostrar no solo la exposición sino la brecha de augmentation: cuánto podría beneficiarse ese rol de herramientas como pm-workspace, comparando capacidad teórica vs adopción real.
+
+Esto convertiría el audit de un análisis de riesgo ("¿me va a reemplazar la IA?") en un análisis de oportunidad ("¿dónde puedo multiplicar mi impacto con IA?").
+
+---
+
+## Próximos pasos
+
+1. Crear `guide-social-services.md` con el vertical de servicios sociales
+2. Crear `guide-sales.md` con el vertical de ventas
+3. Crear `guide-arts-media.md` con el vertical de artes y medios
+4. Extender `/ai-exposure-audit` con la dimensión de brecha de augmentation
+
+> Fuente: Análisis basado en el modelo "AI Augmented Donut" de Anthropic, revisado por Miguel Luengo-Oroz (2025).

--- a/docs/data-flow-guide-en.md
+++ b/docs/data-flow-guide-en.md
@@ -1,0 +1,101 @@
+# Data Flow Guide
+
+> 🦉 I'm Savia. Here I explain how the parts of pm-workspace connect. Every piece of data that enters has a destination, and every report that comes out has a source. Nothing is lost, nothing is duplicated.
+
+---
+
+## Flow 1: Hours → Costs → Invoices → Reports
+
+```
+Team logs hours              Cost Management calculates    Billing             Leadership
+┌──────────────┐    ──→    ┌─────────────────┐    ──→    ┌──────────┐    ──→    ┌────────────┐
+│ /report-hours│           │ cost/hour × h    │           │ monthly  │           │ /ceo-report│
+│ /savia-timesheet│        │ per project      │           │ invoices │           │ margins    │
+└──────────────┘           └─────────────────┘           └──────────┘           └────────────┘
+```
+
+**How it works:** The team logs hours against PBIs (`/savia-timesheet` or Azure DevOps integration). The `cost-management` skill multiplies hours × cost/hour per profile. That generates billing data. `/ceo-report` aggregates margins per project.
+
+**Files involved:** `output/timesheets/` → in-memory calculations → `output/reports/`
+
+**Why it matters:** If hours aren't logged, costs are wrong, invoices fail, and the executive report doesn't reflect reality.
+
+---
+
+## Flow 2: Sprint → Velocity → Capacity → Alerts
+
+```
+Sprint items             Velocity trend         Capacity forecast         Alerts
+┌──────────────┐   ──→  ┌──────────────┐  ──→  ┌──────────────────┐  ──→  ┌────────────┐
+│ /sprint-status│        │ story points  │       │ Monte Carlo sim  │       │ /ceo-alerts│
+│ item states   │        │ last 6 sprints│       │ probability      │       │ burnout    │
+└──────────────┘        └──────────────┘       └──────────────────┘       └────────────┘
+```
+
+**How it works:** Each sprint closes with X story points completed. That feeds the velocity trend (moving average). With that velocity, `/capacity-forecast` runs Monte Carlo to predict if the next sprint is viable. If velocity drops and hours rise → burnout alert for PM and CEO.
+
+**Files involved:** `.claude/commands/sprint-*.md` → `output/sprint-snapshots/` → alerts in `output/alerts/`
+
+**Why it matters:** Without historical velocity, there's no prediction. Without prediction, the PM plans blind.
+
+---
+
+## Flow 3: Spec → Code → Tests → Deploy → Metrics
+
+```
+SDD spec generated      Agent implements        Code review + tests      DORA metrics
+┌──────────────┐  ──→  ┌──────────────┐  ──→  ┌──────────────────┐  ──→  ┌────────────┐
+│ /spec-generate│       │ worktree      │       │ pre-commit hooks  │       │ /kpi-dora  │
+│ exec contract │       │ handlers+tests│       │ quality gates     │       │ lead time  │
+└──────────────┘       └──────────────┘       └──────────────────┘       └────────────┘
+```
+
+**How it works:** The PO or Tech Lead generates a spec (`/spec-generate`). An agent (or human) implements in an isolated worktree. Pre-commit hooks validate size, schema, and rules. If they pass, a PR is created. Automated code review checks against domain rules. Tests update coverage. Everything is measured as DORA metrics.
+
+**Files involved:** `output/specs/` → `.claude/agents/developer-*.md` → `output/implementations/` → metrics in `/kpi-dora`
+
+**Why it matters:** This is the flow that allows a "developer" to be human or AI interchangeably. The spec is the contract that guarantees quality.
+
+---
+
+## Flow 4: Memory → Entities → Continuity
+
+```
+Day's decisions          Memory store           Entity recall          Next session
+┌──────────────┐   ──→  ┌──────────────┐  ──→  ┌──────────────┐  ──→  ┌──────────────┐
+│ conversation  │        │ JSONL + hash  │       │ stakeholders  │       │ /context-load│
+│ ADRs, changes │        │ dedup + topic │       │ components    │       │ auto-inject  │
+└──────────────┘        └──────────────┘       └──────────────┘       └──────────────┘
+```
+
+**How it works:** During a session, decisions are saved to the memory store (JSONL with hash deduplication). Entities (stakeholders, components, services) are tracked with `/entity-recall`. When starting a new session, `/context-load` automatically injects relevant context. The post-compaction hook preserves memory across sessions.
+
+**Files involved:** `output/.memory-store.jsonl` → filter by topic/project → context injection
+
+**Why it matters:** Without persistent memory, every session starts from zero. With it, Savia remembers who each stakeholder is, what was decided, and why.
+
+---
+
+## Hidden dependencies
+
+These are cross-signals I detect automatically:
+
+- **Low velocity + high hours** = possible burnout → alert to PM and CEO
+- **Low coverage + fast PRs** = quality at risk → alert to Tech Lead
+- **High WIP + growing cycle time** = bottleneck → alert to PO
+- **Rising costs + stable velocity** = operational inefficiency → CEO alert
+- **Specs without tests** = growing tech debt → blocked by quality gate
+
+---
+
+## File map
+
+| Data | Where it's generated | Where it's consumed |
+|---|---|---|
+| Logged hours | `output/timesheets/` | cost-management, `/report-hours` |
+| Project costs | in-memory calculation | invoices, `/ceo-report` |
+| Sprint snapshots | `output/sprint-snapshots/` | velocity, forecast, reports |
+| SDD specs | `output/specs/` | developer agents, code review |
+| Implementations | `output/implementations/` | tests, PRs, DORA |
+| Persistent memory | `output/.memory-store.jsonl` | context-load, entity-recall |
+| Executive reports | `output/reports/` | CEO, stakeholders, clients |

--- a/docs/data-flow-guide-es.md
+++ b/docs/data-flow-guide-es.md
@@ -1,0 +1,101 @@
+# Guía de flujo de datos
+
+> 🦉 Soy Savia. Aquí te explico cómo se conectan las partes de pm-workspace. Cada dato que entra tiene un destino, y cada informe que sale tiene un origen. Nada se pierde, nada se duplica.
+
+---
+
+## Flujo 1: Horas → Costes → Facturas → Informes
+
+```
+Equipo imputa horas          Cost Management calcula         Facturación         Dirección
+┌──────────────┐    ──→    ┌─────────────────┐    ──→    ┌──────────┐    ──→    ┌────────────┐
+│ /report-hours│           │ coste/hora × h   │           │ facturas │           │ /ceo-report│
+│ /savia-timesheet│        │ por proyecto     │           │ mensuales│           │ márgenes   │
+└──────────────┘           └─────────────────┘           └──────────┘           └────────────┘
+```
+
+**Cómo funciona:** El equipo imputa horas contra PBIs (`/savia-timesheet` o integración Azure DevOps). El skill `cost-management` multiplica horas × coste/hora por perfil. Eso genera los datos de facturación. El `/ceo-report` agrega márgenes por proyecto.
+
+**Ficheros involucrados:** `output/timesheets/` → cálculos en memoria → `output/reports/`
+
+**Por qué importa:** Si las horas no se imputan, los costes son incorrectos, las facturas fallan y el informe de dirección no refleja la realidad.
+
+---
+
+## Flujo 2: Sprint → Velocity → Capacity → Alertas
+
+```
+Items del sprint         Velocity trend         Capacity forecast         Alertas
+┌──────────────┐   ──→  ┌──────────────┐  ──→  ┌──────────────────┐  ──→  ┌────────────┐
+│ /sprint-status│        │ story points  │       │ Monte Carlo sim  │       │ /ceo-alerts│
+│ estados items │        │ últimos 6 sp  │       │ probabilidad     │       │ burnout    │
+└──────────────┘        └──────────────┘       └──────────────────┘       └────────────┘
+```
+
+**Cómo funciona:** Cada sprint cierra con X story points completados. Eso alimenta la velocity trend (media móvil). Con esa velocity, `/capacity-forecast` simula Monte Carlo para predecir si el próximo sprint es viable. Si la velocity baja y las horas suben → alerta de burnout para el PM y CEO.
+
+**Ficheros involucrados:** `.claude/commands/sprint-*.md` → `output/sprint-snapshots/` → alertas en `output/alerts/`
+
+**Por qué importa:** Sin velocity histórica, no hay predicción. Sin predicción, el PM planifica a ciegas.
+
+---
+
+## Flujo 3: Spec → Código → Tests → Deploy → Métricas
+
+```
+Spec SDD generada      Agente implementa       Code review + tests      DORA metrics
+┌──────────────┐  ──→  ┌──────────────┐  ──→  ┌──────────────────┐  ──→  ┌────────────┐
+│ /spec-generate│       │ worktree      │       │ hooks pre-commit  │       │ /kpi-dora  │
+│ contrato exec │       │ handlers+tests│       │ quality gates     │       │ lead time  │
+└──────────────┘       └──────────────┘       └──────────────────┘       └────────────┘
+```
+
+**Cómo funciona:** El PO o Tech Lead genera una spec (`/spec-generate`). Un agente (o humano) implementa en un worktree aislado. Los hooks pre-commit validan tamaño, schema y reglas. Si pasan, se crea PR. El code review automático verifica contra reglas de dominio. Los tests actualizan cobertura. Todo se mide como DORA metrics.
+
+**Ficheros involucrados:** `output/specs/` → `.claude/agents/developer-*.md` → `output/implementations/` → métricas en `/kpi-dora`
+
+**Por qué importa:** Este es el flujo que permite que un "developer" sea humano o IA indistintamente. La spec es el contrato que garantiza calidad.
+
+---
+
+## Flujo 4: Memoria → Entidades → Continuidad
+
+```
+Decisiones del día       Memory store           Entity recall          Próxima sesión
+┌──────────────┐   ──→  ┌──────────────┐  ──→  ┌──────────────┐  ──→  ┌──────────────┐
+│ conversación  │        │ JSONL + hash  │       │ stakeholders  │       │ /context-load│
+│ ADRs, cambios │        │ dedup + topic │       │ componentes   │       │ auto-inject  │
+└──────────────┘        └──────────────┘       └──────────────┘       └──────────────┘
+```
+
+**Cómo funciona:** Durante la sesión, las decisiones se guardan en el memory store (JSONL con deduplicación por hash). Las entidades (stakeholders, componentes, servicios) se trackean con `/entity-recall`. Al iniciar una nueva sesión, `/context-load` inyecta el contexto relevante automáticamente. El hook post-compactación preserva la memoria entre sesiones.
+
+**Ficheros involucrados:** `output/.memory-store.jsonl` → filtro por topic/project → inyección en contexto
+
+**Por qué importa:** Sin memoria persistente, cada sesión empieza de cero. Con ella, Savia recuerda quién es cada stakeholder, qué se decidió, y por qué.
+
+---
+
+## Dependencias ocultas
+
+Estas son señales cruzadas que detecto automáticamente:
+
+- **Velocity baja + horas altas** = posible burnout → alerta al PM y CEO
+- **Cobertura baja + PRs rápidos** = calidad en riesgo → alerta al Tech Lead
+- **WIP alto + cycle time creciente** = cuello de botella → alerta al PO
+- **Costes subiendo + velocity estable** = ineficiencia operativa → alerta CEO
+- **Specs sin tests** = deuda técnica creciente → bloqueo por quality gate
+
+---
+
+## Mapa de ficheros
+
+| Dato | Dónde se genera | Dónde se consume |
+|---|---|---|
+| Horas imputadas | `output/timesheets/` | cost-management, `/report-hours` |
+| Costes por proyecto | cálculo en memoria | facturas, `/ceo-report` |
+| Sprint snapshots | `output/sprint-snapshots/` | velocity, forecast, reports |
+| Specs SDD | `output/specs/` | agentes developer, code review |
+| Implementaciones | `output/implementations/` | tests, PRs, DORA |
+| Memoria persistente | `output/.memory-store.jsonl` | context-load, entity-recall |
+| Informes ejecutivos | `output/reports/` | CEO, stakeholders, clientes |

--- a/docs/quick-starts/quick-start-ceo.md
+++ b/docs/quick-starts/quick-start-ceo.md
@@ -1,0 +1,83 @@
+# Quick Start — CEO / CTO
+
+> 🦉 Hola. Soy Savia. Para ti filtro solo lo que requiere decisión de dirección: estado del portfolio, métricas DORA, gobernanza IA y alertas que no pueden esperar. Sin ruido, solo señal.
+
+---
+
+## Primeros 10 minutos
+
+```
+/portfolio-overview --deps
+```
+Vista bird's-eye de todos los proyectos: estado, dependencias entre equipos y semáforo de riesgo.
+
+```
+/ceo-alerts
+```
+Solo las alertas que requieren tu decisión: sprints en riesgo, presupuestos excedidos, incidentes abiertos.
+
+```
+/kpi-dora
+```
+Métricas DORA del equipo: deployment frequency, lead time, change failure rate, time to restore.
+
+---
+
+## Tu día a día
+
+**Lunes** — `/portfolio-overview` para la foto semanal. `/ceo-alerts` para lo urgente.
+
+**Quincenal** — `/ceo-report --format pptx` genera la presentación de dirección con semáforo, métricas y recomendaciones.
+
+**Mensual** — `/org-metrics --trend 6` para tendencias organizativas. `/ai-exposure-audit` para entender el impacto de la IA en los roles del equipo.
+
+**Trimestral** — `/governance-report` consolida el estado de compliance. `/okr-track --trend` muestra el progreso estratégico.
+
+---
+
+## Cómo hablarme
+
+| Tú dices... | Yo ejecuto... |
+|---|---|
+| "¿Cómo van los proyectos?" | `/portfolio-overview` |
+| "¿Qué necesita mi atención?" | `/ceo-alerts` |
+| "Dame el informe para el board" | `/ceo-report --format pptx` |
+| "¿Cómo estamos en DORA?" | `/kpi-dora` |
+| "¿Qué riesgo tiene la IA en el equipo?" | `/ai-exposure-audit` |
+| "¿Cumplimos con gobernanza?" | `/governance-report` |
+
+---
+
+## Dónde están tus ficheros
+
+```
+output/
+├── reports/
+│   ├── ceo-report-*.pptx   ← informes de dirección
+│   ├── portfolio-*.md       ← vistas de portfolio
+│   └── governance-*.md      ← informes de compliance
+└── alerts/                  ← histórico de alertas
+
+.claude/commands/
+├── ceo-*.md                 ← report, alerts
+├── portfolio-*.md           ← overview, deps
+├── governance-*.md          ← audit, report, certify
+└── ai-*.md                  ← exposure audit, model cards
+```
+
+---
+
+## Cómo se conecta tu trabajo
+
+Todo lo que ves en `/ceo-report` viene de abajo: las horas del equipo (imputación) → costes por proyecto (cost-management) → márgenes. La velocity del sprint → forecast de entrega. Los tests del QA → change failure rate (DORA). Los ADRs del Tech Lead → trazabilidad de decisiones. Las alertas de burnout del PM → wellbeing. Tu vista es la agregación de todo el trabajo del equipo, filtrada para que solo veas lo que necesitas decidir.
+
+El `/ai-exposure-audit` usa datos de O*NET para calcular cuánto de cada rol es automatizable con IA. Esto alimenta los reskilling plans y el workforce forecasting — decisiones estratégicas de dirección.
+
+---
+
+## Siguientes pasos
+
+- [AI Augmentation por sector](../ai-augmentation-opportunities-es.md)
+- [Gobernanza IA](../readme/10-kpis-reglas.md)
+- [Flujo de datos](../data-flow-guide-es.md)
+- [Guías por escenario](../guides/README.md)

--- a/docs/quick-starts/quick-start-developer.md
+++ b/docs/quick-starts/quick-start-developer.md
@@ -1,0 +1,83 @@
+# Quick Start — Developer
+
+> 🦉 Hola, Developer. Soy Savia. Te ayudo a saber qué hacer, implementar specs, ejecutar tests y mantener el foco. Tu sprint, tu código, tu ritmo.
+
+---
+
+## Primeros 10 minutos
+
+```
+/my-sprint
+```
+Tu vista personal del sprint: items asignados, estado, cycle time y prioridad.
+
+```
+/my-focus
+```
+Identifico tu item más prioritario y cargo todo su contexto (spec, ficheros relacionados, decisiones previas).
+
+```
+/code-patterns
+```
+Los patterns del proyecto con ejemplos reales del código existente. Útil si acabas de incorporarte.
+
+---
+
+## Tu día a día
+
+**Al empezar** — `/my-focus` para saber por dónde seguir. Si hay una spec SDD asignada, ya tengo todo el contexto cargado.
+
+**Al implementar** — `/spec-implement {spec}` lanza el flujo SDD: implemento handlers, repositorios y tests siguiendo la spec como contrato. Si prefieres hacerlo tú, la spec te dice exactamente qué ficheros crear y qué interfaces seguir.
+
+**Al terminar un bloque** — `/spec-verify {spec}` verifica que la implementación cumple la spec. Los hooks pre-commit validan tamaño, schema y reglas de dominio automáticamente.
+
+**Si te bloqueas** — `/memory-search {tema}` busca decisiones previas. `/entity-recall {componente}` recupera todo lo que sé de ese componente.
+
+**Viernes** — `/my-learning` analiza tu código de la semana y detecta oportunidades de mejora.
+
+---
+
+## Cómo hablarme
+
+| Tú dices... | Yo ejecuto... |
+|---|---|
+| "¿Qué tengo asignado?" | `/my-sprint` |
+| "¿Qué hago ahora?" | `/my-focus` |
+| "Implementa esta spec" | `/spec-implement {spec}` |
+| "¿Pasan los tests?" | `/spec-verify {spec}` |
+| "¿Cómo se hace X en este proyecto?" | `/code-patterns` + `/memory-search` |
+| "¿Qué decidimos sobre el módulo auth?" | `/entity-recall auth-service` |
+| "Revisa mi código" | `/spec-review {file}` |
+
+---
+
+## Dónde están tus ficheros
+
+```
+output/
+├── specs/              ← specs SDD generadas (contratos ejecutables)
+├── implementations/    ← código generado por agentes
+└── .memory-store.jsonl ← memoria con decisiones y contexto
+
+.claude/
+├── agents/developer-*.md  ← agentes de implementación (usan worktrees)
+├── commands/spec-*.md     ← comandos SDD
+└── rules/language/        ← reglas del lenguaje de tu proyecto
+```
+
+Los agentes developer trabajan en worktrees aislados (`isolation: worktree`). Esto significa que pueden implementar en paralelo sin conflictos de merge. Cuando terminan, el código se integra vía PR.
+
+---
+
+## Cómo se conecta tu trabajo
+
+Tu código empieza en una spec (`/spec-generate`). La spec define el contrato: qué hacer, qué interfaces seguir, qué tests pasar. Cuando implementas (tú o un agente), el code review automático verifica contra las reglas. Los tests actualizan la cobertura. La cobertura alimenta el QA dashboard. El cycle time de tus items alimenta la velocity del sprint, que el PM usa para forecasting. Si imputas horas, esas horas van a cost-management y de ahí a facturación.
+
+---
+
+## Siguientes pasos
+
+- [Spec-Driven Development](../readme/05-sdd.md)
+- [Estructura del workspace](../readme/02-estructura.md)
+- [Guía de flujo de datos](../data-flow-guide-es.md)
+- [Comandos completos](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts/quick-start-pm.md
+++ b/docs/quick-starts/quick-start-pm.md
@@ -1,0 +1,87 @@
+# Quick Start — PM / Scrum Master
+
+> 🦉 Hola, PM. Soy Savia. Voy a ser tu copiloto en la gestión de sprints, capacidad del equipo e informes. Aquí tienes lo esencial para empezar.
+
+---
+
+## Primeros 10 minutos
+
+Abre Claude Code en la raíz de pm-workspace y ejecuta estos tres comandos:
+
+```
+/sprint-status --project MiProyecto
+```
+Verás el burndown, items activos, alertas y capacidad restante del sprint actual.
+
+```
+/team-workload --project MiProyecto
+```
+Muestra la carga de cada miembro: horas asignadas vs disponibles, y detecta sobrecargas.
+
+```
+/daily-routine
+```
+Te propongo la rutina del día según tu rol: qué revisar, en qué orden, qué comandos usar.
+
+---
+
+## Tu día a día
+
+**Lunes** — `/sprint-status` para preparar la semana. Si hay items bloqueados, los verás en las alertas.
+
+**Cada mañana** — `/async-standup --compile` recoge los avances del equipo. Si alguien no reportó, te aviso.
+
+**Miércoles** — `/team-workload` a mitad de sprint para detectar desvíos. Si la velocity baja y las horas suben, puede ser burnout → `/wellbeing-check`.
+
+**Viernes de cierre** — `/sprint-review` genera el resumen. `/sprint-retro` estructura la retrospectiva con patrones detectados.
+
+**Fin de sprint** — `/report-hours` exporta la imputación a Excel. `/report-executive` genera el informe para dirección.
+
+---
+
+## Cómo hablarme
+
+No necesitas memorizar comandos. Puedes pedirme las cosas en lenguaje natural:
+
+| Tú dices... | Yo ejecuto... |
+|---|---|
+| "¿Cómo va el sprint?" | `/sprint-status` |
+| "¿Quién está sobrecargado?" | `/team-workload` + análisis de capacity |
+| "Necesito el informe para el cliente" | `/report-executive` o `/excel-report` |
+| "Prepara la daily de mañana" | `/async-standup --start` |
+| "Descompón este PBI en tareas" | `/pbi-decompose {id}` |
+| "¿Llegaremos a fin de sprint?" | `/sprint-forecast` con Monte Carlo |
+
+---
+
+## Dónde están tus ficheros
+
+```
+output/
+├── reports/           ← informes generados (Excel, PowerPoint)
+├── sprint-snapshots/  ← fotos del estado del sprint
+└── .memory-store.jsonl ← mi memoria persistente
+
+.claude/commands/
+├── sprint-*.md        ← comandos de sprint (plan, status, review, retro)
+├── report-*.md        ← comandos de reporting
+├── team-*.md          ← comandos de equipo y capacity
+└── pbi-*.md           ← gestión de backlog
+```
+
+Los informes se generan en `output/` con fecha en el nombre. Puedes abrirlos directamente o enviarlos.
+
+---
+
+## Cómo se conecta tu trabajo
+
+Las horas que imputa tu equipo (`/report-hours`) las uso para calcular costes por proyecto (`cost-management`). Esos costes alimentan las facturas y aparecen en el informe de dirección (`/ceo-report`). Si la velocity cae y las horas aumentan, activo alertas de burnout que el CEO ve en `/ceo-alerts`. Todo está conectado — tu trabajo como PM es el punto de entrada de datos que alimenta toda la cadena.
+
+---
+
+## Siguientes pasos
+
+- [Sprints e informes en detalle](../readme/04-uso-sprint-informes.md)
+- [Configuración avanzada](../readme/06-configuracion-avanzada.md)
+- [Guía de flujo de datos](../data-flow-guide-es.md)
+- [Comandos y agentes completos](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts/quick-start-po.md
+++ b/docs/quick-starts/quick-start-po.md
@@ -1,0 +1,82 @@
+# Quick Start — Product Owner
+
+> 🦉 Hola, Product Owner. Soy Savia. Te ayudo a medir el impacto de lo que entregas, gestionar stakeholders y mantener el backlog alineado con la estrategia. Aquí tienes lo esencial.
+
+---
+
+## Primeros 10 minutos
+
+```
+/value-stream-map --bottlenecks
+```
+Mapeo el flujo de valor end-to-end y detecto cuellos de botella. Verás dónde se pierde tiempo.
+
+```
+/backlog-prioritize --strategy-aligned
+```
+Priorizo el backlog alineándolo con los objetivos estratégicos (OKRs si están definidos).
+
+```
+/feature-impact --roi
+```
+Analizo el impacto de las features entregadas: ROI estimado, engagement y carga técnica generada.
+
+---
+
+## Tu día a día
+
+**Al empezar el sprint** — `/backlog-groom --top 10` revisa los 10 items más prioritarios. `/pbi-decompose` descompone los que están listos para desarrollo.
+
+**Semanal** — `/stakeholder-report` genera el informe para stakeholders con métricas de entrega y alineación de objetivos.
+
+**Antes de release** — `/release-readiness` verifica que todo está listo: capacidad técnica, riesgos mitigados, comunicación preparada.
+
+**Cada sprint** — `/outcome-track --release` registra los resultados de negocio de lo entregado. Esto es lo que demuestra valor.
+
+**Trimestralmente** — `/okr-track --trend` revisa el progreso de los OKRs. `/strategy-map` visualiza dependencias entre iniciativas.
+
+---
+
+## Cómo hablarme
+
+| Tú dices... | Yo ejecuto... |
+|---|---|
+| "¿Qué priorizo en el backlog?" | `/backlog-prioritize` |
+| "¿Cuál es el impacto de esta feature?" | `/feature-impact` |
+| "Prepara el informe para stakeholders" | `/stakeholder-report` |
+| "¿Estamos listos para la release?" | `/release-readiness` |
+| "Descompón este PBI" | `/pbi-decompose {id}` |
+| "¿Dónde perdemos tiempo en el flujo?" | `/value-stream-map --bottlenecks` |
+
+---
+
+## Dónde están tus ficheros
+
+```
+output/
+├── reports/           ← informes de stakeholders, feature impact
+├── backlog-snapshots/ ← snapshots del estado del backlog
+└── okr-tracking/      ← seguimiento de OKRs
+
+.claude/commands/
+├── backlog-*.md       ← groom, prioritize, patterns
+├── feature-*.md       ← feature impact analysis
+├── stakeholder-*.md   ← reporting para stakeholders
+├── okr-*.md           ← definición y tracking de OKRs
+└── release-*.md       ← readiness checks
+```
+
+---
+
+## Cómo se conecta tu trabajo
+
+Los PBIs que priorizas se descomponen en tasks que el equipo implementa. La velocity de esos items alimenta el sprint forecast del PM. El feature impact que mides se agrega en el portfolio overview del CEO. Los OKRs que defines alinean el backlog con la estrategia, y el value stream map muestra si el flujo es eficiente. Si detectas un cuello de botella, eso se traduce en acciones concretas para el Tech Lead (deuda técnica) o el PM (redistribución de carga).
+
+---
+
+## Siguientes pasos
+
+- [Sprints e informes](../readme/04-uso-sprint-informes.md)
+- [Flujo de datos](../data-flow-guide-es.md)
+- [Guías por escenario](../guides/README.md)
+- [Comandos completos](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts/quick-start-qa.md
+++ b/docs/quick-starts/quick-start-qa.md
@@ -1,0 +1,85 @@
+# Quick Start — QA
+
+> 🦉 Hola, QA. Soy Savia. Te ayudo con planes de pruebas, cobertura, regresión y quality gates. La calidad es mi obsesión tanto como la tuya.
+
+---
+
+## Primeros 10 minutos
+
+```
+/qa-dashboard MiProyecto
+```
+Panel de calidad: cobertura actual, tests flaky, bugs abiertos y escape rate.
+
+```
+/testplan-generate --sprint
+```
+Genero un plan de pruebas basado en los items del sprint actual y sus specs SDD.
+
+```
+/qa-regression-plan --pr {número}
+```
+Analizo el impacto de los cambios de un PR y recomiendo qué tests ejecutar.
+
+---
+
+## Tu día a día
+
+**Al empezar el sprint** — `/testplan-generate --sprint` para tener el plan de pruebas desde el día 1. Cada spec SDD ya define los criterios de aceptación.
+
+**Ante cada PR** — `/qa-regression-plan --pr {n}` calcula qué tests son necesarios. El code review automático ya verifica reglas de dominio.
+
+**Cuando llegan bugs** — `/qa-bug-triage {bug-id}` clasifica por severidad y detecta duplicados.
+
+**Mitad de sprint** — `/qa-dashboard --trend` para ver tendencias. Si la cobertura baja o los flaky tests suben, es momento de actuar.
+
+**Al cerrar sprint** — `/testplan-results` consolida los resultados. Estos datos alimentan el informe de dirección.
+
+---
+
+## Cómo hablarme
+
+| Tú dices... | Yo ejecuto... |
+|---|---|
+| "¿Cómo está la calidad?" | `/qa-dashboard` |
+| "Genera un plan de pruebas" | `/testplan-generate` |
+| "¿Qué tests necesita este PR?" | `/qa-regression-plan --pr` |
+| "Clasifica este bug" | `/qa-bug-triage {id}` |
+| "¿Hay tests flaky?" | `/qa-dashboard --trend` |
+| "¿La spec cubre todos los casos?" | `/spec-verify {spec}` |
+
+---
+
+## Dónde están tus ficheros
+
+```
+output/
+├── testplans/          ← planes de pruebas generados
+├── test-results/       ← resultados consolidados
+└── reports/            ← informes de calidad
+
+.claude/
+├── commands/
+│   ├── qa-*.md         ← dashboard, regression, bug triage
+│   ├── testplan-*.md   ← generación y seguimiento de testplans
+│   └── spec-verify*.md ← verificación de specs
+├── skills/
+│   └── coherence-check/ ← validación de coherencia spec↔implementación
+└── rules/domain/
+    └── eval-criteria.md ← criterios de evaluación (tipo: code)
+```
+
+---
+
+## Cómo se conecta tu trabajo
+
+Los specs SDD definen los criterios de aceptación que tú verificas. Cuando un agente implementa, los tests que genera siguen esos criterios. Tu `/qa-dashboard` agrega cobertura y escape rate, que alimentan las métricas DORA (change failure rate). Si un quality gate falla, bloquea el merge — eso lo ven el Tech Lead y el PM. Los resultados de tus testplans aparecen en el `/report-executive` que recibe dirección.
+
+---
+
+## Siguientes pasos
+
+- [Spec-Driven Development](../readme/05-sdd.md)
+- [KPIs y reglas](../readme/10-kpis-reglas.md)
+- [Guía de flujo de datos](../data-flow-guide-es.md)
+- [Comandos completos](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts/quick-start-tech-lead.md
+++ b/docs/quick-starts/quick-start-tech-lead.md
@@ -1,0 +1,87 @@
+# Quick Start — Tech Lead
+
+> 🦉 Hola, Tech Lead. Soy Savia. Te ayudo con la salud de la arquitectura, la deuda técnica, las code reviews y la coordinación técnica del equipo. Aquí tienes lo esencial.
+
+---
+
+## Primeros 10 minutos
+
+```
+/arch-health --drift --coupling
+```
+Analizo la arquitectura del proyecto: fitness functions, drift detection, métricas de acoplamiento.
+
+```
+/tech-radar MiProyecto
+```
+Mapeo el stack tecnológico con categorización adopt/trial/hold/retire.
+
+```
+/debt-analyze
+```
+Identifico hotspots de deuda técnica, coupling temporal y code smells, priorizados por impacto.
+
+---
+
+## Tu día a día
+
+**Cada mañana** — `/pr-pending` para ver PRs esperando review. `/spec-status` para el progreso de specs SDD.
+
+**Al revisar código** — `/pr-review {PR}` ejecuta análisis automático contra reglas de dominio. El hook pre-commit ya cachea SHA256 para no re-revisar ficheros sin cambios.
+
+**Semanal** — `/arch-health` para verificar que no hay drift arquitectónico. `/team-skills-matrix --bus-factor` para detectar conocimiento concentrado en una persona.
+
+**Ante incidentes** — `/incident-postmortem {desc}` estructura un postmortem blameless con timeline y root cause analysis.
+
+**Cada sprint** — `/debt-budget` para asignar presupuesto de deuda técnica con proyección de impacto en velocity.
+
+---
+
+## Cómo hablarme
+
+| Tú dices... | Yo ejecuto... |
+|---|---|
+| "¿Qué PRs están pendientes?" | `/pr-pending` |
+| "Revisa este PR" | `/pr-review {PR}` |
+| "¿Cómo está la arquitectura?" | `/arch-health` |
+| "¿Qué deuda técnica priorizo?" | `/debt-prioritize` |
+| "¿Quién sabe de este módulo?" | `/team-skills-matrix` |
+| "Hubo un incidente en producción" | `/incident-postmortem` |
+| "Genera un ADR para esta decisión" | `/adr-create {proy} {título}` |
+
+---
+
+## Dónde están tus ficheros
+
+```
+.claude/
+├── agents/
+│   ├── developer-*.md    ← agentes que implementan specs
+│   ├── code-reviewer.md  ← agente de code review
+│   └── architect.md      ← agente de arquitectura
+├── rules/language/       ← reglas por lenguaje (auto-carga por extensión)
+├── rules/domain/
+│   ├── tool-discovery.md ← capability groups para los 360+ comandos
+│   └── eval-criteria.md  ← criterios de evaluación de outputs
+└── commands/
+    ├── arch-*.md         ← comandos de arquitectura
+    ├── debt-*.md         ← comandos de deuda técnica
+    └── spec-*.md         ← comandos de SDD
+```
+
+Las reglas de lenguaje se cargan automáticamente cuando trabajo con ficheros de ese tipo. Si edito un `.cs`, se cargan las reglas de C#.
+
+---
+
+## Cómo se conecta tu trabajo
+
+Las specs SDD que generas (`/spec-generate`) son el contrato que ejecutan los agentes developer. Cuando un agente implementa, el code review automático verifica contra las reglas de dominio. Los tests pasan, se mergea, y las métricas DORA se actualizan automáticamente. Si un ADR cambia la arquitectura, `/arch-health` lo detecta como drift hasta que se acepta. La deuda técnica que priorizas impacta directamente en la velocity que ve el PM.
+
+---
+
+## Siguientes pasos
+
+- [Spec-Driven Development](../readme/05-sdd.md)
+- [Architecture Intelligence](../readme/12-comandos-agentes.md)
+- [Agent Teams SDD](../agent-teams-sdd.md)
+- [Guía de flujo de datos](../data-flow-guide-es.md)

--- a/docs/quick-starts_en/quick-start-ceo.md
+++ b/docs/quick-starts_en/quick-start-ceo.md
@@ -1,0 +1,83 @@
+# Quick Start — CEO / CTO
+
+> 🦉 Hi. I'm Savia. For you, I filter only what requires executive decisions: portfolio status, DORA metrics, AI governance, and alerts that can't wait. No noise, just signal.
+
+---
+
+## First 10 minutes
+
+```
+/portfolio-overview --deps
+```
+Bird's-eye view of all projects: status, cross-team dependencies, and risk traffic light.
+
+```
+/ceo-alerts
+```
+Only alerts that require your decision: at-risk sprints, exceeded budgets, open incidents.
+
+```
+/kpi-dora
+```
+Team DORA metrics: deployment frequency, lead time, change failure rate, time to restore.
+
+---
+
+## Your daily routine
+
+**Monday** — `/portfolio-overview` for the weekly snapshot. `/ceo-alerts` for what's urgent.
+
+**Biweekly** — `/ceo-report --format pptx` generates the board presentation with traffic lights, metrics, and recommendations.
+
+**Monthly** — `/org-metrics --trend 6` for organizational trends. `/ai-exposure-audit` to understand AI's impact on team roles.
+
+**Quarterly** — `/governance-report` consolidates compliance status. `/okr-track --trend` shows strategic progress.
+
+---
+
+## How to talk to me
+
+| You say... | I run... |
+|---|---|
+| "How are the projects going?" | `/portfolio-overview` |
+| "What needs my attention?" | `/ceo-alerts` |
+| "Give me the board report" | `/ceo-report --format pptx` |
+| "How are we doing on DORA?" | `/kpi-dora` |
+| "What's AI's risk to the team?" | `/ai-exposure-audit` |
+| "Are we meeting governance?" | `/governance-report` |
+
+---
+
+## Where your files are
+
+```
+output/
+├── reports/
+│   ├── ceo-report-*.pptx   ← executive reports
+│   ├── portfolio-*.md       ← portfolio views
+│   └── governance-*.md      ← compliance reports
+└── alerts/                  ← alert history
+
+.claude/commands/
+├── ceo-*.md                 ← report, alerts
+├── portfolio-*.md           ← overview, deps
+├── governance-*.md          ← audit, report, certify
+└── ai-*.md                  ← exposure audit, model cards
+```
+
+---
+
+## How your work connects
+
+Everything you see in `/ceo-report` comes from below: team hours (time tracking) → project costs (cost-management) → margins. Sprint velocity → delivery forecast. QA tests → change failure rate (DORA). Tech Lead ADRs → decision traceability. PM burnout alerts → wellbeing. Your view is the aggregation of all team work, filtered so you only see what needs your decision.
+
+The `/ai-exposure-audit` uses O*NET data to calculate how much of each role is automatable with AI. This feeds reskilling plans and workforce forecasting — strategic executive decisions.
+
+---
+
+## Next steps
+
+- [AI Augmentation by sector](../ai-augmentation-opportunities-en.md)
+- [AI governance](../readme_en/10-kpis-reglas.md)
+- [Data flow guide](../data-flow-guide-en.md)
+- [Scenario guides](../guides_en/README.md)

--- a/docs/quick-starts_en/quick-start-developer.md
+++ b/docs/quick-starts_en/quick-start-developer.md
@@ -1,0 +1,83 @@
+# Quick Start — Developer
+
+> 🦉 Hi, Developer. I'm Savia. I help you know what to do, implement specs, run tests, and stay focused. Your sprint, your code, your pace.
+
+---
+
+## First 10 minutes
+
+```
+/my-sprint
+```
+Your personal sprint view: assigned items, status, cycle time, and priority.
+
+```
+/my-focus
+```
+I identify your highest-priority item and load all its context (spec, related files, previous decisions).
+
+```
+/code-patterns
+```
+Project patterns with real code examples. Useful if you just joined the team.
+
+---
+
+## Your daily routine
+
+**Starting the day** — `/my-focus` to know where to pick up. If there's an assigned SDD spec, I already have all the context loaded.
+
+**When implementing** — `/spec-implement {spec}` launches the SDD flow: I implement handlers, repositories, and tests following the spec as contract. If you prefer to do it yourself, the spec tells you exactly which files to create and which interfaces to follow.
+
+**After finishing a block** — `/spec-verify {spec}` verifies the implementation meets the spec. Pre-commit hooks validate size, schema, and domain rules automatically.
+
+**If you're stuck** — `/memory-search {topic}` searches previous decisions. `/entity-recall {component}` retrieves everything I know about that component.
+
+**Friday** — `/my-learning` analyzes your week's code and spots improvement opportunities.
+
+---
+
+## How to talk to me
+
+| You say... | I run... |
+|---|---|
+| "What's assigned to me?" | `/my-sprint` |
+| "What should I do now?" | `/my-focus` |
+| "Implement this spec" | `/spec-implement {spec}` |
+| "Do the tests pass?" | `/spec-verify {spec}` |
+| "How do we do X in this project?" | `/code-patterns` + `/memory-search` |
+| "What did we decide about the auth module?" | `/entity-recall auth-service` |
+| "Review my code" | `/spec-review {file}` |
+
+---
+
+## Where your files are
+
+```
+output/
+├── specs/              ← generated SDD specs (executable contracts)
+├── implementations/    ← agent-generated code
+└── .memory-store.jsonl ← memory with decisions and context
+
+.claude/
+├── agents/developer-*.md  ← implementation agents (use worktrees)
+├── commands/spec-*.md     ← SDD commands
+└── rules/language/        ← your project's language rules
+```
+
+Developer agents work in isolated worktrees (`isolation: worktree`). This means they can implement in parallel without merge conflicts. When done, code integrates via PR.
+
+---
+
+## How your work connects
+
+Your code starts with a spec (`/spec-generate`). The spec defines the contract: what to do, which interfaces to follow, which tests to pass. When you implement (you or an agent), the automated code review checks against the rules. Tests update coverage. Coverage feeds the QA dashboard. Your items' cycle time feeds sprint velocity, which the PM uses for forecasting. If you log hours, those hours go to cost-management and from there to billing.
+
+---
+
+## Next steps
+
+- [Spec-Driven Development](../readme_en/05-sdd.md)
+- [Workspace structure](../readme_en/02-estructura.md)
+- [Data flow guide](../data-flow-guide-en.md)
+- [Full commands](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts_en/quick-start-pm.md
+++ b/docs/quick-starts_en/quick-start-pm.md
@@ -1,0 +1,87 @@
+# Quick Start — PM / Scrum Master
+
+> 🦉 Hi, PM. I'm Savia. I'll be your copilot for sprint management, team capacity, and reports. Here's the essentials to get started.
+
+---
+
+## First 10 minutes
+
+Open Claude Code at the pm-workspace root and run these three commands:
+
+```
+/sprint-status --project MyProject
+```
+You'll see the burndown, active items, alerts, and remaining capacity for the current sprint.
+
+```
+/team-workload --project MyProject
+```
+Shows each member's load: assigned vs available hours, and detects overloads.
+
+```
+/daily-routine
+```
+I suggest the day's routine based on your role: what to review, in what order, what commands to use.
+
+---
+
+## Your daily routine
+
+**Monday** — `/sprint-status` to set up the week. Blocked items show up in alerts.
+
+**Every morning** — `/async-standup --compile` collects team updates. If someone didn't report, I'll flag it.
+
+**Wednesday** — `/team-workload` mid-sprint to detect deviations. If velocity drops and hours rise, it could be burnout → `/wellbeing-check`.
+
+**Closing Friday** — `/sprint-review` generates the summary. `/sprint-retro` structures the retrospective with detected patterns.
+
+**End of sprint** — `/report-hours` exports time tracking to Excel. `/report-executive` generates the report for leadership.
+
+---
+
+## How to talk to me
+
+You don't need to memorize commands. You can ask me things in natural language:
+
+| You say... | I run... |
+|---|---|
+| "How's the sprint going?" | `/sprint-status` |
+| "Who's overloaded?" | `/team-workload` + capacity analysis |
+| "I need the client report" | `/report-executive` or `/excel-report` |
+| "Prepare tomorrow's daily" | `/async-standup --start` |
+| "Break down this PBI into tasks" | `/pbi-decompose {id}` |
+| "Will we finish the sprint?" | `/sprint-forecast` with Monte Carlo |
+
+---
+
+## Where your files are
+
+```
+output/
+├── reports/           ← generated reports (Excel, PowerPoint)
+├── sprint-snapshots/  ← sprint state snapshots
+└── .memory-store.jsonl ← my persistent memory
+
+.claude/commands/
+├── sprint-*.md        ← sprint commands (plan, status, review, retro)
+├── report-*.md        ← reporting commands
+├── team-*.md          ← team and capacity commands
+└── pbi-*.md           ← backlog management
+```
+
+Reports are generated in `output/` with dates in the filename. You can open them directly or send them.
+
+---
+
+## How your work connects
+
+The hours your team logs (`/report-hours`) feed into project costs (`cost-management`). Those costs generate invoices and show up in the executive report (`/ceo-report`). If velocity drops and hours increase, I trigger burnout alerts that the CEO sees in `/ceo-alerts`. Everything is connected — your work as PM is the data entry point that feeds the entire chain.
+
+---
+
+## Next steps
+
+- [Sprints and reports in detail](../readme_en/04-uso-sprint-informes.md)
+- [Advanced configuration](../readme_en/06-configuracion-avanzada.md)
+- [Data flow guide](../data-flow-guide-en.md)
+- [Full commands and agents](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts_en/quick-start-po.md
+++ b/docs/quick-starts_en/quick-start-po.md
@@ -1,0 +1,82 @@
+# Quick Start — Product Owner
+
+> 🦉 Hi, Product Owner. I'm Savia. I help you measure the impact of what you deliver, manage stakeholders, and keep the backlog aligned with strategy. Here's the essentials.
+
+---
+
+## First 10 minutes
+
+```
+/value-stream-map --bottlenecks
+```
+I map the end-to-end value stream and detect bottlenecks. You'll see where time is lost.
+
+```
+/backlog-prioritize --strategy-aligned
+```
+I prioritize the backlog aligning it with strategic goals (OKRs if defined).
+
+```
+/feature-impact --roi
+```
+I analyze the impact of delivered features: estimated ROI, engagement, and technical load generated.
+
+---
+
+## Your daily routine
+
+**Sprint start** — `/backlog-groom --top 10` reviews the top 10 items. `/pbi-decompose` breaks down those ready for development.
+
+**Weekly** — `/stakeholder-report` generates the stakeholder report with delivery metrics and objective alignment.
+
+**Before release** — `/release-readiness` verifies everything is ready: technical capacity, mitigated risks, prepared communications.
+
+**Each sprint** — `/outcome-track --release` records the business outcomes of what was delivered. This is what proves value.
+
+**Quarterly** — `/okr-track --trend` reviews OKR progress. `/strategy-map` visualizes dependencies between initiatives.
+
+---
+
+## How to talk to me
+
+| You say... | I run... |
+|---|---|
+| "What should I prioritize?" | `/backlog-prioritize` |
+| "What's the impact of this feature?" | `/feature-impact` |
+| "Prepare the stakeholder report" | `/stakeholder-report` |
+| "Are we ready for release?" | `/release-readiness` |
+| "Break down this PBI" | `/pbi-decompose {id}` |
+| "Where are we losing time in the flow?" | `/value-stream-map --bottlenecks` |
+
+---
+
+## Where your files are
+
+```
+output/
+├── reports/           ← stakeholder reports, feature impact
+├── backlog-snapshots/ ← backlog state snapshots
+└── okr-tracking/      ← OKR tracking
+
+.claude/commands/
+├── backlog-*.md       ← groom, prioritize, patterns
+├── feature-*.md       ← feature impact analysis
+├── stakeholder-*.md   ← stakeholder reporting
+├── okr-*.md           ← OKR definition and tracking
+└── release-*.md       ← readiness checks
+```
+
+---
+
+## How your work connects
+
+The PBIs you prioritize get broken down into tasks the team implements. The velocity of those items feeds the PM's sprint forecast. The feature impact you measure aggregates into the CEO's portfolio overview. The OKRs you define align the backlog with strategy, and the value stream map shows if the flow is efficient. If you detect a bottleneck, that translates into concrete actions for the Tech Lead (tech debt) or PM (load redistribution).
+
+---
+
+## Next steps
+
+- [Sprints and reports](../readme_en/04-uso-sprint-informes.md)
+- [Data flow](../data-flow-guide-en.md)
+- [Scenario guides](../guides_en/README.md)
+- [Full commands](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts_en/quick-start-qa.md
+++ b/docs/quick-starts_en/quick-start-qa.md
@@ -1,0 +1,85 @@
+# Quick Start — QA
+
+> 🦉 Hi, QA. I'm Savia. I help with test plans, coverage, regression, and quality gates. Quality is my obsession as much as yours.
+
+---
+
+## First 10 minutes
+
+```
+/qa-dashboard MyProject
+```
+Quality panel: current coverage, flaky tests, open bugs, and escape rate.
+
+```
+/testplan-generate --sprint
+```
+I generate a test plan based on the current sprint items and their SDD specs.
+
+```
+/qa-regression-plan --pr {number}
+```
+I analyze the impact of a PR's changes and recommend which tests to run.
+
+---
+
+## Your daily routine
+
+**Sprint start** — `/testplan-generate --sprint` to have the test plan from day 1. Each SDD spec already defines acceptance criteria.
+
+**On each PR** — `/qa-regression-plan --pr {n}` calculates which tests are needed. The automated code review already checks domain rules.
+
+**When bugs arrive** — `/qa-bug-triage {bug-id}` classifies by severity and detects duplicates.
+
+**Mid-sprint** — `/qa-dashboard --trend` for trends. If coverage drops or flaky tests rise, it's time to act.
+
+**Sprint close** — `/testplan-results` consolidates results. This data feeds the executive report.
+
+---
+
+## How to talk to me
+
+| You say... | I run... |
+|---|---|
+| "How's the quality?" | `/qa-dashboard` |
+| "Generate a test plan" | `/testplan-generate` |
+| "What tests does this PR need?" | `/qa-regression-plan --pr` |
+| "Classify this bug" | `/qa-bug-triage {id}` |
+| "Are there flaky tests?" | `/qa-dashboard --trend` |
+| "Does the spec cover all cases?" | `/spec-verify {spec}` |
+
+---
+
+## Where your files are
+
+```
+output/
+├── testplans/          ← generated test plans
+├── test-results/       ← consolidated results
+└── reports/            ← quality reports
+
+.claude/
+├── commands/
+│   ├── qa-*.md         ← dashboard, regression, bug triage
+│   ├── testplan-*.md   ← test plan generation and tracking
+│   └── spec-verify*.md ← spec verification
+├── skills/
+│   └── coherence-check/ ← spec↔implementation coherence validation
+└── rules/domain/
+    └── eval-criteria.md ← evaluation criteria (type: code)
+```
+
+---
+
+## How your work connects
+
+SDD specs define the acceptance criteria you verify. When an agent implements, the tests it generates follow those criteria. Your `/qa-dashboard` aggregates coverage and escape rate, which feed DORA metrics (change failure rate). If a quality gate fails, it blocks the merge — the Tech Lead and PM see this. Your test plan results appear in the `/report-executive` that leadership receives.
+
+---
+
+## Next steps
+
+- [Spec-Driven Development](../readme_en/05-sdd.md)
+- [KPIs and rules](../readme_en/10-kpis-reglas.md)
+- [Data flow guide](../data-flow-guide-en.md)
+- [Full commands](../readme/12-comandos-agentes.md)

--- a/docs/quick-starts_en/quick-start-tech-lead.md
+++ b/docs/quick-starts_en/quick-start-tech-lead.md
@@ -1,0 +1,87 @@
+# Quick Start — Tech Lead
+
+> 🦉 Hi, Tech Lead. I'm Savia. I help with architecture health, tech debt, code reviews, and technical team coordination. Here's the essentials.
+
+---
+
+## First 10 minutes
+
+```
+/arch-health --drift --coupling
+```
+I analyze the project's architecture: fitness functions, drift detection, coupling metrics.
+
+```
+/tech-radar MyProject
+```
+I map the tech stack with adopt/trial/hold/retire categorization.
+
+```
+/debt-analyze
+```
+I identify tech debt hotspots, temporal coupling, and code smells, prioritized by impact.
+
+---
+
+## Your daily routine
+
+**Every morning** — `/pr-pending` for PRs waiting for review. `/spec-status` for SDD spec progress.
+
+**When reviewing code** — `/pr-review {PR}` runs automated analysis against domain rules. The pre-commit hook already caches SHA256 to skip unchanged files.
+
+**Weekly** — `/arch-health` to verify no architectural drift. `/team-skills-matrix --bus-factor` to detect knowledge concentrated in one person.
+
+**On incidents** — `/incident-postmortem {desc}` structures a blameless postmortem with timeline and root cause analysis.
+
+**Each sprint** — `/debt-budget` to allocate tech debt budget with velocity impact projection.
+
+---
+
+## How to talk to me
+
+| You say... | I run... |
+|---|---|
+| "What PRs are pending?" | `/pr-pending` |
+| "Review this PR" | `/pr-review {PR}` |
+| "How's the architecture?" | `/arch-health` |
+| "What tech debt should I prioritize?" | `/debt-prioritize` |
+| "Who knows about this module?" | `/team-skills-matrix` |
+| "There was a production incident" | `/incident-postmortem` |
+| "Create an ADR for this decision" | `/adr-create {proj} {title}` |
+
+---
+
+## Where your files are
+
+```
+.claude/
+├── agents/
+│   ├── developer-*.md    ← agents that implement specs
+│   ├── code-reviewer.md  ← code review agent
+│   └── architect.md      ← architecture agent
+├── rules/language/       ← per-language rules (auto-load by extension)
+├── rules/domain/
+│   ├── tool-discovery.md ← capability groups for 360+ commands
+│   └── eval-criteria.md  ← output evaluation criteria
+└── commands/
+    ├── arch-*.md         ← architecture commands
+    ├── debt-*.md         ← tech debt commands
+    └── spec-*.md         ← SDD commands
+```
+
+Language rules auto-load when I work with files of that type. If I edit a `.cs`, C# rules are loaded.
+
+---
+
+## How your work connects
+
+The SDD specs you generate (`/spec-generate`) are the contract that developer agents execute. When an agent implements, the automated code review checks against domain rules. Tests pass, it merges, and DORA metrics update automatically. If an ADR changes the architecture, `/arch-health` detects it as drift until accepted. The tech debt you prioritize directly impacts the velocity the PM sees.
+
+---
+
+## Next steps
+
+- [Spec-Driven Development](../readme_en/05-sdd.md)
+- [Architecture Intelligence](../readme/12-comandos-agentes.md)
+- [Agent Teams SDD](../agent-teams-sdd.md)
+- [Data flow guide](../data-flow-guide-en.md)

--- a/docs/readme/01-introduccion.md
+++ b/docs/readme/01-introduccion.md
@@ -1,84 +1,88 @@
-# PM-Workspace — AI-Powered Project Management for Claude Code
+# Introducción a PM-Workspace
 
-[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/gonzalezpazmonica/pm-workspace?logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Contributors](https://img.shields.io/github/contributors/gonzalezpazmonica/pm-workspace)](CONTRIBUTORS.md)
-
-> Plataforma de gestión de proyectos **multi-lenguaje** con IA, impulsada por Claude Code como PM automatizada con capacidad de delegar implementación técnica a agentes de IA y gestionar infraestructura cloud. Compatible con Azure DevOps, Jira y Savia Flow (Git-native).
-
-> **🚀 ¿Primera vez aquí?** Consulta la [Guía de Adopción para Consultoras](../ADOPTION_GUIDE.md) — paso a paso desde el registro en Claude hasta la incorporación de proyectos y equipo.
+> 🦉 Soy Savia. Si acabas de llegar, esta página es para ti. En 5 minutos sabrás qué soy, qué puedo hacer por ti, y cómo empezar según tu rol.
 
 ---
 
 ## ¿Qué es esto?
 
-Este workspace convierte a Claude Code en un **Project Manager automatizado con IA** para proyectos de **cualquier lenguaje**. Funciona con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Soporta 16 lenguajes (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) con convenciones, reglas y agentes especializados para cada uno. Su característica más avanzada es el **Spec-Driven Development (SDD)**: un proceso en el que las tareas técnicas se documentan como contratos ejecutables, y Claude puede implementarlas como agente de código.
+PM-Workspace convierte a Claude Code en un Project Manager automatizado con IA. Gestiono sprints, backlog, agentes de código, infraestructura, facturación e informes — en 16 lenguajes, con Azure DevOps, Jira, o 100% Git-native (Savia Flow).
 
-**Gestión de sprints:** seguimiento de burndown, capacity del equipo, estado del board, KPIs, reportes automáticos de retrospectiva y review en Excel/PowerPoint.
-
-**Descomposición de PBIs:** Claude analiza el backlog, descompone cada PBI en tasks con estimación en horas, detecta el balance de carga del equipo y propone asignaciones con un algoritmo de scoring (expertise × disponibilidad × balance × crecimiento).
-
-**Spec-Driven Development:** las tasks se convierten en especificaciones ejecutables. Un "developer" puede ser un humano o un agente Claude. Claude puede implementar automáticamente handlers, repositorios, unit tests y más en el lenguaje del proyecto, siguiendo la spec como contrato.
-
-**Infraestructura como Código:** gestión multi-cloud (Azure, AWS, GCP) con detección automática de recursos existentes, creación al tier más bajo posible, y escalado solo con aprobación humana.
-
-**Multi-entorno:** soporte para DEV/PRE/PRO (o cualquier configuración personalizada) con protección de configuración confidencial — las connection strings y secrets nunca van al repositorio.
+Mi característica más avanzada es el **Spec-Driven Development**: las tareas se documentan como contratos ejecutables, y un agente (o humano) las implementa siguiendo ese contrato.
 
 ---
 
-## Ejemplo — Primeros cinco minutos con el workspace
+## ¿Quién eres?
 
-_Escenario: Es lunes por la mañana. Abres Claude Code por primera vez desde la raíz de `~/claude/`._
+Tu experiencia conmigo depende de tu rol. Ve directamente a tu quick-start:
 
-**Tú escribes:**
-```
-¿Qué proyectos tengo configurados y qué puedo hacer?
-```
+- **PM / Scrum Master** → [quick-start-pm](../quick-starts/quick-start-pm.md)
+- **Tech Lead** → [quick-start-tech-lead](../quick-starts/quick-start-tech-lead.md)
+- **Developer** → [quick-start-developer](../quick-starts/quick-start-developer.md)
+- **QA** → [quick-start-qa](../quick-starts/quick-start-qa.md)
+- **Product Owner** → [quick-start-po](../quick-starts/quick-start-po.md)
+- **CEO / CTO** → [quick-start-ceo](../quick-starts/quick-start-ceo.md)
 
-**Claude responde:**
+---
+
+## Ejemplo — Primeros 5 minutos
+
+_Escenario: Lunes por la mañana. Abres Claude Code en pm-workspace._
+
+**Tú:** `¿Qué proyectos tengo y qué puedo hacer?`
+
+**Savia:**
 ```
-Tengo configurados 2 proyectos activos:
-  • ProyectoAlpha  — equipo de 6 personas, sprint 2026-04 activo
-  • ProyectoBeta   — equipo de 4 personas, precio fijo, sprint 2026-04 activo
+Tengo 2 proyectos activos:
+  • ProyectoAlpha — equipo de 6, sprint 2026-04 activo
+  • ProyectoBeta  — equipo de 4, precio fijo
 
 Puedo ayudarte con:
-  Sprint      → /sprint-status, /sprint-plan, /sprint-review, /sprint-retro
-  Informes    → /report-hours, /report-executive, /report-capacity
-  Backlog     → /pbi-decompose, /pbi-plan-sprint, /pbi-assign
-  SDD (agentes) → /spec-generate, /agent-run, /spec-status
+  Sprint   → /sprint-status, /sprint-plan, /sprint-review
+  Informes → /report-hours, /report-executive
+  Backlog  → /pbi-decompose, /pbi-plan-sprint
+  SDD      → /spec-generate, /agent-run
 
-¿Por dónde quieres empezar? Si es lunes, te recomiendo /sprint-status
-para ver el estado actual del sprint antes de la Daily.
+¿Por dónde empezamos? Si es lunes, te recomiendo /sprint-status.
 ```
 
-**Tú escribes:**
+**Tú:** `/sprint-status --project ProyectoAlpha`
+
+**Savia:**
 ```
-/sprint-status --project ProyectoAlpha
-```
+Sprint 2026-04 · ProyectoAlpha · Día 6/10
+Burndown ████████░░░░░░░░ 40% ⚠️ por debajo del plan
 
-**Claude responde:**
-```
-══════════════════════════════════════════
-  Sprint 2026-04 · ProyectoAlpha · Día 6/10
-══════════════════════════════════════════
+Items activos: 4
+  AB#1021  POST /patients → Laura [3/5h]
+  AB#1022  Unit tests     → 🤖 agente [ejecutando]
+  AB#1023  Migración      → Diego [0/4h] ⚠️ sin avance
+  AB#1024  Swagger        → 🤖 agente [review]
 
-  Burndown  ████████░░░░░░░░  40% completado  ⚠️ por debajo del plan
-  Objetivo sprint: Módulo de Pacientes v2
-
-  Items activos (In Progress): 4
-    AB#1021  Crear endpoint POST /patients  → Laura S.   [3/5h]
-    AB#1022  Unit tests PatientService      → 🤖 agente  [En ejecución]
-    AB#1023  Migración tabla Alergias       → Diego T.   [0/4h] ⚠️ sin avance
-    AB#1024  Swagger annotations            → 🤖 agente  [Terminado, en Review]
-
-  🔴 Alertas:
-    • AB#1023 lleva 2 días sin movimiento — ¿está bloqueado?
-    • Burndown al 40% en día 6 → riesgo de no completar el sprint goal
-    • WIP actual: 4 items (límite configurado: 5) ✅
-
-  Capacidad restante: 68h humanas + ~12h de agente disponibles
+🔴 AB#1023 lleva 2 días sin movimiento
+🔴 Burndown al 40% en día 6 → riesgo de no completar
 ```
 
 ---
+
+## Dónde estamos en la documentación
+
+```
+docs/
+├── readme/
+│   ├── 01-introduccion.md    ← ESTÁS AQUÍ
+│   ├── 02-estructura.md      ← directorios y ficheros
+│   ├── 03-configuracion.md   ← PAT, constantes, setup
+│   ├── 04-uso-sprint-*.md    ← sprints e informes
+│   ├── 05-sdd.md             ← Spec-Driven Development
+│   └── ...                   ← 13 secciones en total
+├── quick-starts/             ← guías rápidas por rol
+├── guides/                   ← 13 guías por escenario
+└── data-flow-guide-es.md     ← cómo se conectan las partes
+```
+
+---
+
+## Siguiente paso
+
+Ve a tu [quick-start por rol](#quién-eres) o continúa con la [estructura del workspace](02-estructura.md).

--- a/docs/readme_en/01-introduction.md
+++ b/docs/readme_en/01-introduction.md
@@ -1,70 +1,88 @@
-# PM-Workspace — AI-Powered Project Management for Claude Code
+# Introduction to PM-Workspace
 
-## What is this?
-
-This workspace turns Claude Code into an **AI-powered automated Project Manager** for projects of **any programming language**. It works with Azure DevOps, Jira, or 100% Git-native via Savia Flow. It supports 16 languages (C#/.NET, TypeScript, Angular, React, Java/Spring, Python, Go, Rust, PHP/Laravel, Swift, Kotlin, Ruby, VB.NET, COBOL, Terraform, Flutter) with specialized conventions, rules, and agents for each. Its most advanced feature is **Spec-Driven Development (SDD)**: a process in which technical tasks are documented as executable contracts, and Claude can implement them as a coding agent.
-
-**Sprint management:** burndown tracking, team capacity, board status, KPIs, automatic retrospective and review reports in Excel/PowerPoint.
-
-**PBI decomposition:** Claude analyzes the backlog, breaks each PBI into tasks with hour estimates, detects team workload balance, and proposes assignments using a scoring algorithm (expertise × availability × balance × growth).
-
-**Spec-Driven Development:** tasks become executable specifications. A "developer" can be a human or a Claude agent. Claude can automatically implement handlers, repositories, unit tests, and more in the project's language — following the spec as a contract.
-
-**Infrastructure as Code:** multi-cloud management (Azure, AWS, GCP) with automatic detection of existing resources, creation at the lowest possible tier, and scaling only with human approval.
-
-**Multi-environment:** support for DEV/PRE/PRO (or any custom configuration) with confidential configuration protection — connection strings and secrets never go into the repository.
+> 🦉 I'm Savia. If you just arrived, this page is for you. In 5 minutes you'll know what I am, what I can do for you, and how to start based on your role.
 
 ---
 
-## EXAMPLE — First five minutes with the workspace
+## What is this?
 
-_Scenario: Monday morning. You open Claude Code for the first time from the `pm-workspace/` root._
+PM-Workspace turns Claude Code into an AI-powered automated Project Manager. I manage sprints, backlog, code agents, infrastructure, billing, and reports — in 16 languages, with Azure DevOps, Jira, or 100% Git-native (Savia Flow).
 
-**You type:**
-```
-What projects do I have configured and what can I do?
-```
+My most advanced feature is **Spec-Driven Development**: tasks are documented as executable contracts, and an agent (or human) implements them following that contract.
 
-**Claude responds:**
+---
+
+## Who are you?
+
+Your experience with me depends on your role. Go directly to your quick-start:
+
+- **PM / Scrum Master** → [quick-start-pm](../quick-starts_en/quick-start-pm.md)
+- **Tech Lead** → [quick-start-tech-lead](../quick-starts_en/quick-start-tech-lead.md)
+- **Developer** → [quick-start-developer](../quick-starts_en/quick-start-developer.md)
+- **QA** → [quick-start-qa](../quick-starts_en/quick-start-qa.md)
+- **Product Owner** → [quick-start-po](../quick-starts_en/quick-start-po.md)
+- **CEO / CTO** → [quick-start-ceo](../quick-starts_en/quick-start-ceo.md)
+
+---
+
+## Example — First 5 minutes
+
+_Scenario: Monday morning. You open Claude Code in pm-workspace._
+
+**You:** `What projects do I have and what can I do?`
+
+**Savia:**
 ```
-I have 2 active projects configured:
-  • ProjectAlpha  — 6-person team, sprint 2026-04 active
-  • ProjectBeta   — 4-person team, fixed price, sprint 2026-04 active
+I have 2 active projects:
+  • ProjectAlpha — 6-person team, sprint 2026-04 active
+  • ProjectBeta  — 4-person team, fixed price
 
 I can help you with:
-  Sprint        → /sprint-status, /sprint-plan, /sprint-review, /sprint-retro
-  Reports       → /report-hours, /report-executive, /report-capacity
-  Backlog       → /pbi-decompose, /pbi-plan-sprint, /pbi-assign
-  SDD (agents)  → /spec-generate, /agent-run, /spec-status
+  Sprint   → /sprint-status, /sprint-plan, /sprint-review
+  Reports  → /report-hours, /report-executive
+  Backlog  → /pbi-decompose, /pbi-plan-sprint
+  SDD      → /spec-generate, /agent-run
 
-Where do you want to start? If it's Monday, I recommend /sprint-status
-to see the current sprint state before the Daily standup.
+Where shall we start? If it's Monday, I recommend /sprint-status.
 ```
 
-**You type:**
+**You:** `/sprint-status --project ProjectAlpha`
+
+**Savia:**
 ```
-/sprint-status --project ProjectAlpha
+Sprint 2026-04 · ProjectAlpha · Day 6/10
+Burndown ████████░░░░░░░░ 40% ⚠️ below plan
+
+Active items: 4
+  AB#1021  POST /patients → Laura [3/5h]
+  AB#1022  Unit tests     → 🤖 agent [running]
+  AB#1023  Migration      → Diego [0/4h] ⚠️ no progress
+  AB#1024  Swagger        → 🤖 agent [review]
+
+🔴 AB#1023 has had no movement for 2 days
+🔴 Burndown at 40% on day 6 → risk of not completing
 ```
 
-**Claude responds:**
+---
+
+## Where we are in the documentation
+
 ```
-══════════════════════════════════════════
-  Sprint 2026-04 · ProjectAlpha · Day 6/10
-══════════════════════════════════════════
-
-  Burndown  ████████░░░░░░░░  40% complete  ⚠️ below plan
-  Sprint goal: Patient Module v2
-
-  Active items (In Progress): 4
-    AB#1021  Create POST /patients endpoint  → Laura S.   [3/5h]
-    AB#1022  Unit tests PatientService       → 🤖 agent   [Running]
-    AB#1023  Allergies table migration       → Diego T.   [0/4h] ⚠️ no progress
-    AB#1024  Swagger annotations             → 🤖 agent   [Done, in Review]
-
-  🔴 Alerts:
-    • AB#1023 has had no movement for 2 days — is it blocked?
-    • Burndown at 40% on day 6 → risk of not completing sprint goal
-    • Current WIP: 4 items (configured limit: 5) ✅
-
-  Remaining capacity: 68 human hours + ~12 agent hours available
+docs/
+├── readme_en/
+│   ├── 01-introduction.md    ← YOU ARE HERE
+│   ├── 02-structure.md       ← directories and files
+│   ├── 03-setup.md           ← PAT, constants, setup
+│   ├── 04-usage-sprint-*.md  ← sprints and reports
+│   ├── 05-sdd.md             ← Spec-Driven Development
+│   └── ...                   ← 13 sections total
+├── quick-starts_en/          ← role-based quick guides
+├── guides_en/                ← 13 scenario guides
+└── data-flow-guide-en.md     ← how the parts connect
 ```
+
+---
+
+## Next step
+
+Go to your [role quick-start](#who-are-you) or continue with [workspace structure](02-structure.md).

--- a/scripts/test-docs-overhaul.sh
+++ b/scripts/test-docs-overhaul.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# test-docs-overhaul.sh — Tests para Documentation Overhaul (Savia-led)
+set -euo pipefail
+PASS=0; FAIL=0; TOTAL=0
+check() { TOTAL=$((TOTAL+1)); if eval "$2" 2>/dev/null; then PASS=$((PASS+1)); echo "✅ $1"; else FAIL=$((FAIL+1)); echo "❌ $1"; fi; }
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🧪 Tests: Documentation Overhaul"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# === Sección 1: README ===
+echo -e "\n📋 Sección 1: README"
+check "README.md existe" "test -f README.md"
+check "README.en.md existe" "test -f README.en.md"
+check "README tiene sección roles" "grep -q '¿Quién eres?' README.md"
+check "README tiene flujo de datos" "grep -q 'fluye la información' README.md"
+check "README tiene estructura" "grep -q 'Dónde vive todo' README.md"
+check "README.en tiene roles" "grep -q 'Who are you' README.en.md"
+check "README.en tiene data flow" "grep -q 'information flows' README.en.md"
+check "README ≤150 líneas" "test $(wc -l < README.md) -le 150"
+check "README.en ≤150 líneas" "test $(wc -l < README.en.md) -le 150"
+
+# === Sección 2: Quick-starts ES ===
+echo -e "\n📋 Sección 2: Quick-starts ES"
+for role in pm tech-lead developer qa po ceo; do
+    F="docs/quick-starts/quick-start-$role.md"
+    check "QS-ES $role existe" "test -f $F"
+    check "QS-ES $role tiene Primeros 10" "grep -q 'Primeros 10' $F"
+    check "QS-ES $role tiene Cómo hablarme" "grep -q 'Cómo hablarme' $F"
+    check "QS-ES $role tiene ficheros" "grep -q 'Dónde están tus ficheros' $F"
+    check "QS-ES $role tiene conexión" "grep -q 'Cómo se conecta' $F"
+    check "QS-ES $role ≤150 líneas" "test $(wc -l < $F) -le 150"
+done
+
+# === Sección 3: Quick-starts EN ===
+echo -e "\n📋 Sección 3: Quick-starts EN"
+for role in pm tech-lead developer qa po ceo; do
+    F="docs/quick-starts_en/quick-start-$role.md"
+    check "QS-EN $role existe" "test -f $F"
+    check "QS-EN $role tiene First 10" "grep -q 'First 10' $F"
+    check "QS-EN $role tiene How to talk" "grep -q 'How to talk' $F"
+    check "QS-EN $role ≤150 líneas" "test $(wc -l < $F) -le 150"
+done
+
+# === Sección 4: Data flow guide ===
+echo -e "\n📋 Sección 4: Data Flow Guide"
+check "data-flow-guide-es.md existe" "test -f docs/data-flow-guide-es.md"
+check "data-flow-guide-en.md existe" "test -f docs/data-flow-guide-en.md"
+check "DFG-ES tiene 4 flujos" "test $(grep -c '^## Flujo' docs/data-flow-guide-es.md) -ge 4"
+check "DFG-EN tiene 4 flows" "test $(grep -c '^## Flow' docs/data-flow-guide-en.md) -ge 4"
+check "DFG-ES tiene dependencias ocultas" "grep -q 'Dependencias ocultas' docs/data-flow-guide-es.md"
+check "DFG-EN tiene hidden dependencies" "grep -q 'Hidden dependencies' docs/data-flow-guide-en.md"
+check "DFG-ES ≤150 líneas" "test $(wc -l < docs/data-flow-guide-es.md) -le 150"
+check "DFG-EN ≤150 líneas" "test $(wc -l < docs/data-flow-guide-en.md) -le 150"
+
+# === Sección 5: 01-introduccion ===
+echo -e "\n📋 Sección 5: 01-introduccion revisada"
+check "01-intro ES existe" "test -f docs/readme/01-introduccion.md"
+check "01-intro EN existe" "test -f docs/readme_en/01-introduction.md"
+check "01-intro ES tiene routing por rol" "grep -q 'quick-start' docs/readme/01-introduccion.md"
+check "01-intro EN tiene routing por rol" "grep -q 'quick-start' docs/readme_en/01-introduction.md"
+check "01-intro ES ≤100 líneas" "test $(wc -l < docs/readme/01-introduccion.md) -le 100"
+check "01-intro EN ≤100 líneas" "test $(wc -l < docs/readme_en/01-introduction.md) -le 100"
+
+# === Sección 6: AI Augmentation ===
+echo -e "\n📋 Sección 6: AI Augmentation Opportunities"
+check "AI-aug ES existe" "test -f docs/ai-augmentation-opportunities-es.md"
+check "AI-aug EN existe" "test -f docs/ai-augmentation-opportunities-en.md"
+check "AI-aug ES tiene 3+ gaps" "test $(grep -c '### ' docs/ai-augmentation-opportunities-es.md) -ge 3"
+check "AI-aug EN tiene 3+ gaps" "test $(grep -c '### ' docs/ai-augmentation-opportunities-en.md) -ge 3"
+check "AI-aug ES ref Donut" "grep -q 'Donut' docs/ai-augmentation-opportunities-es.md"
+check "AI-aug EN ref Donut" "grep -q 'Donut' docs/ai-augmentation-opportunities-en.md"
+check "AI-aug ES ≤150 líneas" "test $(wc -l < docs/ai-augmentation-opportunities-es.md) -le 150"
+check "AI-aug EN ≤150 líneas" "test $(wc -l < docs/ai-augmentation-opportunities-en.md) -le 150"
+
+# === Sección 7: Savia voice ===
+echo -e "\n📋 Sección 7: Savia voice check"
+check "README.md voz Savia" "grep -q 'Soy Savia' README.md"
+check "README.en voz Savia" "grep -q \"I'm Savia\" README.en.md"
+check "01-intro ES voz Savia" "grep -q 'Soy Savia' docs/readme/01-introduccion.md"
+check "01-intro EN voz Savia" "grep -q \"I'm Savia\" docs/readme_en/01-introduction.md"
+check "DFG-ES voz Savia" "grep -q 'Soy Savia' docs/data-flow-guide-es.md"
+check "DFG-EN voz Savia" "grep -q \"I'm Savia\" docs/data-flow-guide-en.md"
+
+# === Sección 8: Consistencia bilingüe ===
+echo -e "\n📋 Sección 8: Consistencia bilingüe"
+ES_QS=$(ls docs/quick-starts/quick-start-*.md 2>/dev/null | wc -l)
+EN_QS=$(ls docs/quick-starts_en/quick-start-*.md 2>/dev/null | wc -l)
+check "Mismo nº quick-starts ES/EN ($ES_QS/$EN_QS)" "test $ES_QS -eq $EN_QS"
+
+# === Resumen ===
+echo -e "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📊 Resultado: $PASS/$TOTAL passed | $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+[[ $FAIL -eq 0 ]] && echo "🎉 Todos los tests pasaron" || echo "⚠️  $FAIL tests fallaron"
+exit $FAIL


### PR DESCRIPTION
## Summary

- **README.md + README.en.md rewritten** — Savia as first-person narrator (~148 lines vs ~525 before), role routing table, ASCII data flow diagram, streamlined file structure tree
- **12 quick-start guides** (6 roles × 2 languages: PM, Tech Lead, Developer, QA, PO, CEO) — each with "First 10 minutes", "How to talk to me", file locations, and data flow connections
- **Bilingual data flow guide** — 4 core pipelines (hours→costs→invoices→reports, sprint→velocity→capacity→alerts, spec→code→tests→deploy→DORA, memory→entities→continuity) + hidden dependencies
- **01-introduccion revised** — Savia voice, role routing, compact example, documentation map
- **AI Augmentation Opportunities** (ES + EN) — Analysis based on Anthropic's "AI Augmented Donut" model identifying gaps in social services, sales, and arts & media verticals

## Test plan

- [x] `bash scripts/test-docs-overhaul.sh` — 98/98 tests passing
- [x] `bash scripts/validate-ci-local.sh` — 14/14 passed
- [ ] Manual review: README readability and Savia voice consistency
- [ ] Verify quick-start links work from README role table

🤖 Generated with [Claude Code](https://claude.com/claude-code)