### PR TITLE
feat: automated rule verification system (compliance gate)

### DIFF
--- a/.claude/commands/compliance-check.md
+++ b/.claude/commands/compliance-check.md
@@ -1,0 +1,54 @@
+---
+name: compliance-check
+description: Ejecuta todas las verificaciones de compliance de reglas
+model: haiku
+allowed-tools: ["Bash"]
+context_cost: low
+---
+
+# /compliance-check — Verificación de compliance de reglas
+
+Ejecuta el sistema de verificación automática de reglas de pm-workspace.
+
+## Qué verifica
+
+1. **Links de comparación en CHANGELOG** — Cada `## [X.Y.Z]` debe tener su `[X.Y.Z]: URL` al final
+2. **Tamaño de ficheros** — Commands, rules, skills ≤ 150 líneas
+3. **Frontmatter YAML** — Comandos nuevos deben tener frontmatter
+4. **READMEs** — Máximo 150 líneas, sincronización ES/EN
+
+## Parámetros
+
+- Sin parámetros: verifica ficheros staged
+- `--all`: verifica todo el repositorio
+
+## Ejecución
+
+```bash
+bash .claude/compliance/runner.sh --all
+```
+
+## Si hay violaciones
+
+1. Lee el mensaje de error — indica qué regla se ha violado
+2. Localiza la regla en `.claude/rules/domain/` para entender el contexto
+3. Corrige la violación
+4. Vuelve a ejecutar `/compliance-check` para verificar
+
+## Cómo funciona
+
+El sistema traduce reglas de prosa (`.claude/rules/domain/*.md`) a verificaciones ejecutables
+(`.claude/compliance/checks/*.sh`). Así, aunque el LLM pierda contexto en conversaciones largas,
+los scripts garantizan que las reglas objetivas se cumplen.
+
+**Reglas cubiertas automáticamente:**
+
+| Regla | Check | Tipo |
+|-------|-------|------|
+| `changelog-enforcement.md` | `validate-changelog-links.sh` | Bloqueante |
+| File size conventions | `check-file-size.sh` | Bloqueante |
+| Command validation | `check-command-frontmatter.sh` | Warning |
+| README conventions | `check-readme-sync.sh` | Bloqueante |
+
+Las reglas conversacionales (tone, workflow, inclusive-review) no son verificables por script
+y siguen dependiendo del contexto cargado en las rules de Claude Code.

--- a/.claude/compliance/RULES-COVERED.md
+++ b/.claude/compliance/RULES-COVERED.md
@@ -1,0 +1,37 @@
+# Cobertura de verificación automática de reglas
+
+## ✅ Verificaciones automáticas (pre-commit gate)
+
+Estas reglas se verifican por script antes de cada commit. No dependen del contexto del LLM.
+
+| Regla | Script de verificación | Severidad |
+|-------|----------------------|-----------|
+| `changelog-enforcement.md` | `scripts/validate-changelog-links.sh` | Bloqueante |
+| File size (commands ≤150) | `.claude/compliance/checks/check-file-size.sh` | Bloqueante |
+| Command frontmatter YAML | `.claude/compliance/checks/check-command-frontmatter.sh` | Warning |
+| README sync ES/EN | `.claude/compliance/checks/check-readme-sync.sh` | Bloqueante |
+
+## 🔄 Verificaciones contextuales (cargadas vía rules)
+
+Estas reglas dependen del contexto de la conversación. Se cargan automáticamente por globs.
+
+- `adaptive-output.md` — Tono y formato de salida
+- `inclusive-review.md` — Code reviews sin rejection sensitivity
+- `guided-work-protocol.md` — Protocolo de trabajo guiado
+- `accessibility-output.md` — Adaptaciones de accesibilidad
+- `pii-sanitization.md` — Datos personales (parcialmente verificable)
+- `security-check-patterns.md` — Patrones de seguridad (parcialmente verificable)
+
+## 📊 Cobertura
+
+- **4 reglas** verificadas automáticamente por script
+- **~80 reglas** dependen del contexto del LLM
+- Las 4 reglas automáticas cubren los errores recurrentes más frecuentes
+
+## Cómo añadir nuevas verificaciones
+
+1. Crear script en `.claude/compliance/checks/check-{nombre}.sh`
+2. El script recibe ficheros como argumentos
+3. Exit 0 = OK, exit 1 = violación
+4. Añadir llamada en `.claude/compliance/runner.sh`
+5. Actualizar esta tabla

--- a/.claude/compliance/checks/check-changelog-links.sh
+++ b/.claude/compliance/checks/check-changelog-links.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# check-changelog-links.sh — Verifica que cada versión en CHANGELOG.md tenga link de comparación
+# Regla: changelog-enforcement.md → "Link de comparación al final del fichero"
+set -euo pipefail
+
+FILE="${1:-CHANGELOG.md}"
+[[ -f "$FILE" ]] || { echo "⚠️  $FILE no encontrado"; exit 0; }
+
+VIOLATIONS=0
+
+# Extraer versiones del heading
+mapfile -t HEADINGS < <(grep -oP '(?<=^## \[)[0-9]+\.[0-9]+\.[0-9]+' "$FILE")
+
+# Extraer versiones con link de comparación
+mapfile -t LINKS < <(grep -oP '(?<=^\[)[0-9]+\.[0-9]+\.[0-9]+(?=\]: https://github\.com/)' "$FILE")
+
+for version in "${HEADINGS[@]}"; do
+  found=false
+  for link in "${LINKS[@]}"; do
+    if [[ "$version" == "$link" ]]; then
+      found=true
+      break
+    fi
+  done
+  if ! $found; then
+    echo "❌ Versión [$version] sin link de comparación al final del CHANGELOG"
+    ((VIOLATIONS++))
+  fi
+done
+
+if [[ $VIOLATIONS -eq 0 ]]; then
+  echo "✅ Todas las versiones tienen link de comparación"
+  exit 0
+else
+  echo "💡 Añadir al final: [$version]: https://github.com/.../compare/vAnterior...v$version"
+  exit 1
+fi

--- a/.claude/compliance/checks/check-command-frontmatter.sh
+++ b/.claude/compliance/checks/check-command-frontmatter.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# check-command-frontmatter.sh — Verifica YAML frontmatter en comandos staged
+# Regla: command-validation (convención pm-workspace)
+# Solo verifica ficheros que están staged (no legacy)
+set -euo pipefail
+
+VIOLATIONS=0
+
+# Obtener ficheros actualmente staged
+STAGED=$(git diff --cached --name-only 2>/dev/null || echo "")
+
+for file in "$@"; do
+  [[ -f "$file" ]] || continue
+  [[ "$file" =~ \.claude/commands/.+\.md$ ]] || continue
+
+  # Solo verificar si el fichero está staged (no pre-existente legacy)
+  if ! echo "$STAGED" | grep -q "$file"; then
+    continue
+  fi
+
+  # Debe empezar con ---
+  first_line=$(head -1 "$file")
+  if [[ "$first_line" != "---" ]]; then
+    echo "⚠️  $file: comando sin frontmatter YAML"
+    ((VIOLATIONS++))
+  fi
+done
+
+if [[ $VIOLATIONS -eq 0 ]]; then
+  echo "✅ Frontmatter de comandos OK"
+  exit 0
+else
+  exit 1
+fi

--- a/.claude/compliance/checks/check-file-size.sh
+++ b/.claude/compliance/checks/check-file-size.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# check-file-size.sh — Verifica que ficheros .md y .sh no excedan 150 líneas
+# Regla: file-size-limit (convención pm-workspace: commands ≤150, rules ≤150)
+# Excluye: CHANGELOG.md, docs/ largos históricos, projects/
+set -euo pipefail
+
+MAX_LINES=150
+VIOLATIONS=0
+
+EXCLUDES="CHANGELOG.md|ACKNOWLEDGMENTS.md|projects/|node_modules/|\.git/|rules/languages/|/references/"
+
+for file in "$@"; do
+  [[ -f "$file" ]] || continue
+  [[ "$file" =~ $EXCLUDES ]] && continue
+  # Solo .md en .claude/commands/, .claude/rules/, .claude/skills/
+  if [[ "$file" =~ \.claude/(commands|rules|skills)/.+\.md$ ]]; then
+    lines=$(wc -l < "$file")
+    if (( lines > MAX_LINES )); then
+      echo "❌ $file: $lines líneas (máx $MAX_LINES)"
+      ((VIOLATIONS++))
+    fi
+  fi
+done
+
+if [[ $VIOLATIONS -eq 0 ]]; then
+  echo "✅ Todos los ficheros dentro del límite de $MAX_LINES líneas"
+  exit 0
+else
+  exit 1
+fi

--- a/.claude/compliance/checks/check-readme-sync.sh
+++ b/.claude/compliance/checks/check-readme-sync.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# check-readme-sync.sh — Verifica que README.md ≤ 150 líneas y que README.en.md existe si README.md cambia
+# Regla: readme conventions (pm-workspace)
+set -euo pipefail
+
+VIOLATIONS=0
+FILES_CHANGED="$*"
+
+# Check README size
+for readme in README.md README.en.md; do
+  [[ -f "$readme" ]] || continue
+  lines=$(wc -l < "$readme")
+  if (( lines > 150 )); then
+    echo "❌ $readme: $lines líneas (máx 150)"
+    ((VIOLATIONS++))
+  fi
+done
+
+# Si README.md cambió, README.en.md debería cambiar también (bilingual sync)
+if echo "$FILES_CHANGED" | grep -q "README.md" && ! echo "$FILES_CHANGED" | grep -q "README.en.md"; then
+  echo "⚠️  README.md modificado pero README.en.md no — ¿falta sincronizar traducción?"
+  # Solo warning, no bloquea
+fi
+
+if [[ $VIOLATIONS -eq 0 ]]; then
+  echo "✅ READMEs dentro de límites"
+  exit 0
+else
+  exit 1
+fi

--- a/.claude/compliance/runner.sh
+++ b/.claude/compliance/runner.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# runner.sh — Orquestador de verificación de reglas
+#
+# Ejecuta checks de compliance sobre ficheros staged o sobre todo el repo.
+# Diseñado para ser llamado desde:
+#   1. Hook PreToolUse (antes de git commit)
+#   2. Manualmente: bash .claude/compliance/runner.sh --all
+#   3. Comando /compliance-check
+#
+# A diferencia de los hooks (que son warnings), este runner BLOQUEA.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKS_DIR="$SCRIPT_DIR/checks"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+MODE="${1:---staged}"
+VIOLATIONS=0
+WARNINGS=0
+
+cd "$PROJECT_DIR"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  COMPLIANCE RUNNER — Verificación de reglas"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Obtener ficheros a verificar
+if [[ "$MODE" == "--all" ]]; then
+  mapfile -t FILES < <(git ls-files -- '*.md' '*.sh' 2>/dev/null)
+else
+  mapfile -t FILES < <(git diff --cached --name-only 2>/dev/null)
+  if [[ ${#FILES[@]} -eq 0 ]]; then
+    mapfile -t FILES < <(git diff --name-only HEAD~1 2>/dev/null || echo "")
+  fi
+fi
+
+run_check() {
+  local name="$1" script="$2"
+  shift 2
+  echo "📋 $name"
+  if ! bash "$script" "$@"; then
+    ((VIOLATIONS++))
+  fi
+  echo ""
+}
+
+# --- Check 1: CHANGELOG links de comparación ---
+if echo "${FILES[*]}" | grep -q "CHANGELOG.md" || [[ "$MODE" == "--all" ]]; then
+  run_check "1. Links de comparación en CHANGELOG" \
+    "$PROJECT_DIR/scripts/validate-changelog-links.sh" \
+    "$PROJECT_DIR/CHANGELOG.md"
+else
+  echo "📋 1. Links de comparación en CHANGELOG"
+  echo "  ⏭️  CHANGELOG.md no modificado, skip"
+  echo ""
+fi
+
+# --- Check 2: Tamaño de ficheros (commands, rules, skills ≤ 150) ---
+CMD_RULE_FILES=()
+for f in "${FILES[@]}"; do
+  [[ "$f" =~ \.claude/(commands|rules|skills)/.+\.md$ ]] && CMD_RULE_FILES+=("$f")
+done
+if [[ ${#CMD_RULE_FILES[@]} -gt 0 ]]; then
+  run_check "2. Límite de líneas (≤150)" \
+    "$CHECKS_DIR/check-file-size.sh" "${CMD_RULE_FILES[@]}"
+else
+  echo "📋 2. Límite de líneas (≤150)"
+  echo "  ⏭️  Sin comandos/reglas/skills modificados"
+  echo ""
+fi
+
+# --- Check 3: Frontmatter de comandos ---
+CMD_FILES=()
+for f in "${FILES[@]}"; do
+  [[ "$f" =~ \.claude/commands/.+\.md$ ]] && CMD_FILES+=("$f")
+done
+if [[ ${#CMD_FILES[@]} -gt 0 ]]; then
+  run_check "3. Frontmatter YAML en comandos" \
+    "$CHECKS_DIR/check-command-frontmatter.sh" "${CMD_FILES[@]}"
+else
+  echo "📋 3. Frontmatter YAML en comandos"
+  echo "  ⏭️  Sin comandos modificados"
+  echo ""
+fi
+
+# --- Check 4: README sync ---
+run_check "4. READMEs (tamaño + sincronización)" \
+  "$CHECKS_DIR/check-readme-sync.sh" "${FILES[*]}"
+
+# --- Resumen ---
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ $VIOLATIONS -eq 0 ]]; then
+  echo "  ✅ Todas las verificaciones pasaron"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 0
+else
+  echo "  ❌ $VIOLATIONS verificación(es) fallida(s)"
+  echo ""
+  echo "  Corrige las violaciones antes de hacer commit."
+  echo "  Las reglas verificadas están en: .claude/rules/domain/"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 2
+fi

--- a/.claude/hooks/compliance-gate.sh
+++ b/.claude/hooks/compliance-gate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# compliance-gate.sh — Gate de compliance que bloquea commits con violaciones
+#
+# Se ejecuta como PreToolUse hook antes de git commit.
+# A diferencia de prompt-hook-commit.sh (warning), este BLOQUEA (exit 2).
+#
+# Verifica:
+#   1. Links de comparación en CHANGELOG.md
+#   2. Tamaño de ficheros (commands/rules/skills ≤ 150 líneas)
+#   3. Frontmatter YAML en comandos nuevos
+#   4. Sincronización de READMEs
+set -euo pipefail
+
+# Solo ejecutar en git commit
+INPUT="${CLAUDE_TOOL_INPUT:-}"
+if ! echo "$INPUT" | grep -q "git commit"; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+RUNNER="$PROJECT_DIR/.claude/compliance/runner.sh"
+
+if [[ ! -x "$RUNNER" ]]; then
+  chmod +x "$RUNNER" 2>/dev/null || true
+fi
+
+if [[ -f "$RUNNER" ]]; then
+  bash "$RUNNER" --staged
+  EXIT_CODE=$?
+  if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "" >&2
+    echo "🛑 COMPLIANCE GATE: Commit bloqueado por violación de reglas." >&2
+    echo "   Ejecuta: bash .claude/compliance/runner.sh --all para diagnóstico completo." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,6 +38,12 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prompt-hook-commit.sh",
             "timeout": 5,
             "statusMessage": "Prompt hook: validando semántica..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/compliance-gate.sh",
+            "timeout": 30,
+            "statusMessage": "Compliance gate: verificando reglas..."
           }
         ]
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.15.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.14.0...v2.15.0
 [2.14.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.10.0...v2.14.0
 [2.10.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.8.2...v2.9.0


### PR DESCRIPTION
## Summary

- **Sistema de verificación automática de reglas** que BLOQUEA commits con violaciones (no solo warning)
- Resuelve el problema de reglas ignoradas cuando el LLM pierde contexto en conversaciones largas
- Los scripts verifican reglas objetivas independientemente del contexto del LLM

## El problema

La regla `changelog-enforcement.md` tiene 3 niveles de protección (regla + script + hook) y aun así se violó. El hook estaba en modo `warning`, no `block`. Las reglas en prosa dependen de que el LLM las tenga en contexto.

## La solución

```
.claude/compliance/
├── runner.sh                          ← Orquestador
├── checks/
│   ├── check-changelog-links.sh       ← Links de comparación en CHANGELOG
│   ├── check-file-size.sh             ← Commands/rules/skills ≤ 150 líneas
│   ├── check-command-frontmatter.sh   ← YAML frontmatter en comandos
│   └── check-readme-sync.sh           ← README tamaño + sync ES/EN
├── RULES-COVERED.md                   ← Manifiesto de cobertura
.claude/hooks/compliance-gate.sh       ← Hook PreToolUse (bloquea git commit)
.claude/commands/compliance-check.md   ← Comando manual /compliance-check
```

- Hook `compliance-gate.sh` se ejecuta como PreToolUse antes de cada `git commit`
- Si hay violaciones → exit 2 → commit bloqueado
- Extensible: añadir nuevo check = script en `checks/` + llamada en `runner.sh`

## También corrige

- Link de comparación faltante `[2.15.0]` en CHANGELOG.md

## Test plan

- [x] `bash .claude/compliance/runner.sh --all` — 4/4 checks passed
- [x] `bash scripts/validate-changelog-links.sh` — all versions have links
- [x] `bash scripts/validate-ci-local.sh` — 14/14 green
- [x] Hook registered in `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)