### PR TITLE
docs: Guide — Start a project from scratch (ES + EN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com). Versioning: [SemVer](htt
 
 ---
 
+## [2.23.1] — 2026-03-06
+
+### Added — Guide: Project from Scratch
+
+Step-by-step guide for PMs to start a project from scratch: client profile, team, architecture, business rules, specs, test requirements, and implementation with Dev Session Protocol. Works across Azure DevOps, Jira, and Savia Flow.
+
+- **`docs/guides/guide-project-from-scratch.md`** (ES) — 8-step workflow with concrete examples: client profile, CLAUDE.md, equipo.md, reglas-negocio.md, PBI decomposition, spec generation, test strategy, dev session orchestration.
+- **`docs/guides_en/guide-project-from-scratch.md`** (EN) — English translation.
+- Updated guides index (ES + EN) with new entry highlighted.
+
+---
+
 ## [2.23.0] — 2026-03-06
 
 ### Added — Era 52: Dev Session Protocol (Context-Optimized Development)
@@ -538,6 +550,7 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.23.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.23.0...v2.23.1
 [2.23.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.22.0...v2.23.0
 [2.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.21.0...v2.22.0
 [2.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.20.3...v2.21.0

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -23,6 +23,7 @@
 | [Auditoría de soberanía cognitiva](guide-sovereignty.md) | Lock-in cognitivo, Sovereignty Score, exit plan | CTO, PM, Compliance |
 | [Gran consultora tecnológica](guide-enterprise-consultancy.md) | 500-5000 empleados, multi-proyecto, multi-cliente | CEO, CTO, PM, Compliance |
 | [Análisis de gaps — Gran consultora](guide-enterprise-gap-analysis.md) | 10 gaps operativos y cómo los resuelve Savia | CEO, CTO, Dir. Operaciones, PM |
+| **[Proyecto desde cero](guide-project-from-scratch.md)** | **Paso a paso completo: cliente, equipo, arquitectura, reglas, specs, tests. Azure DevOps / Jira / Savia Flow** | **PM, Tech Lead** |
 
 ---
 

--- a/docs/guides/guide-project-from-scratch.md
+++ b/docs/guides/guide-project-from-scratch.md
@@ -1,0 +1,252 @@
+# Guía: Arrancar un proyecto desde cero con Savia
+
+> Para PMs que quieren configurar un proyecto completo: cliente, equipo, arquitectura, reglas de negocio, specs y tests. Aplica a Azure DevOps, Jira o Savia Flow.
+
+---
+
+## Paso 1 — Definir al cliente
+
+> "Savia, crea un perfil de cliente para Acme Corp"
+
+Savia ejecuta `/client-profile create` y te pide datos básicos. Se almacena en SaviaHub:
+
+```
+clients/acme-corp/
+├── profile.md      ← Nombre, sector, tamaño, contacto principal
+├── contacts.md     ← Personas clave del cliente (PO, sponsor, TI)
+├── rules.md        ← Reglas del cliente (horarios, compliance, restricciones)
+└── projects/       ← Proyectos asociados a este cliente
+```
+
+**Ejemplo de `profile.md`:**
+
+```yaml
+nombre: Acme Corp
+sector: Retail
+tamaño: 200 empleados
+contrato: T&M (Time & Materials)
+presupuesto_horas: 800
+contacto_principal: María López (maria.lopez@acme.com)
+compliance: RGPD, PCI-DSS (acepta pagos)
+```
+
+---
+
+## Paso 2 — Crear el proyecto
+
+```bash
+mkdir -p projects/acme-tienda/specs projects/acme-tienda/sprints
+```
+
+Crea `projects/acme-tienda/CLAUDE.md` — es el fichero central. Adaptarlo al PM tool:
+
+| Sección | Azure DevOps | Jira | Savia Flow |
+|---------|-------------|------|------------|
+| Identidad | `PROJECT_AZDO_NAME = "AcmeTienda"` | `JIRA_PROJECT_KEY = "ACM"` | `PROJECT_NAME = "acme-tienda"` |
+| Sprint | `ITERATION_PATH_ROOT = "AcmeTienda\\Sprints"` | `JIRA_BOARD_ID = "42"` | `/savia-sprint start` |
+| Repo | `REPO_URL = "https://dev.azure.com/..."` | `REPO_URL = "https://github.com/..."` | Mismo repo Git |
+
+**Ejemplo mínimo de CLAUDE.md del proyecto:**
+
+```
+# Acme Tienda — E-commerce Backend
+
+## CONSTANTES
+PROJECT_NAME        = "acme-tienda"
+SPRINT_ACTUAL       = "Sprint 2026-05"
+SPRINT_GOAL         = "API de catálogo + carrito de compras"
+
+## Stack
+BACKEND             = ".NET 8 / ASP.NET Core"
+DATABASE            = "PostgreSQL 16"
+ARCH_PATTERN        = "Clean Architecture"
+TEST_FRAMEWORK      = "xUnit"
+test_coverage_min   = 80
+
+## Equipo: ver equipo.md
+## Reglas de negocio: ver reglas-negocio.md
+```
+
+---
+
+## Paso 3 — Definir el equipo
+
+Crea `projects/acme-tienda/equipo.md`:
+
+```markdown
+# Equipo — Acme Tienda
+
+| Rol | Persona | Capacidad sprint | Horas/día |
+|-----|---------|-----------------|-----------|
+| PM / Scrum Master | Ana García | 80h | 8h |
+| Tech Lead | Pedro Ruiz | 60h | 6h (2h coordinación) |
+| Developer Backend | Laura Díaz | 70h | 7h |
+| Developer Frontend | Marc Soler | 70h | 7h |
+| QA Engineer | Sara López | 40h | 4h (media jornada) |
+| Claude Agent Team | dev:agent | ilimitada | — |
+
+Capacity total sprint (2 semanas): 320h
+```
+
+> "Savia, incorpora al equipo de acme-tienda"
+
+En **Azure DevOps**: se mapean al Team en el Board. En **Jira**: se asignan como Members del Project. En **Savia Flow**: se crean como usuarios del company repo.
+
+---
+
+## Paso 4 — Documentar reglas de negocio y dominio
+
+Crea `projects/acme-tienda/reglas-negocio.md`. Estructura recomendada:
+
+```markdown
+# Reglas de Negocio — Acme Tienda
+
+## Dominio: Catálogo de Productos
+
+### RN-PROD-01: SKU único
+Cada producto tiene un SKU único alfanumérico (8-20 caracteres).
+- Error: `DuplicateSkuException` · HTTP: 409
+
+### RN-PROD-02: Precio > 0
+El precio de venta debe ser mayor que cero.
+- Error: `ValidationException` · HTTP: 400
+
+### RN-PROD-03: Stock no negativo
+El stock no puede ser negativo. Intentar vender sin stock → error.
+- Error: `InsufficientStockException` · HTTP: 409
+
+## Dominio: Carrito de Compras
+
+### RN-CART-01: Máximo 50 líneas
+Un carrito no puede tener más de 50 líneas distintas.
+
+### RN-CART-02: Cantidad mínima 1
+Cada línea del carrito debe tener cantidad ≥ 1.
+
+### RN-CART-03: Precio se fija al añadir
+El precio de un item se captura al momento de añadirlo al carrito (no cambia si el catálogo actualiza después).
+
+## Glosario
+
+| Término | Definición |
+|---------|-----------|
+| SKU | Stock Keeping Unit — identificador único de producto |
+| Carrito | Colección temporal de productos antes de pagar |
+| Línea | Un producto + cantidad dentro del carrito |
+```
+
+**Clave**: cada regla tiene ID (`RN-XXX-NN`), descripción, error esperado y código HTTP. Esto permite trazar requisito → spec → test.
+
+---
+
+## Paso 5 — Crear PBIs y planificar sprint
+
+| Azure DevOps | Jira | Savia Flow |
+|-------------|------|------------|
+| `/sprint-plan acme-tienda` | `/jira-sync pull` → `/sprint-plan` | `/savia-pbi create "API Catálogo" --project acme-tienda` |
+| Savia descompone PBIs y sincroniza con Azure DevOps | Savia sincroniza con Jira y planifica | Todo en Git, sin herramienta externa |
+
+**Ejemplo universal (funciona en las 3):**
+
+> "Savia, descompone el PBI 'API de Catálogo de Productos' en tasks"
+
+Savia ejecuta `/pbi-decompose` y genera tasks por capa:
+
+```
+PBI: API de Catálogo de Productos (5 SP)
+├── 1.1 [Domain] Entidad Product + Value Object SKU (2h, human)
+├── 2.1 [Application] CreateProductHandler (2h, agent)
+├── 2.2 [Application] GetProductsQueryHandler (1h, agent)
+├── 3.1 [Infrastructure] ProductRepository + EF Config (2h, agent)
+├── 4.1 [API] ProductsController (2h, agent)
+├── 4.2 [Tests] Unit tests Application (3h, agent)
+└── 5.1 [Review] Code Review E1 (2h, human)
+```
+
+---
+
+## Paso 6 — Escribir specs (SDD)
+
+> "Savia, genera un spec para la task 2.1 CreateProductHandler"
+
+Savia ejecuta `/spec-generate` y crea `specs/sprint-2026-05/ACM-B2-create-product-handler.spec.md`:
+
+```markdown
+# Spec: CreateProductHandler
+
+## Requisitos
+- RF-01: Crear producto con nombre, SKU, precio, stock
+- RF-02: Validar RN-PROD-01 (SKU único), RN-PROD-02 (precio > 0)
+
+## Ficheros
+- CREAR: src/Application/Products/Commands/CreateProductHandler.cs
+- CREAR: src/Application/Products/Commands/CreateProductRequest.cs
+
+## Tests que deben pasar
+- CreateProduct_ValidData_ReturnsProductId
+- CreateProduct_DuplicateSku_Returns409
+- CreateProduct_NegativePrice_Returns400
+
+## Criterios de aceptación
+- [ ] Handler recibe CreateProductRequest y devuelve ProductId
+- [ ] Valida SKU único contra repositorio
+- [ ] Valida precio > 0 con FluentValidation
+- [ ] Guarda producto vía IProductRepository
+```
+
+---
+
+## Paso 7 — Definir requisitos de pruebas
+
+Savia sigue la regla: **cobertura mínima 80%**, Code Review E1 siempre humano.
+
+**Tipos de test por capa:**
+
+| Capa | Tipo | Quién | Ejemplo |
+|------|------|-------|---------|
+| Domain | Unit (entidad + domain service) | Human | `Product_InvalidSku_ThrowsException` |
+| Application | Unit (handlers + validators) | Agent | `CreateProduct_DuplicateSku_Returns409` |
+| Infrastructure | Integration (repo + EF) | Human | `ProductRepo_Save_PersistsToDb` |
+| API | Integration (controllers) | Agent | `POST /products → 201 Created` |
+| E2E | Acceptance | QA (human) | Flujo completo login→catálogo→carrito |
+
+En el spec, la sección "Tests que deben pasar" define exactamente qué assertions se esperan. El `test-engineer` agent genera el código de test a partir del spec.
+
+---
+
+## Paso 8 — Implementar con Dev Session Protocol
+
+> "Savia, analiza el spec y divide en slices"
+
+```
+/spec-slice specs/sprint-2026-05/ACM-B2-create-product-handler.spec.md
+```
+
+Luego:
+
+```
+/dev-session start specs/sprint-2026-05/ACM-B2-create-product-handler.spec.md
+/dev-session next    ← implementa slice 1 (subagent), valida, persiste
+/compact             ← obligatorio entre slices
+/dev-session next    ← slice 2
+/compact
+/dev-session review  ← code review final + consensus
+```
+
+---
+
+## Resumen: flujo completo
+
+```
+1. /client-profile create       → Definir cliente
+2. mkdir projects/{nombre}       → Crear estructura
+3. Crear CLAUDE.md del proyecto  → Configurar constantes
+4. Crear equipo.md               → Definir team + capacidad
+5. Crear reglas-negocio.md       → Documentar dominio (RN-XXX-NN)
+6. /pbi-decompose                → Descomponer PBIs en tasks
+7. /spec-generate                → Generar specs SDD por task
+8. /spec-slice + /dev-session    → Implementar con contexto optimizado
+9. Code Review E1 (humano)       → Aprobar
+```
+
+Funciona igual en Azure DevOps, Jira o Savia Flow — cambian los comandos de sincronización, no el método.

--- a/docs/guides_en/README.md
+++ b/docs/guides_en/README.md
@@ -23,6 +23,7 @@
 | [Cognitive Sovereignty Audit](guide-sovereignty.md) | Cognitive lock-in, Sovereignty Score, exit plan | CTO, PM, Compliance |
 | [Large Technology Consultancy](guide-enterprise-consultancy.md) | 500-5000 employees, multi-project, multi-client | CEO, CTO, PM, Compliance |
 | [Gap Analysis — Large Consultancy](guide-enterprise-gap-analysis.md) | 10 operational gaps and how Savia solves them | CEO, CTO, Operations Dir., PM |
+| **[Project from Scratch](guide-project-from-scratch.md)** | **Step-by-step: client, team, architecture, rules, specs, tests. Azure DevOps / Jira / Savia Flow** | **PM, Tech Lead** |
 
 ---
 

--- a/docs/guides_en/guide-project-from-scratch.md
+++ b/docs/guides_en/guide-project-from-scratch.md
@@ -1,0 +1,252 @@
+# Guide: Start a project from scratch with Savia
+
+> For PMs who want to configure a complete project: client, team, architecture, business rules, specs and tests. Applies to Azure DevOps, Jira or Savia Flow.
+
+---
+
+## Step 1 — Define the client
+
+> "Savia, create a client profile for Acme Corp"
+
+Savia executes `/client-profile create` and asks for basic information. It is stored in SaviaHub:
+
+```
+clients/acme-corp/
+├── profile.md      ← Name, industry, size, primary contact
+├── contacts.md     ← Key client people (PO, sponsor, IT)
+├── rules.md        ← Client rules (schedules, compliance, restrictions)
+└── projects/       ← Projects associated with this client
+```
+
+**Example of `profile.md`:**
+
+```yaml
+nombre: Acme Corp
+sector: Retail
+tamaño: 200 empleados
+contrato: T&M (Time & Materials)
+presupuesto_horas: 800
+contacto_principal: María López (maria.lopez@acme.com)
+compliance: RGPD, PCI-DSS (acepta pagos)
+```
+
+---
+
+## Step 2 — Create the project
+
+```bash
+mkdir -p projects/acme-tienda/specs projects/acme-tienda/sprints
+```
+
+Create `projects/acme-tienda/CLAUDE.md` — it is the central file. Adapt it to the PM tool:
+
+| Section | Azure DevOps | Jira | Savia Flow |
+|---------|-------------|------|------------|
+| Identity | `PROJECT_AZDO_NAME = "AcmeTienda"` | `JIRA_PROJECT_KEY = "ACM"` | `PROJECT_NAME = "acme-tienda"` |
+| Sprint | `ITERATION_PATH_ROOT = "AcmeTienda\\Sprints"` | `JIRA_BOARD_ID = "42"` | `/savia-sprint start` |
+| Repo | `REPO_URL = "https://dev.azure.com/..."` | `REPO_URL = "https://github.com/..."` | Same Git repo |
+
+**Minimal example of project CLAUDE.md:**
+
+```
+# Acme Tienda — E-commerce Backend
+
+## CONSTANTS
+PROJECT_NAME        = "acme-tienda"
+SPRINT_ACTUAL       = "Sprint 2026-05"
+SPRINT_GOAL         = "API de catálogo + carrito de compras"
+
+## Stack
+BACKEND             = ".NET 8 / ASP.NET Core"
+DATABASE            = "PostgreSQL 16"
+ARCH_PATTERN        = "Clean Architecture"
+TEST_FRAMEWORK      = "xUnit"
+test_coverage_min   = 80
+
+## Team: see equipo.md
+## Business rules: see reglas-negocio.md
+```
+
+---
+
+## Step 3 — Define the team
+
+Create `projects/acme-tienda/equipo.md`:
+
+```markdown
+# Team — Acme Tienda
+
+| Role | Person | Sprint Capacity | Hours/day |
+|-----|---------|-----------------|-----------|
+| PM / Scrum Master | Ana García | 80h | 8h |
+| Tech Lead | Pedro Ruiz | 60h | 6h (2h coordination) |
+| Backend Developer | Laura Díaz | 70h | 7h |
+| Frontend Developer | Marc Soler | 70h | 7h |
+| QA Engineer | Sara López | 40h | 4h (part-time) |
+| Claude Agent Team | dev:agent | unlimited | — |
+
+Total sprint capacity (2 weeks): 320h
+```
+
+> "Savia, add the acme-tienda team"
+
+In **Azure DevOps**: they are mapped to the Team on the Board. In **Jira**: they are assigned as Project Members. In **Savia Flow**: they are created as company repo users.
+
+---
+
+## Step 4 — Document business rules and domain
+
+Create `projects/acme-tienda/reglas-negocio.md`. Recommended structure:
+
+```markdown
+# Business Rules — Acme Tienda
+
+## Domain: Product Catalog
+
+### RN-PROD-01: Unique SKU
+Each product has a unique alphanumeric SKU (8-20 characters).
+- Error: `DuplicateSkuException` · HTTP: 409
+
+### RN-PROD-02: Price > 0
+The selling price must be greater than zero.
+- Error: `ValidationException` · HTTP: 400
+
+### RN-PROD-03: Non-negative stock
+Stock cannot be negative. Attempting to sell without stock → error.
+- Error: `InsufficientStockException` · HTTP: 409
+
+## Domain: Shopping Cart
+
+### RN-CART-01: Maximum 50 lines
+A cart cannot have more than 50 different lines.
+
+### RN-CART-02: Minimum quantity 1
+Each cart line must have quantity ≥ 1.
+
+### RN-CART-03: Price fixed when added
+An item's price is captured at the moment it is added to the cart (does not change if the catalog is updated later).
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| SKU | Stock Keeping Unit — unique product identifier |
+| Cart | Temporary collection of products before payment |
+| Line | A product + quantity within the cart |
+```
+
+**Key**: each rule has ID (`RN-XXX-NN`), description, expected error and HTTP code. This allows tracing requirement → spec → test.
+
+---
+
+## Step 5 — Create PBIs and plan sprint
+
+| Azure DevOps | Jira | Savia Flow |
+|-------------|------|------------|
+| `/sprint-plan acme-tienda` | `/jira-sync pull` → `/sprint-plan` | `/savia-pbi create "API Catálogo" --project acme-tienda` |
+| Savia decomposes PBIs and syncs with Azure DevOps | Savia syncs with Jira and plans | Everything in Git, no external tool |
+
+**Universal example (works in all 3):**
+
+> "Savia, decompose the PBI 'Product Catalog API' into tasks"
+
+Savia executes `/pbi-decompose` and generates tasks by layer:
+
+```
+PBI: API de Catálogo de Productos (5 SP)
+├── 1.1 [Domain] Entidad Product + Value Object SKU (2h, human)
+├── 2.1 [Application] CreateProductHandler (2h, agent)
+├── 2.2 [Application] GetProductsQueryHandler (1h, agent)
+├── 3.1 [Infrastructure] ProductRepository + EF Config (2h, agent)
+├── 4.1 [API] ProductsController (2h, agent)
+├── 4.2 [Tests] Unit tests Application (3h, agent)
+└── 5.1 [Review] Code Review E1 (2h, human)
+```
+
+---
+
+## Step 6 — Write specs (SDD)
+
+> "Savia, generate a spec for task 2.1 CreateProductHandler"
+
+Savia executes `/spec-generate` and creates `specs/sprint-2026-05/ACM-B2-create-product-handler.spec.md`:
+
+```markdown
+# Spec: CreateProductHandler
+
+## Requirements
+- RF-01: Create product with name, SKU, price, stock
+- RF-02: Validate RN-PROD-01 (unique SKU), RN-PROD-02 (price > 0)
+
+## Files
+- CREATE: src/Application/Products/Commands/CreateProductHandler.cs
+- CREATE: src/Application/Products/Commands/CreateProductRequest.cs
+
+## Tests that must pass
+- CreateProduct_ValidData_ReturnsProductId
+- CreateProduct_DuplicateSku_Returns409
+- CreateProduct_NegativePrice_Returns400
+
+## Acceptance criteria
+- [ ] Handler receives CreateProductRequest and returns ProductId
+- [ ] Validates unique SKU against repository
+- [ ] Validates price > 0 with FluentValidation
+- [ ] Saves product via IProductRepository
+```
+
+---
+
+## Step 7 — Define testing requirements
+
+Savia follows the rule: **minimum 80% coverage**, Code Review E1 always human.
+
+**Test types by layer:**
+
+| Layer | Type | Who | Example |
+|------|------|-------|---------|
+| Domain | Unit (entity + domain service) | Human | `Product_InvalidSku_ThrowsException` |
+| Application | Unit (handlers + validators) | Agent | `CreateProduct_DuplicateSku_Returns409` |
+| Infrastructure | Integration (repo + EF) | Human | `ProductRepo_Save_PersistsToDb` |
+| API | Integration (controllers) | Agent | `POST /products → 201 Created` |
+| E2E | Acceptance | QA (human) | Complete flow login→catalog→cart |
+
+In the spec, the "Tests that must pass" section defines exactly what assertions are expected. The `test-engineer` agent generates the test code from the spec.
+
+---
+
+## Step 8 — Implement with Dev Session Protocol
+
+> "Savia, analyze the spec and divide into slices"
+
+```
+/spec-slice specs/sprint-2026-05/ACM-B2-create-product-handler.spec.md
+```
+
+Then:
+
+```
+/dev-session start specs/sprint-2026-05/ACM-B2-create-product-handler.spec.md
+/dev-session next    ← implements slice 1 (subagent), validates, persists
+/compact             ← mandatory between slices
+/dev-session next    ← slice 2
+/compact
+/dev-session review  ← final code review + consensus
+```
+
+---
+
+## Summary: complete flow
+
+```
+1. /client-profile create       → Define client
+2. mkdir projects/{nombre}       → Create structure
+3. Create project CLAUDE.md      → Configure constants
+4. Create equipo.md              → Define team + capacity
+5. Create reglas-negocio.md      → Document domain (RN-XXX-NN)
+6. /pbi-decompose                → Decompose PBIs into tasks
+7. /spec-generate                → Generate SDD specs per task
+8. /spec-slice + /dev-session    → Implement with optimized context
+9. Code Review E1 (human)        → Approve
+```
+
+Works the same in Azure DevOps, Jira or Savia Flow — the sync commands change, not the method.


### PR DESCRIPTION
## Summary

- **New guide** `docs/guides/guide-project-from-scratch.md` (ES, 252 lines) — Step-by-step for PMs to start a project from scratch
- **English version** `docs/guides_en/guide-project-from-scratch.md` (EN, 252 lines) — Full translation
- **Updated guides index** (ES + EN) with highlighted new entry

### The 8-step workflow covers:

1. **Client profile** — SaviaHub structure, contacts, compliance
2. **Project creation** — CLAUDE.md with examples for Azure DevOps / Jira / Savia Flow
3. **Team definition** — equipo.md with roles, capacity, sprint hours
4. **Business rules** — reglas-negocio.md with RN-XXX-NN pattern, errors, HTTP codes
5. **PBI decomposition** — `/pbi-decompose` with layer-based task breakdown
6. **Spec generation** — SDD specs with requirements, files, test expectations
7. **Test strategy** — Coverage by layer (unit/integration/E2E), human vs agent
8. **Implementation** — `/spec-slice` + `/dev-session` with context optimization

## Test plan

- [x] Compliance runner: 4/4 green
- [x] CHANGELOG comparison link added (v2.23.1)
- [x] Both guide indexes updated (ES + EN)
- [x] Examples use generic data (PII-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)