### PR TITLE
feat(tests): add pentester lab with vulnerable services and validation scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.71.0] — 2026-03-09
+
+### Added — Pentester lab infrastructure
+
+- Docker Compose lab (`tests/pentest-lab/`) with 6 intentionally vulnerable services: vuln-api (Flask), metadata-mock (AWS IMDSv1), tls-bad (weak TLS), MongoDB (no-auth), MinIO (default creds), Redis (no-auth)
+- Vulnerable API with 15+ isolated endpoints mapped to test suite IDs (W-01..W-08, A-01..A-02, Z-01..Z-05, P-05..P-06, N-02..N-03)
+- Lab orchestrator script (`run-lab.sh`) with up/down/status/test commands and 21 smoke tests
+- Finding validator (`validate-findings.py`) for automated PT-NNN format checking
+- All Python files syntax-validated, all shell scripts bash -n validated
+
 ## [2.70.0] — 2026-03-09
 
 ### Added — Pentester agent for dynamic security testing
 
-- New `pentester` agent: elite ethical hacker for dynamic penetration testing against running systems, services and applications across dev/pre/production environments
-- Full offensive toolkit: OWASP Top 10, PTES methodology, MITRE ATT&CK mapping, CVSS v3.1 scoring
+- New `pentester` agent (95L): elite ethical hacker for dynamic penetration testing across dev/pre/production environments. References `pentesting` skill for detailed arsenal
+- New `pentesting` skill (98L): OWASP Top 10, PTES methodology, MITRE ATT&CK mapping, CVSS v3.1 scoring, detailed checklists
 - Expertise areas: web app attacks, API security, authentication/authorization, network/infrastructure, container/cloud, cryptography, post-exploitation
 - Environment-aware rules: aggressive in dev, moderate in pre, restrictive in production
 - Integration with existing security pipeline (security-defender → security-auditor → pentester retest)
-- Test suite with 65 tests across 10 categories, including Docker Compose lab with intentionally vulnerable targets (DVWA, Juice Shop, WebGoat, crAPI)
-- Mandatory 100% pass on reporting quality (CAT-9) and environment awareness (CAT-10)
+- Test suite with 65 tests across 10 categories (mandatory 100% on reporting quality and environment awareness)
 
 ## [2.69.0] — 2026-03-09
 
@@ -3123,6 +3132,7 @@ Initial public release of PM-Workspace.
 
 [0.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.0.0...v0.1.0
 
+[2.71.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.70.0...v2.71.0
 [2.70.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.69.0...v2.70.0
 [2.69.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.68.0...v2.69.0
 [2.68.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.67.0...v2.68.0

--- a/tests/pentest-lab/README.md
+++ b/tests/pentest-lab/README.md
@@ -1,0 +1,43 @@
+# Pentest Lab — Agent Validation Environment
+
+Intentionally vulnerable services for testing the `pentester` agent.
+**NEVER expose these on public networks.**
+
+## Quick Start
+
+```bash
+# Start lab
+./tests/pentest-lab/scripts/run-lab.sh up
+
+# Verify all services are healthy
+./tests/pentest-lab/scripts/run-lab.sh status
+
+# Run smoke tests to confirm vulnerabilities are exploitable
+./tests/pentest-lab/scripts/run-lab.sh test
+
+# Stop and clean up
+./tests/pentest-lab/scripts/run-lab.sh down
+```
+
+## Services
+
+| Service | Port | Purpose | Test IDs |
+|---------|------|---------|----------|
+| vuln-api | 8080 | Flask API with SQLi, XSS, SSRF, CMDi, LFI, IDOR, mass assignment | W-01..W-08, A-01..A-02, Z-01..Z-05, P-05..P-06, N-02..N-03 |
+| metadata-mock | 8169 | AWS IMDSv1 simulator | C-04 |
+| tls-bad | 8443 | TLS server with weak config | N-01, K-05 |
+| mongodb-noauth | 27017 | MongoDB without auth | R-06, N-06 |
+| minio | 9000 | S3-compatible storage (default creds) | C-05 |
+| redis-noauth | 6379 | Redis without auth | R-06 |
+
+## Validation
+
+After running the pentester agent against the lab, validate findings:
+
+```bash
+python3 tests/pentest-lab/scripts/validate-findings.py <findings-dir>
+```
+
+## Test Suite Reference
+
+See `tests/agents/test-pentester.md` for the complete 65-test validation matrix.

--- a/tests/pentest-lab/docker-compose.yml
+++ b/tests/pentest-lab/docker-compose.yml
@@ -1,0 +1,69 @@
+# Pentester Agent — Test Lab
+# Intentionally vulnerable services for agent validation.
+# NEVER expose these on public networks.
+#
+# Usage:
+#   docker compose -f tests/pentest-lab/docker-compose.yml up -d
+#   # run pentester tests...
+#   docker compose -f tests/pentest-lab/docker-compose.yml down -v
+
+services:
+  # ── Vulnerable Web Apps ──────────────────────────────────────
+  vuln-api:
+    build: ./mock-servers
+    ports: ["8080:8080"]
+    environment:
+      APP_ENV: dev
+      SECRET_KEY: "insecure-test-key-do-not-use"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      retries: 3
+
+  # ── Mock Cloud Metadata (SSRF target) ───────────────────────
+  metadata-mock:
+    build: ./mock-metadata
+    ports: ["8169:80"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/latest/meta-data/"]
+      interval: 5s
+      retries: 3
+
+  # ── TLS Misconfiguration Server ─────────────────────────────
+  tls-bad:
+    build: ./mock-tls-bad
+    ports: ["8443:443"]
+
+  # ── Vulnerable MongoDB (no auth) ────────────────────────────
+  mongodb-noauth:
+    image: mongo:6
+    ports: ["27017:27017"]
+    command: ["mongod", "--noauth", "--bind_ip_all"]
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.runCommand('ping').ok"]
+      interval: 5s
+      retries: 3
+
+  # ── MinIO (S3 mock — default creds) ─────────────────────────
+  minio:
+    image: minio/minio:latest
+    ports: ["9000:9000", "9001:9001"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      retries: 3
+
+  # ── Redis (no auth) ─────────────────────────────────────────
+  redis-noauth:
+    image: redis:7-alpine
+    ports: ["6379:6379"]
+    command: ["redis-server", "--protected-mode", "no"]
+
+networks:
+  default:
+    name: pentest-lab
+    driver: bridge

--- a/tests/pentest-lab/mock-metadata/Dockerfile
+++ b/tests/pentest-lab/mock-metadata/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY server.py .
+EXPOSE 80
+CMD ["python", "server.py"]

--- a/tests/pentest-lab/mock-metadata/server.py
+++ b/tests/pentest-lab/mock-metadata/server.py
@@ -1,0 +1,57 @@
+"""
+Mock AWS EC2 Metadata Service (IMDSv1) — for SSRF testing (C-04).
+Simulates http://169.254.169.254/latest/meta-data/ responses.
+NEVER run on a real network.
+"""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+METADATA = {
+    "/latest/meta-data/": "ami-id\nami-launch-index\nhostname\niam/\ninstance-id\nlocal-ipv4\npublic-ipv4",
+    "/latest/meta-data/ami-id": "ami-0abcdef1234567890",
+    "/latest/meta-data/instance-id": "i-0123456789abcdef0",
+    "/latest/meta-data/hostname": "ip-172-31-0-1.ec2.internal",
+    "/latest/meta-data/local-ipv4": "172.31.0.1",
+    "/latest/meta-data/public-ipv4": "203.0.113.42",
+    "/latest/meta-data/iam/": "info\nsecurity-credentials/",
+    "/latest/meta-data/iam/info": json.dumps({
+        "Code": "Success",
+        "InstanceProfileArn": "arn:aws:iam::123456789012:instance-profile/test-role",
+        "InstanceProfileId": "AIPA0123456789EXAMPLE",
+    }),
+    "/latest/meta-data/iam/security-credentials/": "test-role",
+    "/latest/meta-data/iam/security-credentials/test-role": json.dumps({
+        "Code": "Success",
+        "Type": "AWS-HMAC",
+        "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
+        "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "Token": "FwoGZXIvYXdzE...(truncated-test-token)",
+        "Expiration": "2099-12-31T23:59:59Z",
+    }),
+    "/latest/user-data": "#!/bin/bash\necho 'Mock user data'",
+}
+
+
+class MetadataHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path.rstrip("/") + "/" if self.path in METADATA else self.path
+        if path not in METADATA and self.path not in METADATA:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+            return
+        body = METADATA.get(self.path, METADATA.get(path, ""))
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+    def log_message(self, format, *args):
+        pass  # suppress logs
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("0.0.0.0", 80), MetadataHandler)
+    print("Mock metadata service on :80")
+    server.serve_forever()

--- a/tests/pentest-lab/mock-servers/Dockerfile
+++ b/tests/pentest-lab/mock-servers/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 8080
+CMD ["python", "app.py"]

--- a/tests/pentest-lab/mock-servers/app.py
+++ b/tests/pentest-lab/mock-servers/app.py
@@ -1,0 +1,355 @@
+"""
+Intentionally Vulnerable API — Pentester Agent Test Lab
+========================================================
+Each endpoint has ONE intentional vulnerability for isolated testing.
+NEVER deploy this to any real environment.
+
+Vulnerability map (matches tests/agents/test-pentester.md):
+  W-01  /api/sqli/error     → SQL injection (error-based)
+  W-02  /api/sqli/blind     → SQL injection (time-based blind)
+  W-03  /api/xss/reflected  → XSS reflected
+  W-05  /api/ssrf           → SSRF
+  W-07  /api/cmdi           → Command injection
+  W-08  /api/lfi            → Path traversal / LFI
+  A-01  (default creds)     → admin/admin on /api/login
+  A-02  /api/jwt/none       → JWT none algorithm
+  Z-01  /api/users/<id>     → IDOR
+  Z-04  /api/users/register → Mass assignment
+  P-05  /api/docs           → Swagger/OpenAPI exposed
+  P-06  /api/rate-test      → No rate limiting
+  N-02  (all endpoints)     → Missing security headers
+  N-03  (CORS)              → Wildcard CORS with credentials
+"""
+
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import time
+
+import jwt
+from flask import Flask, Response, jsonify, request
+
+app = Flask(__name__)
+SECRET_KEY = os.environ.get("SECRET_KEY", "insecure-test-key-do-not-use")
+DB_PATH = "/tmp/vuln-lab.db"
+
+# ── Database setup ─────────────────────────────────────────────
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY,
+            username TEXT UNIQUE,
+            password TEXT,
+            role TEXT DEFAULT 'user',
+            email TEXT
+        )
+    """)
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS products (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            price REAL,
+            secret_notes TEXT
+        )
+    """)
+    # VULN A-01: default credentials
+    users = [
+        ("admin", hashlib.md5(b"admin").hexdigest(), "admin", "admin@test.local"),
+        ("user1", hashlib.md5(b"password123").hexdigest(), "user", "user1@test.local"),
+        ("user2", hashlib.md5(b"secret").hexdigest(), "user", "user2@test.local"),
+    ]
+    for u, p, r, e in users:
+        c.execute(
+            "INSERT OR IGNORE INTO users (username, password, role, email) VALUES (?,?,?,?)",
+            (u, p, r, e),
+        )
+    products = [
+        ("Widget A", 19.99, "Cost: $2.50 — margin 87%"),
+        ("Widget B", 49.99, "Supplier: ACME Corp, contract #7712"),
+        ("Widget C", 9.99, "Discontinued — clearance"),
+    ]
+    for n, p, s in products:
+        c.execute(
+            "INSERT OR IGNORE INTO products (name, price, secret_notes) VALUES (?,?,?)",
+            (n, p, s),
+        )
+    conn.commit()
+    conn.close()
+
+
+# ── VULN N-02: No security headers ────────────────────────────
+# ── VULN N-03: CORS wildcard + credentials ─────────────────────
+@app.after_request
+def add_vuln_headers(response):
+    # Intentionally missing: CSP, HSTS, X-Frame-Options, X-Content-Type-Options
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+    response.headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "*"
+    response.headers["Server"] = "VulnLab/1.0 (Python/Flask)"
+    return response
+
+
+@app.route("/health")
+def health():
+    return jsonify({"status": "ok"})
+
+
+# ── VULN P-05: Swagger/OpenAPI exposed without auth ───────────
+@app.route("/api/docs")
+def api_docs():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "VulnLab API", "version": "1.0.0"},
+        "paths": {
+            "/api/login": {"post": {"summary": "Login (admin/admin)"}},
+            "/api/users/{id}": {"get": {"summary": "Get user by ID (IDOR)"}},
+            "/api/sqli/error": {"get": {"summary": "SQL injection endpoint"}},
+            "/api/ssrf": {"get": {"summary": "SSRF endpoint"}},
+            "/api/cmdi": {"get": {"summary": "Command injection endpoint"}},
+            "/api/lfi": {"get": {"summary": "Local file inclusion endpoint"}},
+            "/api/admin/secrets": {"get": {"summary": "Admin-only secrets"}},
+        },
+    }
+    return jsonify(spec)
+
+
+# ── VULN W-01: SQL injection (error-based) ─────────────────────
+@app.route("/api/sqli/error")
+def sqli_error():
+    query = request.args.get("q", "")
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        # INTENTIONALLY VULNERABLE: string interpolation in SQL
+        results = conn.execute(
+            f"SELECT id, name, price FROM products WHERE name LIKE '%{query}%'"
+        ).fetchall()
+        return jsonify(
+            {"products": [{"id": r[0], "name": r[1], "price": r[2]} for r in results]}
+        )
+    except Exception as e:
+        # VULN: leaking SQL error details
+        return jsonify({"error": str(e)}), 500
+    finally:
+        conn.close()
+
+
+# ── VULN W-02: SQL injection (time-based blind) ───────────────
+@app.route("/api/sqli/blind")
+def sqli_blind():
+    user_id = request.args.get("id", "1")
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        # INTENTIONALLY VULNERABLE
+        row = conn.execute(
+            f"SELECT id, username FROM users WHERE id = {user_id}"
+        ).fetchone()
+        if row:
+            return jsonify({"exists": True})
+        return jsonify({"exists": False})
+    except Exception:
+        return jsonify({"exists": False})
+    finally:
+        conn.close()
+
+
+# ── VULN W-03: XSS reflected ──────────────────────────────────
+@app.route("/api/xss/reflected")
+def xss_reflected():
+    name = request.args.get("name", "World")
+    # INTENTIONALLY VULNERABLE: no escaping
+    html = f"<html><body><h1>Hello {name}</h1></body></html>"
+    return Response(html, mimetype="text/html")
+
+
+# ── VULN W-05: SSRF ───────────────────────────────────────────
+@app.route("/api/ssrf")
+def ssrf():
+    import urllib.request
+
+    url = request.args.get("url", "")
+    if not url:
+        return jsonify({"error": "url parameter required"}), 400
+    try:
+        # INTENTIONALLY VULNERABLE: no URL validation
+        resp = urllib.request.urlopen(url, timeout=5)
+        data = resp.read().decode("utf-8", errors="replace")[:2000]
+        return jsonify({"status": resp.status, "body": data})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# ── VULN W-07: Command injection ──────────────────────────────
+@app.route("/api/cmdi")
+def cmdi():
+    host = request.args.get("host", "localhost")
+    try:
+        # INTENTIONALLY VULNERABLE: shell=True with user input
+        result = subprocess.check_output(
+            f"ping -c 1 -W 1 {host}", shell=True, timeout=5, stderr=subprocess.STDOUT
+        )
+        return jsonify({"output": result.decode("utf-8", errors="replace")})
+    except subprocess.TimeoutExpired:
+        return jsonify({"error": "timeout"}), 504
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# ── VULN W-08: Path traversal / LFI ───────────────────────────
+@app.route("/api/lfi")
+def lfi():
+    filename = request.args.get("file", "readme.txt")
+    # INTENTIONALLY VULNERABLE: no path sanitization
+    try:
+        with open(f"/app/{filename}") as f:
+            return jsonify({"content": f.read()[:5000]})
+    except FileNotFoundError:
+        return jsonify({"error": "File not found"}), 404
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# ── Auth endpoints ─────────────────────────────────────────────
+@app.route("/api/login", methods=["POST"])
+def login():
+    data = request.get_json(silent=True) or {}
+    username = data.get("username", "")
+    password = data.get("password", "")
+    pwd_hash = hashlib.md5(password.encode()).hexdigest()
+
+    conn = sqlite3.connect(DB_PATH)
+    row = conn.execute(
+        "SELECT id, username, role FROM users WHERE username=? AND password=?",
+        (username, pwd_hash),
+    ).fetchone()
+    conn.close()
+
+    if not row:
+        # VULN P-06: no rate limiting on login
+        return jsonify({"error": "Invalid credentials"}), 401
+
+    token = jwt.encode(
+        {"sub": row[0], "username": row[1], "role": row[2]},
+        SECRET_KEY,
+        algorithm="HS256",
+    )
+    return jsonify({"token": token})
+
+
+# ── VULN A-02: JWT none algorithm ──────────────────────────────
+@app.route("/api/jwt/none")
+def jwt_none():
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return jsonify({"error": "Missing token"}), 401
+    token = auth[7:]
+    try:
+        # INTENTIONALLY VULNERABLE: accepts 'none' algorithm
+        payload = jwt.decode(
+            token, SECRET_KEY, algorithms=["HS256", "none"], options={"verify_signature": False}
+        )
+        return jsonify({"user": payload})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 401
+
+
+# ── VULN Z-01: IDOR ───────────────────────────────────────────
+@app.route("/api/users/<int:user_id>")
+def get_user(user_id):
+    # INTENTIONALLY VULNERABLE: no authorization check
+    conn = sqlite3.connect(DB_PATH)
+    row = conn.execute(
+        "SELECT id, username, email, role FROM users WHERE id=?", (user_id,)
+    ).fetchone()
+    conn.close()
+    if not row:
+        return jsonify({"error": "Not found"}), 404
+    return jsonify({"id": row[0], "username": row[1], "email": row[2], "role": row[3]})
+
+
+# ── VULN Z-04: Mass assignment ─────────────────────────────────
+@app.route("/api/users/register", methods=["POST"])
+def register():
+    data = request.get_json(silent=True) or {}
+    username = data.get("username", "")
+    password = data.get("password", "")
+    # INTENTIONALLY VULNERABLE: accepts 'role' from user input
+    role = data.get("role", "user")
+    email = data.get("email", "")
+
+    if not username or not password:
+        return jsonify({"error": "username and password required"}), 400
+
+    pwd_hash = hashlib.md5(password.encode()).hexdigest()
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        conn.execute(
+            "INSERT INTO users (username, password, role, email) VALUES (?,?,?,?)",
+            (username, pwd_hash, role, email),
+        )
+        conn.commit()
+        return jsonify({"message": "User created", "role": role}), 201
+    except sqlite3.IntegrityError:
+        return jsonify({"error": "Username already exists"}), 409
+    finally:
+        conn.close()
+
+
+# ── VULN Z-05: Admin panel without auth ────────────────────────
+@app.route("/api/admin/secrets")
+def admin_secrets():
+    # INTENTIONALLY VULNERABLE: no auth check
+    conn = sqlite3.connect(DB_PATH)
+    rows = conn.execute("SELECT id, name, secret_notes FROM products").fetchall()
+    conn.close()
+    return jsonify(
+        {"secrets": [{"id": r[0], "name": r[1], "notes": r[2]} for r in rows]}
+    )
+
+
+# ── VULN P-06: No rate limiting ────────────────────────────────
+@app.route("/api/rate-test")
+def rate_test():
+    return jsonify({"timestamp": time.time(), "message": "No rate limit here"})
+
+
+# ── Hidden paths for directory brute-force (R-02) ──────────────
+@app.route("/admin")
+def hidden_admin():
+    return Response("<h1>Admin Panel</h1>", mimetype="text/html")
+
+
+@app.route("/backup")
+def hidden_backup():
+    return jsonify({"files": ["db-dump-2026-01.sql", "users-export.csv"]})
+
+
+@app.route("/.git/config")
+def hidden_git():
+    return Response(
+        "[core]\n\trepositoryformatversion = 0\n\tbare = false", mimetype="text/plain"
+    )
+
+
+@app.route("/.env")
+def hidden_env():
+    return Response(
+        "DB_PASSWORD=test123\nSECRET_KEY=insecure-test-key", mimetype="text/plain"
+    )
+
+
+@app.route("/robots.txt")
+def robots():
+    return Response(
+        "User-agent: *\nDisallow: /admin\nDisallow: /backup\nDisallow: /.git",
+        mimetype="text/plain",
+    )
+
+
+if __name__ == "__main__":
+    init_db()
+    app.run(host="0.0.0.0", port=8080, debug=True)

--- a/tests/pentest-lab/mock-servers/requirements.txt
+++ b/tests/pentest-lab/mock-servers/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.1.0
+pyjwt==2.10.1
+cryptography==44.0.0

--- a/tests/pentest-lab/mock-tls-bad/Dockerfile
+++ b/tests/pentest-lab/mock-tls-bad/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY gen-cert.sh server.py ./
+RUN chmod +x gen-cert.sh && ./gen-cert.sh
+EXPOSE 443
+CMD ["python", "server.py"]

--- a/tests/pentest-lab/mock-tls-bad/gen-cert.sh
+++ b/tests/pentest-lab/mock-tls-bad/gen-cert.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate a self-signed cert with INTENTIONALLY BAD properties:
+# - Wrong CN (mismatch)
+# - Short RSA key (1024 bit)
+# - Expired yesterday
+openssl req -x509 -nodes \
+  -newkey rsa:1024 \
+  -keyout /app/server.key \
+  -out /app/server.crt \
+  -days -1 \
+  -subj "/CN=wrong-hostname.invalid/O=VulnLab/C=XX" \
+  2>/dev/null || true
+
+# Fallback: if -days -1 isn't supported, use 1 day (still bad)
+if [ ! -f /app/server.crt ]; then
+  openssl req -x509 -nodes \
+    -newkey rsa:1024 \
+    -keyout /app/server.key \
+    -out /app/server.crt \
+    -days 1 \
+    -subj "/CN=wrong-hostname.invalid/O=VulnLab/C=XX"
+fi

--- a/tests/pentest-lab/mock-tls-bad/server.py
+++ b/tests/pentest-lab/mock-tls-bad/server.py
@@ -1,0 +1,23 @@
+"""
+TLS server with intentionally bad configuration for testing (N-01).
+- Self-signed cert with wrong CN
+- Weak RSA key (1024-bit)
+- Allows TLS 1.0/1.1 (if openssl supports)
+"""
+
+import ssl
+import http.server
+
+handler = http.server.SimpleHTTPRequestHandler
+httpd = http.server.HTTPServer(("0.0.0.0", 443), handler)
+
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain("/app/server.crt", "/app/server.key")
+# Intentionally weak: allow old TLS versions
+ctx.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+# Allow weak ciphers
+ctx.set_ciphers("ALL:@SECLEVEL=0")
+
+httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+print("Bad TLS server on :443")
+httpd.serve_forever()

--- a/tests/pentest-lab/scripts/run-lab.sh
+++ b/tests/pentest-lab/scripts/run-lab.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# ───────────────────────────────────────────────────────────────
+# Pentester Lab — Orchestrator
+# Usage: ./tests/pentest-lab/scripts/run-lab.sh [up|down|status|test]
+# ───────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LAB_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$LAB_DIR/docker-compose.yml"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+usage() {
+  echo "Usage: $0 {up|down|status|test}"
+  echo "  up     — Start pentest lab services"
+  echo "  down   — Stop and remove lab services"
+  echo "  status — Show service status"
+  echo "  test   — Run smoke tests against lab services"
+  exit 1
+}
+
+lab_up() {
+  echo -e "${YELLOW}Starting pentest lab...${NC}"
+  docker compose -f "$COMPOSE_FILE" up -d --build
+  echo -e "${GREEN}Lab services starting. Run '$0 status' to check health.${NC}"
+}
+
+lab_down() {
+  echo -e "${YELLOW}Stopping pentest lab...${NC}"
+  docker compose -f "$COMPOSE_FILE" down -v --remove-orphans
+  echo -e "${GREEN}Lab stopped and cleaned up.${NC}"
+}
+
+lab_status() {
+  docker compose -f "$COMPOSE_FILE" ps
+}
+
+lab_test() {
+  echo -e "${YELLOW}Running smoke tests against lab services...${NC}"
+  local passed=0
+  local failed=0
+
+  # Helper
+  check() {
+    local name="$1" cmd="$2"
+    if eval "$cmd" > /dev/null 2>&1; then
+      echo -e "  ${GREEN}✅ $name${NC}"
+      passed=$((passed + 1))
+    else
+      echo -e "  ${RED}❌ $name${NC}"
+      failed=$((failed + 1))
+    fi
+  }
+
+  echo "── Service Availability ──"
+  check "vuln-api health"        "curl -sf http://localhost:8080/health"
+  check "vuln-api SQLi endpoint" "curl -sf 'http://localhost:8080/api/sqli/error?q=test'"
+  check "vuln-api XSS endpoint"  "curl -sf 'http://localhost:8080/api/xss/reflected?name=test'"
+  check "vuln-api SSRF endpoint" "curl -sf 'http://localhost:8080/api/ssrf?url=http://localhost:8080/health'"
+  check "vuln-api docs exposed"  "curl -sf http://localhost:8080/api/docs"
+  check "vuln-api hidden /admin" "curl -sf http://localhost:8080/admin"
+  check "metadata-mock"          "curl -sf http://localhost:8169/latest/meta-data/"
+  check "metadata IAM creds"     "curl -sf http://localhost:8169/latest/meta-data/iam/security-credentials/test-role"
+  check "minio reachable"        "curl -sf http://localhost:9000/minio/health/live"
+  check "redis ping"             "redis-cli -h localhost -p 6379 ping 2>/dev/null | grep -q PONG"
+  check "mongodb ping"           "mongosh --quiet --eval 'db.runCommand({ping:1}).ok' 2>/dev/null | grep -q 1"
+
+  echo ""
+  echo "── Vulnerability Verification ──"
+  check "W-01: SQLi error-based"     "curl -sf 'http://localhost:8080/api/sqli/error?q=%27' | grep -qi error"
+  check "W-03: XSS reflected"       "curl -sf 'http://localhost:8080/api/xss/reflected?name=%3Cscript%3Ealert(1)%3C/script%3E' | grep -q script"
+  check "W-07: Command injection"   "curl -sf 'http://localhost:8080/api/cmdi?host=localhost;id' | grep -q uid"
+  check "W-08: Path traversal"      "curl -sf 'http://localhost:8080/api/lfi?file=../../../etc/passwd' | grep -q root"
+  check "A-01: Default creds"       'curl -sf -X POST http://localhost:8080/api/login -H "Content-Type: application/json" -d "{\"username\":\"admin\",\"password\":\"admin\"}" | grep -q token'
+  check "Z-01: IDOR"                "curl -sf http://localhost:8080/api/users/1 | grep -q admin"
+  check "Z-04: Mass assignment"     'curl -sf -X POST http://localhost:8080/api/users/register -H "Content-Type: application/json" -d "{\"username\":\"hacker\",\"password\":\"x\",\"role\":\"admin\"}" | grep -q admin'
+  check "N-02: Missing sec headers" "curl -sI http://localhost:8080/health | grep -qiv Content-Security-Policy"
+  check "N-03: CORS wildcard"       "curl -sI http://localhost:8080/health | grep -q 'Access-Control-Allow-Origin: *'"
+  check "C-04: SSRF to metadata"    "curl -sf 'http://localhost:8080/api/ssrf?url=http://metadata-mock/latest/meta-data/iam/security-credentials/test-role' | grep -q AKIAIOSFODNN7EXAMPLE"
+
+  echo ""
+  echo -e "═══════════════════════════════════════════════"
+  echo -e "  Results: ${GREEN}${passed} passed${NC}, ${RED}${failed} failed${NC}"
+  echo -e "═══════════════════════════════════════════════"
+  [ "$failed" -eq 0 ]
+}
+
+case "${1:-}" in
+  up)     lab_up ;;
+  down)   lab_down ;;
+  status) lab_status ;;
+  test)   lab_test ;;
+  *)      usage ;;
+esac

--- a/tests/pentest-lab/scripts/validate-findings.py
+++ b/tests/pentest-lab/scripts/validate-findings.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Pentester Agent — Output Validator
+===================================
+Validates that the pentester agent's findings match expected format
+and content per the test suite in tests/agents/test-pentester.md.
+
+Usage:
+    python3 validate-findings.py <findings-dir>
+
+The findings-dir should contain the pentester's output files:
+  - vulns-raw.md or pentest-report.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+# ── Expected finding format fields ─────────────────────────────
+REQUIRED_FIELDS = [
+    "Severidad",
+    "CVSS",
+    "CWE",
+    "Target",
+    "Descripción",
+    "Evidencia",
+    "Impacto",
+    "Reproducción",
+    "Remediación",
+]
+
+VALID_SEVERITIES = {"CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"}
+
+CVSS_PATTERN = re.compile(r"\d+\.\d+")
+CWE_PATTERN = re.compile(r"CWE-\d+")
+PT_ID_PATTERN = re.compile(r"PT-\d{3}")
+
+
+def validate_finding(text: str, finding_id: str) -> list[str]:
+    """Validate a single finding block. Returns list of errors."""
+    errors = []
+
+    for field in REQUIRED_FIELDS:
+        if field not in text:
+            errors.append(f"{finding_id}: missing field '{field}'")
+
+    # Check severity
+    sev_match = re.search(r"Severidad:\s*(\w+)", text)
+    if sev_match:
+        if sev_match.group(1) not in VALID_SEVERITIES:
+            errors.append(
+                f"{finding_id}: invalid severity '{sev_match.group(1)}'"
+            )
+    else:
+        errors.append(f"{finding_id}: could not parse severity")
+
+    # Check CVSS score present
+    if not CVSS_PATTERN.search(text.split("CVSS")[1] if "CVSS" in text else ""):
+        errors.append(f"{finding_id}: missing CVSS score")
+
+    # Check CWE mapping
+    if not CWE_PATTERN.search(text):
+        errors.append(f"{finding_id}: missing CWE mapping")
+
+    return errors
+
+
+def validate_report(filepath: Path) -> tuple[int, int, list[str]]:
+    """Validate all findings in a report file."""
+    content = filepath.read_text()
+    findings = PT_ID_PATTERN.findall(content)
+
+    if not findings:
+        return 0, 0, ["No PT-NNN findings found in report"]
+
+    all_errors = []
+    # Split content by finding IDs
+    blocks = re.split(r"(PT-\d{3})", content)
+    validated = 0
+
+    for i, block in enumerate(blocks):
+        if PT_ID_PATTERN.match(block) and i + 1 < len(blocks):
+            finding_text = block + blocks[i + 1]
+            errs = validate_finding(finding_text, block)
+            all_errors.extend(errs)
+            validated += 1
+
+    passed = validated - len(
+        {e.split(":")[0] for e in all_errors}
+    )
+    return passed, validated, all_errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: validate-findings.py <findings-dir>")
+        sys.exit(1)
+
+    findings_dir = Path(sys.argv[1])
+    if not findings_dir.is_dir():
+        print(f"Error: {findings_dir} is not a directory")
+        sys.exit(1)
+
+    # Look for report files
+    report_files = list(findings_dir.glob("*report*.md")) + list(
+        findings_dir.glob("*vulns*.md")
+    )
+
+    if not report_files:
+        print("No report files found (expected *report*.md or *vulns*.md)")
+        sys.exit(1)
+
+    total_passed = 0
+    total_validated = 0
+    all_errors = []
+
+    for f in report_files:
+        print(f"\nValidating: {f.name}")
+        passed, validated, errors = validate_report(f)
+        total_passed += passed
+        total_validated += validated
+        all_errors.extend(errors)
+
+        if errors:
+            for e in errors:
+                print(f"  ❌ {e}")
+        else:
+            print(f"  ✅ All {validated} findings valid")
+
+    print(f"\n{'='*50}")
+    print(f"Total: {total_passed}/{total_validated} findings passed validation")
+    if all_errors:
+        print(f"Errors: {len(all_errors)}")
+        sys.exit(1)
+    else:
+        print("All findings conform to PT-NNN format ✅")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumen

Infraestructura de test para el agente `pentester`: Docker Compose lab con 6 servicios intencionalmente vulnerables, script orquestador y validador de hallazgos.

## Summary

Test infrastructure for the `pentester` agent: Docker Compose lab with 6 intentionally vulnerable services, orchestrator script and findings validator.

### Services
- **vuln-api** (Flask, :8080) — 15+ endpoints with isolated vulnerabilities: SQLi, XSS, SSRF, CMDi, LFI, IDOR, mass assignment, JWT none-alg, default creds, missing headers, CORS wildcard
- **metadata-mock** (:8169) — AWS IMDSv1 simulator with IAM credentials for SSRF testing
- **tls-bad** (:8443) — TLS server with 1024-bit RSA, wrong CN, weak ciphers
- **mongodb-noauth** (:27017) — MongoDB without authentication
- **minio** (:9000) — S3-compatible storage with default credentials
- **redis-noauth** (:6379) — Redis without authentication

### Scripts
- `run-lab.sh` — Orchestrator (up/down/status/test) with 21 smoke tests
- `validate-findings.py` — Validates PT-NNN finding format against expected fields

### Validation
- All Python files: `ast.parse()` syntax validated ✅
- All shell scripts: `bash -n` validated ✅
- Docker not available in CI env — lab designed for local/dev use

## Test plan

- [x] Python syntax validation (ast.parse)
- [x] Shell script syntax validation (bash -n)
- [x] Dockerfile structure validation
- [ ] Docker Compose up + smoke tests (requires Docker, run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)