### PR TITLE
docs: documentation consistency audit — stats, features & frontmatter

### DIFF
--- a/.claude/commands/capacity-forecast-telco.md
+++ b/.claude/commands/capacity-forecast-telco.md
@@ -1,5 +1,5 @@
 ---
-title: "Previsión de Capacidad Telecomunicaciones"
+name: capacity-forecast-telco
 description: "Medición, previsión y planificación de capacidad de red con alertas automáticas"
 icon: "📊"
 category: "Telecomunicaciones"

--- a/.claude/commands/inventory-manage.md
+++ b/.claude/commands/inventory-manage.md
@@ -1,5 +1,5 @@
 ---
-title: "Gestión de Inventario"
+name: inventory-manage
 description: "Gestiona inventario: stock, reordenes, transferencias, conteos, alertas"
 section: "Retail/eCommerce"
 category: "Inventory Management"

--- a/.claude/commands/network-incident.md
+++ b/.claude/commands/network-incident.md
@@ -1,5 +1,5 @@
 ---
-title: "Incidentes de Red Telecomunicaciones"
+name: network-incident
 description: "Gestión del ciclo de vida de incidentes de red con reporte, clasificación, escalado y resolución"
 icon: "🚨"
 category: "Telecomunicaciones"

--- a/.claude/commands/order-track.md
+++ b/.claude/commands/order-track.md
@@ -1,5 +1,5 @@
 ---
-title: "Seguimiento de Pedidos"
+name: order-track
 description: "Gestiona pedidos: crear, actualizar estado, cumplir, procesar devoluciones y reportes"
 section: "Retail/eCommerce"
 category: "Order Management"

--- a/.claude/commands/product-catalog.md
+++ b/.claude/commands/product-catalog.md
@@ -1,5 +1,5 @@
 ---
-title: "Catálogo de Productos"
+name: product-catalog
 description: "Gestiona el catálogo de productos: añadir, actualizar, listar, buscar y exportar"
 section: "Retail/eCommerce"
 category: "Inventory Management"

--- a/.claude/commands/promotion-engine.md
+++ b/.claude/commands/promotion-engine.md
@@ -1,5 +1,5 @@
 ---
-title: "Motor de Promociones"
+name: promotion-engine
 description: "Gestiona promociones: crear, activar, desactivar, evaluar, reportes"
 section: "Retail/eCommerce"
 category: "Marketing & Promotions"

--- a/.claude/commands/service-catalog-telco.md
+++ b/.claude/commands/service-catalog-telco.md
@@ -1,5 +1,5 @@
 ---
-title: "Catálogo de Servicios Telecomunicaciones"
+name: service-catalog-telco
 description: "Gestión del catálogo de servicios de telecom con definiciones, configuración y precios"
 icon: "📋"
 category: "Telecomunicaciones"

--- a/.claude/commands/subscriber-lifecycle.md
+++ b/.claude/commands/subscriber-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-title: "Ciclo de Vida del Suscriptor"
+name: subscriber-lifecycle
 description: "Gestión integral del ciclo de vida del suscriptor desde onboarding hasta análisis de churn"
 icon: "👥"
 category: "Telecomunicaciones"

--- a/.claude/rules/domain/agents-catalog.md
+++ b/.claude/rules/domain/agents-catalog.md
@@ -1,4 +1,4 @@
-# Catálogo de Subagentes (27)
+# Catálogo de Subagentes (31)
 
 | Agente | Modelo | Especialidad |
 |---|---|---|
@@ -29,6 +29,10 @@
 | `drift-auditor` | Opus 4.6 | Auditoría de convergencia repo: detecta drift entre docs, config y código |
 | `reflection-validator` | Opus 4.6 | Validación meta-cognitiva (System 2): supuestos, cadena causal, brechas |
 | `coherence-validator` | Sonnet 4.6 | Coherencia output↔objetivo: cobertura, consistencia, completitud |
+| `frontend-test-runner` | Sonnet 4.6 | Tests frontend: E2E, componentes, accesibilidad |
+| `security-attacker` | Sonnet 4.6 | Red Team: OWASP Top 10, CWE Top 25, dependency audit |
+| `security-defender` | Sonnet 4.6 | Blue Team: patches, hardening, NIST/CIS |
+| `security-auditor` | Sonnet 4.6 | Auditor independiente: evaluación, score 0-100, gap analysis |
 
 ## Flujos
 
@@ -39,6 +43,7 @@
 - **Post-commit**: `test-runner` (tests completos + cobertura ≥ `TEST_COVERAGE_MIN_PERCENT`)
 - **Consenso**: `reflection-validator` + `code-reviewer` + `business-analyst` → panel 3 jueces → score ponderado → veredicto
 - **Equality Shield** (Era 26): `/bias:check` audita sesgos contrafácticos en asignaciones y comunicaciones. Integración transversal: antes de `/pbi:assign`, `/sprint:review`, `/sprint:retro`, `/report:executive`.
+- **Adversarial Security** (Era 47): `security-attacker` → `security-defender` → `security-auditor` → informe con score 0-100. Pipeline: `/security-pipeline`.
 
 El agente developer se selecciona según el Language Pack del proyecto.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.20.1] — 2026-03-06
+
+### Fixed — Documentation Consistency Audit
+
+Full documentation audit to align all stats and features with current state after Eras 43-48.
+
+- **README.md / README.en.md** — Updated stats: 396+ commands (was 360+), 31 agents (was 27), 41 skills (was 38), 16 hooks (was 14), 14 guides (was 13). Added new feature sections: universal accessibility, industry verticals, adversarial security, adaptive intelligence.
+- **CLAUDE.md** — Synchronized all resource counts: commands (396+), agents (31), skills (41), hooks (16).
+- **agents-catalog.md** — Added 4 missing agents: `frontend-test-runner`, `security-attacker`, `security-defender`, `security-auditor`. Updated count: 31. Added adversarial security flow.
+- **ROADMAP.md** — Corrected agent/skill counts in Era 46 (41 skills), Era 47 (31 agents, 41 skills), Era 48 (31 agents, 41 skills, 16 hooks).
+
+---
+
 ## [2.20.0] — 2026-03-06
 
 ### Added — More Industry Verticals: Insurance, Retail, Telco (Era 48)
@@ -454,6 +467,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.20.0...v2.20.1
 [2.20.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.19.0...v2.20.0
 [2.19.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.18.0...v2.19.0
 [2.18.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.17.0...v2.18.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,12 @@ TEST_COVERAGE_MIN_PERCENT = 80
 ```
 ~/claude/                          ← Raíz y repositorio GitHub
 ├── .claude/
-│   ├── agents/ (27)               ← @.claude/rules/domain/agents-catalog.md
-│   ├── commands/ (360+)            ← @.claude/rules/domain/pm-workflow.md
+│   ├── agents/ (31)               ← @.claude/rules/domain/agents-catalog.md
+│   ├── commands/ (396+)            ← @.claude/rules/domain/pm-workflow.md
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
-│   ├── hooks/ (14)                ← .claude/settings.json
+│   ├── hooks/ (16)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
-│   ├── skills/ (38)               ← Skills reutilizables
+│   ├── skills/ (41)               ← Skills reutilizables
 │   └── settings.json              ← Hooks + Agent Teams env
 ├── docs/ · projects/ · scripts/
 ```
@@ -54,7 +54,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 
 Inicio de sesión: `active-user.md` → voz Savia → si perfil: saludar; si no: `/profile-setup` (`@.claude/rules/domain/profile-onboarding.md`). Fragmentos por demanda: `@.claude/profiles/context-map.md`
 
-> Catálogo completo de comandos (360+): `@.claude/rules/domain/pm-workflow.md`
+> Catálogo completo de comandos (396+): `@.claude/rules/domain/pm-workflow.md`
 > MCP servers se conectan bajo demanda con `/mcp-server start {nombre}`, NO al arranque.
 
 ---
@@ -89,7 +89,7 @@ Inicio de sesión: `active-user.md` → voz Savia → si perfil: saludar; si no:
 
 ## Subagentes
 
-> Catálogo (27): `@.claude/rules/domain/agents-catalog.md` · Agent Notes: `@docs/agent-notes-protocol.md`
+> Catálogo (31): `@.claude/rules/domain/agents-catalog.md` · Agent Notes: `@docs/agent-notes-protocol.md`
 
 Cada agente: `memory: project`, `skills:` precargados, `permissionMode:` apropiado. Developers: `isolation: worktree`.
 Flujos: SDD (analyst→architect→security→tester→developer→reviewer) · Infra · Diagramas · Agent Teams (`@docs/agent-teams-sdd.md`)
@@ -108,7 +108,7 @@ Ciclo: Explorar → Planificar → Implementar → Commit. Arquitectura: **Comma
 
 ## Hooks · Memoria
 
-> Hooks (14): `.claude/settings.json` — Arranque blindado (sin red, sin dependencias externas)
+> Hooks (16): `.claude/settings.json` — Arranque blindado (sin red, sin dependencias externas)
 > Memoria: `@docs/memory-system.md` · Store: `scripts/memory-store.sh` (JSONL, dedup, topic_key, `<private>`) · Agent Notes: `@docs/agent-notes-protocol.md` · Security: `/security-review {spec}` — OWASP pre-implementación
 
 ---

--- a/README.en.md
+++ b/README.en.md
@@ -53,15 +53,15 @@ More detail in the [Data flow guide](docs/data-flow-guide-en.md).
 ```
 pm-workspace/
 ├── .claude/
-│   ├── commands/       ← 360+ commands (what you can ask me)
-│   ├── agents/         ← 27 specialized agents
-│   ├── skills/         ← 38 skills with domain knowledge
-│   ├── hooks/          ← 14 hooks that enforce rules automatically
+│   ├── commands/       ← 396+ commands (what you can ask me)
+│   ├── agents/         ← 31 specialized agents
+│   ├── skills/         ← 41 skills with domain knowledge
+│   ├── hooks/          ← 16 hooks that enforce rules automatically
 │   └── rules/          ← context, language, and domain rules
 ├── docs/
 │   ├── quick-starts/   ← role-based guides (PM, Dev, QA, PO, TL, CEO)
 │   ├── readme/         ← detailed documentation (13 sections)
-│   ├── guides/         ← 13 scenario guides (Azure, Jira, startup...)
+│   ├── guides/         ← 14 guides (Azure, Jira, startup, healthcare...)
 │   └── savia-flow/     ← Git-native system docs
 ├── scripts/            ← validation, CI, utilities
 ├── output/             ← generated files (reports, specs, exports)
@@ -88,7 +88,13 @@ Every command has YAML frontmatter with metadata (model, context cost, descripti
 
 **Executive reporting** — Multi-project CEO report, executive alerts, portfolio overview, DORA metrics, value stream mapping.
 
-**Collaboration** — Company Savia (shared repo with E2E encrypted messaging), Savia Flow (Git-native PM), Travel Mode, encrypted backup, and Savia School for educational centers. Full reference: [360+ commands · 27 agents · 38 skills](docs/readme/12-comandos-agentes.md)
+**Universal accessibility** — Step-by-step guided work for people with disabilities (visual, motor, ADHD, autism, dyslexia, hearing). 3-5 min micro-tasks, block detection, adaptive reformulation.
+
+**Industry verticals** — Research lab, hardware lab, legal, healthcare, nonprofit, insurance, retail and telco — 32 specialized commands covering 8 industries with native workflows.
+
+**Adversarial security & adaptive intelligence** — Red/Blue/Auditor pipeline with score 0-100, STRIDE/PASTA threat modeling. Skill evaluation engine with auto-detection of 7 project types and instincts system with confidence scoring.
+
+**Collaboration** — Company Savia (E2E encrypted messaging), Savia Flow (Git-native PM), Travel Mode, encrypted backup, Savia School. Reference: [396+ commands · 31 agents · 41 skills](docs/readme/12-comandos-agentes.md)
 
 ---
 
@@ -112,17 +118,14 @@ Configurable with `SAVIA_HOME`, `--skip-tests`. Details: `install.sh --help`
 
 | Section | Description |
 |---|---|
-| **Getting started** | |
 | [Introduction & example](docs/readme_en/01-introduccion.md) | First 5 minutes |
 | [Workspace structure](docs/readme_en/02-estructura.md) | Directories and layout |
 | [Initial configuration](docs/readme_en/03-configuracion.md) | PAT, constants, verification |
 | [Adoption guide](docs/ADOPTION_GUIDE.en.md) | Step by step for consulting firms |
-| **Daily use** | |
 | [Sprints & reports](docs/readme_en/04-uso-sprint-informes.md) | Sprint, reporting, KPIs |
 | [Spec-Driven Development](docs/readme_en/05-sdd.md) | SDD: specs, agents, patterns |
 | [Data flow](docs/data-flow-guide-en.md) | How the parts connect |
-| **Reference** | |
-| [Commands & agents](docs/readme/12-comandos-agentes.md) | 360+ commands + 27 agents |
+| [Commands & agents](docs/readme/12-comandos-agentes.md) | 396+ commands + 31 agents |
 | [Scenario guides](docs/guides_en/README.md) | Azure, Jira, startup, healthcare... |
 | [AI Augmentation](docs/ai-augmentation-opportunities-en.md) | Opportunities by sector |
 | [Context Engineering](docs/context-engineering-en.md) | Context & AI improvements |
@@ -142,7 +145,5 @@ Use `/contribute` to create PRs directly. Use `/feedback` to open issues. Before
 Credits to the projects, studies, and people that inspired features: [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md).
 
 > Full changelog in [CHANGELOG.md](CHANGELOG.md) · Releases at [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
-
----
 
 *🦉 Savia — your AI-powered PM. Compatible with Azure DevOps, Jira, and Savia Flow.*

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ Más detalle en la [Guía de flujo de datos](docs/data-flow-guide-es.md).
 ```
 pm-workspace/
 ├── .claude/
-│   ├── commands/       ← 360+ comandos (lo que me puedes pedir)
-│   ├── agents/         ← 27 agentes especializados
-│   ├── skills/         ← 38 skills con conocimiento de dominio
-│   ├── hooks/          ← 14 hooks que refuerzan reglas automáticamente
+│   ├── commands/       ← 396+ comandos (lo que me puedes pedir)
+│   ├── agents/         ← 31 agentes especializados
+│   ├── skills/         ← 41 skills con conocimiento de dominio
+│   ├── hooks/          ← 16 hooks que refuerzan reglas automáticamente
 │   └── rules/          ← reglas de contexto, lenguaje, dominio
 ├── docs/
 │   ├── quick-starts/   ← guías por rol (PM, Dev, QA, PO, TL, CEO)
 │   ├── readme/         ← documentación detallada (13 secciones)
-│   ├── guides/         ← 13 guías por escenario (Azure, Jira, startup...)
+│   ├── guides/         ← 14 guías por escenario (Azure, Jira, startup...)
 │   └── savia-flow/     ← docs del sistema Git-native
 ├── scripts/            ← validación, CI, utilidades
 ├── output/             ← ficheros generados (informes, specs, exports)
@@ -88,7 +88,13 @@ Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, des
 
 **Informes ejecutivos** — CEO report multi-proyecto, alertas de dirección, portfolio overview, DORA metrics, value stream mapping.
 
-**Colaboración** — Company Savia (repo compartido con mensajería E2E cifrada), Savia Flow (PM Git-native), Travel Mode, backup cifrado, y Savia School para centros educativos. Referencia completa: [360+ comandos · 27 agentes · 38 skills](docs/readme/12-comandos-agentes.md)
+**Accesibilidad universal** — Trabajo guiado para personas con discapacidad (visual, motora, TDAH, autismo, dislexia, auditiva). Micro-tareas de 3-5 min, detección de bloqueos, reformulación adaptativa.
+
+**Verticales sectoriales** — Research lab, hardware lab, legal, healthcare, nonprofit, insurance, retail y telco — 32 comandos especializados cubriendo 8 industrias con sus flujos de trabajo nativos.
+
+**Seguridad adversarial e inteligencia adaptativa** — Pipeline Red/Blue/Auditor con score 0-100, threat modeling STRIDE/PASTA. Motor de evaluación de skills con auto-detección de 7 tipos de proyecto y sistema de instintos con scoring de confianza.
+
+**Colaboración** — Company Savia (mensajería E2E cifrada), Savia Flow (PM Git-native), Travel Mode, backup cifrado, Savia School. Referencia: [396+ comandos · 31 agentes · 41 skills](docs/readme/12-comandos-agentes.md)
 
 ---
 
@@ -112,17 +118,14 @@ Configurable con `SAVIA_HOME`, `--skip-tests`. Detalles: `install.sh --help`
 
 | Sección | Descripción |
 |---|---|
-| **Empezar** | |
 | [Introducción y ejemplo](docs/readme/01-introduccion.md) | Primeros 5 minutos |
 | [Estructura del workspace](docs/readme/02-estructura.md) | Directorios y organización |
 | [Configuración inicial](docs/readme/03-configuracion.md) | PAT, constantes, verificación |
 | [Guía de adopción](docs/ADOPTION_GUIDE.md) | Paso a paso para consultoras |
-| **Uso diario** | |
 | [Sprints e informes](docs/readme/04-uso-sprint-informes.md) | Sprint, reporting, KPIs |
 | [Spec-Driven Development](docs/readme/05-sdd.md) | SDD: specs, agentes, patrones |
 | [Flujo de datos](docs/data-flow-guide-es.md) | Cómo se conectan las partes |
-| **Referencia** | |
-| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 360+ comandos + 27 agentes |
+| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 396+ comandos + 31 agentes |
 | [Guías por escenario](docs/guides/README.md) | Azure, Jira, startup, sanidad... |
 | [AI Augmentation](docs/ai-augmentation-opportunities-es.md) | Oportunidades por sector |
 | [Context Engineering](docs/context-engineering-es.md) | Mejoras de contexto e IA |
@@ -142,7 +145,5 @@ Con `/contribute` puedes crear PRs directamente. Con `/feedback` abrir issues. A
 Créditos a los proyectos, estudios y personas que inspiraron funcionalidades: [ACKNOWLEDGMENTS.md](ACKNOWLEDGMENTS.md).
 
 > Changelog completo en [CHANGELOG.md](CHANGELOG.md) · Releases en [GitHub Releases](https://github.com/gonzalezpazmonica/pm-workspace/releases)
-
----
 
 *🦉 Savia — tu PM automatizada con IA. Compatible con Azure DevOps, Jira y Savia Flow.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -392,7 +392,7 @@ Self-learning intelligence layer: automatic skill recommendation based on prompt
 - **Instincts Protocol Rule** — `instincts-protocol.md`: lifecycle (detect ≥3 repetitions → propose → create → reinforce/penalize → decay → review). Security: no destructive actions, no sensitive data, explicit rules always prevail.
 - **Skill Evaluation Skill** — `skill-evaluation/SKILL.md`: prompt tokenization, context detection (7 project types), project→skills mapping, instinct integration (+20 boost for high-confidence instincts).
 - **Registries** — `eval-registry.json` (skill activations) + `instincts/registry.json` (instinct entries).
-- Total: 382 commands, 39 skills. Compliance runner passed. CI green.
+- Total: 382 commands, 41 skills. Compliance runner passed. CI green.
 
 ---
 
@@ -405,7 +405,7 @@ Red Team / Blue Team / Auditor pattern for systematic security testing. Inspired
 - **`/threat-model`** — STRIDE/PASTA threat modeling. Asset inventory, threat analysis (probability × impact), control mapping, gap identification, prioritized recommendations.
 - **Adversarial Security Rule** — `adversarial-security.md`: severity classification, scoring formula (100 - critical×25 - high×10 - medium×3 - low×1), agent independence, compliance integration.
 - **Adversarial Security Skill** — CVSS scoring, STRIDE mapping, OWASP checklist, dependency audit commands (npm/pip/dotnet).
-- Total: 384 commands, 30 agents, 40 skills. Compliance runner passed. CI green.
+- Total: 384 commands, 31 agents, 41 skills. Compliance runner passed. CI green.
 
 ---
 
@@ -416,7 +416,7 @@ Red Team / Blue Team / Auditor pattern for systematic security testing. Inspired
 - **Insurance (4)** — `/insurance-policy` (create/renew/cancel/list/compare, POL-NNN IDs, endorsement tracking), `/insurance-claim` (open/investigate/resolve, CLM-NNN, loss ratio analytics), `/solvency-report` (Solvency II: SCR/MCR/own funds, RAG indicator, regulator submission), `/underwriting-rule` (define/evaluate/list/audit, accept/refer/decline decisions, override tracking).
 - **Retail/eCommerce (4)** — `/product-catalog` (SKU-NNNN, categories, pricing, stock management, CSV/JSON export), `/order-track` (ORD-NNNN, status lifecycle: pending→delivered, returns, revenue analytics), `/inventory-manage` (stock/reorder/transfer/count/alert, multi-warehouse, dead stock detection), `/promotion-engine` (PROMO-NNN, discount/BOGO/bundle/coupon, cart evaluation, ROI analysis).
 - **Telco (4)** — `/service-catalog-telco` (SVC-NNN, voz/datos/fibra/tv/convergente, SLA, bundling with discounts), `/network-incident` (NI-NNNN, eTOM classification, escalation tiers, SLA compliance verification), `/subscriber-lifecycle` (SUB-NNNN, onboard/upgrade/downgrade, churn-risk scoring, ARPU/LTV analytics), `/capacity-forecast-telco` (utilization measurement, trend-based forecasting, expansion planning, threshold alerts).
-- Total: 396 commands, 30 agents, 40 skills. Compliance runner passed. CI green.
+- Total: 396 commands, 31 agents, 41 skills, 16 hooks. Compliance runner passed. CI green.
 
 ---
 


### PR DESCRIPTION
## Summary

Full documentation audit to align all stats and content with current state after Eras 43-48.

- **Stats updated everywhere**: README.md, README.en.md, CLAUDE.md, ROADMAP.md, agents-catalog.md → 396+ commands, 31 agents, 41 skills, 16 hooks, 14 guides
- **New feature sections**: universal accessibility, industry verticals (8), adversarial security, adaptive intelligence added to both READMEs
- **Frontmatter fixed**: 8 Retail/Telco commands had `title:` instead of `name:` — corrected with kebab-case
- **agents-catalog.md**: Added 4 missing agents (frontend-test-runner, security-attacker/defender/auditor) + adversarial security flow
- **CHANGELOG**: v2.20.1 entry documenting the audit

## Test plan

- [x] Compliance runner: 4/4 passed
- [x] CI local: 14/14 passed
- [x] README.md: 149 lines (≤150)
- [x] README.en.md: 149 lines (≤150)
- [x] CHANGELOG comparison link present for v2.20.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)