### PR TITLE
fix(bridge): correct versionCode parsing + bump app to v0.2.0

### DIFF
--- a/projects/savia-mobile-android/app/build.gradle.kts
+++ b/projects/savia-mobile-android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.savia.mobile"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 2
+        versionName = "0.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/scripts/savia-bridge.py
+++ b/scripts/savia-bridge.py
@@ -168,7 +168,7 @@ def _get_apk_version_code(apk_path: Path) -> int:
                     for token in result.stdout.split():
                         if token.startswith("versionCode="):
                             try:
-                                return int(token.split("=", 1)[1])
+                                return int(token.split("=", 1)[1].strip("'\""))
                             except (ValueError, IndexError):
                                 pass
     except Exception:


### PR DESCRIPTION
## Summary

- Fix aapt versionCode parsing: strips quotes from output (`versionCode='2'` → `2`)
- Bump Savia Mobile to v0.2.0 (versionCode 2) to match all v0.2 features
- Bridge `/update/check` now correctly returns `versionCode: 2`

## Test plan
- [x] Bridge restarted, `/update/check` returns `versionCode: 2`
- [x] `/update/download` returns HTTP 200 with correct content-type

🤖 Generated with [Claude Code](https://claude.com/claude-code)