### PR TITLE
feat: Era 48 — Insurance, Retail, Telco verticals (12 commands)

### DIFF
--- a/.claude/commands/capacity-forecast-telco.md
+++ b/.claude/commands/capacity-forecast-telco.md
@@ -1,0 +1,113 @@
+---
+title: "Previsión de Capacidad Telecomunicaciones"
+description: "Medición, previsión y planificación de capacidad de red con alertas automáticas"
+icon: "📊"
+category: "Telecomunicaciones"
+---
+
+# Previsión de Capacidad Telecomunicaciones
+
+Administra la medición de capacidad actual, previsión de necesidades futuras, planificación de expansión con análisis de costes y alertas automáticas de acercamiento a límites.
+
+## Subcomandos
+
+### measure
+Registra la utilización actual de capacidad por segmento de red.
+
+**Uso:** `capacity-forecast-telco measure [opciones]`
+
+**Parámetros:**
+- `--segmento` - Segmento de red (backbone, acceso, core, borde) (requerido)
+- `--utilizacion` - Porcentaje de utilización (0-100) (requerido)
+- `--capacidad-total` - Capacidad total en Gbps (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+capacity-forecast-telco measure \
+  --segmento "backbone" \
+  --utilizacion "65" \
+  --capacidad-total "500" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Crea registro en `projects/{proyecto}/telco/capacity/measurements.yaml` con timestamp de medición.
+
+### forecast
+Proyecta necesidades futuras de capacidad basadas en tendencias y crecimiento de suscriptores.
+
+**Uso:** `capacity-forecast-telco forecast [opciones]`
+
+**Parámetros:**
+- `--segmento` - Segmento de red (requerido)
+- `--periodos` - Número de meses a proyectar (requerido)
+- `--tasa-crecimiento` - Tasa de crecimiento esperada % (opcional)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+capacity-forecast-telco forecast \
+  --segmento "acceso" \
+  --periodos "12" \
+  --tasa-crecimiento "15" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Proyección mes a mes con estimación de cuándo se alcanzará 80% de utilización.
+
+### plan
+Crea un plan de expansión de capacidad con costes y timeline.
+
+**Uso:** `capacity-forecast-telco plan [opciones]`
+
+**Parámetros:**
+- `--segmento` - Segmento a expandir (requerido)
+- `--capacidad-adicional` - Capacidad a añadir en Gbps (requerido)
+- `--timeline` - Plazo de implementación en meses (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+capacity-forecast-telco plan \
+  --segmento "backbone" \
+  --capacidad-adicional "200" \
+  --timeline "6" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Plan guardado en `projects/{proyecto}/telco/capacity/plans/PLAN-NNNN.yaml` con:
+- Desglose de costes (equipamiento, instalación, personal)
+- Cronograma de implementación
+- Riesgos identificados
+- Alternativas evaluadas
+
+### alert
+Muestra segmentos que se aproximan a los límites de capacidad.
+
+**Uso:** `capacity-forecast-telco alert [opciones]`
+
+**Parámetros:**
+- `--umbral` - Umbral de alerta: 70, 80, 90 (opcional, default: 80)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+capacity-forecast-telco alert \
+  --umbral "80" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Lista segmentos en riesgo:
+```
+🔴 CRÍTICO (>90%): core — 92% utilización — ACCIÓN INMEDIATA
+🟡 ALTO (80-90%): acceso — 85% utilización — planificar expansión Q2
+🟢 NORMAL (<80%): borde — 45% utilización
+```
+
+## Almacenamiento
+
+Todos los datos se guardan en `projects/{proyecto}/telco/capacity/` con estructura YAML:
+- `measurements.yaml` — Mediciones históricas
+- `forecasts.yaml` — Proyecciones calculadas
+- `plans/` — Planes de expansión
+

--- a/.claude/commands/insurance-claim.md
+++ b/.claude/commands/insurance-claim.md
@@ -1,0 +1,89 @@
+---
+name: insurance-claim
+description: >
+  Gestiona reclamaciones de seguros: apertura, investigación, resolución, listado y reportes.
+  Almacena en projects/{proyecto}/insurance/claims/ con identificadores CLM-NNN.
+  Enlaza con pólizas e incluye notas de investigación y asignación de ajustador.
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+  - Bash
+---
+
+# /insurance-claim {proyecto} {subcomando} [opciones]
+
+## Subcomandos
+
+### open
+```bash
+/insurance-claim {proyecto} open \
+  --policy POL-NNN \
+  --date {YYYY-MM-DD} \
+  --type {siniestro|accidente|robo|daño} \
+  --description "Descripción del evento" \
+  --estimated-amount {monto}
+```
+Registra CLM-NNN vinculado a póliza, estado ABIERTA.
+
+### investigate
+```bash
+/insurance-claim {proyecto} investigate \
+  --claim-id CLM-NNN \
+  --notes "Notas de investigación" \
+  --adjuster "Nombre ajustador"
+```
+Añade notas, asigna adjuster, estado INVESTIGACIÓN.
+
+### resolve
+```bash
+/insurance-claim {proyecto} resolve \
+  --claim-id CLM-NNN \
+  --resolution {approved|denied|partial} \
+  --payout {monto}
+```
+Cierra claim, registra resolución y monto pagado.
+
+### list
+```bash
+/insurance-claim {proyecto} list \
+  [--status {ABIERTA|INVESTIGACIÓN|RESUELTA}] \
+  [--policy POL-NNN] \
+  [--type {tipo}] \
+  [--date-from] [--date-to]
+```
+Tabla: CLM-NNN, póliza, tipo, estado, fecha, monto estimado.
+
+### report
+```bash
+/insurance-claim {proyecto} report
+```
+Resumen: frecuencia, severidad, ratio de pérdida por tipo.
+
+## Estructura de datos
+
+```yaml
+id: CLM-NNN
+policy_ref: POL-NNN
+date_opened: YYYY-MM-DD
+type: siniestro|accidente|robo|daño
+description: Texto
+estimated_amount: XXX.XX
+status: ABIERTA|INVESTIGACIÓN|RESUELTA
+investigation:
+  notes: []
+  adjuster: Nombre
+  assigned_date: YYYY-MM-DD
+resolution:
+  resolution_type: approved|denied|partial
+  payout_amount: XXX.XX
+  date_resolved: YYYY-MM-DD
+```
+
+## Reglas
+
+- CLM-NNN numeración secuencial (3 dígitos)
+- Debe referenciar póliza existente
+- Investigación requiere adjuster asignado
+- Resolución cierra reclamación
+- Frecuencia de reclamaciones afecta risk_profile en póliza

--- a/.claude/commands/insurance-policy.md
+++ b/.claude/commands/insurance-policy.md
@@ -1,0 +1,97 @@
+---
+name: insurance-policy
+description: >
+  Gestiona pólizas de seguros: creación, renovación, cancelación, listado y comparación.
+  Almacena en projects/{proyecto}/insurance/policies/ con identificadores POL-NNN.
+  Rastrea endorsos, reclamaciones y perfil de riesgo.
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+  - Bash
+---
+
+# /insurance-policy {proyecto} {subcomando} [opciones]
+
+## Subcomandos
+
+### create
+```bash
+/insurance-policy {proyecto} create \
+  --holder "Titular" \
+  --type {vida|auto|hogar|salud|responsabilidad} \
+  --coverage "Descripción" \
+  --premium {monto} \
+  --start {YYYY-MM-DD} \
+  --end {YYYY-MM-DD} \
+  --beneficiaries "Nombre1, Nombre2"
+```
+Crea POL-NNN con timestamp, estado ACTIVA.
+
+### renew
+```bash
+/insurance-policy {proyecto} renew \
+  --policy-id POL-NNN \
+  --new-end {YYYY-MM-DD} \
+  --new-premium {monto}
+```
+Extiende vigencia, crea endorsement record.
+
+### cancel
+```bash
+/insurance-policy {proyecto} cancel \
+  --policy-id POL-NNN \
+  --reason {texto} \
+  --date {YYYY-MM-DD}
+```
+Marca como CANCELADA, registra motivo y fecha.
+
+### list
+```bash
+/insurance-policy {proyecto} list \
+  [--type {tipo}] \
+  [--status {ACTIVA|CANCELADA|VENCIDA}] \
+  [--expiring-days N]
+```
+Tabla: POL-NNN, titular, tipo, estado, fecha fin, prima.
+
+### compare
+```bash
+/insurance-policy {proyecto} compare \
+  --policy-1 POL-NNN \
+  --policy-2 POL-MMM
+```
+Matriz de diferencias: cobertura, prima, beneficiarios.
+
+## Estructura de datos
+
+```yaml
+id: POL-NNN
+holder: Nombre
+type: vida|auto|hogar|salud|responsabilidad
+coverage: Descripción
+premium:
+  amount: XXX.XX
+  currency: EUR
+period:
+  start: YYYY-MM-DD
+  end: YYYY-MM-DD
+beneficiaries:
+  - name: Nombre
+    relationship: relación
+status: ACTIVA|CANCELADA|VENCIDA
+endorsements:
+  - date: YYYY-MM-DD
+    change: descripción
+claims_count: N
+risk_profile: bajo|medio|alto
+```
+
+## Reglas
+
+- POL-NNN numeración secuencial (3 dígitos)
+- Premium positivo en EUR
+- Start date ≤ end date
+- Cambios en póliza activa generan endorsement
+- Cancelaciones requieren motivo explícito
+- Risk profile se calcula desde frecuencia de reclamaciones

--- a/.claude/commands/inventory-manage.md
+++ b/.claude/commands/inventory-manage.md
@@ -1,0 +1,96 @@
+---
+title: "Gestión de Inventario"
+description: "Gestiona inventario: stock, reordenes, transferencias, conteos, alertas"
+section: "Retail/eCommerce"
+category: "Inventory Management"
+keywords: ["inventario", "stock", "almacén", "reorden"]
+author: "Claude Code"
+---
+
+## Descripción
+
+Comando para gestionar el inventario del proyecto de retail. Permite consultar niveles de stock, generar órdenes de compra automáticas, registrar transferencias entre ubicaciones, realizar conteos físicos y monitorizar alertas de stock.
+
+Almacenamiento: `projects/{proyecto}/retail/inventory/`
+
+## Subcomandos
+
+### stock
+Muestra niveles de stock actuales por producto o almacén.
+
+```
+savia inventory-manage stock \
+  --product SKU-0001 \
+  --warehouse "Almacén Central" \
+  --group-by "location"
+```
+
+**Parámetros:**
+- `--product`: SKU específico (opcional)
+- `--warehouse`: Almacén específico (opcional)
+- `--group-by`: (product/location/category)
+
+### reorder
+Genera órdenes de compra automáticas cuando stock está bajo reorden.
+
+```
+savia inventory-manage reorder \
+  --threshold-percent 30 \
+  --auto-generate true \
+  --output PO-20260306.md
+```
+
+**Parámetros:**
+- `--threshold-percent`: Porcentaje para generar orden
+- `--auto-generate`: (true/false)
+- `--output`: Nombre fichero de salida
+
+### transfer
+Registra transferencia de inventario entre ubicaciones.
+
+```
+savia inventory-manage transfer \
+  --sku SKU-0001 \
+  --quantity 50 \
+  --from "Almacén Central" \
+  --to "Almacén Regional" \
+  --reference TRF-20260306-001
+```
+
+**Parámetros:**
+- `--sku`: Producto a transferir
+- `--quantity`: Cantidad
+- `--from`: Ubicación origen
+- `--to`: Ubicación destino
+- `--reference`: ID de transferencia
+
+### count
+Registra recuento físico de inventario con varianzas.
+
+```
+savia inventory-manage count \
+  --location "Almacén Central" \
+  --type "cycle-count" \
+  --variance-report true
+```
+
+**Parámetros:**
+- `--location`: Almacén a contar
+- `--type`: (full-count/cycle-count)
+- `--variance-report`: Generar informe de varianzas
+
+### alert
+Muestra alertas de inventario activas.
+
+```
+savia inventory-manage alert \
+  --type "low-stock" \
+  --severity "critical" \
+  --warehouse "Almacén Central"
+```
+
+**Tipos de alerta:**
+- `low-stock`: Stock bajo reorden
+- `overstock`: Exceso de inventario
+- `dead-stock`: Producto sin movimiento >90 días
+- `expiry-soon`: Vencimiento próximo

--- a/.claude/commands/network-incident.md
+++ b/.claude/commands/network-incident.md
@@ -1,0 +1,123 @@
+---
+title: "Incidentes de Red Telecomunicaciones"
+description: "Gestión del ciclo de vida de incidentes de red con reporte, clasificación, escalado y resolución"
+icon: "🚨"
+category: "Telecomunicaciones"
+---
+
+# Incidentes de Red Telecomunicaciones
+
+Administra el ciclo de vida completo de incidentes de red incluyendo reportes, clasificación por procesos eTOM, escalado entre niveles y resolución con análisis de cumplimiento SLA.
+
+## Subcomandos
+
+### report
+Registra un nuevo incidente de red con identificador único (NI-NNNN).
+
+**Uso:** `network-incident report [opciones]`
+
+**Parámetros:**
+- `--tipo` - Tipo de incidente: outage, degradation, maintenance (requerido)
+- `--area-afectada` - Área geográfica o de red afectada (requerido)
+- `--impacto` - Descripción del impacto en servicios (requerido)
+- `--severidad` - Nivel de severidad: crítica, alta, media, baja (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+network-incident report \
+  --tipo outage \
+  --area-afectada "Región Metropolitana - Zona Norte" \
+  --impacto "Pérdida total de servicio de datos a 5000 clientes" \
+  --severidad crítica \
+  --proyecto mi-telco
+```
+
+**Resultado:** Crea archivo `projects/{proyecto}/telco/incidents/NI-NNNN.yaml` con datos del incidente registrado.
+
+### classify
+Categoriza un incidente según las áreas de proceso eTOM (Operaciones, Gestión y Mantenimiento).
+
+**Uso:** `network-incident classify [opciones]`
+
+**Parámetros:**
+- `--incidente` - Identificador del incidente (requerido)
+- `--area-etom` - Área eTOM de clasificación (requerido)
+- `--causa-raiz` - Descripción preliminar de causa raíz (opcional)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+network-incident classify \
+  --incidente NI-0001 \
+  --area-etom "Gestión de Infraestructura de Red" \
+  --causa-raiz "Fallo de equipo de enrutamiento en nodo central" \
+  --proyecto mi-telco
+```
+
+### escalate
+Escala un incidente al siguiente nivel de soporte con notas técnicas.
+
+**Uso:** `network-incident escalate [opciones]`
+
+**Parámetros:**
+- `--incidente` - Identificador del incidente (requerido)
+- `--nivel` - Nivel de escalado: 1, 2, 3, especialista (requerido)
+- `--notas` - Notas técnicas para el siguiente nivel (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+network-incident escalate \
+  --incidente NI-0001 \
+  --nivel 3 \
+  --notas "Se requiere intervención de especialista en enrutamiento. Verificar configuración BGP." \
+  --proyecto mi-telco
+```
+
+### resolve
+Cierra un incidente registrando la causa raíz y la resolución aplicada.
+
+**Uso:** `network-incident resolve [opciones]`
+
+**Parámetros:**
+- `--incidente` - Identificador del incidente (requerido)
+- `--causa-raiz` - Causa raíz identificada (requerido)
+- `--resolucion` - Descripción de la resolución (requerido)
+- `--duracion` - Duración total del incidente en minutos (opcional)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+network-incident resolve \
+  --incidente NI-0001 \
+  --causa-raiz "Degradación de la interfaz de enrutamiento por sobrecarga" \
+  --resolucion "Reemplazo del módulo de interfaz y reconfiguración de carga" \
+  --duracion 180 \
+  --proyecto mi-telco
+```
+
+### sla-check
+Verifica el cumplimiento del acuerdo de nivel de servicio para un incidente.
+
+**Uso:** `network-incident sla-check [opciones]`
+
+**Parámetros:**
+- `--incidente` - Identificador del incidente (requerido)
+- `--severidad` - Severidad del incidente (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+network-incident sla-check \
+  --incidente NI-0001 \
+  --severidad crítica \
+  --proyecto mi-telco
+```
+
+**Resultado:** Muestra análisis de cumplimiento SLA con tiempos de respuesta, resolución y desviaciones.
+
+## Almacenamiento
+
+Todos los incidentes se guardan en `projects/{proyecto}/telco/incidents/` con estructura YAML incluyendo auditoría completa de cambios.
+

--- a/.claude/commands/order-track.md
+++ b/.claude/commands/order-track.md
@@ -1,0 +1,97 @@
+---
+title: "Seguimiento de Pedidos"
+description: "Gestiona pedidos: crear, actualizar estado, cumplir, procesar devoluciones y reportes"
+section: "Retail/eCommerce"
+category: "Order Management"
+keywords: ["pedidos", "seguimiento", "entregas", "devoluciones"]
+author: "Claude Code"
+---
+
+## Descripción
+
+Comando para gestionar el ciclo completo de pedidos. Permite crear nuevos pedidos, actualizar estados, registrar cumplimiento con seguimiento, procesar devoluciones y generar análisis de rendimiento.
+
+Almacenamiento: `projects/{proyecto}/retail/orders/`
+
+## Subcomandos
+
+### create
+Registra un nuevo pedido con identificador ORD-NNNN.
+
+```
+savia order-track create \
+  --customer-ref CUST-0523 \
+  --items "SKU-0001,SKU-0045" \
+  --quantities "2,1" \
+  --total 249.97 \
+  --payment-method "credit-card"
+```
+
+**Parámetros:**
+- `--customer-ref`: Referencia del cliente
+- `--items`: SKUs de productos (separados por comas)
+- `--quantities`: Cantidades respectivas (separadas por comas)
+- `--total`: Monto total del pedido
+- `--payment-method`: Método de pago (credit-card/debit/transfer/cash)
+
+### status
+Actualiza el estado del pedido en el flujo de procesamiento.
+
+```
+savia order-track status \
+  --order ORD-0001 \
+  --state delivered
+```
+
+**Estados válidos:**
+- `pending`: Pendiente de confirmación
+- `confirmed`: Confirmado
+- `processing`: En procesamiento
+- `shipped`: Enviado
+- `delivered`: Entregado
+- `cancelled`: Cancelado
+
+### fulfill
+Marca el pedido como cumplido registrando información de seguimiento.
+
+```
+savia order-track fulfill \
+  --order ORD-0001 \
+  --carrier "DHL" \
+  --tracking-number "1Z999AA10123456784"
+```
+
+**Parámetros:**
+- `--order`: Número de pedido
+- `--carrier`: Proveedor de envío
+- `--tracking-number`: Número de seguimiento
+
+### return
+Procesa una devolución registrando razón y monto de reembolso.
+
+```
+savia order-track return \
+  --order ORD-0001 \
+  --reason "defective" \
+  --refund-amount 249.97
+```
+
+**Parámetros:**
+- `--order`: Número de pedido
+- `--reason`: Motivo (defective/wrong-item/not-needed/damaged)
+- `--refund-amount`: Monto a reembolsar
+
+### report
+Genera análisis de pedidos: volumen, ingresos, valor promedio, tasa de devolución.
+
+```
+savia order-track report \
+  --period "monthly" \
+  --start-date "2026-02-01" \
+  --end-date "2026-03-06"
+```
+
+**Parámetros:**
+- `--period`: (daily/weekly/monthly/yearly)
+- `--start-date`: Fecha inicial (YYYY-MM-DD)
+- `--end-date`: Fecha final (YYYY-MM-DD)

--- a/.claude/commands/product-catalog.md
+++ b/.claude/commands/product-catalog.md
@@ -1,0 +1,105 @@
+---
+title: "Catálogo de Productos"
+description: "Gestiona el catálogo de productos: añadir, actualizar, listar, buscar y exportar"
+section: "Retail/eCommerce"
+category: "Inventory Management"
+keywords: ["productos", "catálogo", "SKU", "categorías"]
+author: "Claude Code"
+---
+
+## Descripción
+
+Comando para gestionar el catálogo de productos del proyecto de retail. Permite agregar nuevos productos, actualizar información existente, listar con filtros, buscar por atributos y exportar datos.
+
+Almacenamiento: `projects/{proyecto}/retail/catalog/`
+
+## Subcomandos
+
+### add
+Añade un nuevo producto al catálogo con identificador SKU-NNNN.
+
+```
+savia product-catalog add \
+  --sku SKU-0001 \
+  --name "Nombre Producto" \
+  --category "Electrónica" \
+  --price 99.99 \
+  --cost 45.00 \
+  --stock 150 \
+  --description "Descripción detallada" \
+  --attributes "Color:Azul,Tamaño:M" \
+  --images "img-ref-001,img-ref-002"
+```
+
+**Parámetros:**
+- `--sku`: Identificador único (SKU-NNNN)
+- `--name`: Nombre del producto
+- `--category`: Categoría
+- `--price`: Precio de venta
+- `--cost`: Precio de costo
+- `--stock`: Stock inicial
+- `--description`: Descripción
+- `--attributes`: Atributos (Color, Tamaño, etc.)
+- `--images`: Referencias de imágenes
+
+### update
+Modifica campos específicos de un producto existente.
+
+```
+savia product-catalog update \
+  --sku SKU-0001 \
+  --price 89.99 \
+  --stock 120 \
+  --status "active"
+```
+
+**Parámetros:**
+- `--sku`: SKU del producto a actualizar
+- `--price`: Nuevo precio (opcional)
+- `--stock`: Nuevo stock (opcional)
+- `--status`: Estado (active/inactive/discontinued)
+
+### list
+Lista productos con opciones de filtrado.
+
+```
+savia product-catalog list \
+  --category "Electrónica" \
+  --price-min 50 \
+  --price-max 150 \
+  --stock-level high
+```
+
+**Parámetros:**
+- `--category`: Filtrar por categoría
+- `--price-min`: Precio mínimo
+- `--price-max`: Precio máximo
+- `--stock-level`: (low/medium/high)
+
+### search
+Busca productos por palabra clave, categoría o atributos.
+
+```
+savia product-catalog search \
+  --keyword "laptop" \
+  --category "Electrónica" \
+  --attribute "Marca:Dell"
+```
+
+**Parámetros:**
+- `--keyword`: Palabra clave de búsqueda
+- `--category`: Categoría específica
+- `--attribute`: Atributo y valor (formato: Clave:Valor)
+
+### export
+Exporta el catálogo a CSV o JSON.
+
+```
+savia product-catalog export \
+  --format json \
+  --output catalog-20260306.json
+```
+
+**Parámetros:**
+- `--format`: (csv/json)
+- `--output`: Nombre del archivo de salida

--- a/.claude/commands/promotion-engine.md
+++ b/.claude/commands/promotion-engine.md
@@ -1,0 +1,107 @@
+---
+title: "Motor de Promociones"
+description: "Gestiona promociones: crear, activar, desactivar, evaluar, reportes"
+section: "Retail/eCommerce"
+category: "Marketing & Promotions"
+keywords: ["promociones", "descuentos", "ofertas", "campañas"]
+author: "Claude Code"
+---
+
+## Descripción
+
+Comando para gestionar promociones y ofertas del proyecto de retail. Permite definir promociones con distintos tipos (descuentos, BOGO, bundling, cupones), activarlas, desactivarlas, evaluar su aplicabilidad a carritos y analizar el impacto en negocio.
+
+Almacenamiento: `projects/{proyecto}/retail/promotions/`
+
+## Subcomandos
+
+### create
+Define una nueva promoción con identificador PROMO-NNN.
+
+```
+savia promotion-engine create \
+  --type "discount" \
+  --name "Rebajas Primavera" \
+  --value 20 \
+  --conditions "category:Electrónica,min-purchase:100" \
+  --start-date "2026-03-08" \
+  --end-date "2026-03-22" \
+  --max-uses 1000
+```
+
+**Tipos:**
+- `discount`: Descuento porcentaje o cantidad
+- `bogo`: Buy One Get One
+- `bundle`: Paquete de productos
+- `coupon`: Código cupón
+
+**Parámetros:**
+- `--type`: Tipo de promoción
+- `--name`: Nombre descriptivo
+- `--value`: Valor (% o cantidad según tipo)
+- `--conditions`: Condiciones (format: clave:valor,...)
+- `--start-date`: Inicio (YYYY-MM-DD)
+- `--end-date`: Fin (YYYY-MM-DD)
+- `--max-uses`: Uso máximo (opcional)
+
+### activate
+Pone una promoción en vivo.
+
+```
+savia promotion-engine activate \
+  --promo PROMO-001 \
+  --channels "web,mobile,tienda"
+```
+
+**Parámetros:**
+- `--promo`: ID de promoción
+- `--channels`: Canales (web/mobile/tienda/todos)
+
+### deactivate
+Detiene una promoción activa.
+
+```
+savia promotion-engine deactivate \
+  --promo PROMO-001 \
+  --reason "fin-temporada"
+```
+
+**Parámetros:**
+- `--promo`: ID de promoción
+- `--reason`: Motivo de desactivación
+
+### evaluate
+Evalúa si un carrito califica para promociones.
+
+```
+savia promotion-engine evaluate \
+  --cart-items "SKU-0001:2,SKU-0045:1" \
+  --cart-total 250 \
+  --customer-segment "premium"
+```
+
+**Parámetros:**
+- `--cart-items`: Productos en carrito (SKU:cant,...)
+- `--cart-total`: Monto total carrito
+- `--customer-segment`: Segmento cliente (opcional)
+
+**Salida:** Promociones aplicables + ahorros
+
+### report
+Analiza performance de promociones activas.
+
+```
+savia promotion-engine report \
+  --period "monthly" \
+  --metrics "redemptions,revenue-impact,margin"
+```
+
+**Parámetros:**
+- `--period`: (daily/weekly/monthly)
+- `--metrics**: métricas a incluir (redemptions/revenue/margin/roi)
+
+**Incluye:**
+- Canjes totales
+- Ingresos generados por promoción
+- Impacto en margen de beneficio
+- ROI estimado

--- a/.claude/commands/service-catalog-telco.md
+++ b/.claude/commands/service-catalog-telco.md
@@ -1,0 +1,126 @@
+---
+title: "Catálogo de Servicios Telecomunicaciones"
+description: "Gestión del catálogo de servicios de telecom con definiciones, configuración y precios"
+icon: "📋"
+category: "Telecomunicaciones"
+---
+
+# Catálogo de Servicios Telecomunicaciones
+
+Administra el catálogo completo de servicios de telecomunicaciones incluyendo definiciones, listados, configuración personalizada, cálculo de precios y empaquetamiento de servicios.
+
+## Subcomandos
+
+### define
+Crea una nueva definición de servicio de telecomunicaciones con identificador único (SVC-NNN).
+
+**Uso:** `service-catalog-telco define [opciones]`
+
+**Parámetros:**
+- `--nombre` - Nombre del servicio (requerido)
+- `--tipo` - Tipo de servicio: voz, datos, fibra, tv, convergente (requerido)
+- `--velocidad` - Velocidad o capacidad del servicio (requerido)
+- `--sla` - Acuerdo de nivel de servicio (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+service-catalog-telco define \
+  --nombre "Fibra Óptica 300Mbps" \
+  --tipo fibra \
+  --velocidad "300 Mbps" \
+  --sla "99.5%" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Crea archivo `projects/{proyecto}/telco/services/SVC-NNN.yaml` con la definición completa.
+
+### list
+Muestra todos los servicios del catálogo con opciones de filtrado.
+
+**Uso:** `service-catalog-telco list [opciones]`
+
+**Parámetros:**
+- `--proyecto` - Identificador del proyecto (requerido)
+- `--tipo` - Filtrar por tipo de servicio (opcional)
+- `--activos` - Mostrar solo servicios activos (opcional)
+- `--formato` - Formato de salida: tabla, json, yaml (default: tabla)
+
+**Ejemplo:**
+```bash
+service-catalog-telco list \
+  --proyecto mi-telco \
+  --tipo fibra \
+  --activos
+```
+
+### configure
+Personaliza los parámetros de un servicio para un perfil específico de cliente.
+
+**Uso:** `service-catalog-telco configure [opciones]`
+
+**Parámetros:**
+- `--servicio` - Identificador del servicio (requerido)
+- `--perfil` - Perfil de cliente (requerido)
+- `--parametro` - Parámetro a personalizar (requerido)
+- `--valor` - Valor del parámetro (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+service-catalog-telco configure \
+  --servicio SVC-001 \
+  --perfil corporativo \
+  --parametro velocidad \
+  --valor "500 Mbps" \
+  --proyecto mi-telco
+```
+
+### price
+Calcula el precio de un servicio basado en su configuración actual.
+
+**Uso:** `service-catalog-telco price [opciones]`
+
+**Parámetros:**
+- `--servicio` - Identificador del servicio (requerido)
+- `--perfil` - Perfil de cliente (opcional)
+- `--cantidad` - Cantidad de unidades (opcional)
+- `--moneda` - Moneda de cálculo (default: USD)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+service-catalog-telco price \
+  --servicio SVC-001 \
+  --perfil corporativo \
+  --cantidad 10 \
+  --moneda EUR \
+  --proyecto mi-telco
+```
+
+### bundle
+Combina múltiples servicios en paquetes con descuentos aplicables.
+
+**Uso:** `service-catalog-telco bundle [opciones]`
+
+**Parámetros:**
+- `--nombre` - Nombre del paquete (requerido)
+- `--servicios` - Lista de servicios a agrupar (requerido)
+- `--descuento` - Descuento aplicable al paquete (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+service-catalog-telco bundle \
+  --nombre "Pack Convergente Hogar" \
+  --servicios "SVC-001,SVC-002,SVC-003" \
+  --descuento "15%" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Crea archivo `projects/{proyecto}/telco/services/BUNDLE-NNN.yaml` con la definición del paquete y cálculos de precio final.
+
+## Almacenamiento
+
+Todos los datos se guardan en `projects/{proyecto}/telco/services/` con estructura YAML.
+

--- a/.claude/commands/solvency-report.md
+++ b/.claude/commands/solvency-report.md
@@ -1,0 +1,74 @@
+---
+name: solvency-report
+description: >
+  Gestiona reportes de solvencia Solvency II: cálculo de ratios, estado actual,
+  sumisión a regulador y evolución histórica.
+  Almacena en projects/{proyecto}/insurance/solvency/ con simplificación de fórmulas.
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+  - Bash
+---
+
+# /solvency-report {proyecto} {subcomando} [opciones]
+
+## Subcomandos
+
+### calculate
+```bash
+/solvency-report {proyecto} calculate \
+  [--date {YYYY-MM-DD}]
+```
+Computa ratios Solvency II: SCR, MCR, fondos propios, ratio SCR.
+Usa fórmulas básicas, no modelo interno completo.
+
+Ratios calculados:
+- **Fondos propios**: suma neta de activos - pasivos
+- **SCR (Solvency Capital Req)**: 18% × fondos propios (simplificado)
+- **MCR (Minimum Capital Req)**: 6% × SCR
+- **Ratio SCR**: fondos propios / SCR (objetivo ≥ 100%)
+
+### status
+```bash
+/solvency-report {proyecto} status
+```
+Muestra posición actual con indicador RAG:
+- 🟢 GREEN (≥ 150%): Posición fuerte
+- 🟡 YELLOW (100-150%): Cumple, pero vigilar
+- 🔴 RED (< 100%): Incumplimiento, acción requerida
+
+### submit
+```bash
+/solvency-report {proyecto} submit \
+  --date {YYYY-MM-DD}
+```
+Marca reporte como enviado a regulador, registra fecha.
+
+### history
+```bash
+/solvency-report {proyecto} history \
+  [--months N]
+```
+Tabla histórica: fechas, ratios SCR, tendencia gráfica ASCII.
+
+## Estructura de datos
+
+```yaml
+date: YYYY-MM-DD
+own_funds: XXX.XX
+scr_requirement: XXX.XX
+mcr_requirement: XXX.XX
+scr_ratio: XXX.XX%
+status: GREEN|YELLOW|RED
+submitted: false
+submitted_date: null
+created_by: "sistema"
+```
+
+## Reglas
+
+- Cálculos base sin modelo interno (simplificación)
+- Ratio SCR < 100% es incumplimiento
+- Historiales se retienen 3 años mínimo
+- Sumisión requiere confirmación explícita

--- a/.claude/commands/subscriber-lifecycle.md
+++ b/.claude/commands/subscriber-lifecycle.md
@@ -1,0 +1,133 @@
+---
+title: "Ciclo de Vida del Suscriptor"
+description: "Gestión integral del ciclo de vida del suscriptor desde onboarding hasta análisis de churn"
+icon: "👥"
+category: "Telecomunicaciones"
+---
+
+# Ciclo de Vida del Suscriptor
+
+Administra el ciclo de vida completo del suscriptor incluyendo onboarding, cambios de plan, cálculo de riesgo de churn y análisis analíticos. Todos los datos son anonimizados para mantener privacidad.
+
+## Subcomandos
+
+### onboard
+Registra un nuevo suscriptor con identificador único (SUB-NNNN).
+
+**Uso:** `subscriber-lifecycle onboard [opciones]`
+
+**Parámetros:**
+- `--plan` - Plan de suscripción inicial (requerido)
+- `--fecha-activacion` - Fecha de activación (YYYY-MM-DD) (requerido)
+- `--canal` - Canal de adquisición: web, tienda, agente, referencia (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+subscriber-lifecycle onboard \
+  --plan "Fibra 300Mbps" \
+  --fecha-activacion "2026-03-05" \
+  --canal "web" \
+  --proyecto mi-telco
+```
+
+**Resultado:** Crea archivo `projects/{proyecto}/telco/subscribers/SUB-NNNN.yaml` con perfil del suscriptor anonimizado.
+
+### upgrade
+Registra una mejora de plan con valor de upsell calculado.
+
+**Uso:** `subscriber-lifecycle upgrade [opciones]`
+
+**Parámetros:**
+- `--suscriptor` - Identificador del suscriptor (requerido)
+- `--nuevo-plan` - Plan nuevo (requerido)
+- `--razon` - Razón de la mejora (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+subscriber-lifecycle upgrade \
+  --suscriptor SUB-0001 \
+  --nuevo-plan "Fibra 1Gbps" \
+  --razon "Solicitud de mayor velocidad" \
+  --proyecto mi-telco
+```
+
+### downgrade
+Registra una reducción de plan con análisis de causas.
+
+**Uso:** `subscriber-lifecycle downgrade [opciones]`
+
+**Parámetros:**
+- `--suscriptor` - Identificador del suscriptor (requerido)
+- `--nuevo-plan` - Plan reducido (requerido)
+- `--razon` - Razón de la reducción (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+subscriber-lifecycle downgrade \
+  --suscriptor SUB-0001 \
+  --nuevo-plan "Fibra 100Mbps" \
+  --razon "Reducción de costos operativos" \
+  --proyecto mi-telco
+```
+
+### churn-risk
+Calcula la probabilidad de churn basada en patrones de uso, quejas y antigüedad.
+
+**Uso:** `subscriber-lifecycle churn-risk [opciones]`
+
+**Parámetros:**
+- `--suscriptor` - Identificador del suscriptor (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+
+**Ejemplo:**
+```bash
+subscriber-lifecycle churn-risk \
+  --suscriptor SUB-0001 \
+  --proyecto mi-telco
+```
+
+**Resultado:** Genera score de riesgo (0-100%) basado en:
+- Patrones de uso (actividad, cambios recientes)
+- Historial de quejas (número, severidad)
+- Antigüedad en plataforma (meses de suscripción)
+- Comparativa con cohorte
+
+### report
+Genera análisis de ciclo de vida del suscriptor con métricas agregadas anonimizadas.
+
+**Uso:** `subscriber-lifecycle report [opciones]`
+
+**Parámetros:**
+- `--periodo` - Período a analizar: mes, trimestre, año (requerido)
+- `--proyecto` - Identificador del proyecto (requerido)
+- `--formato` - Formato de salida: tabla, json, yaml (default: tabla)
+
+**Ejemplo:**
+```bash
+subscriber-lifecycle report \
+  --periodo trimestre \
+  --proyecto mi-telco \
+  --formato tabla
+```
+
+**Resultado:** Informe con métricas agregadas anonimizadas:
+- ARPU (Average Revenue Per User)
+- Churn rate (porcentaje de bajas)
+- LTV (Lifetime Value)
+- CAC (Customer Acquisition Cost)
+
+## Almacenamiento
+
+Todos los datos se guardan en `projects/{proyecto}/telco/subscribers/` con estructura YAML.
+
+## Privacidad
+
+Ningún dato personal se almacena:
+- Solo identificadores anonimizados (SUB-NNNN)
+- Métricas agregadas para reportes
+- Análisis basado en patrones, no en datos personales
+- Cumplimiento total GDPR/LOPD
+

--- a/.claude/commands/underwriting-rule.md
+++ b/.claude/commands/underwriting-rule.md
@@ -1,0 +1,87 @@
+---
+name: underwriting-rule
+description: >
+  Gestiona reglas de underwriting para decisiones de asunción de riesgo.
+  Almacena en projects/{proyecto}/insurance/underwriting/ con definición,
+  evaluación y auditoría de cambios y overrides.
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+  - Bash
+---
+
+# /underwriting-rule {proyecto} {subcomando} [opciones]
+
+## Subcomandos
+
+### define
+```bash
+/underwriting-rule {proyecto} define \
+  --name "Nombre regla" \
+  --product {vida|auto|hogar|salud|responsabilidad} \
+  --criteria "Criterio 1; Criterio 2" \
+  --risk-factors "Factor1:límite; Factor2:límite" \
+  --auto-approve "condiciones de aprobación automática"
+```
+Crea regla de underwriting. Cada regla tiene ID secuencial.
+
+### evaluate
+```bash
+/underwriting-rule {proyecto} evaluate \
+  --case-data "{json o fichero}" \
+  --product {tipo}
+```
+Ejecuta caso contra reglas activas del producto.
+Resultado: ACCEPT | REFER (revisión manual) | DECLINE.
+
+Muestra:
+- Reglas aplicadas
+- Factores encontrados
+- Decisión y justificación
+- Confianza (%)
+
+### list
+```bash
+/underwriting-rule {proyecto} list \
+  [--product {tipo}] \
+  [--status {active|inactive}]
+```
+Tabla: ID, nombre, producto, criterios, estado, creada, actualizada.
+
+### audit
+```bash
+/underwriting-rule {proyecto} audit \
+  [--rule-id UW-NNN]
+```
+Historial: cambios en regla, quién modificó, cuándo.
+Frecuencia overrides por regla.
+
+## Estructura de datos
+
+```yaml
+id: UW-NNN
+name: Nombre
+product: vida|auto|hogar|salud|responsabilidad
+criteria:
+  - descripción
+risk_factors:
+  factor1: límite_max
+  factor2: límite_max
+auto_approve_conditions: descripción
+status: active|inactive
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+change_history:
+  - date: YYYY-MM-DD
+    change: descripción
+override_count: N
+```
+
+## Reglas
+
+- UW-NNN numeración secuencial (3 dígitos)
+- Producto determina reglas aplicables
+- Evaluación es determinística (misma entrada → mismo resultado)
+- Overrides se registran para auditoría
+- Cambios a reglas no afectan decisiones previas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.20.0] — 2026-03-06
+
+### Added — More Industry Verticals: Insurance, Retail, Telco (Era 48)
+
+12 domain-specific commands for 3 additional industries.
+
+- **Insurance (4 commands):** `/insurance-policy` (POL-NNN, lifecycle: create/renew/cancel, endorsement tracking), `/insurance-claim` (CLM-NNN, investigation→resolution, loss ratio analytics), `/solvency-report` (Solvency II: SCR/MCR/own funds, RAG indicator), `/underwriting-rule` (criteria definition, accept/refer/decline evaluation, audit trail).
+- **Retail/eCommerce (4 commands):** `/product-catalog` (SKU-NNNN, pricing, stock, CSV/JSON export), `/order-track` (ORD-NNNN, status lifecycle, returns, revenue analytics), `/inventory-manage` (multi-warehouse, reorder points, dead stock alerts), `/promotion-engine` (PROMO-NNN, discount/BOGO/bundle/coupon, ROI analysis).
+- **Telco (4 commands):** `/service-catalog-telco` (SVC-NNN, voz/datos/fibra/tv, SLA, bundling), `/network-incident` (NI-NNNN, eTOM classification, SLA compliance), `/subscriber-lifecycle` (SUB-NNNN, churn-risk scoring, ARPU/LTV), `/capacity-forecast-telco` (utilization, trend-based forecasting, expansion planning).
+
+### Changed
+
+- **ROADMAP.md** — Added Era 48 entry. Removed "More industry verticals" from backlog (implemented). Updated stats: 396+ commands.
+
+---
+
 ## [2.19.0] — 2026-03-06
 
 ### Added — Adversarial Security Pipeline (Era 47)
@@ -438,6 +454,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.20.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.19.0...v2.20.0
 [2.19.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.18.0...v2.19.0
 [2.18.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.17.0...v2.18.0
 [2.17.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.16.1...v2.17.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 384+ commands, 30 agents, 40 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into thematic eras and outlines what comes next.
+pm-workspace has evolved from a Scrum toolkit into a full PM intelligence platform with 396+ commands, 30 agents, 40 skills, 15 hooks, and its own persona (Savia). This roadmap groups the released versions into thematic eras and outlines what comes next.
 
 Status: ✅ Released · 🟡 In progress · 💡 Proposed
 
@@ -409,10 +409,20 @@ Red Team / Blue Team / Auditor pattern for systematic security testing. Inspired
 
 ---
 
+## ✅ Era 48 — More Industry Verticals: Insurance, Retail, Telco (v2.20.0, Mar 2026)
+
+12 domain-specific commands for 3 additional industries, completing the vertical coverage from the strategic backlog.
+
+- **Insurance (4)** — `/insurance-policy` (create/renew/cancel/list/compare, POL-NNN IDs, endorsement tracking), `/insurance-claim` (open/investigate/resolve, CLM-NNN, loss ratio analytics), `/solvency-report` (Solvency II: SCR/MCR/own funds, RAG indicator, regulator submission), `/underwriting-rule` (define/evaluate/list/audit, accept/refer/decline decisions, override tracking).
+- **Retail/eCommerce (4)** — `/product-catalog` (SKU-NNNN, categories, pricing, stock management, CSV/JSON export), `/order-track` (ORD-NNNN, status lifecycle: pending→delivered, returns, revenue analytics), `/inventory-manage` (stock/reorder/transfer/count/alert, multi-warehouse, dead stock detection), `/promotion-engine` (PROMO-NNN, discount/BOGO/bundle/coupon, cart evaluation, ROI analysis).
+- **Telco (4)** — `/service-catalog-telco` (SVC-NNN, voz/datos/fibra/tv/convergente, SLA, bundling with discounts), `/network-incident` (NI-NNNN, eTOM classification, escalation tiers, SLA compliance verification), `/subscriber-lifecycle` (SUB-NNNN, onboard/upgrade/downgrade, churn-risk scoring, ARPU/LTV analytics), `/capacity-forecast-telco` (utilization measurement, trend-based forecasting, expansion planning, threshold alerts).
+- Total: 396 commands, 30 agents, 40 skills. Compliance runner passed. CI green.
+
+---
+
 ### Backlog — Strategic Evaluation
 
 - **Claude Connectors vs MCP** — Evaluar si Connectors simplifican la arquitectura de integraciones
-- **More industry verticals** — Insurance (Guidewire, Solvency II), Retail/eCommerce, Telco (OSS/BSS, eTOM/SID)
 - **Multimodal quality gates** — Visual regression via VLM screenshot analysis, diagram-to-spec, wireframe-driven decompose
 - **Observability extensions** — New Relic, Splunk, Elastic APM. LLM observability (token usage, prompt latency, model drift)
 - **Developer experience** — VS Code / Cursor extension, CLI mode, mobile companion (read-only sprint status)


### PR DESCRIPTION
## Summary

- **12 new commands** for 3 additional industry verticals
- **Insurance (4):** insurance-policy (POL-NNN), insurance-claim (CLM-NNN), solvency-report (Solvency II), underwriting-rule (accept/refer/decline)
- **Retail/eCommerce (4):** product-catalog (SKU-NNNN), order-track (ORD-NNNN), inventory-manage (multi-warehouse), promotion-engine (PROMO-NNN)
- **Telco (4):** service-catalog-telco (SVC-NNN), network-incident (NI-NNNN, eTOM), subscriber-lifecycle (SUB-NNNN, churn-risk), capacity-forecast-telco
- Total: 396 commands. ROADMAP.md and CHANGELOG.md updated to v2.20.0

## Test plan

- [x] All 12 commands have YAML frontmatter
- [x] All files ≤150 lines (max: 133)
- [x] Compliance runner: 4/4 passed
- [x] CHANGELOG comparison link present for v2.20.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)