### PR TITLE
docs: guía actualizada con paso /pbi-from-rules

### DIFF
--- a/docs/guides/guide-project-from-scratch.md
+++ b/docs/guides/guide-project-from-scratch.md
@@ -139,7 +139,39 @@ El precio de un item se captura al momento de añadirlo al carrito (no cambia si
 
 ---
 
-## Paso 5 — Crear PBIs y planificar sprint
+## Paso 5 — Generar PBIs desde reglas de negocio
+
+> "Savia, mapea las reglas de negocio de acme-tienda a PBIs"
+
+Savia ejecuta `/pbi-from-rules acme-tienda` y analiza cada regla (RN-XXX-NN) para:
+1. Comprobar qué reglas ya están cubiertas por PBIs existentes
+2. Identificar brechas (reglas sin cobertura)
+3. Proponer nuevos PBIs con trazabilidad directa regla → PBI
+
+```
+Resumen de Trazabilidad — acme-tienda
+
+Total RNs: 6
+RNs con cobertura completa: 2 (33%)   ← RN-PROD-01, RN-CART-03
+RNs con cobertura parcial: 1 (17%)    ← RN-PROD-03
+RNs sin cobertura: 3 (50%)            ← RN-PROD-02, RN-CART-01, RN-CART-02
+
+PBIs propuestos: 3
+  - 3 simple rules → PBIs directas (validación precio, límite carrito, cantidad mínima)
+```
+
+Savia te pregunta si crear los PBIs propuestos. Si confirmas:
+- En **Azure DevOps**: los crea vía API con tags RN-XXX-NN
+- En **Jira**: los sincroniza como Stories
+- En **Savia Flow**: los crea como ficheros en `projects/acme-tienda/pbis/`
+
+Para ver el reporte completo después: `/pbi-from-rules-report acme-tienda`
+
+> **Tip:** Usa `--dry-run` para solo ver propuestas sin crear nada: `/pbi-from-rules acme-tienda --dry-run`
+
+---
+
+## Paso 6 — Descomponer PBIs en tasks y planificar sprint
 
 | Azure DevOps | Jira | Savia Flow |
 |-------------|------|------------|
@@ -165,7 +197,7 @@ PBI: API de Catálogo de Productos (5 SP)
 
 ---
 
-## Paso 6 — Escribir specs (SDD)
+## Paso 7 — Escribir specs (SDD)
 
 > "Savia, genera un spec para la task 2.1 CreateProductHandler"
 
@@ -196,7 +228,7 @@ Savia ejecuta `/spec-generate` y crea `specs/sprint-2026-05/ACM-B2-create-produc
 
 ---
 
-## Paso 7 — Definir requisitos de pruebas
+## Paso 8 — Definir requisitos de pruebas
 
 Savia sigue la regla: **cobertura mínima 80%**, Code Review E1 siempre humano.
 
@@ -214,7 +246,7 @@ En el spec, la sección "Tests que deben pasar" define exactamente qué assertio
 
 ---
 
-## Paso 8 — Implementar con Dev Session Protocol
+## Paso 9 — Implementar con Dev Session Protocol
 
 > "Savia, analiza el spec y divide en slices"
 
@@ -238,15 +270,18 @@ Luego:
 ## Resumen: flujo completo
 
 ```
-1. /client-profile create       → Definir cliente
-2. mkdir projects/{nombre}       → Crear estructura
-3. Crear CLAUDE.md del proyecto  → Configurar constantes
-4. Crear equipo.md               → Definir team + capacidad
-5. Crear reglas-negocio.md       → Documentar dominio (RN-XXX-NN)
-6. /pbi-decompose                → Descomponer PBIs en tasks
-7. /spec-generate                → Generar specs SDD por task
-8. /spec-slice + /dev-session    → Implementar con contexto optimizado
-9. Code Review E1 (humano)       → Aprobar
+ 1. /client-profile create       → Definir cliente
+ 2. mkdir projects/{nombre}       → Crear estructura
+ 3. Crear CLAUDE.md del proyecto  → Configurar constantes
+ 4. Crear equipo.md               → Definir team + capacidad
+ 5. Crear reglas-negocio.md       → Documentar dominio (RN-XXX-NN)
+ 6. /pbi-from-rules               → Mapear reglas → PBIs con trazabilidad
+ 7. /pbi-decompose                → Descomponer PBIs en tasks
+ 8. /spec-generate                → Generar specs SDD por task
+ 9. /spec-slice + /dev-session    → Implementar con contexto optimizado
+10. Code Review E1 (humano)       → Aprobar
 ```
+
+El paso 6 (`/pbi-from-rules`) es la pieza clave que conecta las reglas de negocio documentadas con PBIs concretos. Sin él, las reglas quedan como documentación pasiva; con él, cada regla tiene trazabilidad directa hasta su implementación.
 
 Funciona igual en Azure DevOps, Jira o Savia Flow — cambian los comandos de sincronización, no el método.


### PR DESCRIPTION
## Summary
- Actualiza `docs/guides/guide-project-from-scratch.md` con el nuevo **paso 5: /pbi-from-rules**
- Cierra el gap entre documentar reglas de negocio (paso 4) y descomponer PBIs (ahora paso 6)
- Renumera pasos 6→7→8→9 para mantener coherencia secuencial
- Incluye ejemplo práctico con output esperado y tips de uso (`--dry-run`)

## Test plan
- [x] `validate-ci-local.sh --quick` pasa
- [x] 9 pasos secuenciales sin gaps
- [x] Resumen final actualizado con 10 pasos (incluye Code Review)
- [x] Referencias a `/pbi-from-rules` y `/pbi-from-rules-report` correctas

🤖 Generated with [Claude Code](https://claude.com/claude-code)