### PR TITLE
fix: CHANGELOG links + visual-quality 150-line limit

### DIFF
--- a/.claude/skills/visual-quality/SKILL.md
+++ b/.claude/skills/visual-quality/SKILL.md
@@ -136,20 +136,11 @@ visual_match = (layout×0.30) + (colors×0.20) + (typography×0.15) + (spacing×
 - Layout: 90 | Colors: 80 | Typography: 85 | Spacing: 82 | Content: 88
 
 ## Findings by Severity
-### Critical (blocks functionality)
-[annotated screenshots]
+- Critical (blocks functionality): [annotated screenshots]
+- Major (UX impact): [annotated screenshots]
+- Minor (quality): [list]
 
-### Major (UX impact)
-[annotated screenshots]
-
-### Minor (quality)
-[list]
-
-## Accessibility Status
-- Contrast: PASS/FAIL
-- Touch targets: PASS/FAIL
-- Text size: PASS/FAIL
-
-## Recommendations
-[actionable fixes by priority]
+## Accessibility & Recommendations
+- Contrast / Touch targets / Text size: PASS/FAIL
+- [actionable fixes by priority]
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2985,6 +2985,15 @@ Initial public release of PM-Workspace.
 
 [0.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.0.0...v0.1.0
 
+[2.58.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.57.0...v2.58.0
+[2.57.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.56.0...v2.57.0
+[2.56.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.55.0...v2.56.0
+[2.55.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.54.0...v2.55.0
+[2.54.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.53.0...v2.54.0
+[2.53.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.52.0...v2.53.0
+[2.52.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.51.0...v2.52.0
+[2.51.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.50.0...v2.51.0
+[2.50.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.49.0...v2.50.0
 [2.49.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.48.0...v2.49.0
 [2.48.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.47.0...v2.48.0
 [2.47.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.46.0...v2.47.0


### PR DESCRIPTION
## Summary
- Add link references for v2.50.0–v2.58.0 so CHANGELOG version headers render as clickable hyperlinks
- Trim `visual-quality/SKILL.md` from 155→146 lines to pass CI file-size validation

## Test plan
- [x] All 9/9 test suites pass
- [x] `visual-quality/SKILL.md` is 146 lines (under 150 limit)
- [x] CHANGELOG link references complete from v2.50.0 to v2.58.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)