### PR TITLE
docs: integrate Savia Mobile across pm-workspace documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.67.0] — 2026-03-08
+
+### Added — Savia Mobile: Android App + Bridge Server
+
+Native Android companion app for pm-workspace with Python Bridge server.
+
+- **Savia Mobile Android** — Native Kotlin/Jetpack Compose app with Clean Architecture (`:app`, `:domain`, `:data`). Chat with Claude via SSE streaming, session persistence (Room + Tink AES-256-GCM), Material 3 violet theme, dual-backend (Bridge primary, API fallback). 39 Kotlin files, 157 tests.
+- **Savia Bridge** — Python HTTPS server (port 8922) wrapping Claude Code CLI. SSE streaming, session management, Bearer token auth, auto-TLS. HTTP install server (port 8080) for APK distribution. 1,191 lines, v1.2.0.
+- **Updated installers** — `install.sh` and `install.ps1` now include Step 6: automatic Bridge setup (systemd/launchd/Windows service, token generation, health check).
+- **Documentation** — KDoc on all 39 source files, 8 specs rewritten, 3 new guides (ARCHITECTURE, SETUP, BRIDGE-GUIDE), API reference, CHANGELOG.
+- **Path:** `projects/savia-mobile-android/`, `scripts/savia-bridge.py`, `scripts/savia-bridge.service`
+
 ## [2.66.0] — 2026-03-08
 
 ### Added — Era 95: Rules Topology & Consolidation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -472,6 +472,17 @@ Method and protocol for programming teams to produce high-quality code 100% alig
 
 ---
 
+## ✅ Era 53 — Savia Mobile: Android Companion App (v2.67.0, Mar 2026)
+
+Native Android client for pm-workspace, making Savia accessible on mobile devices without SSH, Termux, or VPN knowledge. Connects via Savia Bridge (Python HTTPS/SSE server).
+
+- **Savia Mobile Android** — Native Kotlin 2.1.0 + Jetpack Compose app. Clean Architecture (3 modules), Hilt DI, Room DB, Tink encryption. Chat with SSE streaming, session persistence, Material 3 violet theme. 39 Kotlin files, 157 tests. Target: Android 8.0+ (API 26).
+- **Savia Bridge** — Python stdlib HTTPS server (port 8922) wrapping Claude Code CLI. SSE streaming, session management (`--session-id`, `--resume`), Bearer token auth, auto-generated TLS certs. HTTP install server (port 8080) for APK distribution with branded install page.
+- **Installer integration** — `install.sh` and `install.ps1` updated with Step 6: automatic Bridge setup (systemd on Linux, launchd on macOS, startup on Windows). Token generation, service enable, health check verification.
+- **Full documentation** — 8 specs (PRODUCT-SPEC, TECHNICAL-DESIGN, BACKLOG, etc.), 3 guides (ARCHITECTURE, SETUP, BRIDGE-GUIDE), KDoc on all source files, API reference.
+
+---
+
 ## ✅ Eras 79–87 — Stability & Quality Infrastructure (v2.50.0–v2.58.0, Mar 2026)
 
 | Era | Version | Theme | Highlights |

--- a/docs/data-flow-guide-es.md
+++ b/docs/data-flow-guide-es.md
@@ -76,6 +76,24 @@ Decisiones del día       Memory store           Entity recall          Próxima
 
 ---
 
+## Flujo 5: Mobile → Bridge → Claude CLI → Respuesta
+
+```
+App Savia Mobile       Savia Bridge           Claude Code CLI         Respuesta
+┌──────────────┐  ──→  ┌──────────────┐  ──→  ┌──────────────┐  ──→  ┌──────────────┐
+│ Chat SSE      │       │ HTTPS :8922   │       │ claude --session│      │ Stream SSE   │
+│ POST /chat    │       │ Bearer token  │       │ --resume        │      │ texto → app   │
+└──────────────┘       └──────────────┘       └──────────────┘       └──────────────┘
+```
+
+**Cómo funciona:** La app Savia Mobile envía mensajes vía HTTPS al Savia Bridge (puerto 8922). El Bridge autentica el request con Bearer token, abre una sesión en Claude Code CLI (`--session-id` primera vez, `--resume` después), y retransmite la respuesta como Server-Sent Events (SSE) al móvil en tiempo real.
+
+**Ficheros involucrados:** App Android → `scripts/savia-bridge.py` → Claude CLI → respuesta SSE → persistencia local (Room DB cifrada con Tink)
+
+**Por qué importa:** Extiende el acceso a pm-workspace fuera del terminal. Un PM puede consultar el estado del sprint, descomponer un PBI o revisar una decisión arquitectónica desde el móvil, sin necesitar SSH ni conocimientos técnicos profundos.
+
+---
+
 ## Dependencias ocultas
 
 Estas son señales cruzadas que detecto automáticamente:
@@ -99,3 +117,4 @@ Estas son señales cruzadas que detecto automáticamente:
 | Implementaciones | `output/implementations/` | tests, PRs, DORA |
 | Memoria persistente | `output/.memory-store.jsonl` | context-load, entity-recall |
 | Informes ejecutivos | `output/reports/` | CEO, stakeholders, clientes |
+| Mobile → Bridge | `scripts/savia-bridge.py` | App Android, Room DB local |

--- a/docs/guides/guide-savia-standalone.md
+++ b/docs/guides/guide-savia-standalone.md
@@ -201,6 +201,43 @@ Detecta OS, verifica dependencias, restaura perfil y configuración.
 
 ---
 
+---
+
+## Acceso móvil con Savia Bridge
+
+Para equipos que trabajan en remoto o necesitan acceso desde cualquier lugar, Savia Mobile extiende el workspace al teléfono:
+
+### Setup del Bridge
+
+```bash
+# El servidor Bridge ya se instala con install.sh (Step 6)
+# Verificar que está corriendo:
+systemctl --user status savia-bridge
+
+# Obtener token para la app:
+python3 ~/.savia/scripts/savia-bridge.py --print-token
+```
+
+### Qué puede hacer el equipo desde el móvil
+
+| Escenario | Cómo |
+|---|---|
+| PM revisa sprint en tren | Abre Savia Mobile → "¿cómo va el sprint?" |
+| Dev consulta decisión en reunión | Abre chat → "¿por qué elegimos PostgreSQL?" |
+| Lead revisa PR desde el sofá | Pregunta a Savia → contexto del PR y comentarios |
+| CEO antes de un comité | "Dame el resumen ejecutivo de esta semana" |
+
+### Configuración en la app
+
+1. Instalar APK desde `http://{ip-bridge}:8080/install`
+2. En Ajustes → Bridge URL: `https://{ip-bridge}:8922`
+3. Token: el que obtuviste con `--print-token`
+4. Aceptar el certificado autofirmado (confiable en red local/VPN)
+
+Más detalles: `projects/savia-mobile-android/docs/BRIDGE-GUIDE.md`
+
+---
+
 ## Tips
 
 - Haz `git push` frecuente para que todo el equipo vea los cambios

--- a/docs/quick-starts/quick-start-ceo.md
+++ b/docs/quick-starts/quick-start-ceo.md
@@ -75,6 +75,14 @@ El `/ai-exposure-audit` usa datos de O*NET para calcular cuánto de cada rol es 
 
 ---
 
+---
+
+## Desde el móvil
+
+Con Savia Mobile puedes consultar `/portfolio-overview`, `/ceo-alerts` y `/kpi-dora` desde tu Android. La app conecta al Bridge HTTPS y entrega respuestas en streaming — ideal para antes de un comité o mientras viajas. Setup: `projects/savia-mobile-android/docs/BRIDGE-GUIDE.md`
+
+---
+
 ## Siguientes pasos
 
 - [AI Augmentation por sector](../ai-augmentation-opportunities-es.md)

--- a/docs/quick-starts/quick-start-developer.md
+++ b/docs/quick-starts/quick-start-developer.md
@@ -75,9 +75,16 @@ Tu código empieza en una spec (`/spec-generate`). La spec define el contrato: q
 
 ---
 
+## Desde el móvil
+
+Con Savia Mobile puedes consultar tu sprint, preguntar por specs o revisar decisiones de diseño desde el móvil. Útil en reuniones o cuando estás lejos del terminal. Setup: `projects/savia-mobile-android/docs/BRIDGE-GUIDE.md`
+
+---
+
 ## Siguientes pasos
 
 - [Spec-Driven Development](../readme/05-sdd.md)
 - [Estructura del workspace](../readme/02-estructura.md)
 - [Guía de flujo de datos](../data-flow-guide-es.md)
 - [Comandos completos](../readme/12-comandos-agentes.md)
+- [Savia Mobile](../../projects/savia-mobile-android/README.md)

--- a/docs/quick-starts/quick-start-pm.md
+++ b/docs/quick-starts/quick-start-pm.md
@@ -79,6 +79,16 @@ Las horas que imputa tu equipo (`/report-hours`) las uso para calcular costes po
 
 ---
 
+---
+
+## Desde el móvil
+
+Si tienes Savia Mobile instalado, puedes consultar estos mismos comandos desde tu teléfono Android. La app se conecta al Savia Bridge y te permite chatear con Savia con streaming en tiempo real — ideal para reuniones, desplazamientos o revisiones rápidas.
+
+Configura el Bridge: `python3 savia-bridge.py --print-token` para obtener el token de conexión. Más info: `projects/savia-mobile-android/docs/BRIDGE-GUIDE.md`
+
+---
+
 ## Siguientes pasos
 
 - [Sprints e informes en detalle](../readme/04-uso-sprint-informes.md)

--- a/docs/quick-starts/quick-start-tech-lead.md
+++ b/docs/quick-starts/quick-start-tech-lead.md
@@ -79,9 +79,16 @@ Las specs SDD que generas (`/spec-generate`) son el contrato que ejecutan los ag
 
 ---
 
+## Desde el móvil
+
+Con Savia Mobile puedes consultar `/arch-health`, revisar deuda técnica o preguntar por decisiones arquitectónicas desde Android. Ideal para reuniones de diseño o antes de una code review. Setup: `projects/savia-mobile-android/docs/BRIDGE-GUIDE.md`
+
+---
+
 ## Siguientes pasos
 
 - [Spec-Driven Development](../readme/05-sdd.md)
 - [Architecture Intelligence](../readme/12-comandos-agentes.md)
 - [Agent Teams SDD](../agent-teams-sdd.md)
 - [Guía de flujo de datos](../data-flow-guide-es.md)
+- [Savia Mobile](../../projects/savia-mobile-android/README.md)

--- a/docs/readme/02-estructura.md
+++ b/docs/readme/02-estructura.md
@@ -100,12 +100,14 @@
 │   ├── ADOPTION_GUIDE.md / .en.md
 │   └── ...
 │
-├── projects/                    ← Proyectos reales (git-ignorados)
+├── projects/                    ← Proyectos reales (parte git-ignorados)
+│   ├── savia-mobile-android/    ← App Android + Bridge (publicado)
 │   ├── proyecto-alpha/          ← Ejemplo: CLAUDE.md, equipo.md, specs/
-│   ├── proyecto-beta/
 │   └── sala-reservas/           ← Proyecto de test con mock data
 │
 ├── scripts/
+│   ├── savia-bridge.py          ← Servidor HTTPS Bridge para Savia Mobile
+│   ├── savia-bridge.service     ← Servicio systemd del Bridge
 │   ├── azdevops-queries.sh      ← Queries a Azure DevOps REST API
 │   ├── test-workspace.sh        ← Validación de estructura del workspace
 │   └── validate-commands.sh     ← Validación estática de slash commands


### PR DESCRIPTION
## Summary

Integrate Savia Mobile references across the entire pm-workspace documentation ecosystem so the Android app and Bridge server are visible as first-class components.

- **CHANGELOG.md**: New v2.67.0 entry documenting the Savia Mobile release
- **ROADMAP.md**: New Era 53 — Savia Mobile: Android Companion App
- **data-flow-guide-es.md**: New Flujo 5 (Mobile → Bridge → CLI → Response) with ASCII diagram
- **02-estructura.md**: Add `savia-mobile-android/` and `savia-bridge.py` to workspace tree
- **4 quick-starts** (PM, CEO, Tech Lead, Developer): "Desde el móvil" section with use cases
- **guide-savia-standalone.md**: Full mobile access section with setup, use cases table, and config steps

## Test plan

- [x] All relative links verified
- [x] Spanish language maintained in all Spanish docs
- [x] Content consistent with actual Savia Mobile implementation
- [x] No broken cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)