### PR TITLE
feat: Era 74 — Session Recording

### DIFF
--- a/.claude/commands/record-export.md
+++ b/.claude/commands/record-export.md
@@ -1,0 +1,46 @@
+# /record-export
+
+Exporta una sesión grabada como informe markdown con formato legible para documentación, auditoría o capacitación.
+
+## Parámetros
+
+- `$ARGUMENTS`: ID de sesión a exportar (`session-YYYYMMDD-hash`)
+
+## Comportamiento
+
+- **Lectura**: Carga JSONL de la sesión
+- **Procesamiento**: Transforma eventos en narrative markdown
+- **Almacenamiento**: Guarda en `output/recordings/{session-id}-report.md`
+- **Formato**: Documento estructurado con secciones, tablas y ejemplos
+
+## Output
+
+Informe markdown en:
+
+```
+📄 Informe generado: output/recordings/session-20260307-abc123-report.md
+⏱️  Duración: 42 minutos
+📊 Total eventos: 127
+✅ Informe completo con timeline, decisiones y artefactos
+```
+
+Estructura del informe:
+- Encabezado (ID sesión, duración, fecha)
+- Timeline de acciones
+- Archivos modificados
+- Decisiones y notas
+- Apéndice: comandos ejecutados
+
+## Ejemplos
+
+✅ Correcto:
+```
+PM: /record-export session-20260307-abc123
+Savia: Informe guardado en output/recordings/session-20260307-abc123-report.md
+```
+
+❌ Incorrecto:
+```
+PM: /record-export session-inexistente
+Savia: ❌ Sesión no encontrada
+```

--- a/.claude/commands/record-replay.md
+++ b/.claude/commands/record-replay.md
@@ -1,0 +1,47 @@
+# /record-replay
+
+Reproduce una sesión grabada anteriormente. Muestra una línea de tiempo de todas las acciones registradas.
+
+## Parámetros
+
+- `$ARGUMENTS`: ID de sesión a reproducir (`session-YYYYMMDD-hash`)
+
+## Comportamiento
+
+- **Carga**: Lee el archivo JSONL de la sesión
+- **Ordenamiento**: Ordena eventos cronológicamente
+- **Presentación**: Muestra timeline interactivo con timestamps
+- **Detalles**: Permite expandir cada evento para ver contenido completo
+
+## Output
+
+Timeline visual:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📽️ /record-replay session-20260307-abc123
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+10:30:15 — [command]      /sprint-status
+10:31:02 — [file-modify]  Created: project-plan.md
+10:31:45 — [decision]     Selected approach: async-first
+10:32:30 — [command]      /spec-generate --project alpha
+...
+10:55:42 — [file-modify]  Modified: service.ts (3 métodos)
+
+⏱️  Total: 42 min | 127 eventos | 8 archivos
+```
+
+## Ejemplos
+
+✅ Correcto:
+```
+PM: /record-replay session-20260307-abc123
+Savia: [muestra timeline completo]
+```
+
+❌ Incorrecto:
+```
+PM: /record-replay session-inexistente
+Savia: ❌ Sesión no encontrada: session-inexistente
+```

--- a/.claude/commands/record-start.md
+++ b/.claude/commands/record-start.md
@@ -1,0 +1,39 @@
+# /record-start
+
+Inicia la grabación de la sesión actual. Todos los comandos, modificaciones de archivos y decisiones de agentes se registran en un archivo JSONL para auditoría y documentación posterior.
+
+## Comportamiento
+
+- **Sesión nueva**: Genera un ID de sesión único (`session-{timestamp}-{hash}`)
+- **Grabación**: Crea fichero en `data/recordings/{session-id}.jsonl`
+- **Eventos**: Cada acción registra tipo, timestamp, actor, contenido
+- **Confirmación**: Muestra ID de sesión y ruta de almacenamiento
+
+## Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ /record-start — Grabación iniciada
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🎬 Sesión: session-20260307-abc123
+📁 Archivo: data/recordings/session-20260307-abc123.jsonl
+⏱️  Hora inicio: 2026-03-07T10:30:15Z
+
+💡 Parar grabación: /record-stop
+💾 Reproducir: /record-replay session-20260307-abc123
+📊 Exportar: /record-export session-20260307-abc123
+```
+
+## Ejemplos
+
+✅ Correcto:
+```
+PM: /record-start
+Savia: Sesión iniciada. ID: session-20260307-xyz789
+```
+
+❌ Incorrecto:
+```
+PM: /record-start
+Savia: [nada sucede, sin confirmación visual]
+```

--- a/.claude/commands/record-stop.md
+++ b/.claude/commands/record-stop.md
@@ -1,0 +1,37 @@
+# /record-stop
+
+Detiene la grabación de sesión actual y muestra un resumen de lo registrado.
+
+## Comportamiento
+
+- **Finalización**: Cierra el archivo JSONL de grabación
+- **Resumen**: Calcula y muestra estadísticas
+- **Limpieza**: Marca la sesión como completada
+
+## Output
+
+Resumen con:
+- Duración total de la sesión
+- Cantidad de eventos registrados (desglosado por tipo)
+- Número de archivos modificados
+- Ruta de almacenamiento del fichero JSONL
+
+## Ejemplo
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ /record-stop — Grabación completada
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📊 Resumen:
+  Duración: 42 minutos
+  Eventos: 127 total
+    · Comandos: 18
+    · Modificaciones: 45
+    · Decisiones: 12
+    · Notas: 52
+  Archivos modificados: 8
+📁 Grabación: data/recordings/session-20260307-abc123.jsonl
+
+💾 Reproducir: /record-replay session-20260307-abc123
+📋 Exportar: /record-export session-20260307-abc123
+```

--- a/.claude/skills/pm-mcp-server/DOMAIN.md
+++ b/.claude/skills/pm-mcp-server/DOMAIN.md
@@ -1,0 +1,22 @@
+# Dominio: PM-Workspace MCP Server
+
+**Propósito:** Servidor Model Context Protocol que expone la gestión de proyectos para integración externa.
+
+**Conceptos Clave:**
+
+- **MCP Server** — Protocolo estándar para compartir recursos, herramientas y prompts
+- **Transporte Dual** — stdio (local, seguro) y SSE (remoto, escalable)
+- **Recursos** — Datos de solo lectura: proyectos, tareas, métricas, riesgos
+- **Herramientas** — Operaciones escribibles: crear, actualizar, asignar, reportar
+- **Prompts** — Plantillas inteligentes para planificación, descomposición, evaluación
+- **Modo Solo Lectura** — Protección para clientes no confiables
+
+**Responsabilidades:**
+
+- Exponer estado actual de PM-Workspace seguramente
+- Manejar autenticación por token en modo remoto
+- Mantener integridad de datos bajo acceso concurrente
+- Servir métricas actualizadas en tiempo real
+- Cumplir especificación oficial MCP
+
+**Audiencia:** Herramientas externas, dashboards, sistemas de automatización

--- a/.claude/skills/pm-mcp-server/SKILL.md
+++ b/.claude/skills/pm-mcp-server/SKILL.md
@@ -1,0 +1,65 @@
+# PM-Workspace MCP Server
+
+**Nombre:** pm-mcp-server
+
+**Descripción:** Expone el estado de PM-Workspace como servidor MCP para consumo de herramientas externas, permitiendo que clientes remotos accedan a la gestión de proyectos sin interfaz directa.
+
+## Recursos Expuestos
+
+1. **project-list** — Lista de proyectos activos con estado, propietario y métricas
+2. **pbi-details** — Detalles de Product Backlog Items: descripción, criterios de aceptación, estado
+3. **task-status** — Estado actual de tareas: asignado, en progreso, completado, bloqueado
+4. **team-capacity** — Capacidad del equipo: disponibilidad, carga actual, velocidad
+5. **sprint-metrics** — Métricas de sprint: burn-down, completitud, velocidad, tendencias
+6. **risk-register** — Registro de riesgos: identificación, impacto, mitigación, estado
+
+## Herramientas Expuestas
+
+1. **create-pbi** — Crear nuevo Product Backlog Item con descripción y criterios
+2. **update-task-status** — Actualizar estado de tarea (asignado, en progreso, completado)
+3. **assign-task** — Asignar tarea a miembro del equipo
+4. **generate-report** — Generar reportes: sprint, proyecto, equipo, riesgos
+
+## Prompts Expuestos
+
+1. **sprint-planning** — Asistencia para planificación de sprint con recomendaciones
+2. **pbi-decomposition** — Descomposición de PBI en tareas técnicas
+3. **risk-assessment** — Evaluación de riesgos y estrategias de mitigación
+
+## Transporte
+
+- **Modo Local (stdio)** — Comunicación directa sin red, máxima seguridad
+- **Modo Remoto (SSE)** — Server-Sent Events sobre HTTP, acceso remoto seguro
+
+## Configuración
+
+Archivo: `.claude/mcp-server-config.json`
+
+```json
+{
+  "transport": "stdio|sse",
+  "port": 3000,
+  "resources": ["project-list", "pbi-details", "task-status", "team-capacity", "sprint-metrics", "risk-register"],
+  "tools": ["create-pbi", "update-task-status", "assign-task", "generate-report"],
+  "prompts": ["sprint-planning", "pbi-decomposition", "risk-assessment"],
+  "auth": {"type": "token|none", "tokenRequired": true},
+  "readOnly": false
+}
+```
+
+## Autenticación
+
+- **Local (stdio)** — Sin autenticación
+- **Remoto (SSE)** — Token Bearer obligatorio
+- **Modo Solo Lectura** — Disponible para ambos transportes, desactiva herramientas de escritura
+
+## Casos de Uso
+
+- Integración con herramientas de IA externas
+- Dashboards de terceros consumiendo métricas
+- Automatización de flujos de trabajo PM
+- Reportería personalizada desde sistemas externos
+
+## Estado
+
+✓ Implementado en Release 21 — 2026-03-07

--- a/.claude/skills/session-recording/DOMAIN.md
+++ b/.claude/skills/session-recording/DOMAIN.md
@@ -1,0 +1,32 @@
+# Session Recording Domain
+
+## Overview
+The session recording domain handles capture, storage, replay, and export of agent session activities.
+
+## Core Concepts
+
+### Session
+A bounded period of agent activity with a unique session ID. Contains all recorded events during that period.
+
+### Event
+An atomic action within a session (command execution, file operation, API call, decision, note).
+
+### Recording
+The complete JSONL file containing all events for a session, stored in `data/recordings/{session-id}.jsonl`.
+
+### Timeline
+The chronological view of all events in a session during replay.
+
+## Data Model
+
+```jsonl
+{"type": "command", "timestamp": "2026-03-07T10:30:15Z", "actor": "claude-agent", "content": {"command": "git status", "output": "..."}}
+{"type": "file-modification", "timestamp": "2026-03-07T10:30:20Z", "actor": "claude-agent", "content": {"action": "create", "path": "file.md"}}
+{"type": "decision", "timestamp": "2026-03-07T10:30:25Z", "actor": "claude-agent", "content": {"reasoning": "...", "choice": "..."}}
+```
+
+## Storage
+- Location: `data/recordings/`
+- Format: JSONL (one event per line)
+- Naming: `{session-id}.jsonl`
+- Lifecycle: Created on `/record-start`, appended on each action, finalized on `/record-stop`

--- a/.claude/skills/session-recording/SKILL.md
+++ b/.claude/skills/session-recording/SKILL.md
@@ -1,0 +1,48 @@
+# Session Recording Skill
+
+## Name
+session-recording
+
+## Description
+Record and replay agent sessions for auditing and documentation. Captures all actions performed during a session and enables comprehensive replay and export capabilities.
+
+## What Gets Recorded
+- **Commands executed**: CLI commands with arguments and outputs
+- **Files modified**: Create, read, update, delete operations
+- **API calls made**: External service interactions and responses
+- **Decisions taken**: Agent reasoning and choices
+- **Agent notes generated**: Observations and insights
+- **Timestamps**: Precise timing for all events
+
+## Storage Format
+Storage location: `data/recordings/{session-id}.jsonl`
+
+Each recording is a JSONL (JSON Lines) file with one event per line. Each event contains:
+- `type`: event category (command, file-modification, api-call, decision, note, etc.)
+- `timestamp`: ISO 8601 format
+- `actor`: agent or system component
+- `content`: event details and metadata
+
+## Replay
+The replay function reads a recording file and displays a chronological timeline of all actions, showing:
+- Event timestamps
+- Action descriptions
+- Actor information
+- Relevant content details
+
+## Export
+Recordings can be exported as markdown reports from the JSONL format, creating human-readable documentation suitable for distribution and review.
+
+## Use Cases
+
+### 1. Compliance Audit
+Record sensitive operations for compliance verification and regulatory requirements. Create audit trails with full action history.
+
+### 2. Onboarding Training
+Record exemplary agent sessions to use as training material. New team members can replay sessions to understand workflows and decision patterns.
+
+### 3. Postmortem Analysis
+When issues occur, replay the recording to understand exactly what happened, identify failure points, and improve processes.
+
+### 4. Documentation of Complex Operations
+Automatically generate documentation by recording and exporting sessions of complex multi-step operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [2.45.0] — 2026-03-07
+
+### Added — Era 74: Session Recording
+
+Record, replay, and export agent sessions for auditing, documentation, and training.
+
+- **`/record-start`** — Begin recording all session actions. Creates unique session ID, stores events in JSONL format.
+- **`/record-stop`** — Stop recording. Summary: duration, events count, files modified.
+- **`/record-replay {session-id}`** — Replay recorded session with timeline. Chronological view of all actions performed.
+- **`/record-export {session-id}`** — Export as markdown report to output/recordings/. Includes timeline, decisions, modified files, commands executed.
+- **`session-recording` skill** — Records commands executed, files modified, API calls made, decisions taken, agent-notes generated, with timestamps. Storage: `data/recordings/{session-id}.jsonl` (one event per line). Use cases: compliance audit, onboarding training, postmortem analysis, documentation of complex operations.
+
+---
+
 # Changelog — pm-workspace
 
 ## [2.42.0] — 2026-03-07


### PR DESCRIPTION
## Summary

Release 22 implementation: Session Recording for audit and documentation. Adds 4 new commands and a supporting skill to record, replay, and export agent sessions.

## Features

- **`/record-start`** — Begin recording all session actions with unique session ID
- **`/record-stop`** — Stop recording and display summary (duration, event count, files modified)
- **`/record-replay {session-id}`** — Replay session with chronological timeline
- **`/record-export {session-id}`** — Export session as markdown report
- **`session-recording` skill** — Records: commands, files modified, API calls, decisions, agent-notes. Storage: JSONL format. Use cases: audit, training, postmortem, documentation

## Test Plan

- [ ] Verify all command files created (4 commands, max 50 lines each)
- [ ] Verify skill files created (SKILL.md ≤110 lines, DOMAIN.md ≤40 lines)
- [ ] Verify CHANGELOG.md updated with Release 2.45.0
- [ ] Verify all files within 150-line limit
- [ ] Confirm Spanish user-facing documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)