### PR TITLE
feat: adb-run.sh — single-command wrapper to eliminate permission popups

### DIFF
--- a/.claude/hooks/validate-bash-global.sh
+++ b/.claude/hooks/validate-bash-global.sh
@@ -3,8 +3,16 @@ set -uo pipefail
 # validate-bash-global.sh — Validación global de comandos Bash peligrosos
 # Usado por: settings.json (PreToolUse hook para toda la sesión)
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# Read stdin with timeout to avoid hanging if no input arrives
+INPUT=""
+if read -t 2 -r FIRST_LINE; then
+  INPUT="$FIRST_LINE"
+  while read -t 0.1 -r LINE; do
+    INPUT+="$LINE"
+  done
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || COMMAND=""
 
 if [ -z "$COMMAND" ]; then
   exit 0

--- a/.claude/skills/android-autonomous-debugger/SKILL.md
+++ b/.claude/skills/android-autonomous-debugger/SKILL.md
@@ -11,6 +11,27 @@ context: fork
 
 **Keywords**: android debug, test on device, install apk, check crash, mobile testing, e2e test, verify on phone, run on device, screen capture device.
 
+## CRITICAL: Use adb-run.sh for All Commands
+
+**NEVER use `source scripts/lib/adb-wrapper.sh && cmd1 && cmd2`** — Claude Code's shell-aware permission system blocks compound `&&`/`||` chains, causing permission popups that break autonomous operation.
+
+**ALWAYS use `./scripts/adb-run.sh`** which wraps everything in a single command:
+
+```bash
+# WRONG — causes permission popups:
+source scripts/lib/adb-wrapper.sh && adb_auto_select && adb_screenshot /tmp/s.png
+
+# CORRECT — single command, no popups:
+./scripts/adb-run.sh adb_auto_select "adb_screenshot /tmp/s.png"
+```
+
+Each argument is one function call. Quote arguments with spaces:
+```bash
+./scripts/adb-run.sh adb_auto_select "adb_tap 500 900" "adb_screenshot /tmp/after.png"
+./scripts/adb-run.sh adb_auto_select "adb_install ./app.apk" "adb_launch com.savia.mobile"
+./scripts/adb-run.sh adb_auto_select "adb_logcat_errors 30 com.savia.mobile"
+```
+
 ## Prerequisites
 
 - Android device connected via USB with USB debugging enabled
@@ -21,60 +42,52 @@ context: fork
 
 ### 1. Device Discovery
 ```bash
-source scripts/lib/adb-wrapper.sh
-adb_auto_select          # Auto-select single device
-adb_devices              # JSON list of all devices
-adb_device_info          # JSON device properties
+./scripts/adb-run.sh adb_auto_select adb_device_info
+./scripts/adb-run.sh adb_devices
 ```
 
 ### 2. APK Lifecycle
 ```bash
-adb_install ./path/to/app.apk   # Install (with -r -t flags)
-adb_uninstall com.package.name   # Uninstall
-adb_launch com.package.name      # Launch via monkey
-adb_stop com.package.name        # Force stop
-adb_clear_data com.package.name  # Clear app data
-adb_is_installed com.package.name && echo "yes"
+./scripts/adb-run.sh adb_auto_select "adb_install ./path/to/app.apk"
+./scripts/adb-run.sh adb_auto_select "adb_uninstall com.package.name"
+./scripts/adb-run.sh adb_auto_select "adb_launch com.package.name"
+./scripts/adb-run.sh adb_auto_select "adb_stop com.package.name"
+./scripts/adb-run.sh adb_auto_select "adb_clear_data com.package.name"
 ```
 
 ### 3. Visual Inspection
 ```bash
-adb_screenshot /tmp/screen.png   # Capture current screen
-adb_hierarchy /tmp/ui.xml        # Dump UI tree (UIAutomator)
-adb_snapshot /tmp/prefix          # screenshot + hierarchy + logcat at once
+./scripts/adb-run.sh adb_auto_select "adb_screenshot /tmp/screen.png"
+./scripts/adb-run.sh adb_auto_select "adb_hierarchy /tmp/ui.xml"
+./scripts/adb-run.sh adb_auto_select "adb_snapshot /tmp/prefix"
 ```
 
 ### 4. UI Interaction
 ```bash
-adb_tap 500 900                  # Tap at coordinates
-adb_tap_id "login_button"       # Tap element by resource-id
-adb_tap_text "Conectar"          # Tap element by visible text
-adb_swipe 500 1200 500 400 300   # Swipe gesture
-adb_scroll_down                  # Scroll screen down
-adb_scroll_up                    # Scroll screen up
-adb_type "hello world"           # Type text
-adb_key back                     # Press BACK
-adb_key home                     # Press HOME
-adb_key enter                    # Press ENTER
-adb_long_press 500 900 2000      # Long press 2 seconds
+./scripts/adb-run.sh adb_auto_select "adb_tap 500 900"
+./scripts/adb-run.sh adb_auto_select "adb_tap_id login_button"
+./scripts/adb-run.sh adb_auto_select "adb_tap_text Conectar"
+./scripts/adb-run.sh adb_auto_select "adb_swipe 500 1200 500 400 300"
+./scripts/adb-run.sh adb_auto_select adb_scroll_down
+./scripts/adb-run.sh adb_auto_select "adb_type hello_world"
+./scripts/adb-run.sh adb_auto_select "adb_key back"
 ```
 
 ### 5. Debugging
 ```bash
-adb_logcat_clear                 # Clear log buffer
-adb_logcat_errors 30             # Errors from last 30 seconds
-adb_logcat_errors 60 com.savia.mobile  # Package-filtered errors
-adb_logcat_recent 10             # All logs last 10 seconds
-adb_detect_crash 60              # Detect crash patterns
-adb_meminfo com.savia.mobile     # Memory usage
+./scripts/adb-run.sh adb_auto_select adb_logcat_clear
+./scripts/adb-run.sh adb_auto_select "adb_logcat_errors 30"
+./scripts/adb-run.sh adb_auto_select "adb_logcat_errors 60 com.savia.mobile"
+./scripts/adb-run.sh adb_auto_select "adb_detect_crash 60"
+./scripts/adb-run.sh adb_auto_select "adb_meminfo com.savia.mobile"
 ```
 
 ### 6. Element Finding & Waiting
 ```bash
-adb_find_by_id "btn_send"        # Returns "x1,y1,x2,y2" bounds
-adb_find_by_text "Savia"         # Find by visible text
-adb_wait_for_text "Welcome" 15   # Wait up to 15s for text
-adb_wait_for_id "main_screen" 10 # Wait for element by ID
+./scripts/adb-run.sh adb_auto_select "adb_find_by_id btn_send"
+./scripts/adb-run.sh adb_auto_select "adb_find_by_text Savia"
+./scripts/adb-run.sh adb_auto_select "adb_wait_for_text Welcome 15"
+./scripts/adb-run.sh adb_auto_select "adb_wait_for_id main_screen 10"
 ```
 
 ## Autonomous Debug Cycle
@@ -82,33 +95,28 @@ adb_wait_for_id "main_screen" 10 # Wait for element by ID
 When asked to verify an app on device, follow this cycle:
 
 ### Phase 1: Setup
-1. Source the wrapper: `source scripts/lib/adb-wrapper.sh`
-2. Auto-select device: `adb_auto_select`
-3. Get device info: `adb_device_info`
-4. Clear logcat: `adb_logcat_clear`
+```bash
+./scripts/adb-run.sh adb_auto_select adb_device_info adb_logcat_clear
+```
 
 ### Phase 2: Install & Launch
-5. Install APK: `adb_install <path>`
-6. Verify installed: `adb_is_installed <package>`
-7. Launch app: `adb_launch <package>`
-8. Wait for main screen: `adb_wait_for_text "..." 15`
-9. Take baseline screenshot: `adb_screenshot /tmp/baseline.png`
+```bash
+./scripts/adb-run.sh adb_auto_select "adb_install <path>" "adb_launch <package>" "adb_wait_for_text MainScreen 15" "adb_screenshot /tmp/baseline.png"
+```
 
 ### Phase 3: Interact & Verify
-10. For each screen/feature to test:
-    - Navigate to it (tap, swipe, type)
-    - Take screenshot
-    - Check hierarchy for expected elements
-    - Check logcat for errors after each action
-11. If a crash is detected: `adb_detect_crash 30`
-    - Capture full logcat
-    - Report crash details with stack trace
+For each screen/feature to test:
+```bash
+./scripts/adb-run.sh adb_auto_select "adb_tap_text FeatureName" "adb_wait_for_text ExpectedText 10" "adb_screenshot /tmp/feature-X.png" "adb_logcat_errors 10"
+```
+
+If a crash is detected:
+```bash
+./scripts/adb-run.sh adb_auto_select "adb_detect_crash 30" "adb_logcat_errors 60 com.package"
+```
 
 ### Phase 4: Report
-12. Summarize: PASS/FAIL per screen tested
-13. Include screenshots as evidence
-14. Include crash logs if any
-15. Suggest fixes based on stack traces
+Summarize: PASS/FAIL per screen tested. Include screenshots as evidence. Include crash logs if any. Suggest fixes based on stack traces.
 
 ## Security Model
 
@@ -133,9 +141,11 @@ The `android-adb-validate.sh` hook enforces this classification.
 
 ## Tips for Agents
 
-- Always `adb_auto_select` before any other operation
+- **ALWAYS use `./scripts/adb-run.sh`** — never `source wrapper.sh && ...`
+- Always start with `adb_auto_select` as the first function in any call
 - Take screenshots BEFORE and AFTER each interaction
 - Check `adb_detect_crash` after navigating to a new screen
 - Use `adb_wait_for_text` instead of `sleep` — it's faster and more reliable
 - The `adb_snapshot` function captures everything at once (screen + UI tree + logs)
 - When debugging crashes: `adb_logcat_errors 60 <package>` gives package-specific errors
+- You can chain many functions in a single `adb-run.sh` call for efficiency

--- a/.claude/skills/android-autonomous-debugger/SKILL.md
+++ b/.claude/skills/android-autonomous-debugger/SKILL.md
@@ -142,10 +142,7 @@ The `android-adb-validate.sh` hook enforces this classification.
 ## Tips for Agents
 
 - **ALWAYS use `./scripts/adb-run.sh`** — never `source wrapper.sh && ...`
-- Always start with `adb_auto_select` as the first function in any call
-- Take screenshots BEFORE and AFTER each interaction
-- Check `adb_detect_crash` after navigating to a new screen
-- Use `adb_wait_for_text` instead of `sleep` — it's faster and more reliable
-- The `adb_snapshot` function captures everything at once (screen + UI tree + logs)
-- When debugging crashes: `adb_logcat_errors 60 <package>` gives package-specific errors
-- You can chain many functions in a single `adb-run.sh` call for efficiency
+- Always start with `adb_auto_select` as first function in any call
+- Screenshots BEFORE and AFTER each interaction; `adb_snapshot` captures screen + UI + logs
+- Use `adb_wait_for_text` instead of `sleep`; check `adb_detect_crash` after navigation
+- Chain many functions in a single `adb-run.sh` call for efficiency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.76.2] — 2026-03-10
+
+### Fixed — Era 104: adb-run.sh wrapper + hook error fix
+
+- **adb-run.sh**: New single-command runner that replaces `source wrapper.sh && cmd1 && cmd2` chains. Claude Code's shell-aware `*` doesn't cross `&&`/`||` operators, making compound command patterns impossible to whitelist. `adb-run.sh` encapsulates source + functions in one simple command
+- **Hook stdin fix**: `validate-bash-global.sh` now uses `read -t 2` with timeout instead of `cat` (which could hang indefinitely waiting for stdin)
+- **SKILL.md rewrite**: All examples now use `./scripts/adb-run.sh` pattern exclusively
+
 ## [2.76.1] — 2026-03-10
 
 ### Fixed — Era 104: CHANGELOG link enforcement + Claude Code permission cleanup
@@ -3060,6 +3068,7 @@ Initial public release of PM-Workspace.
 - **Documentation** with methodology
 
 
+[2.76.2]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.1...v2.76.2
 [2.76.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.0...v2.76.1
 [2.76.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.75.0...v2.76.0
 [2.75.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.74.2...v2.75.0

--- a/scripts/adb-run.sh
+++ b/scripts/adb-run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# adb-run.sh — Execute adb-wrapper functions without compound && chains
+#
+# Usage:
+#   ./scripts/adb-run.sh adb_auto_select
+#   ./scripts/adb-run.sh adb_auto_select adb_screenshot /tmp/screen.png
+#   ./scripts/adb-run.sh adb_auto_select "adb_tap 500 900" "adb_screenshot /tmp/after.png"
+#   ./scripts/adb-run.sh --logcat-errors 30 com.savia.mobile
+#
+# Why this exists:
+#   Claude Code is shell-aware and treats && || ; as command boundaries.
+#   Permission patterns like Bash(source wrapper.sh && *) don't cover
+#   multi-step chains. This script wraps everything into a single command
+#   that needs only one permission pattern: Bash(./scripts/adb-run.sh *)
+#
+# Each argument is one adb-wrapper function call (with its args).
+# Use quotes for calls with arguments: "adb_tap 500 900"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/lib/adb-wrapper.sh"
+
+if [[ ! -f "$WRAPPER" ]]; then
+  echo "ERROR: adb-wrapper.sh not found at $WRAPPER" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/adb-wrapper.sh
+source "$WRAPPER"
+
+# Special flags
+case "${1:-}" in
+  -h|--help)
+    echo "Usage: ./scripts/adb-run.sh <func> [<func> ...]"
+    echo ""
+    echo "Execute one or more adb-wrapper functions sequentially."
+    echo "Each argument is a function call (quote args with spaces)."
+    echo ""
+    echo "Examples:"
+    echo "  ./scripts/adb-run.sh adb_auto_select adb_devices"
+    echo "  ./scripts/adb-run.sh adb_auto_select \"adb_screenshot /tmp/s.png\""
+    echo "  ./scripts/adb-run.sh adb_auto_select \"adb_tap 500 900\" \"adb_screenshot /tmp/after.png\""
+    echo "  ./scripts/adb-run.sh adb_auto_select adb_logcat_clear \"adb_launch com.savia.mobile\""
+    exit 0
+    ;;
+  "")
+    echo "ERROR: No commands specified. Use --help for usage." >&2
+    exit 1
+    ;;
+esac
+
+# Execute each argument as a function call
+FAILED=0
+for cmd in "$@"; do
+  # Split the command string into function name and arguments
+  # shellcheck disable=SC2086
+  if ! eval "$cmd"; then
+    echo "FAILED: $cmd" >&2
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+if [[ $FAILED -gt 0 ]]; then
+  echo "$FAILED command(s) failed" >&2
+  exit 1
+fi

--- a/scripts/setup-claude-permissions.sh
+++ b/scripts/setup-claude-permissions.sh
@@ -123,15 +123,11 @@ if [[ -n "$ADB_BIN" ]]; then
   ADB_PERMS+="      \"Bash(adb *)\","$'\n'
   ADB_PERMS+="      \"Bash(adb_*)\","$'\n'
   ADB_PERMS+="      \"Bash($ADB_BIN *)\","$'\n'
-  ADB_PERMS+="      \"Bash(\$ANDROID_HOME/platform-tools/adb *)\","$'\n'
-  ADB_PERMS+="      \"Bash(\$ADB_PATH *)\","$'\n'
-  ADB_PERMS+="      \"Bash(ADB=*)\","$'\n'
-  # Compound commands: source wrapper && any adb_ chain
-  ADB_PERMS+="      \"Bash(source scripts/lib/adb-wrapper.sh && *)\","$'\n'
-  ADB_PERMS+="      \"Bash(source $ROOT/scripts/lib/adb-wrapper.sh && *)\","$'\n'
-  # sleep N && source wrapper && ... (screenshot delays)
-  ADB_PERMS+="      \"Bash(sleep * && source scripts/lib/adb-wrapper.sh && *)\","$'\n'
-  ADB_PERMS+="      \"Bash(sleep * && source $ROOT/scripts/lib/adb-wrapper.sh && *)\","$'\n'
+  # adb-run.sh: single-command wrapper that avoids && chains
+  # Claude Code is shell-aware: * doesn't cross && || ; operators.
+  # adb-run.sh wraps source + functions into one simple command.
+  ADB_PERMS+="      \"Bash(./scripts/adb-run.sh *)\","$'\n'
+  ADB_PERMS+="      \"Bash(bash scripts/adb-run.sh *)\","$'\n'
 fi
 if [[ -n "$ANDROID_SDK" ]]; then
   ADB_PERMS+="      \"Read(//$ANDROID_SDK/**)\","$'\n'


### PR DESCRIPTION
## Summary
- New `scripts/adb-run.sh` encapsulates `source adb-wrapper.sh` + function calls into a single command
- Claude Code's shell-aware `*` doesn't cross `&&`/`||` operators, so compound commands always trigger permission popups. `adb-run.sh` eliminates this by being a single executable with arguments (no shell operators)
- Fixed `validate-bash-global.sh` — replaced `cat` (hangs on empty stdin) with `read -t 2` with timeout
- Rewrote SKILL.md with all examples using `./scripts/adb-run.sh` exclusively
- Updated `setup-claude-permissions.sh` to generate `adb-run.sh` patterns

## Example
```bash
# Before (triggers popup):
source scripts/lib/adb-wrapper.sh && adb_auto_select && adb_screenshot /tmp/s.png

# After (no popup):
./scripts/adb-run.sh adb_auto_select "adb_screenshot /tmp/s.png"
```

## Test plan
- [ ] `./scripts/adb-run.sh adb_auto_select adb_device_info` works
- [ ] `./scripts/adb-run.sh adb_auto_select "adb_screenshot /tmp/test.png"` works
- [ ] CI passes all gates
- [ ] Claude Code uses `adb-run.sh` without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)