### PR TITLE
fix: restore CHANGELOG.md truncated since Era 59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -844,6 +844,10 @@ Confidentiality hardening: E2E encryption testing, subject sensitivity validatio
 
 - **test-integration-company.sh**: Runs 18 suites (197 tests total, all green). Accepts repo URL as parameter.
 
+[2.28.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.27.0...v2.28.0
+[2.27.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.26.0...v2.27.0
+[2.26.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.25.0...v2.26.0
+[2.25.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.24.0...v2.25.0
 [2.24.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.23.1...v2.24.0
 [2.23.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.23.0...v2.23.1
 [2.23.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.22.0...v2.23.0


### PR DESCRIPTION
## Summary

- Restored 175 versions from git history (v2.48.0 to v0.1.0)
- Added missing Eras 58-77 entries extracted from individual commits
- Fixed duplicate entries, added all version comparison links
- Fixed missing links for v2.25.0-v2.28.0

## Root cause

Since Era 59, each session used `Write` instead of `Edit` on CHANGELOG, overwriting the entire file with only the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)