### PR TITLE
feat(era91): mature 13 alpha skills to beta

### DIFF
--- a/.claude/skills/banking-architecture/SKILL.md
+++ b/.claude/skills/banking-architecture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: banking-architecture
 description: Skill: Banking Architecture
-maturity: alpha
+maturity: beta
 ---
 
 # Skill: Banking Architecture

--- a/.claude/skills/context-optimized-dev/SKILL.md
+++ b/.claude/skills/context-optimized-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: context-optimized-dev
 description: Context-Optimized Development — Skill
-maturity: alpha
+maturity: beta
 ---
 
 # Context-Optimized Development — Skill

--- a/.claude/skills/evaluations-framework/SKILL.md
+++ b/.claude/skills/evaluations-framework/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: evaluations-framework
 description: Evaluations Framework
-maturity: alpha
+maturity: beta
 ---
 
 # Evaluations Framework

--- a/.claude/skills/google-sheets-tracker/SKILL.md
+++ b/.claude/skills/google-sheets-tracker/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-sheets-tracker
 description: Google Sheets Tracker
-maturity: alpha
+maturity: beta
 ---
 
 # Google Sheets Tracker

--- a/.claude/skills/headroom-optimization/SKILL.md
+++ b/.claude/skills/headroom-optimization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: headroom-optimization
 description: headroom-optimization
-maturity: alpha
+maturity: beta
 ---
 
 # headroom-optimization

--- a/.claude/skills/non-engineer-templates/SKILL.md
+++ b/.claude/skills/non-engineer-templates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: non-engineer-templates
 description: Non-Engineer Templates
-maturity: alpha
+maturity: beta
 ---
 
 # Non-Engineer Templates

--- a/.claude/skills/postmortem-training/SKILL.md
+++ b/.claude/skills/postmortem-training/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: postmortem-training
 description: Postmortem Training Skill
-maturity: alpha
+maturity: beta
 ---
 
 # Postmortem Training Skill

--- a/.claude/skills/resource-references/SKILL.md
+++ b/.claude/skills/resource-references/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resource-references
 description: skill: resource-references
-maturity: alpha
+maturity: beta
 ---
 
 # skill: resource-references

--- a/.claude/skills/sdlc-state-machine/SKILL.md
+++ b/.claude/skills/sdlc-state-machine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sdlc-state-machine
 description: sdlc-state-machine
-maturity: alpha
+maturity: beta
 ---
 
 # sdlc-state-machine

--- a/.claude/skills/semantic-memory/SKILL.md
+++ b/.claude/skills/semantic-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: semantic-memory
 description: semantic-memory
-maturity: alpha
+maturity: beta
 ---
 
 # semantic-memory

--- a/.claude/skills/session-recording/SKILL.md
+++ b/.claude/skills/session-recording/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: session-recording
 description: Session Recording Skill
-maturity: alpha
+maturity: beta
 ---
 
 # Session Recording Skill

--- a/.claude/skills/skills-marketplace/SKILL.md
+++ b/.claude/skills/skills-marketplace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skills-marketplace
 description: skills-marketplace
-maturity: alpha
+maturity: beta
 ---
 
 # skills-marketplace

--- a/.claude/skills/visual-quality/SKILL.md
+++ b/.claude/skills/visual-quality/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: visual-quality
 description: Visual Quality Analysis Skill
-maturity: alpha
+maturity: beta
 ---
 
 # Visual Quality Analysis Skill


### PR DESCRIPTION
## Summary
- Upgrade 13 skills from alpha→beta (50+ lines with clear instructions)
- 1 skill remains alpha (pm-mcp-server: placeholder content)
- **New distribution: 51 stable, 15 beta, 1 alpha**

## Test plan
- [x] 21/21 suites pass (193 tests)
- [x] All upgraded skills have frontmatter with name+description
- [x] All upgraded skills have >50 lines of substantive content

🤖 Generated with [Claude Code](https://claude.com/claude-code)