### PR TITLE
fix(docs): correct code review roadmap after verification

### DIFF
--- a/docs/roadmap-code-review-improvements.md
+++ b/docs/roadmap-code-review-improvements.md
@@ -4,52 +4,65 @@ Based on analysis of Claude's code review capabilities (March 2026), this roadma
 
 ## Current State
 
-pm-workspace uses `code-reviewer` agent with 3-judge consensus panel (reflection, code-review, business). Reviews produce structured findings with severity levels. The `verification-lattice` skill provides multi-layer verification.
+pm-workspace already has a mature review pipeline:
 
-## Identified Gaps
+- **`code-reviewer` agent** — quality gate before merge (Opus 4.6)
+- **`consensus-validation` skill** — 3-judge panel (reflection-validator, code-reviewer, business-analyst) with weighted scoring: `(reflection × 0.4) + (code × 0.3) + (business × 0.3)`. Veto rule for security/GDPR findings
+- **`verification-lattice` skill** — 5-layer verification (deterministic → semantic → security → agentic → human)
+- **`scoring-curves` rule** — piecewise linear normalization replacing binary pass/fail (PR size, context usage, file size, velocity deviation, test coverage, Brier confidence)
+- **`risk-scoring` skill** — 4-tier risk escalation (Low/Medium/High/Critical) with automatic routing to appropriate review level
+- **`dag-scheduling` skill** — parallel agent orchestration via DAGs with worktree isolation
+- **`performance-audit` skill** — static performance analysis (complexity, async anti-patterns, hotspots, N+1 detection)
+- **PR Guardian** — 9-gate CI workflow (`.github/workflows/pr-guardian.yml`): description quality, conventional commits, CLAUDE.md guard, ShellCheck, Gitleaks, hook safety, context impact, CHANGELOG enforcement, PR digest
 
-### 1. Confidence Scoring (Priority: High)
+## Remaining Gaps
 
-**Gap**: Current reviews produce binary pass/fail findings without confidence levels.
+### 1. Performance Audit as 4th Consensus Judge (Priority: High)
 
-**Improvement**: Add confidence scores (0.0–1.0) to each finding. Low-confidence findings get flagged for human review rather than blocking PRs. High-confidence findings auto-apply fixes.
+**Gap**: `performance-audit` exists as a standalone skill but is NOT integrated into the `consensus-validation` 3-judge panel. Performance findings don't participate in the weighted consensus score or veto rules.
 
-**Files**: `.claude/agents/code-reviewer.md`, `.claude/skills/verification-lattice/SKILL.md`
+**Improvement**: Add `performance-audit` as a 4th judge in `consensus-validation`. Proposed weight distribution: `(reflection × 0.3) + (code × 0.3) + (business × 0.2) + (performance × 0.2)`. Performance findings with severity CRITICAL should trigger veto (same as security).
 
-### 2. Performance Analysis Agent (Priority: Medium)
+**Files**: `.claude/skills/consensus-validation/SKILL.md`
 
-**Gap**: No automated performance impact analysis during code review.
+### 2. Parallel Consensus Execution (Priority: Medium)
 
-**Improvement**: Add a `performance-analyzer` agent that detects: N+1 queries, unnecessary re-renders, missing memoization, large bundle imports, algorithmic complexity regressions. Runs as a parallel judge alongside the existing 3-judge panel.
+**Gap**: The `dag-scheduling` skill exists for SDD agent orchestration but is not used by `consensus-validation`. The 3 judges could run in parallel via DAG but currently execute sequentially within a single prompt.
 
-**Files**: New `.claude/agents/performance-analyzer.md`
+**Improvement**: Wire `consensus-validation` to dispatch judges via `dag-scheduling` (no dependencies between judges → all run in parallel cohort). Reduces review time from ~120s sequential to ~40s parallel.
 
-### 3. Parallel Agent Dispatch (Priority: Medium)
+**Files**: `.claude/skills/consensus-validation/SKILL.md`, `.claude/skills/dag-scheduling/SKILL.md`
 
-**Gap**: Review agents run sequentially, increasing total review time.
+### 3. Adaptive Review Depth via Risk Routing (Priority: Medium)
 
-**Improvement**: Dispatch all review judges (reflection, code-review, business, performance) in parallel using the existing `dag-scheduling` skill. Merge results after all complete.
+**Gap**: `risk-scoring` calculates 4-tier risk levels but the routing is advisory — all PRs still go through the same consensus panel regardless of tier.
 
-**Files**: `.claude/skills/dag-scheduling/SKILL.md`, `.claude/skills/consensus-validation/SKILL.md`
+**Improvement**: Enforce risk-based routing: Low-risk PRs (docs, formatting) skip consensus panel entirely and auto-merge after Gate 1-5. Medium-risk gets standard 3-judge. High/Critical gets 4-judge (with performance) + human reviewer requirement.
 
-### 4. Adaptive Review Depth (Priority: Low)
+**Files**: `.claude/skills/risk-scoring/SKILL.md`, `.github/workflows/pr-guardian.yml`
 
-**Gap**: All PRs get the same review depth regardless of risk level.
+### 4. Confidence Calibration on Findings (Priority: Low)
 
-**Improvement**: Use `risk-scoring` skill to classify PRs into tiers. High-risk PRs (security, data model, API changes) get full 3-judge + performance review. Low-risk PRs (docs, comments, formatting) get lightweight single-pass review.
+**Gap**: `scoring-curves` provides Brier score calibration at the PR level, but individual findings from consensus judges lack per-finding confidence. A judge might flag something with high certainty vs. uncertainty, but both get the same weight.
 
-**Files**: `.claude/skills/risk-scoring/SKILL.md`, `.claude/rules/domain/pr-guardian.md`
+**Improvement**: Each judge emits per-finding confidence (0.0–1.0). Low-confidence findings (<0.5) get flagged as "needs human review" rather than contributing to the aggregate score. Enables auto-fix for high-confidence findings.
+
+**Files**: `.claude/skills/consensus-validation/SKILL.md`, `.claude/rules/domain/scoring-curves.md`
 
 ## Implementation Order
 
-1. Confidence scoring on existing review findings
-2. Performance analyzer as 4th parallel judge
-3. DAG-based parallel dispatch of all judges
-4. Risk-based adaptive depth using PR Guardian gates
+1. Integrate `performance-audit` as 4th judge in consensus-validation
+2. Wire `dag-scheduling` for parallel judge execution
+3. Enforce risk-scoring routing in PR Guardian workflow
+4. Per-finding confidence calibration
 
 ## References
 
-- PR Guardian: `.claude/rules/domain/pr-guardian.md` (8 gates)
+- PR Guardian: `.github/workflows/pr-guardian.yml` (9 gates)
 - Code Reviewer: `.claude/agents/code-reviewer.md`
 - Consensus Validation: `.claude/skills/consensus-validation/SKILL.md`
+- Verification Lattice: `.claude/skills/verification-lattice/SKILL.md`
+- Scoring Curves: `.claude/rules/domain/scoring-curves.md`
 - Risk Scoring: `.claude/skills/risk-scoring/SKILL.md`
+- DAG Scheduling: `.claude/skills/dag-scheduling/SKILL.md`
+- Performance Audit: `.claude/skills/performance-audit/SKILL.md`


### PR DESCRIPTION
## Summary

- Fixed 3 inaccuracies in `docs/roadmap-code-review-improvements.md` found during verification
- `scoring-curves` rule already exists — removed from gaps, added to current state
- `performance-audit` skill exists — gap refined to "integrate as 4th consensus judge"
- PR Guardian has 9 gates (workflow), not 8 (no rule file) — corrected reference
- Added complete current state section documenting all 8 existing review components

## Test plan

- [x] All file references verified to exist
- [x] Gate count verified against pr-guardian.yml (9 gates)
- [x] scoring-curves.md existence confirmed
- [x] performance-audit/SKILL.md existence confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)