### PR TITLE
feat(era84): component index + quick-start guide

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -1,0 +1,96 @@
+# Quick Start — pm-workspace
+
+> Get productive with pm-workspace in 5 minutes.
+
+## What is pm-workspace?
+
+A Claude Code workspace for Project Managers, with 454 commands, 67 skills, 33 agents, and 17 safety hooks — all orchestrated through natural language.
+
+## First Steps
+
+1. **Open a project**: `/project-open <nombre>` or ask Savia to create one
+2. **Check sprint status**: `/sprint-status` shows current sprint progress
+3. **Decompose a PBI**: `/pbi-decompose` breaks user stories into tasks
+4. **Run a standup**: `/standup-generate` produces daily standup summaries
+
+## Key Command Categories
+
+**Project Management**: `/sprint-*`, `/backlog-*`, `/pbi-*`, `/capacity-*`
+**Quality & Testing**: `/test-*`, `/audit-*`, `/coverage-*`
+**Security**: `/security-scan`, `/vuln-scan`
+**Reporting**: `/executive-report`, `/time-tracking-report`
+**Team**: `/team-onboard`, `/wellbeing-check`, `/developer-experience`
+
+## Discovering Commands
+
+```bash
+# List all available commands
+ls .claude/commands/
+
+# Search for commands by keyword
+grep -rl "sprint" .claude/commands/
+
+# Generate full component index
+bash scripts/generate-index.sh --markdown
+```
+
+## Skills & Maturity
+
+Every skill has a maturity level in its frontmatter:
+
+- **stable** (51) — production-ready, well-documented, tested
+- **beta** (2) — functional but may evolve
+- **alpha** (14) — experimental, missing frontmatter or documentation
+
+## Safety Hooks
+
+All destructive operations are gated by PreToolUse hooks:
+
+- `block-credential-leak` — prevents committing secrets
+- `block-force-push` — blocks force push to main/master
+- `block-infra-destructive` — gates terraform/az/aws destroy ops
+- `tdd-gate` — requires test files before production code
+- `validate-bash-global` — blocks dangerous bash commands
+
+## Running Tests
+
+```bash
+# Full test suite
+bash tests/run-all.sh
+
+# Individual suite
+bats tests/hooks/test-block-credential-leak.bats
+
+# Quality audit
+bash scripts/audit-test-quality.sh --summary
+
+# Coverage report
+bash scripts/coverage-report.sh --summary
+
+# Security scan
+bash scripts/security-scan.sh --verbose
+```
+
+## Project Structure
+
+```
+pm-workspace/
+├── .claude/
+│   ├── commands/     # 454 slash commands
+│   ├── skills/       # 67 skills with SKILL.md
+│   ├── agents/       # 33 sub-agents
+│   ├── hooks/        # 17 PreToolUse hooks
+│   ├── rules/        # 105 domain rules
+│   └── settings.json # Hook configuration
+├── scripts/          # Tooling (test, audit, coverage, security)
+├── tests/            # BATS test suites
+├── docs/             # Documentation
+└── projects/         # Project workspaces (gitignored)
+```
+
+## Further Reading
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — contribution guidelines
+- [SECURITY.md](../SECURITY.md) — security policy
+- [CHANGELOG.md](../CHANGELOG.md) — version history with Era references
+- [ROADMAP.md](ROADMAP.md) — strategic direction

--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# generate-index.sh — Generate discoverable index of all workspace components
+# Usage: bash scripts/generate-index.sh [--markdown | --json | --summary]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MODE="${1:---summary}"
+
+count_glob() {
+  local n=0
+  for f in $1; do [ -e "$f" ] && n=$((n + 1)); done
+  echo "$n"
+}
+
+# Gather stats
+COMMANDS=$(count_glob "$ROOT/.claude/commands/*.md")
+SKILLS=$(count_glob "$ROOT/.claude/skills/*/SKILL.md")
+AGENTS=$(count_glob "$ROOT/.claude/agents/*.md")
+HOOKS=$(count_glob "$ROOT/.claude/hooks/*.sh")
+RULES_DOMAIN=$(count_glob "$ROOT/.claude/rules/domain/*.md")
+RULES_WORKFLOW=$(count_glob "$ROOT/.claude/rules/workflow/*.md")
+TESTS=$(count_glob "$ROOT/tests/hooks/*.bats")
+TESTS_STRUCT=$(count_glob "$ROOT/tests/structure/*.bats")
+
+STABLE=$(grep -rl "^maturity: stable" "$ROOT/.claude/skills/"/*/SKILL.md 2>/dev/null | wc -l)
+BETA=$(grep -rl "^maturity: beta" "$ROOT/.claude/skills/"/*/SKILL.md 2>/dev/null | wc -l)
+ALPHA=$(grep -rl "^maturity: alpha" "$ROOT/.claude/skills/"/*/SKILL.md 2>/dev/null | wc -l)
+
+if [ "$MODE" = "--summary" ]; then
+  echo "═══════════════════════════════════════════════════"
+  echo "  📚 pm-workspace Component Index"
+  echo "═══════════════════════════════════════════════════"
+  echo ""
+  echo "  Commands:     $COMMANDS"
+  echo "  Skills:       $SKILLS (🟢$STABLE 🟡$BETA 🔴$ALPHA)"
+  echo "  Agents:       $AGENTS"
+  echo "  Hooks:        $HOOKS"
+  echo "  Rules:        $((RULES_DOMAIN + RULES_WORKFLOW)) (domain: $RULES_DOMAIN, workflow: $RULES_WORKFLOW)"
+  echo "  Tests:        $((TESTS + TESTS_STRUCT)) BATS suites"
+  echo ""
+  echo "═══════════════════════════════════════════════════"
+
+elif [ "$MODE" = "--json" ]; then
+  cat <<JSON
+{
+  "generated": "$(date -Iseconds)",
+  "components": {
+    "commands": $COMMANDS,
+    "skills": { "total": $SKILLS, "stable": $STABLE, "beta": $BETA, "alpha": $ALPHA },
+    "agents": $AGENTS,
+    "hooks": $HOOKS,
+    "rules": { "domain": $RULES_DOMAIN, "workflow": $RULES_WORKFLOW },
+    "tests": { "hooks": $TESTS, "structure": $TESTS_STRUCT }
+  }
+}
+JSON
+
+elif [ "$MODE" = "--markdown" ]; then
+  echo "# pm-workspace Component Index"
+  echo ""
+  echo "> Auto-generated on $(date '+%Y-%m-%d')"
+  echo ""
+  echo "## Overview"
+  echo ""
+  echo "| Category | Count | Details |"
+  echo "|----------|-------|---------|"
+  echo "| Commands | $COMMANDS | Slash commands for PM workflows |"
+  echo "| Skills | $SKILLS | $STABLE stable, $BETA beta, $ALPHA alpha |"
+  echo "| Agents | $AGENTS | Specialized sub-agents |"
+  echo "| Hooks | $HOOKS | PreToolUse validation hooks |"
+  echo "| Rules | $((RULES_DOMAIN + RULES_WORKFLOW)) | $RULES_DOMAIN domain + $RULES_WORKFLOW workflow |"
+  echo "| Tests | $((TESTS + TESTS_STRUCT)) | BATS test suites |"
+  echo ""
+
+  echo "## Skills by Maturity"
+  echo ""
+  for level in stable beta alpha; do
+    emoji="🟢"; [ "$level" = "beta" ] && emoji="🟡"; [ "$level" = "alpha" ] && emoji="🔴"
+    echo "### $emoji $(echo "$level" | tr '[:lower:]' '[:upper:]')"
+    echo ""
+    for f in "$ROOT/.claude/skills"/*/SKILL.md; do
+      [ -f "$f" ] || continue
+      if head -10 "$f" | grep -q "^maturity: $level"; then
+        name=$(basename "$(dirname "$f")")
+        desc=$(head -10 "$f" | grep "^description:" | sed 's/^description: *//' | sed 's/^"//' | sed 's/"$//')
+        echo "- **$name** — $desc"
+      fi
+    done
+    echo ""
+  done
+
+  echo "## Commands (top 20 by category)"
+  echo ""
+  for f in "$ROOT/.claude/commands/"*.md; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f" .md)
+    desc=$(head -10 "$f" | grep "^description:" | sed 's/^description: *//' | head -1)
+    [ -n "$desc" ] && echo "- \`/$name\` — $desc"
+  done | head -20
+  echo ""
+  echo "*($(( COMMANDS - 20 )) more commands available)*"
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/generate-index.sh` with `--summary`, `--json`, `--markdown` modes
- Create `docs/QUICK-START.md` — 5-minute onboarding guide
- Covers all 454 commands, 67 skills, 33 agents, 17 hooks

## Test plan
- [x] All 111 tests pass
- [x] `generate-index.sh --summary` outputs correct counts
- [x] `generate-index.sh --json` produces valid JSON
- [x] Quick-start guide links to existing docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)