### PR TITLE
fix(docs): add missing version links in CHANGELOGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3093,6 +3093,8 @@ Initial public release of PM-Workspace.
 
 [0.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.0.0...v0.1.0
 
+[2.68.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.67.0...v2.68.0
+[2.67.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.66.0...v2.67.0
 [2.66.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.65.0...v2.66.0
 [2.65.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.64.0...v2.65.0
 [2.64.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.63.0...v2.64.0

--- a/projects/savia-mobile-android/CHANGELOG.md
+++ b/projects/savia-mobile-android/CHANGELOG.md
@@ -171,7 +171,10 @@ vía Savia Bridge, un servidor HTTPS/SSE que envuelve Claude Code CLI.
 
 ## Roadmap
 
-- **v0.2.0** — Sincronización offline, plantillas rápidas
-- **v0.3.0** — Integración nativa Jira/Azure DevOps
 - **v0.4.0** — Widgets, notificaciones inteligentes
 - **v1.0.0** — Beta pública en Google Play
+
+---
+
+[0.3.34]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0-savia-mobile...v0.3.34-savia-mobile
+[0.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/releases/tag/v0.1.0-savia-mobile


### PR DESCRIPTION
## Summary
- Add missing `[2.67.0]` and `[2.68.0]` comparison links in pm-workspace CHANGELOG.md
- Add version comparison links section to savia-mobile-android CHANGELOG.md
- Clean up outdated roadmap entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)