### PR TITLE
feat(security): Triple-layer project privacy protection

### DIFF
--- a/.claude/.project-authorizations
+++ b/.claude/.project-authorizations
@@ -1,0 +1,5 @@
+proyecto-alpha
+proyecto-beta
+sala-reservas
+savia-mobile-android
+claude-code-templates

--- a/.claude/hooks/block-project-whitelist.sh
+++ b/.claude/hooks/block-project-whitelist.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# block-project-whitelist.sh — Bloquea whitelist de proyectos en .gitignore
+set -uo pipefail
+# Capa de defensa adicional al pre-commit hook. Actúa a nivel de Claude Code.
+
+# Lee el input del hook
+INPUT="${CLAUDE_TOOL_INPUT:-}"
+
+# Solo nos interesa si se está editando .gitignore
+if ! echo "$INPUT" | grep -q "\.gitignore"; then
+    exit 0
+fi
+
+# Detectar si el contenido incluye un whitelist de proyecto (!projects/)
+if echo "$INPUT" | grep -qE '!projects/'; then
+    echo "🛑 BLOQUEADO: Intento de añadir whitelist de proyecto en .gitignore" >&2
+    echo "" >&2
+    echo "La regla de privacidad de proyectos requiere confirmación humana explícita" >&2
+    echo "antes de publicar cualquier proyecto nuevo en el repositorio." >&2
+    echo "" >&2
+    echo "Pide confirmación a la persona humana antes de modificar .gitignore." >&2
+    echo "Si ya tienes confirmación, pide al humano que ejecute:" >&2
+    echo "  bash scripts/protect-project-privacy.sh --authorize <nombre-proyecto>" >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/rules/domain/project-privacy-protection.md
+++ b/.claude/rules/domain/project-privacy-protection.md
@@ -1,0 +1,43 @@
+# Regla: Protección de Privacidad de Proyectos
+
+## Contexto
+
+El directorio `projects/` contiene proyectos que pueden ser privados (clientes,
+datos sensibles, propiedad intelectual). El `.gitignore` del workspace aplica
+una política deny-by-default: todos los proyectos nuevos quedan excluidos del
+repositorio git automáticamente. Solo los proyectos explícitamente whitelisteados
+con `!projects/nombre/` se publican.
+
+## Regla OBLIGATORIA
+
+**NUNCA modificar `.gitignore` para añadir un whitelist de proyecto (`!projects/...`)
+sin confirmación explícita de la persona humana en la conversación.**
+
+Esto incluye:
+
+- Añadir líneas `!projects/nuevo-proyecto/` al .gitignore
+- Usar `git add -f` para forzar el tracking de un proyecto ignorado
+- Mover contenido de un proyecto a una ruta no ignorada para evadir la protección
+- Cualquier otro mecanismo que resulte en publicar un proyecto no autorizado
+
+## Procedimiento obligatorio
+
+1. **Informar al humano** del estado actual: el proyecto está ignorado por defecto
+2. **Preguntar explícitamente**: "¿Este proyecto debe ser público en el repo? Modificar
+   .gitignore para incluirlo requiere tu confirmación."
+3. **Esperar respuesta afirmativa** en la conversación antes de proceder
+4. **Si hay duda**, NO incluir. Es preferible un paso extra que una filtración.
+
+## Justificación
+
+Un error en este punto puede causar:
+- Filtración de datos de clientes (violación RGPD/LOPD)
+- Exposición de propiedad intelectual
+- Ruptura de acuerdos de confidencialidad (NDA)
+- Responsabilidad legal directa
+
+## Mecanismo de defensa adicional
+
+Además de esta regla, existe un hook de git pre-commit (`scripts/protect-project-privacy.sh`)
+que actúa como barrera independiente. Aunque Savia ignore esta regla por error de contexto,
+el hook bloqueará el commit y pedirá confirmación interactiva.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,6 +65,12 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/plan-gate.sh",
             "statusMessage": "Verificando spec aprobada..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-project-whitelist.sh",
+            "timeout": 5,
+            "statusMessage": "Verificando privacidad de proyectos..."
           }
         ]
       },

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Git pre-commit hook — Protección de privacidad de proyectos
+# Se ejecuta ANTES de cada commit, independientemente de Savia o Claude Code.
+#
+# Instalación: git config core.hooksPath .githooks
+
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Ejecutar el script de protección en modo hook
+if [ -f "$ROOT/scripts/protect-project-privacy.sh" ]; then
+    bash "$ROOT/scripts/protect-project-privacy.sh" --hook
+    exit $?
+fi
+
+# Si el script no existe, permitir el commit (no bloquear por ausencia)
+exit 0

--- a/scripts/protect-project-privacy.sh
+++ b/scripts/protect-project-privacy.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# protect-project-privacy.sh — Barrera de protección contra publicación accidental de proyectos
+#
+# PROPÓSITO: Detectar y BLOQUEAR cualquier intento de añadir proyectos nuevos al repositorio
+# git sin confirmación humana explícita. Actúa como mecanismo de defensa INDEPENDIENTE
+# de las reglas de Savia, para proteger contra errores de contexto de la IA.
+#
+# USO:
+#   Como pre-commit hook:  Se invoca automáticamente antes de cada commit
+#   Manual:                bash scripts/protect-project-privacy.sh [--check | --authorize <proyecto>]
+#
+# FUNCIONAMIENTO:
+#   1. Examina los cambios staged (git diff --cached)
+#   2. Detecta si .gitignore fue modificado para añadir whitelist de proyectos (!projects/...)
+#   3. Detecta si hay archivos staged dentro de projects/ que no están en la whitelist actual
+#   4. Si detecta cualquiera de los dos → BLOQUEA el commit y pide confirmación humana
+#   5. El humano debe ejecutar --authorize <proyecto> para crear un permiso temporal
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AUTHORIZED_FILE="$ROOT/.claude/.project-authorizations"
+MODE="${1:---hook}"
+
+# ─── Colores ──────────────────────────────────────────────────
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ─── Funciones ────────────────────────────────────────────────
+
+die() {
+    echo -e "${RED}${BOLD}🛑 BLOQUEADO: $1${NC}" >&2
+    echo -e "${YELLOW}   Motivo: Protección de privacidad de proyectos${NC}" >&2
+    echo "" >&2
+    echo -e "   Para autorizar un proyecto público, ejecuta:" >&2
+    echo -e "   ${GREEN}bash scripts/protect-project-privacy.sh --authorize <nombre-proyecto>${NC}" >&2
+    echo "" >&2
+    echo -e "   ${RED}⚠️  NUNCA autorices un proyecto de cliente o con datos sensibles.${NC}" >&2
+    exit 1
+}
+
+is_authorized() {
+    local project="$1"
+    [ -f "$AUTHORIZED_FILE" ] && grep -qx "$project" "$AUTHORIZED_FILE" 2>/dev/null
+}
+
+get_whitelisted_projects() {
+    grep -E '^!projects/' "$ROOT/.gitignore" 2>/dev/null | sed 's|^!projects/||; s|/$||'
+}
+
+# ─── Modo: Autorizar un proyecto ──────────────────────────────
+
+if [[ "$MODE" == "--authorize" ]]; then
+    PROJECT="${2:-}"
+    if [[ -z "$PROJECT" ]]; then
+        echo "Uso: bash scripts/protect-project-privacy.sh --authorize <nombre-proyecto>"
+        exit 1
+    fi
+
+    echo -e "${YELLOW}${BOLD}⚠️  ADVERTENCIA: Vas a autorizar la publicación del proyecto '$PROJECT'${NC}"
+    echo ""
+    echo "   Esto permitirá que el proyecto se añada al repositorio git PÚBLICO."
+    echo "   Antes de continuar, confirma que:"
+    echo ""
+    echo "   ✅ El proyecto NO contiene datos de clientes"
+    echo "   ✅ El proyecto NO contiene información confidencial"
+    echo "   ✅ El proyecto NO está bajo NDA o acuerdo de confidencialidad"
+    echo "   ✅ Tienes autorización para publicar este contenido"
+    echo ""
+
+    read -r -p "¿Confirmas que '$PROJECT' puede ser PÚBLICO? (escribe 'SÍ PÚBLICO' para confirmar): " CONFIRM
+
+    if [[ "$CONFIRM" == "SÍ PÚBLICO" || "$CONFIRM" == "SI PUBLICO" || "$CONFIRM" == "YES PUBLIC" ]]; then
+        mkdir -p "$(dirname "$AUTHORIZED_FILE")"
+        echo "$PROJECT" >> "$AUTHORIZED_FILE"
+        echo -e "${GREEN}✅ Proyecto '$PROJECT' autorizado para publicación.${NC}"
+        echo "   Ahora puedes modificar .gitignore y hacer commit."
+    else
+        echo -e "${RED}❌ Autorización cancelada. El proyecto '$PROJECT' permanece privado.${NC}"
+        exit 1
+    fi
+    exit 0
+fi
+
+# ─── Modo: Check (verificación sin bloqueo) ──────────────────
+
+if [[ "$MODE" == "--check" ]]; then
+    echo "=== Verificación de privacidad de proyectos ==="
+    echo ""
+    echo "Proyectos en whitelist (.gitignore):"
+    get_whitelisted_projects | while read -r p; do
+        if is_authorized "$p"; then
+            echo -e "  ${GREEN}✅ $p (autorizado)${NC}"
+        else
+            echo -e "  ${YELLOW}⚠️  $p (en whitelist pero sin autorización explícita)${NC}"
+        fi
+    done
+    echo ""
+    echo "Autorizaciones registradas:"
+    if [ -f "$AUTHORIZED_FILE" ]; then
+        while read -r p; do echo "  ✅ $p"; done < "$AUTHORIZED_FILE"
+    else
+        echo "  (ninguna)"
+    fi
+    exit 0
+fi
+
+# ─── Modo: Hook pre-commit ────────────────────────────────────
+
+# Verificación 1: ¿Se ha modificado .gitignore para añadir whitelist de proyecto?
+if git diff --cached --name-only 2>/dev/null | grep -q "^\.gitignore$"; then
+    NEW_WHITELISTS=$(git diff --cached -- .gitignore 2>/dev/null \
+        | grep "^+" | grep -v "^+++" \
+        | grep -E '^\+!projects/' \
+        | sed 's|^\+!projects/||; s|/$||' || true)
+
+    if [[ -n "$NEW_WHITELISTS" ]]; then
+        while IFS= read -r project; do
+            if ! is_authorized "$project"; then
+                die "Intento de añadir proyecto '$project' al whitelist de .gitignore sin autorización.
+
+   Se detectó que .gitignore fue modificado para incluir: !projects/$project/
+   Esto publicaría el proyecto en el repositorio git público.
+
+   Si este proyecto DEBE ser público, primero autorízalo:
+   bash scripts/protect-project-privacy.sh --authorize $project"
+            fi
+        done <<< "$NEW_WHITELISTS"
+    fi
+fi
+
+# Verificación 2: ¿Hay archivos staged en projects/ de un proyecto no whitelisteado?
+STAGED_PROJECTS=$(git diff --cached --name-only 2>/dev/null \
+    | grep "^projects/" \
+    | sed 's|^projects/||; s|/.*||' \
+    | sort -u || true)
+
+if [[ -n "$STAGED_PROJECTS" ]]; then
+    CURRENT_WHITELIST=$(get_whitelisted_projects)
+    while IFS= read -r project; do
+        if ! echo "$CURRENT_WHITELIST" | grep -qx "$project"; then
+            # Proyecto no está en whitelist pero hay archivos staged → alguien usó git add -f
+            die "Intento de añadir archivos del proyecto '$project' que NO está en el whitelist.
+
+   Se detectaron archivos staged en projects/$project/ pero este proyecto
+   está ignorado por .gitignore. Esto indica un 'git add -f' forzado.
+
+   Si este proyecto DEBE ser público, primero autorízalo:
+   bash scripts/protect-project-privacy.sh --authorize $project"
+        fi
+    done <<< "$STAGED_PROJECTS"
+fi
+
+# Todo OK
+exit 0

--- a/tests/hooks/test-block-project-whitelist.bats
+++ b/tests/hooks/test-block-project-whitelist.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Tests for block-project-whitelist.sh Claude Code hook
+
+setup() {
+  HOOK="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.claude/hooks" && pwd)/block-project-whitelist.sh"
+}
+
+@test "hook exists and is executable" {
+  [ -f "$HOOK" ]
+  [ -x "$HOOK" ] || chmod +x "$HOOK"
+}
+
+@test "allows edits to non-.gitignore files" {
+  run bash -c "CLAUDE_TOOL_INPUT='file_path: src/main.kt' bash '$HOOK'"
+  [ "$status" -eq 0 ]
+}
+
+@test "allows .gitignore edits without project whitelist" {
+  run bash -c "CLAUDE_TOOL_INPUT='.gitignore adding node_modules/' bash '$HOOK'"
+  [ "$status" -eq 0 ]
+}
+
+@test "BLOCKS .gitignore edit with project whitelist pattern" {
+  run bash -c "CLAUDE_TOOL_INPUT='.gitignore !projects/client-secret/' bash '$HOOK'"
+  [ "$status" -eq 2 ]
+}
+
+@test "BLOCKS .gitignore with !projects/ anywhere in input" {
+  run bash -c "CLAUDE_TOOL_INPUT='editing .gitignore to add !projects/nuevo-proyecto/' bash '$HOOK'"
+  [ "$status" -eq 2 ]
+}
+
+@test "allows empty CLAUDE_TOOL_INPUT" {
+  run bash -c "CLAUDE_TOOL_INPUT='' bash '$HOOK'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/hooks/test-protect-project-privacy.bats
+++ b/tests/hooks/test-protect-project-privacy.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Tests for protect-project-privacy.sh pre-commit script
+
+setup() {
+  SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/protect-project-privacy.sh"
+  TEST_TMPDIR="$(mktemp -d)"
+
+  # Create minimal git repo for testing
+  git init "$TEST_TMPDIR/repo" --quiet
+  cd "$TEST_TMPDIR/repo"
+  echo "# Test" > README.md
+  echo "projects/*" > .gitignore
+  echo "!projects/allowed/" >> .gitignore
+  git add -A && git commit -m "init" --quiet
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+@test "script exists and is executable" {
+  [ -f "$SCRIPT" ]
+  [ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+}
+
+@test "--check mode runs without error" {
+  cd "$TEST_TMPDIR/repo"
+  # Copy script into the test repo so ROOT resolves
+  mkdir -p scripts
+  cp "$SCRIPT" scripts/protect-project-privacy.sh
+  chmod +x scripts/protect-project-privacy.sh
+  run bash scripts/protect-project-privacy.sh --check
+  [ "$status" -eq 0 ]
+}
+
+@test "allows commit when .gitignore not modified" {
+  cd "$TEST_TMPDIR/repo"
+  mkdir -p scripts
+  cp "$SCRIPT" scripts/protect-project-privacy.sh
+  chmod +x scripts/protect-project-privacy.sh
+
+  echo "new line" >> README.md
+  git add README.md
+  run bash scripts/protect-project-privacy.sh --hook
+  [ "$status" -eq 0 ]
+}
+
+@test "BLOCKS commit when .gitignore adds new project whitelist" {
+  cd "$TEST_TMPDIR/repo"
+  mkdir -p scripts .claude
+  cp "$SCRIPT" scripts/protect-project-privacy.sh
+  chmod +x scripts/protect-project-privacy.sh
+
+  echo "!projects/secret-client/" >> .gitignore
+  git add .gitignore
+  run bash scripts/protect-project-privacy.sh --hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"BLOQUEADO"* ]]
+  [[ "$output" == *"secret-client"* ]]
+}
+
+@test "allows commit when project is authorized" {
+  cd "$TEST_TMPDIR/repo"
+  mkdir -p scripts .claude
+  cp "$SCRIPT" scripts/protect-project-privacy.sh
+  chmod +x scripts/protect-project-privacy.sh
+
+  # Pre-authorize the project
+  echo "authorized-project" > .claude/.project-authorizations
+  echo "!projects/authorized-project/" >> .gitignore
+  git add .gitignore
+  run bash scripts/protect-project-privacy.sh --hook
+  [ "$status" -eq 0 ]
+}
+
+@test "BLOCKS git add -f of unwhitelisted project files" {
+  cd "$TEST_TMPDIR/repo"
+  mkdir -p scripts .claude projects/sneaky-project
+  cp "$SCRIPT" scripts/protect-project-privacy.sh
+  chmod +x scripts/protect-project-privacy.sh
+
+  echo "secret data" > projects/sneaky-project/data.txt
+  git add -f projects/sneaky-project/data.txt
+  run bash scripts/protect-project-privacy.sh --hook
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"BLOQUEADO"* ]]
+  [[ "$output" == *"sneaky-project"* ]]
+}


### PR DESCRIPTION
## Summary
- **Problem**: Savia modified `.gitignore` to whitelist a project without human confirmation. With a private/client project, this could cause data protection and IP violations.
- **Layer 1 — Domain rule**: `.claude/rules/domain/project-privacy-protection.md` instructs Savia to ALWAYS ask before modifying `.gitignore`
- **Layer 2 — Claude Code hook**: `block-project-whitelist.sh` (PreToolUse) BLOCKS any Edit/Write containing `!projects/` pattern
- **Layer 3 — Git pre-commit hook**: `protect-project-privacy.sh` BLOCKS commits with unauthorized project whitelists. Human must run `--authorize <name>` with explicit confirmation phrase

## Test plan
- [x] 6 BATS tests for Claude Code hook — all pass
- [x] 6 BATS tests for pre-commit script — all pass
- [x] 24 total suites, all passing
- [x] Pre-commit hook active (`.githooks/pre-commit` + `core.hooksPath`)
- [x] Existing projects retroactively authorized in `.project-authorizations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)