### PR TITLE
fix: CHANGELOG.md integrity validation in CI checks

### DIFF
--- a/.claude/rules/domain/changelog-integrity.md
+++ b/.claude/rules/domain/changelog-integrity.md
@@ -1,0 +1,36 @@
+# Regla: CHANGELOG.md — Integridad y Buenas Prácticas
+
+## Problema
+
+El CHANGELOG.md es un punto caliente de conflictos de merge. Cuando múltiples
+ramas lo modifican simultáneamente, la resolución de conflictos puede:
+
+1. **Truncar entradas** — eliminar versiones existentes al quedarse con una rama
+2. **Desordenar versiones** — dejar una versión mayor después de una menor
+3. **Dejar marcadores de conflicto** — `<<<<<<<`, `=======`, `>>>>>>>` residuales
+4. **Duplicar entradas** — la misma versión aparece dos veces
+5. **Perder la cabecera** — sobreescribir la cabecera estándar con la de una rama
+
+## Reglas obligatorias al modificar CHANGELOG.md
+
+1. **Solo añadir AL INICIO** — nueva entrada siempre después de la cabecera
+2. **Versión descendente estricta** — cada `## [x.y.z]` debe ser menor que la anterior
+3. **Sin gaps mayores a 2 minor** — si faltan versiones, buscar si se perdieron
+4. **Formato obligatorio** — `## [x.y.z] — YYYY-MM-DD`
+5. **Links comparativos** — `[x.y.z]: https://github.com/.../compare/vA...vB` al final
+6. **Tras resolver conflictos** — verificar SIEMPRE con:
+   ```bash
+   grep -c '^## \[' CHANGELOG.md  # contar entradas (debe coincidir con pre-merge)
+   grep -E '^(<<<<|====|>>>>)' CHANGELOG.md  # cero resultados
+   ```
+7. **Pre-push** — `bash scripts/validate-ci-local.sh --quick` incluye check de integridad
+
+## Para agentes
+
+Cuando un agente modifica CHANGELOG.md, DEBE:
+
+- Leer la versión más alta actual ANTES de escribir
+- Usar versión = más_alta + 0.1.0 (o +1.0.0 si major change)
+- Verificar tras escribir que `grep '^## \[' CHANGELOG.md` muestra orden descendente
+- NUNCA reemplazar el contenido completo del archivo — solo insertar la nueva entrada
+- Si hay conflicto de merge, preservar TODAS las entradas de ambas ramas

--- a/scripts/validate-ci-local.sh
+++ b/scripts/validate-ci-local.sh
@@ -111,12 +111,102 @@ else
 fi
 echo ""
 
+# ── 4. CHANGELOG integrity ──────────────────────────────────────────
+echo "📋 4. CHANGELOG.md integrity"
+
+if [ -f "CHANGELOG.md" ]; then
+  CL_FAIL=0
+
+  # 4a. No merge conflict markers
+  if grep -qE '^(<<<<<<<|=======|>>>>>>>)' CHANGELOG.md; then
+    fail "CHANGELOG.md contiene marcadores de conflicto git (<<<<<<<, =======, >>>>>>>)"
+    CL_FAIL=$((CL_FAIL + 1))
+  fi
+
+  # 4b. Versions in descending order (no out-of-order entries)
+  VERSIONS=$(grep -oP '(?<=^## \[)[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md)
+  PREV=""
+  LINE_NUM=0
+  while IFS= read -r ver; do
+    LINE_NUM=$((LINE_NUM + 1))
+    if [ -n "$PREV" ]; then
+      # Compare semver: PREV must be >= ver (descending)
+      PREV_MAJOR=$(echo "$PREV" | cut -d. -f1)
+      PREV_MINOR=$(echo "$PREV" | cut -d. -f2)
+      PREV_PATCH=$(echo "$PREV" | cut -d. -f3)
+      CUR_MAJOR=$(echo "$ver" | cut -d. -f1)
+      CUR_MINOR=$(echo "$ver" | cut -d. -f2)
+      CUR_PATCH=$(echo "$ver" | cut -d. -f3)
+      OUT_OF_ORDER=false
+      if [ "$CUR_MAJOR" -gt "$PREV_MAJOR" ]; then
+        OUT_OF_ORDER=true
+      elif [ "$CUR_MAJOR" -eq "$PREV_MAJOR" ] && [ "$CUR_MINOR" -gt "$PREV_MINOR" ]; then
+        OUT_OF_ORDER=true
+      elif [ "$CUR_MAJOR" -eq "$PREV_MAJOR" ] && [ "$CUR_MINOR" -eq "$PREV_MINOR" ] && [ "$CUR_PATCH" -gt "$PREV_PATCH" ]; then
+        OUT_OF_ORDER=true
+      fi
+      if [ "$OUT_OF_ORDER" = true ]; then
+        fail "CHANGELOG.md versiones fuera de orden: [$PREV] seguida de [$ver] (entrada #$LINE_NUM)"
+        CL_FAIL=$((CL_FAIL + 1))
+        break
+      fi
+    fi
+    PREV="$ver"
+  done <<< "$VERSIONS"
+
+  # 4c. No consecutive gaps >1 in minor version (within same major)
+  PREV=""
+  while IFS= read -r ver; do
+    if [ -n "$PREV" ]; then
+      PREV_MAJOR=$(echo "$PREV" | cut -d. -f1)
+      PREV_MINOR=$(echo "$PREV" | cut -d. -f2)
+      CUR_MAJOR=$(echo "$ver" | cut -d. -f1)
+      CUR_MINOR=$(echo "$ver" | cut -d. -f2)
+      if [ "$PREV_MAJOR" -eq "$CUR_MAJOR" ]; then
+        GAP=$((PREV_MINOR - CUR_MINOR))
+        if [ "$GAP" -gt 2 ]; then
+          warn "CHANGELOG.md posible gap de versiones: [$PREV] → [$ver] (salto de $GAP minor versions)"
+        fi
+      fi
+    fi
+    PREV="$ver"
+  done <<< "$VERSIONS"
+
+  # 4d. No duplicate version entries
+  DUP_VERSIONS=$(grep -oP '(?<=^## \[)[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sort | uniq -d)
+  if [ -n "$DUP_VERSIONS" ]; then
+    fail "CHANGELOG.md versiones duplicadas: $DUP_VERSIONS"
+    CL_FAIL=$((CL_FAIL + 1))
+  fi
+
+  # 4e. Header present (Keep a Changelog reference)
+  if ! head -6 CHANGELOG.md | grep -qi "keep a changelog\|changelog\|notable changes"; then
+    warn "CHANGELOG.md: cabecera estándar no detectada en las primeras 6 líneas"
+  fi
+
+  # 4f. First version header has correct format
+  FIRST_VER_LINE=$(grep -n '## \[' CHANGELOG.md | head -1)
+  if [ -n "$FIRST_VER_LINE" ]; then
+    if ! echo "$FIRST_VER_LINE" | grep -qP '## \[\d+\.\d+\.\d+\] — \d{4}-\d{2}-\d{2}'; then
+      warn "CHANGELOG.md: primera entrada no sigue formato '## [x.y.z] — YYYY-MM-DD'"
+    fi
+  fi
+
+  VER_COUNT=$(echo "$VERSIONS" | wc -l)
+  if [ "$CL_FAIL" -eq 0 ]; then
+    pass "CHANGELOG.md íntegro ($VER_COUNT versiones, orden correcto, sin duplicados, sin conflictos)"
+  fi
+else
+  fail "CHANGELOG.md no encontrado"
+fi
+echo ""
+
 if [ "$QUICK_MODE" = true ]; then
   echo "  (modo --quick: saltando checks extendidos)"
   echo ""
 else
-  # ── 4. Required open source files ────────────────────────────────────
-  echo "📋 4. Ficheros open source requeridos"
+  # ── 5. Required open source files ────────────────────────────────────
+  echo "📋 5. Ficheros open source requeridos"
 
   REQUIRED_FILES=(
     "LICENSE"
@@ -139,8 +229,8 @@ else
   done
   echo ""
 
-  # ── 5. JSON mock files ──────────────────────────────────────────────
-  echo "📋 5. JSON mock files"
+  # ── 6. JSON mock files ──────────────────────────────────────────────
+  echo "📋 6. JSON mock files"
 
   JSON_OK=0
   JSON_FAIL=0
@@ -158,8 +248,8 @@ else
   fi
   echo ""
 
-  # ── 6. Sensitive data scan ──────────────────────────────────────────
-  echo "📋 6. Scan de datos sensibles"
+  # ── 7. Sensitive data scan ──────────────────────────────────────────
+  echo "📋 7. Scan de datos sensibles"
 
   SECRETS_FOUND=false
   if grep -rn --include="*.md" --include="*.sh" --include="*.json" --include="*.yml" \


### PR DESCRIPTION
## Summary

- Adds CHANGELOG.md integrity check (section 4) to `validate-ci-local.sh`
- Runs in both `--quick` and full modes (cheap check, critical protection)
- New `changelog-integrity` rule for agents with clear instructions

## What it validates

| Check | Type | Detects |
|-------|------|---------|
| Conflict markers | ERROR | `<<<<<<<`, `=======`, `>>>>>>>` residuales |
| Version order | ERROR | Versión mayor después de menor (descendente estricto) |
| Duplicates | ERROR | Misma versión `## [x.y.z]` aparece dos veces |
| Version gaps | WARN | Salto >2 minor versions (posible truncación) |
| Header present | WARN | Cabecera estándar ausente |
| Entry format | WARN | Formato `## [x.y.z] — YYYY-MM-DD` incorrecto |

## Context

After the 25-release batch implementation, CHANGELOG.md got corrupted during merge conflict resolution (commits d472e2f, eb2fc05). Entries were truncated, the header was replaced, and comparison links were lost. This validation prevents it from happening again.

## Test plan

- [x] Clean CHANGELOG passes with 175 versions detected
- [x] Simulated conflict markers → detected as ERROR
- [x] Simulated out-of-order versions → detected as ERROR  
- [x] Simulated duplicate entries → detected as ERROR
- [x] Historical gaps (2.14→2.10, 0.89→0.83) → detected as WARN (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)