### PR TITLE
feat(era85): reusable mock environment library

### DIFF
--- a/scripts/lib/mock-env.sh
+++ b/scripts/lib/mock-env.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# mock-env.sh — Reusable mock environment library for pm-workspace scripts
+# Source this from any script that needs to run without external dependencies.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/mock-env.sh"
+#   mock_init              # Set up mock environment
+#   mock_azure_response    # Returns mock Azure DevOps JSON
+#   mock_mcp_response      # Returns mock MCP server JSON
+#   is_mock_mode           # Returns 0 if in mock mode
+
+MOCK_MODE="${PM_MOCK:-false}"
+MOCK_DATA_DIR="${PM_MOCK_DATA:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/projects/sala-reservas/test-data}"
+
+mock_init() {
+  MOCK_MODE="true"
+  export PM_MOCK="true"
+  export PM_MOCK_DATA="$MOCK_DATA_DIR"
+}
+
+is_mock_mode() {
+  [ "$MOCK_MODE" = "true" ]
+}
+
+mock_azure_response() {
+  local endpoint="${1:-workitems}"
+  local mock_file="$MOCK_DATA_DIR/mock-${endpoint}.json"
+  if [ -f "$mock_file" ]; then
+    cat "$mock_file"
+  else
+    echo '{"value": [], "count": 0}'
+  fi
+}
+
+mock_mcp_response() {
+  local tool="${1:-query}"
+  echo "{\"mock\": true, \"tool\": \"$tool\", \"result\": {\"status\": \"ok\", \"data\": []}}"
+}
+
+mock_sprint_data() {
+  cat << 'JSON'
+{
+  "id": "mock-sprint-42",
+  "name": "Sprint 42",
+  "startDate": "2026-03-01T00:00:00Z",
+  "finishDate": "2026-03-14T00:00:00Z",
+  "state": "current",
+  "workItems": {
+    "total": 15,
+    "completed": 8,
+    "inProgress": 4,
+    "todo": 3
+  },
+  "velocity": {
+    "planned": 34,
+    "completed": 21,
+    "remaining": 13
+  }
+}
+JSON
+}
+
+mock_team_data() {
+  cat << 'JSON'
+{
+  "members": [
+    {"name": "Dev A", "capacity": 6, "role": "developer"},
+    {"name": "Dev B", "capacity": 6, "role": "developer"},
+    {"name": "QA C", "capacity": 6, "role": "tester"},
+    {"name": "PM D", "capacity": 4, "role": "pm"}
+  ],
+  "totalCapacity": 22,
+  "sprintDays": 10
+}
+JSON
+}
+
+# Auto-detect mock mode from environment or --mock flag
+for arg in "$@"; do
+  [ "$arg" = "--mock" ] && mock_init
+done

--- a/tests/structure/test-mock-env.bats
+++ b/tests/structure/test-mock-env.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Tests for scripts/lib/mock-env.sh mock environment library
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/../.." || exit 1
+  MOCK_LIB="$PWD/scripts/lib/mock-env.sh"
+}
+
+@test "mock-env.sh exists and is sourceable" {
+  [ -f "$MOCK_LIB" ]
+  run bash -c "source '$MOCK_LIB' && echo ok"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ok" ]
+}
+
+@test "is_mock_mode returns false by default" {
+  run bash -c "source '$MOCK_LIB' && is_mock_mode && echo yes || echo no"
+  [ "$output" = "no" ]
+}
+
+@test "mock_init enables mock mode" {
+  run bash -c "source '$MOCK_LIB' && mock_init && is_mock_mode && echo yes || echo no"
+  [ "$output" = "yes" ]
+}
+
+@test "--mock flag auto-enables mock mode" {
+  run bash -c "source '$MOCK_LIB' --mock && is_mock_mode && echo yes || echo no"
+  [ "$output" = "yes" ]
+}
+
+@test "mock_sprint_data returns valid JSON" {
+  run bash -c "source '$MOCK_LIB' && mock_sprint_data | jq -e '.name' >/dev/null"
+  [ "$status" -eq 0 ]
+}
+
+@test "mock_team_data returns valid JSON with members" {
+  run bash -c "source '$MOCK_LIB' && mock_team_data | jq -e '.members | length > 0' >/dev/null"
+  [ "$status" -eq 0 ]
+}
+
+@test "mock_mcp_response includes tool name" {
+  run bash -c "source '$MOCK_LIB' && mock_mcp_response 'test-tool' | jq -r '.tool'"
+  [ "$output" = "test-tool" ]
+}
+
+@test "mock_azure_response returns default empty when no mock file" {
+  run bash -c "export PM_MOCK_DATA=/tmp/nonexistent && source '$MOCK_LIB' && mock_azure_response 'nosuchfile' | jq -e '.count == 0'"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Add `scripts/lib/mock-env.sh` — reusable mock library for offline testing
- Mock functions: Azure DevOps responses, MCP server, sprint data, team data
- Auto-detection via `--mock` flag or `PM_MOCK` env var
- 8 new BATS tests validating all mock functions

## Test plan
- [x] 9/9 suites pass (119 tests total)
- [x] Mock mode auto-detection works (flag + env var)
- [x] All mock functions return valid JSON
- [x] Security scan: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)