### PR TITLE
fix(ci): tighten Gate 8 — high-impact paths always require CHANGELOG

### DIFF
--- a/.github/workflows/pr-guardian.yml
+++ b/.github/workflows/pr-guardian.yml
@@ -416,14 +416,7 @@ jobs:
             const pr = context.payload.pull_request;
             const title = pr.title || '';
 
-            // Exempt: docs-only or chore PRs (maintenance, no user-facing changes)
-            const exemptTypes = /^(docs|chore|ci|style)(\(|:)/;
-            if (exemptTypes.test(title)) {
-              core.info('✅ Gate 8: PR type exempt from CHANGELOG requirement');
-              return;
-            }
-
-            // Get changed files
+            // Get changed files first (needed for all checks)
             const filesResponse = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -442,7 +435,25 @@ jobs:
               return;
             }
 
-            // Check if PR only touches docs (all .md files)
+            // High-impact paths that always require CHANGELOG, even in docs/chore PRs
+            const highImpactPaths = [
+              '.claude/rules/',
+              '.claude/hooks/',
+              '.claude/settings.json',
+              '.github/workflows/'
+            ];
+            const touchesHighImpact = files.some(f =>
+              highImpactPaths.some(p => f.startsWith(p) || f === p)
+            );
+
+            // Exempt: docs-only or chore PRs, UNLESS they touch high-impact paths
+            const exemptTypes = /^(docs|chore|ci|style)(\(|:)/;
+            if (exemptTypes.test(title) && !touchesHighImpact) {
+              core.info('✅ Gate 8: PR type exempt from CHANGELOG requirement');
+              return;
+            }
+
+            // Check if PR only touches docs (all .md/.txt files, no high-impact)
             const docsOnly = files.every(f =>
               f.endsWith('.md') ||
               f.endsWith('.txt') ||
@@ -450,19 +461,22 @@ jobs:
               f === '.github/pull_request_template.md'
             );
 
-            if (docsOnly) {
+            if (docsOnly && !touchesHighImpact) {
               core.info('✅ Gate 8: Docs-only PR, CHANGELOG not required');
               return;
             }
 
-            // Code changes without CHANGELOG → fail
+            // Code changes (or high-impact docs) without CHANGELOG → fail
+            const reason = touchesHighImpact
+              ? 'This PR modifies high-impact files (rules, hooks, workflows, or settings) and must update a CHANGELOG.'
+              : 'This PR modifies code but does not update any `CHANGELOG.md`.';
             const msg = '## ❌ Gate 8: CHANGELOG Required\n\n' +
-              'This PR modifies code but does not update any `CHANGELOG.md`.\n\n' +
-              'Every code change must be documented in the relevant CHANGELOG:\n' +
+              reason + '\n\n' +
+              'Every significant change must be documented in the relevant CHANGELOG:\n' +
               '- `CHANGELOG.md` (root) for workspace-level changes\n' +
               '- `projects/*/CHANGELOG.md` for project-specific changes\n\n' +
-              'Exempt PR types: `docs`, `chore`, `ci`, `style`.\n' +
-              'If this is a maintenance PR, change the title prefix accordingly.';
+              'Exempt: `docs`, `chore`, `ci`, `style` PRs that only touch documentation files.\n' +
+              'NOT exempt: PRs touching `.claude/rules/`, `.claude/hooks/`, `.github/workflows/`, or `.claude/settings.json`.';
             core.setFailed(msg);
 
       # ─── Gate 9: PR Digest for Maintainer ───

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Comprehensive security audit across all of pm-workspace with full same-day remed
 - **Shell scripts** — `bash -c` → `eval` in 44 test scripts (C10), trap quoting (C15), `curl | sh` safety (C14/C17), `irm | iex` warning (C18), atomic mv (A8), `mktemp -d` (A19), sudo validation (A20), tar safety (A21), temp cleanup (M5).
 - **CI/CD** — SHA pinning in Actions (C9), npm version pinning (C8), jq mandatory in hooks (C16), expanded secret patterns (A13), tag validation (A9), explicit permissions (A22), BATS SHA pinning (M6), improved secret regex (M7).
 - **Infrastructure** — Systemd hardening (A10), .gitignore binaries (A12), `SECRETS-ROTATION.md` (M13), plan-gate.sh 30s timeout (M15).
-- **PR Guardian** — New Gate 8: CHANGELOG required for code PRs. Exempts `docs`, `chore`, `ci`, `style` types. Previous Gate 8 (PR Digest) renumbered to Gate 9.
-- **PRs:** [#280](https://github.com/gonzalezpazmonica/pm-workspace/pull/280), [#281](https://github.com/gonzalezpazmonica/pm-workspace/pull/281), [#282](https://github.com/gonzalezpazmonica/pm-workspace/pull/282), [#283](https://github.com/gonzalezpazmonica/pm-workspace/pull/283), [#285](https://github.com/gonzalezpazmonica/pm-workspace/pull/285)
+- **PR Guardian** — New Gate 8: CHANGELOG required for code PRs. Exempts `docs`, `chore`, `ci`, `style` types unless they touch domain rules (`.claude/rules/`). Previous Gate 8 (PR Digest) renumbered to Gate 9.
+- **Language rule** — Mandatory English for all versioned content (CHANGELOGs, commits, PR titles, READMEs). Added to `github-flow.md`. Both CHANGELOGs translated from Spanish to English.
+- **PRs:** [#280](https://github.com/gonzalezpazmonica/pm-workspace/pull/280), [#281](https://github.com/gonzalezpazmonica/pm-workspace/pull/281), [#282](https://github.com/gonzalezpazmonica/pm-workspace/pull/282), [#283](https://github.com/gonzalezpazmonica/pm-workspace/pull/283), [#285](https://github.com/gonzalezpazmonica/pm-workspace/pull/285), [#286](https://github.com/gonzalezpazmonica/pm-workspace/pull/286)
 
 ## [2.68.0] — 2026-03-09
 


### PR DESCRIPTION
## Summary

- Gate 8 no longer exempts `docs`/`chore`/`ci`/`style` PRs when they touch high-impact paths: `.claude/rules/`, `.claude/hooks/`, `.github/workflows/`, `.claude/settings.json`
- Added missing PR #286 entry to v2.69.0 CHANGELOG (language rule + translations)
- Root cause: PR #286 modified `.claude/rules/domain/github-flow.md` but passed Gate 8 because `docs:` prefix was exempt — this fix closes that gap

## Resumen

- Gate 8 ya no exime PRs `docs`/`chore`/`ci`/`style` cuando tocan rutas de alto impacto: reglas de dominio, hooks, workflows, settings
- Añadida entrada del PR #286 al CHANGELOG v2.69.0
- Causa raíz: el PR #286 modificó una regla de dominio pero pasó Gate 8 por el prefijo `docs:` — este fix cierra esa brecha

## Test plan

- [ ] Verify CI passes
- [ ] Verify Gate 8 correctly blocks a docs PR touching `.claude/rules/` without CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)