### PR TITLE
ci(pr-guardian): add Gate 8 — CHANGELOG required for code PRs

### DIFF
--- a/.github/workflows/pr-guardian.yml
+++ b/.github/workflows/pr-guardian.yml
@@ -408,8 +408,65 @@ jobs:
               core.warning(`Context impact high: +${net} net lines (threshold: ${threshold} for ${commits} commits). Review if all additions are necessary.`);
             }
 
-      # ─── Gate 8: PR Digest for Maintainer ───
-      - name: "Gate 8: PR Digest"
+      # ─── Gate 8: CHANGELOG Required for Code Changes ───
+      - name: "Gate 8: CHANGELOG Required"
+        uses: actions/github-script@v7  # TODO: pin to SHA
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || '';
+
+            // Exempt: docs-only or chore PRs (maintenance, no user-facing changes)
+            const exemptTypes = /^(docs|chore|ci|style)(\(|:)/;
+            if (exemptTypes.test(title)) {
+              core.info('✅ Gate 8: PR type exempt from CHANGELOG requirement');
+              return;
+            }
+
+            // Get changed files
+            const filesResponse = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+            const files = filesResponse.data.map(f => f.filename);
+
+            // Check if any CHANGELOG was modified
+            const changelogModified = files.some(f =>
+              f.endsWith('CHANGELOG.md') || f === 'CHANGELOG.md'
+            );
+
+            if (changelogModified) {
+              core.info('✅ Gate 8: CHANGELOG updated');
+              return;
+            }
+
+            // Check if PR only touches docs (all .md files)
+            const docsOnly = files.every(f =>
+              f.endsWith('.md') ||
+              f.endsWith('.txt') ||
+              f.startsWith('.github/ISSUE_TEMPLATE/') ||
+              f === '.github/pull_request_template.md'
+            );
+
+            if (docsOnly) {
+              core.info('✅ Gate 8: Docs-only PR, CHANGELOG not required');
+              return;
+            }
+
+            // Code changes without CHANGELOG → fail
+            const msg = '## ❌ Gate 8: CHANGELOG Required\n\n' +
+              'This PR modifies code but does not update any `CHANGELOG.md`.\n\n' +
+              'Every code change must be documented in the relevant CHANGELOG:\n' +
+              '- `CHANGELOG.md` (root) for workspace-level changes\n' +
+              '- `projects/*/CHANGELOG.md` for project-specific changes\n\n' +
+              'Exempt PR types: `docs`, `chore`, `ci`, `style`.\n' +
+              'If this is a maintenance PR, change the title prefix accordingly.';
+            core.setFailed(msg);
+
+      # ─── Gate 9: PR Digest for Maintainer ───
+      - name: "Gate 9: PR Digest"
         if: github.event.action == 'opened'
         uses: actions/github-script@v7  # TODO: pin to SHA
         with:
@@ -571,4 +628,4 @@ jobs:
               body: digest.join('\n')
             });
 
-            core.info('✅ Gate 8: PR Digest posted as comment');
+            core.info('✅ Gate 9: PR Digest posted as comment');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Auditoría de seguridad severa sobre todo pm-workspace con remediación completa
 - **Shell scripts** — `bash -c` → `eval` en 44 test scripts (C10), trap quoting (C15), `curl | sh` safety (C14/C17), `irm | iex` warning (C18), atomic mv (A8), `mktemp -d` (A19), sudo validation (A20), tar safety (A21), temp cleanup (M5).
 - **CI/CD** — SHA pinning en Actions (C9), npm version pinning (C8), jq mandatory en hooks (C16), secret patterns ampliados (A13), tag validation (A9), permissions explícitas (A22), BATS SHA pinning (M6), secret regex mejorado (M7).
 - **Infraestructura** — Systemd hardening (A10), .gitignore binarios (A12), `SECRETS-ROTATION.md` (M13), plan-gate.sh timeout 30s (M15).
-- **PRs:** [#280](https://github.com/gonzalezpazmonica/pm-workspace/pull/280), [#281](https://github.com/gonzalezpazmonica/pm-workspace/pull/281), [#282](https://github.com/gonzalezpazmonica/pm-workspace/pull/282), [#283](https://github.com/gonzalezpazmonica/pm-workspace/pull/283)
+- **PR Guardian** — Nuevo Gate 8: CHANGELOG obligatorio en PRs con cambios de código. Exime PRs de tipo `docs`, `chore`, `ci`, `style`. Renumerado Gate 8→9 (PR Digest).
+- **PRs:** [#280](https://github.com/gonzalezpazmonica/pm-workspace/pull/280), [#281](https://github.com/gonzalezpazmonica/pm-workspace/pull/281), [#282](https://github.com/gonzalezpazmonica/pm-workspace/pull/282), [#283](https://github.com/gonzalezpazmonica/pm-workspace/pull/283), [#285](https://github.com/gonzalezpazmonica/pm-workspace/pull/285)
 
 ## [2.68.0] — 2026-03-09
 


### PR DESCRIPTION
## Summary

- New PR Guardian Gate 8: blocks PRs that modify code without updating at least one `CHANGELOG.md`
- Exempt PR types: `docs`, `chore`, `ci`, `style` (based on conventional commit title prefix)
- Exempt: docs-only PRs (all files are `.md` or `.txt`)
- Previous Gate 8 (PR Digest) renumbered to Gate 9

This prevents the situation where security fixes, features, or bug fixes get merged without being documented in any CHANGELOG — exactly what happened with PRs #280-#282.

## Test plan

- [ ] Verify CI passes with the new gate
- [ ] Verify this PR itself passes Gate 8 (it includes CHANGELOG changes)
- [ ] Future: test that a code-only PR without CHANGELOG is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)