### PR TITLE
refactor: Bridge template separation + code quality rules for all 16 languages

### DIFF
--- a/.claude/rules/domain/code-review-rules.md
+++ b/.claude/rules/domain/code-review-rules.md
@@ -18,6 +18,8 @@ Reglas para el hook de code review pre-commit y `/pr-review`. Cada proyecto pued
 
 **REJECT** debugger statements en producción — `debugger;`, `binding.pry`, `import pdb`, `breakpoint()`. Excepción: ficheros de test.
 
+**REJECT** HTML/CSS/SQL inline en código backend — strings multilínea con marcado HTML, bloques CSS o consultas SQL sin parametrizar en ficheros `.py`, `.java`, `.cs`, `.go`, `.rb`, `.php`, `.rs`, `.kt`. Las plantillas van en ficheros `.html`/`.jinja2`, los estilos en `.css` y las consultas en `.sql` o como parámetros vinculados. Excepción: snippets ≤1 línea para errores simples, y fixtures de test. (ver `domain/template-separation.md`)
+
 ---
 
 ## Reglas REQUIRE (obligatorias)

--- a/.claude/rules/domain/template-separation.md
+++ b/.claude/rules/domain/template-separation.md
@@ -1,0 +1,166 @@
+---
+description: Regla cross-cutting de separación de marcado y lógica
+globs:
+context: on-demand
+---
+
+# Separación de Marcado, Consultas y Estilos — Regla Transversal
+
+> Aplica a **todos** los lenguajes. Complementa las reglas de arquitectura específicas de cada language pack.
+> Última actualización: 2026-03-08
+
+---
+
+## Principio
+
+El código de aplicación **NUNCA** debe contener marcado (HTML/XML), hojas de estilo (CSS) ni consultas (SQL/GraphQL) embebidos como cadenas literales. Cada capa vive en su propio fichero con su propia extensión.
+
+**Motivación**: separar responsabilidades permite cachear assets, reutilizar plantillas, aplicar linting específico a cada capa y evitar errores de escaping.
+
+---
+
+## Reglas REJECT (bloquean PR / commit)
+
+### SEP-01 — HTML embebido en código backend
+
+**Severidad**: Critical · **Tags**: separation-of-concerns, maintainability
+
+Código de servidor (Python, Java, C#, Go, Ruby, PHP, Rust) no debe construir HTML mediante concatenación de strings ni f-strings.
+
+```python
+# ❌ Noncompliant
+def install_page():
+    return f"<html><body><h1>{title}</h1></body></html>"
+
+# ✅ Compliant — template externo
+def install_page():
+    template = load_template("install.html")
+    return template.replace("{{title}}", title)
+```
+
+```csharp
+// ❌ Noncompliant
+return $"<div class='card'>{user.Name}</div>";
+
+// ✅ Compliant — Razor view
+return View("UserCard", user);
+```
+
+**Excepción**: snippets de ≤ 1 línea para respuestas de error simples (ej: `<h1>404</h1>`).
+
+---
+
+### SEP-02 — CSS embebido en código backend
+
+**Severidad**: Major · **Tags**: separation-of-concerns
+
+Estilos CSS no deben definirse como strings en código de servidor.
+
+```python
+# ❌ Noncompliant
+style = "color: red; font-size: 14px;"
+html = f"<div style='{style}'>{content}</div>"
+
+# ✅ Compliant — fichero .css separado + clase
+# styles.css → .error { color: red; font-size: 14px; }
+# template.html → <div class="error">{{content}}</div>
+```
+
+**Excepción**: variables CSS generadas dinámicamente para temas (custom properties).
+
+---
+
+### SEP-03 — SQL como strings literales (sin parametrizar)
+
+**Severidad**: Blocker · **Tags**: security, sql-injection
+
+Consultas SQL deben usar parámetros vinculados, nunca interpolación de strings.
+
+```python
+# ❌ Noncompliant
+query = f"SELECT * FROM users WHERE id = {user_id}"
+
+# ✅ Compliant — parámetros vinculados
+query = "SELECT * FROM users WHERE id = ?"
+cursor.execute(query, (user_id,))
+```
+
+```java
+// ❌ Noncompliant
+String sql = "SELECT * FROM users WHERE name = '" + name + "'";
+
+// ✅ Compliant — PreparedStatement
+String sql = "SELECT * FROM users WHERE name = ?";
+stmt.setString(1, name);
+```
+
+**Nota**: esto ya se cubre en las reglas de seguridad (SQL injection), pero se refuerza aquí como principio de separación.
+
+---
+
+### SEP-04 — Ficheros monolíticos con múltiples responsabilidades
+
+**Severidad**: Major · **Tags**: srp, separation-of-concerns
+
+Un fichero de código no debe mezclar:
+- Lógica HTTP (handlers/controllers) + lógica de negocio + acceso a datos + presentación
+
+Cada responsabilidad va en su propio módulo/fichero.
+
+```python
+# ❌ Noncompliant — un solo fichero con todo
+class MyServer:
+    def handle_request(self):
+        data = db.query("SELECT ...")       # Acceso a datos
+        result = complex_calculation(data)   # Lógica de negocio
+        return f"<html>{result}</html>"      # Presentación
+
+# ✅ Compliant — separado por capas
+# repository.py  → def get_data(): ...
+# service.py     → def calculate(data): ...
+# handler.py     → def handle(): return render("template.html", service.calculate(...))
+```
+
+---
+
+## Reglas PREFER (sugerencias)
+
+### SEP-05 — Usar motores de templates del ecosistema
+
+**Severidad**: Minor · **Tags**: best-practice
+
+Cuando el proyecto necesite renderizar HTML, usar el motor de templates nativo del framework o ecosistema:
+
+| Lenguaje/Framework | Motor recomendado |
+|-------------------|-------------------|
+| Python (FastAPI) | Jinja2 |
+| Python (Django) | Django Templates |
+| Python (stdlib) | `string.Template` o ficheros `.html` con `.replace()` |
+| Java (Spring) | Thymeleaf |
+| C# (ASP.NET) | Razor |
+| Go | `html/template` |
+| Ruby (Rails) | ERB / Slim |
+| PHP (Laravel) | Blade |
+| Rust (Actix/Axum) | Askama / Tera |
+| Node.js (Express) | EJS / Handlebars / Pug |
+
+### SEP-06 — GraphQL schemas en ficheros `.graphql`
+
+**Severidad**: Minor
+
+Definir schemas GraphQL en ficheros `.graphql` separados, no como strings multilínea en código.
+
+---
+
+## Aplicabilidad
+
+Esta regla se aplica a:
+- Todo código nuevo
+- Código existente cuando se modifica (boy scout rule)
+- Scripts de infraestructura (Bridge, CLI wrappers, etc.)
+
+No se aplica a:
+- Tests con HTML/SQL de fixture (contenido de prueba)
+- DSLs explícitos (OpenAPI specs inline, migrations de DB)
+- Ficheros de configuración (CSS variables en Python para temas)
+- CLI tools con output formateado (`--format html` como feature)

--- a/.claude/rules/languages/cobol-conventions.md
+++ b/.claude/rules/languages/cobol-conventions.md
@@ -287,3 +287,151 @@ El agente NO DEBE sin aprobación humana:
   }
 }
 ```
+
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis para COBOL. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### COBOL-SEC-01 — Credenciales en literales
+**Severidad**: Blocker
+```cobol
+*> ❌ Noncompliant
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PASSWORD         PIC X(20) VALUE 'SuperSecret123'.
+       01  WS-API-KEY          PIC X(40) VALUE 'sk-1234567890abcdef'.
+
+*> ✅ Compliant
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT CREDENCIALES ASSIGN TO "credenciales.env".
+
+       DATA DIVISION.
+       FILE SECTION.
+       FD  CREDENCIALES.
+       01  CRED-RECORD         PIC X(100).
+
+       WORKING-STORAGE SECTION.
+       01  WS-PASSWORD         PIC X(20).
+       01  WS-API-KEY          PIC X(40).
+```
+
+#### COBOL-SEC-02 — Falta de validación en entrada
+**Severidad**: Blocker
+```cobol
+*> ❌ Noncompliant
+       ACCEPT WS-USER-ID.
+       MOVE WS-USER-ID TO WS-QUERY.  *> SQL dinámico sin validar
+
+*> ✅ Compliant
+       ACCEPT WS-USER-ID.
+       IF WS-USER-ID IS NOT NUMERIC OR WS-USER-ID <= 0
+           DISPLAY "Error: User ID debe ser numerico y > 0"
+       ELSE
+           MOVE WS-USER-ID TO WS-QUERY
+       END-IF.
+```
+
+### Bugs (Major)
+
+#### COBOL-BUG-01 — GOTO excesivo (spaghetti code)
+**Severidad**: Major
+```cobol
+*> ❌ Noncompliant - Spaghetti code
+       PROCEDURE DIVISION.
+           MOVE 0 TO WS-CONTADOR.
+       INICIO.
+           ADD 1 TO WS-CONTADOR.
+           IF WS-CONTADOR > 100
+               GO TO FIN
+           END-IF.
+           GO TO PROCESAR.
+       PROCESAR.
+           PERFORM HACER-ALGO.
+           GO TO INICIO.
+       FIN.
+           DISPLAY "Hecho".
+           STOP RUN.
+
+*> ✅ Compliant - Usar PERFORM
+       PROCEDURE DIVISION.
+           PERFORM PROCESAR-DATOS
+               VARYING WS-CONTADOR FROM 1 BY 1
+               UNTIL WS-CONTADOR > 100
+           END-PERFORM.
+           DISPLAY "Hecho".
+           STOP RUN.
+```
+
+#### COBOL-BUG-02 — Documentación de copybooks faltante
+**Severidad**: Major
+```cobol
+*> ❌ Noncompliant - Sin documentación
+       01  USUARIO-RECORD.
+           05  USR-ID         PIC 9(8).
+           05  USR-NOMBRE     PIC X(50).
+           05  USR-EMAIL      PIC X(60).
+
+*> ✅ Compliant - Con documentación
+       *> ================================================================
+       *> USUARIO-RECORD: Estructura de datos de usuario
+       *>
+       *> Campos:
+       *>   - USR-ID: ID de usuario (numerico, 8 digitos)
+       *>   - USR-NOMBRE: Nombre completo (alfanumerico, 50 caracteres)
+       *>   - USR-EMAIL: Email (alfanumerico, 60 caracteres)
+       *>
+       *> Versión: 1.0 (2026-02-26)
+       *> ================================================================
+       01  USUARIO-RECORD.
+           05  USR-ID         PIC 9(8).
+           05  USR-NOMBRE     PIC X(50).
+           05  USR-EMAIL      PIC X(60).
+```
+
+### Code Smells (Critical)
+
+#### COBOL-SMELL-01 — Párrafo > 50 líneas
+**Severidad**: Critical
+Párrafos de más de 50 líneas deben dividirse en párrafos más pequeños.
+
+#### COBOL-SMELL-02 — WORKING-STORAGE desordenada
+**Severidad**: Critical
+WORKING-STORAGE debe estar organizada lógicamente, no caóticamente.
+
+### Arquitectura
+
+#### COBOL-ARCH-01 — Undocumented copybooks
+**Severidad**: Critical
+Código COBOL no debe usar copybooks sin documentación. Cada copybook debe tener cabecera con versión, propósito y campos.
+```cobol
+*> ❌ Noncompliant - Sin cabecera
+       01  DATOS-VENDEDOR.
+           05  VENDEDOR-ID     PIC 9(5).
+           05  VENDEDOR-COMISION PIC 9(5)V99.
+
+*> ✅ Compliant - Con cabecera obligatoria
+       *> ================================================================
+       *> Copybook: DATOS-VENDEDOR.cpy
+       *> Proposito: Estructura para datos de vendedor en reportes
+       *>
+       *> Campos:
+       *>   VENDEDOR-ID: Identificador del vendedor (1-99999)
+       *>   VENDEDOR-COMISION: Comision en porcentaje (0.00 a 99999.99)
+       *>
+       *> Version: 2.1
+       *> Fecha Creacion: 2026-01-15
+       *> Ultima Modificacion: 2026-02-26
+       *> Modificado Por: Equipo Legacy Modernization
+       *> ================================================================
+       01  DATOS-VENDEDOR.
+           05  VENDEDOR-ID     PIC 9(5).
+           05  VENDEDOR-COMISION PIC 9(5)V99.
+```
+
+

--- a/.claude/rules/languages/flutter-conventions.md
+++ b/.claude/rules/languages/flutter-conventions.md
@@ -376,3 +376,117 @@ dev_dependencies:
   }
 }
 ```
+
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis Dart Analyzer/Flutter Lint para Dart. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### FLUTTER-SEC-01 — Credenciales hardcodeadas
+**Severidad**: Blocker
+```dart
+// ❌ Noncompliant
+const apiKey = 'sk-1234567890abcdef';
+const password = 'SuperSecret123';
+
+// ✅ Compliant
+final apiKey = String.fromEnvironment('API_KEY');
+final password = const String.fromEnvironment('DB_PASSWORD');
+```
+
+#### FLUTTER-SEC-02 — SQL Injection en queries locales
+**Severidad**: Blocker
+```dart
+// ❌ Noncompliant
+final query = 'SELECT * FROM users WHERE id = $userId';
+db.execute(query);
+
+// ✅ Compliant
+final query = 'SELECT * FROM users WHERE id = ?';
+db.execute(query, [userId]);
+```
+
+### Bugs (Major)
+
+#### FLUTTER-BUG-01 — BuildContext across async gaps
+**Severidad**: Major
+```dart
+// ❌ Noncompliant
+onPressed: () async {
+  final result = await fetchData();
+  Navigator.of(context).push(...);  // context puede no ser válido tras async
+}
+
+// ✅ Compliant
+onPressed: () async {
+  if (!mounted) return;
+  final result = await fetchData();
+  if (!mounted) return;
+  Navigator.of(context).push(...);
+}
+```
+
+#### FLUTTER-BUG-02 — setState() after dispose
+**Severidad**: Major
+```dart
+// ❌ Noncompliant
+void _onDataReceived(data) {
+  setState(() => _data = data);  // puede ser llamado tras dispose()
+}
+
+// ✅ Compliant
+void _onDataReceived(data) {
+  if (mounted) {
+    setState(() => _data = data);
+  }
+}
+```
+
+### Code Smells (Critical)
+
+#### FLUTTER-SMELL-01 — Widget > 50 líneas
+**Severidad**: Critical
+Widgets de más de 50 líneas deben dividirse en widgets más pequeños.
+
+#### FLUTTER-SMELL-02 — Complejidad ciclomática > 10
+**Severidad**: Critical
+Usar early returns, extraer métodos y simplificar condicionales.
+
+### Arquitectura
+
+#### FLUTTER-ARCH-01 — State management inconsistency
+**Severidad**: Critical
+Código Flutter no debe mezclar Riverpod, Provider, setState en la misma app.
+```dart
+// ❌ Noncompliant - Mezcla de patrones
+class MyWidget extends StatefulWidget {
+  @override
+  State<MyWidget> createState() => _MyWidgetState();
+}
+
+class _MyWidgetState extends State<MyWidget> {
+  final provider = ChangeNotifierProvider(/* ... */);  // ChangeNotifier (anticuado)
+  var state = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    setState(() => state++);  // setState (anticuado)
+  }
+}
+
+// ✅ Compliant - Usar Riverpod en todo
+final stateProvider = StateProvider((ref) => 0);
+
+class MyWidget extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(stateProvider);
+    return Text('$state');
+  }
+}
+```
+
+

--- a/.claude/rules/languages/kotlin-conventions.md
+++ b/.claude/rules/languages/kotlin-conventions.md
@@ -274,3 +274,87 @@ adb logcat                                     # ver logs
   }
 }
 ```
+
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis Detekt/Lint para Kotlin. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### KOTLIN-SEC-01 — Credenciales hardcodeadas
+**Severidad**: Blocker
+```kotlin
+// ❌ Noncompliant
+val apiKey = "sk-1234567890abcdef"
+val password = "SuperSecret123"
+
+// ✅ Compliant
+val apiKey = BuildConfig.API_KEY
+val password = System.getenv("DB_PASSWORD")
+```
+
+#### KOTLIN-SEC-02 — Intent extras sin validación
+**Severidad**: Blocker
+```kotlin
+// ❌ Noncompliant
+val userId = intent.getStringExtra("user_id")
+val user = repository.getUser(userId)  // null si no existe
+
+// ✅ Compliant
+val userId = intent.getStringExtra("user_id") ?: return
+val user = repository.getUser(userId)
+```
+
+### Bugs (Major)
+
+#### KOTLIN-BUG-01 — Force unwrap (!!) sin null checking
+**Severidad**: Major
+```kotlin
+// ❌ Noncompliant
+val user = getUserOrNull()!!  // crash si null
+
+// ✅ Compliant
+val user = getUserOrNull() ?: return
+// o
+val user = getUserOrNull()?.let { processUser(it) }
+```
+
+#### KOTLIN-BUG-02 — Corrutine scope sin lifecycle
+**Severidad**: Major
+```kotlin
+// ❌ Noncompliant
+GlobalScope.launch { loadData() }  // pierde scope si Activity se destruye
+
+// ✅ Compliant
+viewModelScope.launch { loadData() }  // se cancela con ViewModel
+```
+
+### Code Smells (Critical)
+
+#### KOTLIN-SMELL-01 — Función/método > 50 líneas
+**Severidad**: Critical
+Funciones de más de 50 líneas deben dividirse en funciones más pequeñas con responsabilidad única.
+
+#### KOTLIN-SMELL-02 — Complejidad ciclomática > 10
+**Severidad**: Critical
+Usar early returns, extraer métodos y simplificar condicionales.
+
+### Arquitectura
+
+#### KOTLIN-ARCH-01 — Memoria leak en listeners/callbacks
+**Severidad**: Critical
+Código Kotlin no debe retener referencias a Activity/Fragment fuera de su lifecycle.
+```kotlin
+// ❌ Noncompliant - Memory leak
+class UserManager {
+    var activity: Activity? = null  // retiene Activity indefinidamente
+}
+
+// ✅ Compliant - WeakReference o scope correcto
+class UserViewModel : ViewModel() {
+    // viewModelScope garantiza limpieza
+    init { viewModelScope.launch { /* ... */ } }
+}
+```

--- a/.claude/rules/languages/php-conventions.md
+++ b/.claude/rules/languages/php-conventions.md
@@ -274,3 +274,94 @@ Añadir en `.claude/settings.json`:
 }
 ```
 
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis PHPStan/Psalm para PHP. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### PHP-SEC-01 — Credenciales hardcodeadas
+**Severidad**: Blocker
+```php
+// ❌ Noncompliant
+define('API_KEY', 'sk-1234567890abcdef');
+$password = 'SuperSecret123';
+
+// ✅ Compliant
+$apiKey = config('services.api.key');
+$password = env('DB_PASSWORD');
+```
+
+#### PHP-SEC-02 — Unescaped output (XSS)
+**Severidad**: Blocker
+```php
+// ❌ Noncompliant
+echo $userData['name'];  // vulnerable si $userData viene de usuario
+
+// ✅ Compliant
+echo htmlspecialchars($userData['name'], ENT_QUOTES, 'UTF-8');
+// O en Blade:
+{{ $userData['name'] }}  <!-- escapa automáticamente -->
+```
+
+### Bugs (Major)
+
+#### PHP-BUG-01 — Type coercion bugs
+**Severidad**: Major
+```php
+// ❌ Noncompliant
+if ($status == 0) { } // "0" == 0 es true, peligroso
+
+// ✅ Compliant
+if ($status === 0) { } // comparación estricta
+```
+
+#### PHP-BUG-02 — N+1 queries en loops
+**Severidad**: Major
+```php
+// ❌ Noncompliant
+$orders = Order::all();
+foreach ($orders as $order) {
+    echo $order->user->name;  // N queries
+}
+
+// ✅ Compliant
+$orders = Order::with('user')->get();  // eager loading
+foreach ($orders as $order) {
+    echo $order->user->name;
+}
+```
+
+### Code Smells (Critical)
+
+#### PHP-SMELL-01 — Función/método > 50 líneas
+**Severidad**: Critical
+Funciones de más de 50 líneas deben dividirse en funciones más pequeñas con responsabilidad única.
+
+#### PHP-SMELL-02 — Complejidad ciclomática > 10
+**Severidad**: Critical
+Usar early returns, extraer métodos y simplificar condicionales.
+
+### Arquitectura
+
+#### PHP-ARCH-01 — Lógica de negocio en controllers
+**Severidad**: Critical
+Código PHP no debe contener lógica de negocio en controllers. Usar action classes o services.
+```php
+// ❌ Noncompliant - Lógica en controller
+public function store(Request $request) {
+    $order = Order::create($request->validated());
+    $user = $order->user;
+    Mail::send(...);
+    Queue::push(...);
+}
+
+// ✅ Compliant - Usar action/service
+public function store(StoreOrderRequest $request, CreateOrderAction $action) {
+    $order = $action->execute($request->validated());
+    return response()->json(new OrderResource($order), 201);
+}
+```
+

--- a/.claude/rules/languages/python-rules.md
+++ b/.claude/rules/languages/python-rules.md
@@ -657,6 +657,29 @@ async def get_user(user_id: str, service: UserService = Depends()):
 
 **Impacto**: Independencia de framework, testabilidad, clean architecture.
 
+#### ARCH-04 — Separación de marcado y lógica (ver `domain/template-separation.md`)
+
+**Severidad**: Critical · **Tags**: separation-of-concerns, maintainability
+
+Código Python no debe contener HTML, CSS ni SQL como strings literales multilínea. Las plantillas viven en ficheros `.html` (o `.jinja2`, `.sql`) separados y se cargan desde disco.
+
+```python
+# ❌ Noncompliant — HTML inline
+def build_page():
+    return f"""<!DOCTYPE html>
+    <html><head><style>body {{ color: red; }}</style></head>
+    <body><h1>{title}</h1></body></html>"""
+
+# ✅ Compliant — template en fichero separado
+def build_page():
+    template = (TEMPLATES_DIR / "page.html").read_text()
+    return template.replace("{{title}}", title)
+```
+
+**Impacto**: Mantenibilidad, cacheo de assets, linting separado por capa, reutilización de plantillas.
+
+> Regla completa con ejemplos multi-lenguaje: `.claude/rules/domain/template-separation.md`
+
 ---
 
 ---

--- a/.claude/rules/languages/ruby-conventions.md
+++ b/.claude/rules/languages/ruby-conventions.md
@@ -318,3 +318,96 @@ RAILS_ENV=production bin/rails s
   }
 }
 ```
+
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis Brakeman/RuboCop para Ruby. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### RUBY-SEC-01 — Credenciales hardcodeadas
+**Severidad**: Blocker
+```ruby
+# ❌ Noncompliant
+API_KEY = "sk-1234567890abcdef"
+DB_PASSWORD = "SuperSecret123"
+
+# ✅ Compliant
+API_KEY = ENV.fetch('API_KEY')
+DB_PASSWORD = Rails.application.credentials.database_password
+```
+
+#### RUBY-SEC-02 — eval() con entrada de usuario
+**Severidad**: Blocker
+```ruby
+# ❌ Noncompliant
+code = params[:expression]
+result = eval(code)  # ejecución arbitraria de código
+
+# ✅ Compliant
+result = safe_eval(params[:expression])  # usar gema como Dentaku
+```
+
+### Bugs (Major)
+
+#### RUBY-BUG-01 — N+1 queries en loops
+**Severidad**: Major
+```ruby
+# ❌ Noncompliant
+@orders = Order.all
+@orders.each { |order| order.user.name }  # N queries
+
+# ✅ Compliant
+@orders = Order.includes(:user)  # 1 query
+@orders.each { |order| order.user.name }
+```
+
+#### RUBY-BUG-02 — mass_assignment sin permitting
+**Severidad**: Major
+```ruby
+# ❌ Noncompliant
+@user = User.new(params[:user])  # acepta cualquier parámetro
+
+# ✅ Compliant
+@user = User.new(user_params)
+private def user_params
+  params.require(:user).permit(:name, :email)
+end
+```
+
+### Code Smells (Critical)
+
+#### RUBY-SMELL-01 — Función/método > 50 líneas
+**Severidad**: Critical
+Funciones de más de 50 líneas deben dividirse en funciones más pequeñas con responsabilidad única.
+
+#### RUBY-SMELL-02 — Complejidad ciclomática > 10
+**Severidad**: Critical
+Usar early returns, extraer métodos y simplificar condicionales.
+
+### Arquitectura
+
+#### RUBY-ARCH-01 — Lógica de negocio en controllers
+**Severidad**: Critical
+Código Ruby no debe contener lógica de negocio en controllers. Usar service objects.
+```ruby
+# ❌ Noncompliant - Lógica en controller
+def create
+  user = User.create(user_params)
+  send_welcome_email(user) if user.valid?
+  UserNotifier.notify(user)
+  render json: user
+end
+
+# ✅ Compliant - Usar service
+def create
+  service = UserCreationService.new(user_params)
+  if service.call
+    render json: service.user, status: :created
+  else
+    render json: service.errors, status: :unprocessable_entity
+  end
+end
+```

--- a/.claude/rules/languages/rust-conventions.md
+++ b/.claude/rules/languages/rust-conventions.md
@@ -198,3 +198,90 @@ Añadir en `.claude/settings.json` o `.claude/settings.local.json`:
 }
 ```
 
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis Clippy/Miri para Rust. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### RUST-SEC-01 — Credenciales hardcodeadas
+**Severidad**: Blocker
+```rust
+// ❌ Noncompliant
+const API_KEY: &str = "sk-1234567890abcdef";
+let password = "SuperSecret123";
+
+// ✅ Compliant
+let api_key = std::env::var("API_KEY").expect("API_KEY not set");
+let password = std::env::var("DB_PASSWORD")?;
+```
+
+#### RUST-SEC-02 — Unsafe sin justificación documentada
+**Severidad**: Blocker
+```rust
+// ❌ Noncompliant
+unsafe { ptr.read() }  // sin comentario explicativo
+
+// ✅ Compliant
+// SAFETY: ptr viene de una Box válida y la Box no se reusa tras este read
+unsafe { ptr.read() }
+```
+
+### Bugs (Major)
+
+#### RUST-BUG-01 — unwrap() sin manejo de error
+**Severidad**: Major
+```rust
+// ❌ Noncompliant
+let file = std::fs::read_to_string("data.txt").unwrap();  // panic si no existe
+
+// ✅ Compliant
+let file = std::fs::read_to_string("data.txt")?;
+// o
+let file = std::fs::read_to_string("data.txt")
+    .unwrap_or_else(|e| eprintln!("Error: {}", e));
+```
+
+#### RUST-BUG-02 — Bloqueo en async sin spawn_blocking
+**Severidad**: Major
+```rust
+// ❌ Noncompliant
+async fn fetch_data() {
+    let data = expensive_cpu_work();  // bloquea el executor
+}
+
+// ✅ Compliant
+async fn fetch_data() {
+    let data = tokio::task::spawn_blocking(expensive_cpu_work).await?;
+}
+```
+
+### Code Smells (Critical)
+
+#### RUST-SMELL-01 — Función/método > 50 líneas
+**Severidad**: Critical
+Funciones de más de 50 líneas deben dividirse en funciones más pequeñas con responsabilidad única.
+
+#### RUST-SMELL-02 — Complejidad ciclomática > 10
+**Severidad**: Critical
+Usar early returns, extraer métodos y simplificar condicionales.
+
+### Arquitectura
+
+#### RUST-ARCH-01 — Clone excesivo en hot path
+**Severidad**: Critical
+Código Rust no debe clonar datos innecesariamente en caminos críticos.
+```rust
+// ❌ Noncompliant - Clone en loop
+for item in items {
+    process(item.clone());  // clone innecesario
+}
+
+// ✅ Compliant - Usar referencia
+for item in &items {
+    process(item);
+}
+```
+

--- a/.claude/rules/languages/swift-conventions.md
+++ b/.claude/rules/languages/swift-conventions.md
@@ -198,3 +198,96 @@ Añadir en `.claude/settings.json`:
   }
 }
 ```
+
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis SwiftLint para Swift. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### SWIFT-SEC-01 — Credenciales hardcodeadas
+**Severidad**: Blocker
+```swift
+// ❌ Noncompliant
+let apiKey = "sk-1234567890abcdef"
+let password = "SuperSecret123"
+
+// ✅ Compliant
+let apiKey = Bundle.main.infoDictionary?["API_KEY"] as? String
+let password = Keychain.read(key: "db_password")
+```
+
+#### SWIFT-SEC-02 — URL scheme sin validación
+**Severidad**: Blocker
+```swift
+// ❌ Noncompliant
+if let url = URL(string: userInput) {
+    UIApplication.shared.open(url)  // podría abrir URL maliciosa
+}
+
+// ✅ Compliant
+let allowed = ["https", "http"]
+if let url = URL(string: userInput),
+   allowed.contains(url.scheme ?? "") {
+    UIApplication.shared.open(url)
+}
+```
+
+### Bugs (Major)
+
+#### SWIFT-BUG-01 — Force unwrap (!) sin null checking
+**Severidad**: Major
+```swift
+// ❌ Noncompliant
+let user = getUser()!  // crash si nil
+
+// ✅ Compliant
+guard let user = getUser() else { return }
+// o
+if let user = getUser() { process(user) }
+```
+
+#### SWIFT-BUG-02 — Retain cycle en closures
+**Severidad**: Major
+```swift
+// ❌ Noncompliant
+apiClient.fetch { result in
+    self.data = result  // captura fuerte de self
+}
+
+// ✅ Compliant
+apiClient.fetch { [weak self] result in
+    self?.data = result  // captura débil de self
+}
+```
+
+### Code Smells (Critical)
+
+#### SWIFT-SMELL-01 — Función/método > 50 líneas
+**Severidad**: Critical
+Funciones de más de 50 líneas deben dividirse en funciones más pequeñas con responsabilidad única.
+
+#### SWIFT-SMELL-02 — Complejidad ciclomática > 10
+**Severidad**: Critical
+Usar early returns, extraer métodos y simplificar condicionales.
+
+### Arquitectura
+
+#### SWIFT-ARCH-01 — Main thread violations
+**Severidad**: Critical
+Código Swift no debe actualizar la UI desde un hilo no-principal.
+```swift
+// ❌ Noncompliant
+DispatchQueue.global().async {
+    let data = fetchData()
+    self.label.text = data  // actualizar UI en background thread
+}
+
+// ✅ Compliant
+Task { @MainActor in
+    let data = try await fetchData()
+    self.label.text = data  // garantizado en main thread
+}
+```

--- a/.claude/rules/languages/terraform-conventions.md
+++ b/.claude/rules/languages/terraform-conventions.md
@@ -426,3 +426,153 @@ module "vpc" {
 ```bash
 terraform-docs markdown . > README.md
 ```
+
+---
+
+## Reglas de Análisis Estático
+
+> Equivalente a análisis TFLint/TFSec para Terraform. Aplica en code review y pre-commit.
+
+### Vulnerabilities (Blocker)
+
+#### TERRAFORM-SEC-01 — Hardcoded values en variables
+**Severidad**: Blocker
+```hcl
+# ❌ Noncompliant
+resource "aws_db_instance" "main" {
+  allocated_storage    = 20
+  storage_type        = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "admin"
+  password             = "SuperSecret123"  # hardcoded
+  parameter_group_name = "default.mysql5.7"
+  skip_final_snapshot  = true
+}
+
+# ✅ Compliant
+resource "aws_db_instance" "main" {
+  allocated_storage    = var.allocated_storage
+  storage_type        = var.storage_type
+  engine               = var.engine
+  engine_version       = var.engine_version
+  instance_class       = var.instance_class
+  name                 = var.database_name
+  username             = var.db_username
+  password             = var.db_password  # usar variable con sensitive = true
+  parameter_group_name = aws_db_parameter_group.main.name
+  skip_final_snapshot  = var.skip_final_snapshot
+}
+```
+
+#### TERRAFORM-SEC-02 — Falta de lifecycle blocks
+**Severidad**: Blocker
+```hcl
+# ❌ Noncompliant - Recurso destruible sin restricción
+resource "aws_s3_bucket" "main" {
+  bucket = "my-important-bucket"
+}
+
+# ✅ Compliant - Proteger recurso crítico
+resource "aws_s3_bucket" "main" {
+  bucket = "my-important-bucket"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+### Bugs (Major)
+
+#### TERRAFORM-BUG-01 — Versiones dinámicas de provider
+**Severidad**: Major
+```hcl
+# ❌ Noncompliant
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"  # acepta cualquier versión >= 5.0
+    }
+  }
+}
+
+# ✅ Compliant
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.15"  # permite 5.15, 5.16, ... pero no 6.0
+    }
+  }
+}
+```
+
+#### TERRAFORM-BUG-02 — Missing tags en recursos
+**Severidad**: Major
+```hcl
+# ❌ Noncompliant
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro"
+  # sin tags para tracking
+}
+
+# ✅ Compliant
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+
+  tags = {
+    Name        = "web-server-${var.environment}"
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+    CreatedAt   = timestamp()
+  }
+}
+```
+
+### Code Smells (Critical)
+
+#### TERRAFORM-SMELL-01 — Módulo > 50 líneas
+**Severidad**: Critical
+Módulos de más de 50 líneas deben dividirse en módulos más pequeños.
+
+#### TERRAFORM-SMELL-02 — Complejidad de variables
+**Severidad**: Critical
+Variables con lógica compleja deben extraerse a locals.
+
+### Arquitectura
+
+#### TERRAFORM-ARCH-01 — Mezcla de recursos en main.tf
+**Severidad**: Critical
+Código Terraform no debe contener todo en un único main.tf. Usar módulos.
+```hcl
+# ❌ Noncompliant - Todo mezclado
+resource "aws_vpc" "main" { ... }
+resource "aws_subnet" "public" { ... }
+resource "aws_db_instance" "main" { ... }
+resource "aws_elb" "main" { ... }
+resource "aws_autoscaling_group" "main" { ... }
+
+# ✅ Compliant - Modularizado
+module "vpc" {
+  source = "./modules/vpc"
+  cidr   = var.vpc_cidr
+}
+
+module "database" {
+  source = "./modules/database"
+  vpc_id = module.vpc.vpc_id
+}
+
+module "compute" {
+  source = "./modules/compute"
+  vpc_id = module.vpc.vpc_id
+}
+```
+
+

--- a/projects/savia-mobile-android/docs/FEATURE-RESEARCH-v0.2.md
+++ b/projects/savia-mobile-android/docs/FEATURE-RESEARCH-v0.2.md
@@ -1,0 +1,419 @@
+# Savia Mobile — Investigación de Funciones v0.2+
+
+> **Fecha**: 8 marzo 2026
+> **Contexto**: PM-Workspace tiene 457+ comandos, 33 agentes y 43 skills. La app móvil (v0.1.0) tiene chat SSE, sesiones y ajustes básicos. Este documento analiza qué funciones del workspace tienen sentido en móvil sin saturar la experiencia.
+
+---
+
+## Principios de Diseño Móvil
+
+1. **Complementario, no sustitutivo** — El móvil resuelve lo que el desktop no: movilidad, rapidez, voz, notificaciones push.
+2. **Read-heavy, write-light** — En móvil se consulta mucho y se escribe poco. Priorizar dashboards y consultas rápidas.
+3. **3 toques máximo** — Cualquier acción frecuente debe completarse en 3 interacciones o menos.
+4. **Offline-first** — Los datos clave deben estar cacheados localmente para consulta sin conexión.
+5. **No saturar** — Mejor 20 funciones bien hechas que 100 mediocres. Cada pantalla tiene un propósito claro.
+
+---
+
+## 1. Selector de Proyecto
+
+### Problema
+La app actual no tiene concepto de "proyecto". Todo va al workspace general. PM-Workspace gestiona múltiples proyectos con distintos equipos, iteraciones y backlogs.
+
+### Propuesta
+
+**Pantalla de selección de proyecto** como primer paso tras el login o accesible desde un dropdown en la barra superior.
+
+| Elemento | Detalle |
+|----------|---------|
+| **Vista** | Lista de cards con nombre del proyecto, equipo asignado y estado del sprint actual |
+| **Datos** | Se obtienen de `pm-config.md` (constantes Azure DevOps) vía Bridge |
+| **Persistencia** | Último proyecto seleccionado se guarda en DataStore |
+| **Impacto** | Toda la app se contextualiza al proyecto: dashboard, comandos, notificaciones |
+
+### Nuevo endpoint Bridge
+```
+GET /projects → [{id, name, team, currentSprint, health}]
+```
+
+### Prioridad: **ALTA** (prerequisito para la mayoría de funciones)
+
+---
+
+## 2. Botonera de Comandos por Familias
+
+### Problema
+PM-Workspace tiene 457+ slash commands. Escribirlos en chat es tedioso en móvil. Necesitamos un acceso visual organizado.
+
+### Propuesta
+
+**Command Palette** con pestañas por familia + buscador integrado.
+
+#### Familias propuestas (10 familias, ~40 comandos móvil-friendly)
+
+| Familia | Icono | Comandos móvil-friendly | Tipo |
+|---------|-------|------------------------|------|
+| **Sprint** | 🏃 | sprint-status, sprint-forecast, velocity-trend, board-flow, kpi-dashboard | Solo lectura |
+| **Mi Trabajo** | 👤 | my-sprint (nuevo), team-workload, pbi-assign | Lectura + acción |
+| **Backlog** | 📋 | backlog-capture, pbi-decompose, pbi-jtbd | Escritura rápida |
+| **Horas** | ⏱️ | report-hours, daily-log (nuevo) | Escritura rápida |
+| **Calidad** | ✅ | pr-pending, testplan-status, security-alerts | Solo lectura |
+| **Equipo** | 👥 | team-workload, report-capacity, team-onboarding | Solo lectura |
+| **Repos** | 🔀 | repos-pr-list, pr-review (resumen), repos-branches | Lectura + links |
+| **Pipelines** | 🚀 | pipeline-status, pipeline-run | Lectura + 1 acción |
+| **Infra** | ☁️ | infra-status, infra-estimate | Solo lectura |
+| **Conectores** | 🔗 | notify-slack, notify-whatsapp, slack-search | Acción rápida |
+
+#### UX del Command Palette
+
+```
+┌──────────────────────────────┐
+│ 🔍 Buscar comando...        │
+├──────────────────────────────┤
+│ Sprint │ Mi Trabajo │ Backlog│ ← Tabs scrollables
+├──────────────────────────────┤
+│ ┌────────┐ ┌────────┐       │
+│ │ 🏃     │ │ 📊     │       │ ← Grid 2 columnas
+│ │ Sprint │ │ Veloci- │       │
+│ │ Status │ │ dad     │       │
+│ └────────┘ └────────┘       │
+│ ┌────────┐ ┌────────┐       │
+│ │ 🎯     │ │ 📈     │       │
+│ │ Board  │ │ KPI    │       │
+│ │ Flow   │ │ Dash   │       │
+│ └────────┘ └────────┘       │
+└──────────────────────────────┘
+```
+
+- **Búsqueda**: Filtra por nombre y descripción en tiempo real
+- **Favoritos**: El usuario puede marcar comandos como favoritos (aparecen primero)
+- **Recientes**: Los últimos 5 comandos usados se muestran al abrir
+- **Ejecución**: Al pulsar un comando, se pre-llena el chat con el slash command y el proyecto seleccionado
+
+### Nuevo endpoint Bridge
+```
+GET /commands → [{name, family, description, params, mobileEnabled}]
+POST /execute → {command, project, params} → SSE stream
+```
+
+### Prioridad: **ALTA** (diferenciador principal de la app)
+
+---
+
+## 3. Perfil de Usuario
+
+### Problema
+La app no muestra quién eres ni tu rol. PM-Workspace tiene datos del PM user configurado.
+
+### Propuesta
+
+**Pantalla de perfil** accesible desde Settings o avatar en la barra.
+
+| Sección | Datos | Fuente |
+|---------|-------|--------|
+| **Identidad** | Nombre, email, foto Google | GoogleAuthManager (ya existe) |
+| **Rol PM** | Display name, organización | `pm-config.md` → `AZURE_DEVOPS_PM_USER`, `PM_DISPLAY` |
+| **Estadísticas** | Sprints gestionados, PBIs cerrados, horas logadas | Azure DevOps queries |
+| **Proyectos activos** | Lista de proyectos asignados | `pm-config.md` |
+| **Preferencias** | Tema, idioma, notificaciones | DataStore local |
+
+### Nuevo endpoint Bridge
+```
+GET /profile → {name, email, role, org, stats: {sprints, pbis, hours}}
+```
+
+### Prioridad: **MEDIA** (mejora la personalización)
+
+---
+
+## 4. Datos de la Empresa / Organización
+
+### Problema
+No hay visibilidad del contexto organizacional desde la app.
+
+### Propuesta
+
+**Sección Organización** en Settings o como pantalla dedicada.
+
+| Dato | Fuente |
+|------|--------|
+| Nombre org | `AZURE_DEVOPS_ORG_NAME` |
+| URL Azure DevOps | `AZURE_DEVOPS_ORG_URL` |
+| Proyectos activos | Conteo de proyectos configurados |
+| Equipos | Lista de equipos por proyecto |
+| Cadencia sprint | `SPRINT_DURATION_WEEKS`, días, horarios |
+| Métricas DORA | Deployment frequency, lead time, MTTR, change failure rate |
+| Conectores activos | Slack, GitHub, Sentry, etc. (cuáles están configurados) |
+
+### Prioridad: **BAJA** (informativo, no accionable)
+
+---
+
+## 5. Dashboard Inteligente (Rediseño de la Home)
+
+### Problema
+La pantalla actual de Dashboard (Sessions) solo muestra conversaciones. Podría ser mucho más útil como centro de control.
+
+### Propuesta
+
+**Home redesignada** con widgets configurables:
+
+```
+┌──────────────────────────────┐
+│ 👋 Buenos días, Mónica       │
+│ Proyecto: Alpha · Sprint 24  │
+├──────────────────────────────┤
+│ ┌──────────────────────────┐ │
+│ │ Sprint Progress    78%   │ │ ← Widget: barra de progreso
+│ │ ████████████░░░░  12/15  │ │
+│ └──────────────────────────┘ │
+│ ┌────────────┐┌────────────┐ │
+│ │ 🔴 3       ││ ⏱️ 6.5h    │ │ ← Widget doble
+│ │ Bloqueados ││ Hoy logadas│ │
+│ └────────────┘└────────────┘ │
+│ ┌──────────────────────────┐ │
+│ │ 📋 Mis tareas (5)       │ │ ← Widget: lista compacta
+│ │ • Fix auth bug    [▓▓░]  │ │
+│ │ • Update API docs [▓░░]  │ │
+│ │ • Review PR #45   [░░░]  │ │
+│ └──────────────────────────┘ │
+│ ┌──────────────────────────┐ │
+│ │ 🔔 Actividad reciente    │ │ ← Widget: feed
+│ │ Juan completó PBI-234    │ │
+│ │ PR #67 aprobado          │ │
+│ │ Pipeline deploy OK       │ │
+│ └──────────────────────────┘ │
+├──────────────────────────────┤
+│ 💬 Chat  │ 🏠 Home │ ⚡ Cmd │ ← Nav inferior rediseñada
+└──────────────────────────────┘
+```
+
+### Widgets disponibles
+1. **Sprint Progress** — Barra con SP completados / total
+2. **Blockers** — Contador de items bloqueados (tappable)
+3. **Mis Tareas** — Lista compacta de tareas asignadas al PM
+4. **Horas Hoy** — Timer de horas logadas + botón de log rápido
+5. **Activity Feed** — Últimos eventos del proyecto (PRs, deploys, PBIs)
+6. **Velocity** — Mini-gráfico de velocidad últimos 5 sprints
+7. **Health Score** — Radar compacto del workspace health
+
+### Prioridad: **ALTA** (transforma la app de "chat client" a "PM companion")
+
+---
+
+## 6. Captura Rápida (Voice-to-PBI)
+
+### Problema
+Las ideas surgen en movimiento. Capturar un PBI desde el desktop requiere abrir Azure DevOps, rellenar formularios, etc.
+
+### Propuesta
+
+**Botón flotante de captura rápida** (FAB) presente en todas las pantallas:
+
+1. **Texto**: Campo de texto libre → se envía como `/backlog-capture {texto}`
+2. **Voz**: Usa `SpeechRecognizer` de Android → transcripción → `/backlog-capture`
+3. **Foto**: Cámara o galería → adjunto al PBI (futuro)
+
+El Bridge procesa la captura y devuelve confirmación con ID del Work Item creado.
+
+### Nuevo endpoint Bridge
+```
+POST /capture → {type: "pbi"|"bug"|"note", content, project} → {workItemId, url}
+```
+
+### Prioridad: **ALTA** (ventaja exclusiva del móvil)
+
+---
+
+## 7. Log Rápido de Horas
+
+### Problema
+La imputación de horas es una tarea diaria obligatoria en muchas empresas. Hacerla desde el desktop es tedioso.
+
+### Propuesta
+
+**Widget de timer + log manual**:
+
+```
+┌──────────────────────────────┐
+│ ⏱️ Tiempo Hoy: 6h 30m       │
+├──────────────────────────────┤
+│ Task     │ Horas │ Estado    │
+│──────────│───────│──────────│
+│ PBI-234  │ 3.0h  │ ✅       │
+│ PBI-456  │ 2.5h  │ ✅       │
+│ PBI-789  │ 1.0h  │ 🔄       │
+├──────────────────────────────┤
+│ [+ Añadir entrada]          │
+└──────────────────────────────┘
+```
+
+- **Log rápido**: Seleccionar tarea → horas → guardar (3 toques)
+- **Timer activo**: Iniciar/parar cronómetro por tarea
+- **Resumen semanal**: Vista de horas por día de la semana
+- **Sincronización**: Se persiste en Room + sync a Azure DevOps vía Bridge
+
+### Nuevo endpoint Bridge
+```
+POST /time-log → {taskId, hours, date, note}
+GET /time-log/today → [{taskId, hours, note}]
+GET /time-log/week → [{date, entries: [...]}]
+```
+
+### Prioridad: **MEDIA-ALTA** (necesidad diaria, encaja perfecto en móvil)
+
+---
+
+## 8. Notificaciones Push Inteligentes
+
+### Problema
+El PM se entera tarde de bloqueos, PRs pendientes, fallos de pipeline.
+
+### Propuesta
+
+**Firebase Cloud Messaging** con categorías configurables:
+
+| Categoría | Trigger | Prioridad |
+|-----------|---------|-----------|
+| **Blocker** | Work item marcado como Blocked | Alta (sonido) |
+| **PR pendiente** | PR asignado al PM sin review > 4h | Media |
+| **Pipeline fallo** | Build o deploy fallido | Alta |
+| **Sprint** | Planning/Review/Retro a punto de empezar | Media (15min antes) |
+| **Capacity** | Equipo por encima del WIP limit | Baja |
+| **Deploy** | Deploy exitoso a PRO | Baja (informativa) |
+
+### Implementación
+- Bridge expone `/notifications/subscribe` con FCM token
+- Un cron job en el Bridge (o tarea programada) consulta Azure DevOps periódicamente
+- Envía push vía Firebase Admin SDK cuando detecta eventos relevantes
+
+### Prioridad: **MEDIA** (requiere Firebase setup + cron en Bridge)
+
+---
+
+## 9. Aprobaciones Rápidas
+
+### Problema
+Ciertas acciones en PM-Workspace requieren aprobación humana (infra, deploys a PRO, PRs).
+
+### Propuesta
+
+**Panel de aprobaciones** en la Home con acción directa:
+
+```
+┌──────────────────────────────┐
+│ ⚡ Pendiente de tu aprobación │
+├──────────────────────────────┤
+│ 🔀 PR #67: Fix auth cache   │
+│ Juan García · hace 2h        │
+│ [✅ Aprobar] [❌ Rechazar]    │
+├──────────────────────────────┤
+│ ☁️ Infra: Scale API to 4 pods│
+│ Coste: +€45/mes              │
+│ [✅ Aprobar] [❌ Rechazar]    │
+└──────────────────────────────┘
+```
+
+- **PRs**: Ver resumen + aprobar/rechazar (link a GitHub/DevOps para diff completo)
+- **Infra**: Ver propuesta + coste estimado → aprobar/rechazar
+- **Deploys**: Aprobar promoción PRE→PRO
+
+### Prioridad: **MEDIA** (alto valor, complejidad moderada)
+
+---
+
+## 10. Kanban Compacto
+
+### Problema
+Ver el tablero del sprint requiere abrir Azure DevOps en el navegador.
+
+### Propuesta
+
+**Vista Kanban horizontal scrollable** con las columnas del sprint:
+
+```
+┌──────────┬──────────┬──────────┬──────────┐
+│ New (3)  │ Active(5)│ Review(2)│ Done(12) │
+├──────────┼──────────┼──────────┼──────────┤
+│ ┌──────┐ │ ┌──────┐ │ ┌──────┐ │ ┌──────┐ │
+│ │PBI-45│ │ │PBI-23│ │ │PBI-12│ │ │PBI-01│ │
+│ │Fix.. │ │ │API.. │ │ │Auth..│ │ │Setup │ │
+│ │👤Juan│ │ │👤Ana │ │ │👤PM  │ │ │👤All │ │
+│ │3 SP  │ │ │5 SP  │ │ │2 SP  │ │ │1 SP  │ │
+│ └──────┘ │ └──────┘ │ └──────┘ │ └──────┘ │
+└──────────┴──────────┴──────────┴──────────┘
+```
+
+- **Solo lectura** en v1 (mover cards es complejo en móvil)
+- **Filtros**: Por persona, por estado, por prioridad
+- **Tap en card**: Expande detalle con descripción, acceptance criteria, tasks
+
+### Prioridad: **MEDIA** (visual, pero Azure DevOps web ya lo tiene)
+
+---
+
+## Navegación Propuesta (v0.2)
+
+### Barra inferior (4 tabs)
+
+| Tab | Pantalla | Contenido |
+|-----|----------|-----------|
+| 🏠 **Home** | Dashboard inteligente | Widgets, actividad, resumen sprint |
+| 💬 **Chat** | Chat conversacional | Chat SSE actual + slash commands |
+| ⚡ **Comandos** | Command Palette | Familias, buscador, favoritos, recientes |
+| 👤 **Perfil** | Perfil + Settings | Datos usuario, proyecto, ajustes |
+
+### Flujos principales
+
+```
+Home → Ver sprint → Tap blocker → Detalle PBI → Chat para resolver
+Home → FAB captura → Voz/texto → PBI creado
+Comandos → Sprint Status → Dashboard sprint
+Comandos → Report Hours → Log rápido
+Chat → Escribir /sprint-status → Respuesta streaming
+Perfil → Cambiar proyecto → Home se actualiza
+```
+
+---
+
+## Resumen de Prioridades
+
+| # | Función | Prioridad | Complejidad | Dependencias |
+|---|---------|-----------|-------------|-------------|
+| 1 | Selector de proyecto | **Alta** | Baja | Bridge endpoint |
+| 2 | Command Palette por familias | **Alta** | Media | Bridge endpoint + catálogo |
+| 5 | Dashboard inteligente (Home) | **Alta** | Alta | Proyecto seleccionado + Bridge queries |
+| 6 | Captura rápida (voz/texto) | **Alta** | Media | SpeechRecognizer + Bridge |
+| 7 | Log rápido de horas | **Media-Alta** | Media | Bridge + Azure DevOps |
+| 3 | Perfil de usuario | **Media** | Baja | Google Auth + pm-config |
+| 8 | Notificaciones push | **Media** | Alta | Firebase + Bridge cron |
+| 9 | Aprobaciones rápidas | **Media** | Media | Bridge + Azure DevOps |
+| 10 | Kanban compacto | **Media** | Media | Bridge + Azure DevOps |
+| 4 | Datos organización | **Baja** | Baja | pm-config |
+
+---
+
+## Funciones que NO llevar al móvil
+
+Estas funciones deben quedarse exclusivamente en desktop:
+
+- **Edición de código** y diffs de PR (pantalla demasiado pequeña)
+- **Generación de specs** (SDD) — documentos técnicos extensos
+- **Orquestación de agentes** — ejecuciones de 10-40 minutos
+- **Diagramas de arquitectura** — requieren lienzo grande
+- **Infraestructura provisioning** — complejidad y riesgo
+- **Informes ejecutivos complejos** — PPT/Word de múltiples páginas
+- **COBOL migration** — contexto masivo
+- **Security audit completo** — resultados extensos
+
+Para estas funciones, el móvil puede **notificar** cuando se completan y mostrar un **resumen**, pero la ejecución y revisión se hace en desktop.
+
+---
+
+## Próximos Pasos
+
+1. Diseñar wireframes de las 4 pantallas principales (Home, Chat, Comandos, Perfil)
+2. Definir los endpoints del Bridge necesarios para v0.2
+3. Crear PBIs en el backlog para cada función priorizada
+4. Implementar selector de proyecto + Command Palette como primera iteración
+5. Iterar el dashboard con widgets incrementales

--- a/scripts/savia-bridge.py
+++ b/scripts/savia-bridge.py
@@ -90,8 +90,9 @@ MAX_LOG_SIZE = 5 * 1024 * 1024
 
 # --- APK Install Page ---
 
-BRIDGE_VERSION = "1.2.0"
+BRIDGE_VERSION = "1.3.0"
 
+TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 LOGO_B64_FILE = CONFIG_DIR / "logo_b64.txt"
 
 def _find_apk() -> Path | None:
@@ -146,8 +147,26 @@ def _load_logo_b64() -> str:
     # Fallback: simple SVG circle with "S"
     return "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI0OCIgZmlsbD0iIzZCNEM5QSIvPjx0ZXh0IHg9IjUwIiB5PSI2MiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0id2hpdGUiIGZvbnQtc2l6ZT0iNDAiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXdlaWdodD0iYm9sZCI+UzwvdGV4dD48L3N2Zz4="
 
+def _load_template(name: str) -> str:
+    """Load an HTML template from the templates/ directory.
+
+    Args:
+        name: Template filename (e.g. 'install.html')
+
+    Returns:
+        The raw template string with {{placeholders}} intact.
+
+    Raises:
+        FileNotFoundError: If the template file does not exist.
+    """
+    template_path = TEMPLATES_DIR / name
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template not found: {template_path}")
+    return template_path.read_text(encoding="utf-8")
+
+
 def _build_install_html(apk: Path | None) -> str:
-    """Build the install page HTML with real data."""
+    """Build the install page HTML by loading the template and injecting data."""
     logo_src = _load_logo_b64()
 
     if apk:
@@ -167,107 +186,13 @@ def _build_install_html(apk: Path | None) -> str:
             f'Coloca el archivo .apk en:<br><code>{APK_DIR}</code></p>'
         )
 
-    return f"""<!DOCTYPE html>
-<html lang="es">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Savia App — Descargar</title>
-<style>
-  * {{ box-sizing: border-box; margin: 0; padding: 0; }}
-  body {{
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: linear-gradient(135deg, #f5f0ff 0%, #ede7f6 100%);
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 20px;
-  }}
-  .card {{
-    background: white;
-    border-radius: 24px;
-    padding: 40px 32px 32px;
-    max-width: 400px;
-    width: 100%;
-    text-align: center;
-    box-shadow: 0 8px 32px rgba(107, 76, 154, 0.15);
-  }}
-  .logo {{ width: 100px; height: 100px; margin-bottom: 20px; border-radius: 22px; }}
-  h1 {{ color: #6B4C9A; font-size: 26px; margin-bottom: 6px; font-weight: 700; }}
-  .subtitle {{ color: #555; font-size: 14px; margin-bottom: 28px; line-height: 1.6; }}
-  .btn {{
-    display: inline-block;
-    background: #6B4C9A;
-    color: white;
-    text-decoration: none;
-    padding: 14px 44px;
-    border-radius: 14px;
-    font-size: 17px;
-    font-weight: 600;
-    letter-spacing: 0.3px;
-    transition: transform 0.15s, box-shadow 0.15s;
-    box-shadow: 0 4px 16px rgba(107, 76, 154, 0.3);
-  }}
-  .btn:hover {{ transform: translateY(-2px); box-shadow: 0 6px 24px rgba(107, 76, 154, 0.4); }}
-  .btn:active {{ transform: translateY(0); }}
-  .btn-disabled {{ background: #bbb; box-shadow: none; cursor: default; pointer-events: none; }}
-  .apk-info {{
-    margin-top: 16px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-  }}
-  .apk-name {{ color: #6B4C9A; font-weight: 600; font-size: 13px; }}
-  .apk-detail {{ color: #999; font-size: 12px; }}
-  .instructions {{
-    color: #888;
-    font-size: 12px;
-    margin-top: 24px;
-    line-height: 1.7;
-    padding-top: 20px;
-    border-top: 1px solid #f0ecf5;
-    text-align: left;
-  }}
-  .instructions ol {{
-    padding-left: 20px;
-    margin: 0;
-  }}
-  .instructions li {{
-    margin-bottom: 4px;
-  }}
-  .footer {{
-    margin-top: 20px;
-    padding-top: 16px;
-    border-top: 1px solid #f0ecf5;
-    color: #bbb;
-    font-size: 11px;
-    line-height: 1.5;
-  }}
-  .footer span {{ color: #a58bc4; }}
-</style>
-</head>
-<body>
-<div class="card">
-  <img src="{logo_src}" class="logo" alt="Savia">
-  <h1>Savia App</h1>
-  <p class="subtitle">Tu asistente inteligente de gestión de proyectos.<br>Descarga e instala la app en tu dispositivo Android.</p>
-  {download_section}
-  <div class="instructions">
-    <ol>
-      <li>Pulsa <strong>Descargar Savia App</strong></li>
-      <li>Abre la notificación de descarga completada</li>
-      <li>Permite la instalación desde orígenes desconocidos</li>
-      <li>Abre Savia App y configura la conexión al Bridge</li>
-    </ol>
-  </div>
-  <div class="footer">
-    Savia Bridge <span>v{BRIDGE_VERSION}</span>
-  </div>
-</div>
-</body>
-</html>"""
+    template = _load_template("install.html")
+    return (
+        template
+        .replace("{{logo_src}}", logo_src)
+        .replace("{{download_section}}", download_section)
+        .replace("{{bridge_version}}", BRIDGE_VERSION)
+    )
 
 # --- Logging ---
 

--- a/scripts/templates/install.html
+++ b/scripts/templates/install.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Savia App — Descargar</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: linear-gradient(135deg, #f5f0ff 0%, #ede7f6 100%);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+  }
+  .card {
+    background: white;
+    border-radius: 24px;
+    padding: 40px 32px 32px;
+    max-width: 400px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 8px 32px rgba(107, 76, 154, 0.15);
+  }
+  .logo { width: 100px; height: 100px; margin-bottom: 20px; border-radius: 22px; }
+  h1 { color: #6B4C9A; font-size: 26px; margin-bottom: 6px; font-weight: 700; }
+  .subtitle { color: #555; font-size: 14px; margin-bottom: 28px; line-height: 1.6; }
+  .btn {
+    display: inline-block;
+    background: #6B4C9A;
+    color: white;
+    text-decoration: none;
+    padding: 14px 44px;
+    border-radius: 14px;
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    transition: transform 0.15s, box-shadow 0.15s;
+    box-shadow: 0 4px 16px rgba(107, 76, 154, 0.3);
+  }
+  .btn:hover { transform: translateY(-2px); box-shadow: 0 6px 24px rgba(107, 76, 154, 0.4); }
+  .btn:active { transform: translateY(0); }
+  .btn-disabled { background: #bbb; box-shadow: none; cursor: default; pointer-events: none; }
+  .apk-info {
+    margin-top: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+  .apk-name { color: #6B4C9A; font-weight: 600; font-size: 13px; }
+  .apk-detail { color: #999; font-size: 12px; }
+  .instructions {
+    color: #888;
+    font-size: 12px;
+    margin-top: 24px;
+    line-height: 1.7;
+    padding-top: 20px;
+    border-top: 1px solid #f0ecf5;
+    text-align: left;
+  }
+  .instructions ol {
+    padding-left: 20px;
+    margin: 0;
+  }
+  .instructions li {
+    margin-bottom: 4px;
+  }
+  .footer {
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid #f0ecf5;
+    color: #bbb;
+    font-size: 11px;
+    line-height: 1.5;
+  }
+  .footer span { color: #a58bc4; }
+</style>
+</head>
+<body>
+<div class="card">
+  <img src="{{logo_src}}" class="logo" alt="Savia">
+  <h1>Savia App</h1>
+  <p class="subtitle">Tu asistente inteligente de gestión de proyectos.<br>Descarga e instala la app en tu dispositivo Android.</p>
+  {{download_section}}
+  <div class="instructions">
+    <ol>
+      <li>Pulsa <strong>Descargar Savia App</strong></li>
+      <li>Abre la notificación de descarga completada</li>
+      <li>Permite la instalación desde orígenes desconocidos</li>
+      <li>Abre Savia App y configura la conexión al Bridge</li>
+    </ol>
+  </div>
+  <div class="footer">
+    Savia Bridge <span>v{{bridge_version}}</span>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **Bridge refactor**: Extracted 100+ lines of inline HTML from `savia-bridge.py` into `scripts/templates/install.html` using `_load_template()` — proper separation of concerns
- **New cross-cutting rule**: `domain/template-separation.md` (SEP-01 to SEP-06) — prohibits inline HTML/CSS/SQL in backend code across all languages
- **Code review rules updated**: Added REJECT rule for inline markup in `code-review-rules.md`
- **8 language conventions enhanced**: Added static analysis rules (Vulnerabilities, Bugs, Code Smells, Architecture) to Kotlin, Rust, Swift, Ruby, PHP, Flutter, Terraform, COBOL
- **Feature research**: Added `FEATURE-RESEARCH-v0.2.md` with 10 prioritized Savia Mobile features

## Test plan
- [x] Bridge `--help` works with v1.3.0
- [x] Template renders correctly with no unresolved `{{placeholders}}`
- [x] All 14 files pass markdown lint
- [x] Python syntax valid (`python3 -c "import ..."`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)