### PR TITLE
feat: Era 78 — Agent Dispatch Validation

### DIFF
--- a/.claude/hooks/agent-dispatch-validate.sh
+++ b/.claude/hooks/agent-dispatch-validate.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# ────────────────────────────────────────────────────────────────────────────
+# PreToolUse Hook: agent-dispatch-validate.sh
+# Valida que los prompts enviados a subagentes contengan contexto requerido.
+# Previene que agentes creen ficheros sin cumplir convenciones del proyecto.
+# ────────────────────────────────────────────────────────────────────────────
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Solo aplica al tool Task (subagentes)
+if [ "$TOOL_NAME" != "Task" ]; then
+  exit 0
+fi
+
+PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
+if [ -z "$PROMPT" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+CHECKLIST="$PROJECT_DIR/.claude/rules/domain/agent-dispatch-checklist.md"
+WARNINGS=""
+ERRORS=""
+
+# ── Helper: comprobar si el prompt menciona un patrón ──────────────────
+prompt_contains() {
+  echo "$PROMPT" | grep -qiE "$1"
+}
+
+# ── 1. Si el agente va a crear commands (.claude/commands/) ────────────
+if prompt_contains 'commands/.*\.md|crear.*command|create.*command'; then
+  if ! prompt_contains 'name:|^name:|frontmatter.*name'; then
+    ERRORS+="⚠ DISPATCH: prompt crea commands pero no menciona campo 'name' en frontmatter.\n"
+    ERRORS+="  Añadir al prompt: 'Frontmatter obligatorio: name, description'\n"
+  fi
+  if ! prompt_contains 'description:|frontmatter'; then
+    ERRORS+="⚠ DISPATCH: prompt crea commands sin mencionar frontmatter requerido.\n"
+  fi
+  # Sugerir incluir ejemplo de comando existente
+  if ! prompt_contains 'ejemplo|example|como.*existente|existing.*pattern|head.*commands'; then
+    WARNINGS+="💡 DISPATCH: prompt crea commands sin referenciar un ejemplo existente como modelo.\n"
+  fi
+fi
+
+# ── 2. Si el agente va a modificar CHANGELOG.md ───────────────────────
+if prompt_contains 'CHANGELOG|changelog'; then
+  if ! prompt_contains 'versión actual|current version|última versión|latest version|top|inicio'; then
+    WARNINGS+="💡 DISPATCH: prompt modifica CHANGELOG sin indicar leer la versión actual primero.\n"
+  fi
+  if ! prompt_contains 'descendente|descending|orden|order'; then
+    ERRORS+="⚠ DISPATCH: prompt modifica CHANGELOG sin mencionar orden descendente de versiones.\n"
+  fi
+  if ! prompt_contains 'solo insertar|only insert|no reemplazar|nunca reemplazar|append|prepend'; then
+    ERRORS+="⚠ DISPATCH: prompt modifica CHANGELOG sin prohibir reemplazo completo del fichero.\n"
+  fi
+fi
+
+# ── 3. Si el agente va a crear skills (.claude/skills/) ───────────────
+if prompt_contains 'skills/.*SKILL\.md|crear.*skill|create.*skill'; then
+  if ! prompt_contains '150 líneas|150 lines|max.*150|≤.*150'; then
+    WARNINGS+="💡 DISPATCH: prompt crea skills sin mencionar límite de 150 líneas.\n"
+  fi
+  if ! prompt_contains 'DOMAIN\.md|domain.*doc|clara.*philosophy'; then
+    WARNINGS+="💡 DISPATCH: prompt crea skill sin mencionar DOMAIN.md (Clara Philosophy).\n"
+  fi
+fi
+
+# ── 4. Si el agente va a hacer git push/PR/merge ─────────────────────
+if prompt_contains 'git push|gh pr|merge'; then
+  if ! prompt_contains 'validate-ci-local|pipeline|CI|lint'; then
+    WARNINGS+="💡 DISPATCH: prompt incluye push/PR sin mencionar validación CI local previa.\n"
+  fi
+fi
+
+# ── 5. Si el agente va a crear rules (.claude/rules/) ────────────────
+if prompt_contains 'rules/.*\.md|crear.*rule|create.*rule'; then
+  if ! prompt_contains '150 líneas|150 lines|max.*150|≤.*150'; then
+    WARNINGS+="💡 DISPATCH: prompt crea rules sin mencionar límite de líneas.\n"
+  fi
+fi
+
+# ── Output ─────────────────────────────────────────────────────────────
+if [ -n "$ERRORS" ] || [ -n "$WARNINGS" ]; then
+  echo ""
+  echo "═══ Agent Dispatch Validation ═══"
+  if [ -n "$ERRORS" ]; then
+    echo -e "$ERRORS"
+  fi
+  if [ -n "$WARNINGS" ]; then
+    echo -e "$WARNINGS"
+  fi
+  echo "Ref: .claude/rules/domain/agent-dispatch-checklist.md"
+  echo "═════════════════════════════════"
+
+  # Errores bloquean (exit 2), warnings solo informan (exit 0)
+  if [ -n "$ERRORS" ]; then
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/rules/domain/agent-dispatch-checklist.md
+++ b/.claude/rules/domain/agent-dispatch-checklist.md
@@ -1,0 +1,47 @@
+# Regla: Checklist de Dispatch a Agentes
+
+Antes de enviar un prompt a un subagente (Tool: Task), el orquestador DEBE
+incluir contexto suficiente para que el agente cumpla las convenciones del
+proyecto. El hook `agent-dispatch-validate.sh` valida automáticamente.
+
+## Checklists por tipo de tarea
+
+### Crear commands (.claude/commands/*.md)
+
+- [ ] Mencionar frontmatter obligatorio: `name` + `description`
+- [ ] Incluir ejemplo de un command existente como referencia de formato
+- [ ] Especificar límite de 150 líneas
+- [ ] Si el command tiene `$ARGUMENTS`, documentar su formato
+
+### Modificar CHANGELOG.md
+
+- [ ] Indicar leer la versión actual antes de escribir (versión más alta)
+- [ ] Exigir orden descendente estricto de versiones
+- [ ] Prohibir reemplazo completo del fichero — solo insertar nueva entrada
+- [ ] Exigir formato `## [x.y.z] — YYYY-MM-DD`
+- [ ] Incluir link comparativo al final: `[x.y.z]: .../compare/...`
+
+### Crear skills (.claude/skills/*/SKILL.md)
+
+- [ ] Especificar límite de 150 líneas
+- [ ] Exigir frontmatter YAML: `name`, `description`, `context`
+- [ ] Pedir DOMAIN.md acompañante (Clara Philosophy)
+- [ ] Referenciar skill existente como modelo de formato
+
+### Crear rules (.claude/rules/domain/*.md)
+
+- [ ] Especificar límite recomendado de 150 líneas (warn)
+- [ ] Indicar formato: título con `#`, secciones claras, sin frontmatter
+
+### Git push / PR / merge
+
+- [ ] Incluir paso de validación CI: `bash scripts/validate-ci-local.sh`
+- [ ] Verificar que no se está en rama main
+
+## Hook automático
+
+El hook `agent-dispatch-validate.sh` (PreToolUse, matcher: Task):
+- **BLOQUEA** (exit 2) si falta contexto crítico para CHANGELOG o frontmatter
+- **AVISA** (exit 0 + mensaje) si falta contexto recomendado
+- Se ejecuta antes de cada invocación de subagente
+- Ref: `.claude/settings.json` → PreToolUse → Task

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,17 @@
         ]
       },
       {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/agent-dispatch-validate.sh",
+            "timeout": 5,
+            "statusMessage": "Validando contexto del agente..."
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

PreToolUse hook that validates subagent prompts contain required project context before execution. Prevents the class of bugs where agents create files that violate CI conventions.

## What it validates

| Task type | Blocks (exit 2) | Warns (exit 0) |
|-----------|-----------------|-----------------|
| Create commands | Missing `name`/`description` frontmatter mention | Missing example reference |
| Modify CHANGELOG | Missing order rules, missing replace prohibition | Missing "read current version" |
| Create skills | — | Missing 150-line limit, missing DOMAIN.md |
| Git push/PR | — | Missing CI validation step |

## Root cause this prevents

In the 25-release batch, agents created 46 commands without frontmatter because the dispatch prompts never mentioned the `name` field requirement. The CHANGELOG got corrupted because prompts didn't prohibit full-file replacement during conflict resolution.

## Files

- `.claude/hooks/agent-dispatch-validate.sh` — PreToolUse hook (97 lines)
- `.claude/rules/domain/agent-dispatch-checklist.md` — Checklist reference (42 lines)
- `.claude/settings.json` — Hook registration (PreToolUse → Task)

## Test plan

- [x] BAD prompt creating commands without frontmatter → BLOCKED (exit 2)
- [x] BAD prompt modifying CHANGELOG without order rules → BLOCKED (exit 2)
- [x] GOOD prompt with all required context → PASS (exit 0)
- [x] Non-Task tool calls → PASS (ignored)
- [x] Task prompts without file operations → PASS (ignored)
- [x] settings.json validates as clean JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)