### PR TITLE
feat: orgchart diagrams + project management updates

### DIFF
--- a/.claude/commands/diagram-generate.md
+++ b/.claude/commands/diagram-generate.md
@@ -9,13 +9,15 @@ description: >
 
 **Proyecto:** $ARGUMENTS
 
-> Uso: `/diagram-generate {proyecto} [--tool draw.io|miro|local] [--type architecture|flow|sequence]`
+> Uso: `/diagram-generate {target} [--tool draw.io|miro|local] [--type architecture|flow|sequence|orgchart]`
 
 ## Parámetros
 
-- `{proyecto}` — Nombre del proyecto en `projects/` (obligatorio)
+- `{target}` — Nombre del proyecto en `projects/` o departamento en `teams/` (obligatorio)
 - `--tool {draw.io|miro|local}` — Herramienta destino (default: valor de `DIAGRAM_DEFAULT_TOOL` o `local`)
-- `--type {architecture|flow|sequence}` — Tipo de diagrama (default: `architecture`)
+- `--type {architecture|flow|sequence|orgchart}` — Tipo de diagrama (default: `architecture`)
+
+> Con `--type orgchart`, el argumento posicional es `{departamento}` (de `teams/`), no un proyecto.
 
 ## 2. Cargar perfil de usuario
 
@@ -84,9 +86,33 @@ Leer en este orden (Progressive Disclosure):
 Si `--type architecture` y el proyecto tiene >10 componentes:
 → Delegar validación de consistencia al agente `diagram-architect`
 
+## Orgchart: flujo específico
+
+Si `--type orgchart`:
+
+1. **Validar departamento** — Verificar que `teams/{dept}/dept.md` existe
+2. **Leer jerarquía**:
+   - `teams/{dept}/dept.md` → nombre, responsable, lista de equipos
+   - Por cada equipo: `teams/{dept}/{team}/team.md` → leads, miembros, roles, capacity
+   - Opcional: `teams/members/{handle}.md` → nombre real (solo para Draw.io remoto, NO en ficheros locales por PII)
+3. **Generar Mermaid** usando plantilla `references/orgchart-mermaid-template.md`
+   - Nodo raíz: departamento (con responsable si existe)
+   - Nodos intermedios: equipos (con capacity_total)
+   - Hojas: miembros (★ si es lead, rol como subtítulo)
+4. **Exportar** según `--tool` (igual que otros tipos)
+5. **Metadata** en `teams/diagrams/{tool}/orgchart-{dept}.meta.json`
+6. **Presentar**:
+   ```
+   ✅ Organigrama: {dept}
+   🏢 {N} equipos, {N} personas
+   🔗 URL: {link}
+   📁 Local: teams/diagrams/local/orgchart-{dept}.mermaid
+   ```
+
 ## Restricciones
 
 - Crear directorio `diagrams/` si no existe
 - No sobrescribir diagramas existentes sin confirmar
 - Siempre generar copia local en Mermaid además de la exportación al tool
 - No incluir secrets, connection strings ni tokens en el diagrama
+- Orgchart: solo @handles en ficheros locales, NUNCA nombres reales (regla PII-Free)

--- a/.claude/commands/project-new.md
+++ b/.claude/commands/project-new.md
@@ -1,0 +1,143 @@
+---
+name: project-new
+description: >
+  Create a new project interactively — directory structure, CLAUDE.md,
+  environments, memory, and CLAUDE.local.md entry. Asks all data step by step.
+argument-hint: "<nombre-proyecto>"
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /project-new — Create New Project
+
+Interactive wizard to set up a new project from scratch in pm-workspace.
+
+## Usage
+
+- `/project-new mi-proyecto` — Start wizard with project name
+- `/project-new` — Start wizard (asks name interactively)
+
+## Workflow
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🆕 /project-new — New Project Setup
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Step 1 — Validate name
+
+If `$ARGUMENTS` provided → use as project name. Otherwise ask.
+Name must be kebab-case: `^[a-z0-9]+(-[a-z0-9]+)*$`
+Verify `projects/{name}/` does NOT already exist.
+
+### Step 2 — Gather project data (interactive, one question at a time)
+
+Ask each field using AskUserQuestion. Show default in brackets.
+
+| # | Question | Field | Default |
+|---|----------|-------|---------|
+| 1 | Brief description (1 line) | description | — |
+| 2 | Tech stack / language | language_pack | auto-detect later |
+| 3 | Git provider (github / azure-repos / gitlab / local) | git_provider | github |
+| 4 | Repository URL (if remote) | repo_url | — |
+| 5 | PM tool (azure-devops / jira / savia-flow / none) | pm_tool | none |
+| 6 | If azure-devops: project name in Azure DevOps | azdo_project | — |
+| 7 | If azure-devops: team name | azdo_team | — |
+| 8 | If azure-devops: iteration path | azdo_iteration | — |
+| 9 | Environments (comma-separated) | environments | DEV,PRO |
+| 10 | Auto-deploy DEV? (y/n) | auto_deploy_dev | y |
+
+Skip questions 6-8 if pm_tool is not azure-devops.
+Skip question 4 if git_provider is local.
+
+### Step 3 — Create directory structure
+
+```
+projects/{name}/
+├── CLAUDE.md                    ← Generated from answers
+├── config.local/                ← git-ignored secrets
+│   └── .env.example             ← Template with placeholders
+├── diagrams/                    ← Architecture diagrams
+│   └── local/                   ← Mermaid diagrams
+└── docs/                        ← Project-specific docs
+```
+
+### Step 4 — Generate CLAUDE.md (≤ 150 lines)
+
+Use the gathered data to generate `projects/{name}/CLAUDE.md`:
+
+```markdown
+# {name} — {description}
+
+## Stack
+Language Pack: {language_pack}
+Git: {git_provider} | {repo_url}
+
+## PM Tool
+{pm_tool config block — Azure DevOps fields if applicable}
+
+## Environments
+{table of environments with auto_deploy flag}
+
+## Conventions
+(To be filled as the project evolves)
+
+## Notes
+Created: {date} via /project-new
+```
+
+### Step 5 — Add entry to CLAUDE.local.md
+
+Append to `CLAUDE.local.md` projects table:
+
+```markdown
+| {name} | {pm_tool} | `projects/{name}/CLAUDE.md` |
+```
+
+If pm_tool is azure-devops, also append to `.claude/rules/pm-config.local.md`:
+
+```
+PROJECT_{SLUG}_NAME           = "{azdo_project}"
+PROJECT_{SLUG}_TEAM           = "{azdo_team}"
+PROJECT_{SLUG}_ITERATION_PATH = "{azdo_iteration}"
+PROJECT_{SLUG}_LOCAL_PATH     = "projects/{name}"
+```
+
+### Step 6 — Initialize memory
+
+Run: `bash scripts/setup-memory.sh {name}`
+Creates 6 template files in `~/.claude/projects/{name}/memory/`.
+
+### Step 7 — Generate .env.example in config.local/
+
+Template with `APP_ENVIRONMENT`, `DATABASE_CONNECTION_STRING`, `LOG_LEVEL` as placeholders.
+
+### Step 8 — Summary banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ /project-new — Project created
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Project .............. {name}
+  Path ................. projects/{name}/
+  CLAUDE.md ............ projects/{name}/CLAUDE.md
+  PM Tool .............. {pm_tool}
+  Environments ......... {list}
+  Memory ............... initialized
+
+  Next steps:
+  → /context-load {name}     — Load project context
+  → /project-audit {name}    — Run initial audit
+  → /onboard --project {name} — Onboard team members
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚡ /compact
+```
+
+## Restrictions
+
+- NEVER overwrite an existing project directory
+- NEVER write real credentials — only placeholders
+- NEVER commit CLAUDE.local.md or pm-config.local.md
+- All generated CLAUDE.md ≤ 150 lines

--- a/.claude/commands/user-profile.md
+++ b/.claude/commands/user-profile.md
@@ -1,0 +1,111 @@
+---
+name: user-profile
+description: Gestiona perfiles de miembros del equipo — ver, crear o editar.
+argument-hint: "@handle [--edit] [--section skills|vacations|locality]"
+model: sonnet
+context_cost: low
+---
+
+# /user-profile — Perfil de miembro del equipo
+
+**Argumentos:** $ARGUMENTS
+
+> Gestiona datos de miembros: habilidades, debilidades, vacaciones, localidad.
+> Estos datos alimentan la asignación de tareas y el cálculo de capacidad.
+
+## 0. Preparación
+
+1. Leer `.claude/profiles/savia.md` — adoptar voz de Savia
+2. Parsear `$ARGUMENTS`:
+   - `@handle` — obligatorio (sin @ → error)
+   - `--edit` — modo edición (sin flag = modo lectura)
+   - `--section {s}` — editar solo una sección específica
+3. Ruta del perfil: `teams/members/{handle}.md` (sin @)
+
+## 1. Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🦉 /user-profile — Perfil de @{handle}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## 2. Si el perfil NO existe → Crear
+
+Savia inicia conversación para crear el perfil:
+
+> "No tengo perfil de @{handle}. Vamos a crearlo."
+
+Preguntar en orden (una pregunta a la vez, AskUserQuestion):
+
+1. **Nombre completo**
+2. **Email**
+3. **Rol** — developer, qa, tech-lead, architect, pm, designer
+4. **Supervisor** — @handle de su responsable
+5. **Localidad** — país, región y ciudad (para festivos)
+6. **Skills** — "¿En qué destaca?" (lista, separada por comas)
+7. **Dislikes** — "¿Tareas que no le gustan o le cuestan?" (lista)
+8. **Vacaciones** — periodos preferidos, periodos a evitar, notas
+
+Guardar en `teams/members/{handle}.md` usando formato de `teams/members/template.md`.
+
+## 3. Si el perfil EXISTE y NO --edit → Mostrar
+
+Leer `teams/members/{handle}.md` y presentar:
+
+```
+🧑 @{handle} — {name} ({role})
+📧 {email} | 👤 Supervisor: {supervisor}
+📍 {city}, {region}, {country}
+
+💪 Skills: {skills como lista}
+👎 Prefiere evitar: {dislikes como lista}
+
+🏖️ Vacaciones:
+   Prefiere: {preferred_periods}
+   Evita: {avoid_periods}
+   Notas: {notes}
+   Planificadas: {planned_vacations o "ninguna"}
+
+🏢 Equipos: {teams o "sin asignar"}
+```
+
+## 4. Si --edit → Editar
+
+Si `--section` especificado → editar solo esa sección.
+Si no → preguntar qué editar:
+
+| Sección | Campos |
+|---|---|
+| `identity` | name, email, role, supervisor |
+| `locality` | country, region, city |
+| `skills` | skills[], dislikes[] |
+| `vacations` | preferred_periods, avoid_periods, notes, planned |
+
+Mostrar valores actuales, preguntar cambios, guardar.
+
+## 5. Banner final
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🦉 Perfil de @{handle} — {acción: creado|mostrado|actualizado}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✏️ /user-profile @{handle} --edit
+⚡ /compact
+```
+
+## Integración
+
+| Comando | Uso del perfil |
+|---|---|
+| `/sprint-plan` | Consulta locality → festivos → capacidad real |
+| `/pbi-assign` | Consulta skills/dislikes → match de tareas |
+| `/capacity-forecast` | Consulta planned_vacations → disponibilidad |
+| `/team-orchestrator assign` | Actualiza campo teams[] del perfil |
+| `/workload-balance` | Consulta skills para redistribución |
+
+## Restricciones
+
+- Datos personales (RGPD) → fichero git-ignorado
+- NUNCA mostrar email completo en informes públicos
+- NUNCA commitear perfiles reales al repositorio

--- a/.claude/rules/domain/diagram-config.md
+++ b/.claude/rules/domain/diagram-config.md
@@ -18,8 +18,10 @@ MIRO_TOKEN_FILE             = "$HOME/.azure/miro-token"           # OAuth token 
 # Draw.io HTTP oficial no requiere auth para operaciones básicas
 
 # ── Tipos de diagrama soportados ─────────────────────────────────────────────
-DIAGRAM_TYPES               = "architecture,flow,sequence"
+DIAGRAM_TYPES               = "architecture,flow,sequence,orgchart"
 DIAGRAM_DEFAULT_TYPE        = "architecture"
+ORGCHART_DATA_DIR           = "teams"                            # fuente de datos para orgchart
+ORGCHART_OUTPUT_DIR         = "teams/diagrams"                   # output de organigramas
 
 # ── Formatos ─────────────────────────────────────────────────────────────────
 DIAGRAM_FORMAT_DRAWIO       = "xml"                              # Draw.io nativo: XML (.drawio)

--- a/.claude/skills/diagram-generation/SKILL.md
+++ b/.claude/skills/diagram-generation/SKILL.md
@@ -38,6 +38,9 @@ Analizar el proyecto para identificar componentes arquitectónicos:
 3. **Documentación existente** — `CLAUDE.md` del proyecto, `architecture.md`
 4. **Azure DevOps** — Repos, pipelines, service connections
 
+Para tipo orgchart: la fuente de datos es `teams/{dept}/` (dept.md + team.md de cada equipo),
+NO infraestructura de proyecto. Opcionalmente enriquecer con `teams/members/{handle}.md`.
+
 ### Entidades a detectar
 
 > Detalle: @references/diagram-entities.md
@@ -64,6 +67,7 @@ Construir la representación en Mermaid según el tipo de diagrama:
 - **Architecture** — C4-style con capas (Frontend, Backend, Data)
 - **Flow** — Data flow entre componentes
 - **Sequence** — Secuencia temporal de interacciones
+- **Orgchart** — Jerarquía organizativa desde datos de `teams/`
 
 ---
 
@@ -120,3 +124,5 @@ Crear `projects/{p}/diagrams/{tool}/{tipo}.meta.json`:
 - `references/mermaid-templates.md` — Plantillas por tipo
 - `references/diagram-entities.md` — Detección de componentes
 - `references/draw-io-shapes.md` — Mapeo entidades → shapes
+- `references/orgchart-shapes.md` — Shapes de organigrama
+- `references/orgchart-mermaid-template.md` — Plantilla Mermaid para orgchart

--- a/.claude/skills/diagram-generation/references/orgchart-mermaid-template.md
+++ b/.claude/skills/diagram-generation/references/orgchart-mermaid-template.md
@@ -1,0 +1,60 @@
+# Orgchart Mermaid Template
+
+> Plantilla para generar organigramas con `graph TB` y subgraphs por equipo.
+
+## Convenciones
+
+- Nodo raíz: departamento con responsable (si existe)
+- Subgraph por equipo: nombre del equipo como título
+- Leads: sufijo ` ★` y rol como subtítulo
+- Miembros: @handle con rol como subtítulo
+- IDs de nodo: `DEPT`, `SQ_{team}_{handle}` (sin @, sin guiones)
+
+## Plantilla base
+
+```mermaid
+graph TB
+    DEPT["🏢 {dept_name}<br/><i>Responsable: {responsable}</i>"]
+
+    subgraph squad1["{team1_name}"]
+        SQ_T1_handle1["@handle1<br/>{role1} ★"]
+        SQ_T1_handle2["@handle2<br/>{role2}"]
+    end
+
+    subgraph squad2["{team2_name}"]
+        SQ_T2_handle3["@handle3<br/>{role3} ★"]
+        SQ_T2_handle4["@handle4<br/>{role4}"]
+    end
+
+    DEPT --- squad1
+    DEPT --- squad2
+```
+
+## Reglas de generación
+
+1. Leer `teams/{dept}/dept.md` para nombre y responsable
+2. Leer `teams/{dept}/{team}/team.md` para cada equipo
+3. Miembros con rol en `lead:` llevan ★
+4. IDs sin caracteres especiales: `@ana` → `SQ_T1_ana`
+5. Solo usar @handles, NUNCA nombres reales (regla PII-Free)
+6. Capacity total del equipo se muestra en el subgraph title si >0
+
+## Ejemplo real (SoftwareEngineering)
+
+```mermaid
+graph TB
+    DEPT["🏢 SoftwareEngineering<br/><i>Responsable: —</i>"]
+
+    subgraph squad1["Squad1 (cap: 2.0)"]
+        SQ_S1_eduardo["@eduardo<br/>tech-lead ★"]
+        SQ_S1_daniel["@daniel<br/>tech-lead ★"]
+    end
+
+    subgraph squad2["Squad2 (cap: 2.0)"]
+        SQ_S2_ana["@ana<br/>tech-lead ★"]
+        SQ_S2_bernardo["@bernardo<br/>tech-lead ★"]
+    end
+
+    DEPT --- squad1
+    DEPT --- squad2
+```

--- a/.claude/skills/diagram-generation/references/orgchart-shapes.md
+++ b/.claude/skills/diagram-generation/references/orgchart-shapes.md
@@ -1,0 +1,78 @@
+# Orgchart Shapes — Draw.io XML Reference
+
+> Shapes específicos para organigramas de equipo. Layout vertical (TB).
+
+## Entidades
+
+| Entidad | Shape | Fill | Border |
+|---|---|---|---|
+| Departamento | Container/swimlane con header | `#4472C4` | `#2F5496` |
+| Equipo | Rounded rect, borde grueso (2px) | `#dae8fc` | `#6c8ebf` |
+| Lead (★) | Persona, borde bold (2px) | `#d5e8d4` | `#82b366` |
+| Miembro | Persona, borde normal | `#f5f5f5` | `#666666` |
+| Supervisor link | Flecha punteada ascendente | — | `#999999` dashed |
+| Jerarquía | Línea sólida, orthogonal, sin flecha | — | `#333333` |
+
+## Layout
+
+- Direction: Top-to-Bottom (TB)
+- Vertical spacing entre niveles: 100px
+- Horizontal spacing entre nodos: 60px
+- Container padding: 20px
+
+## XML Snippets
+
+### Departamento (container)
+
+```xml
+<mxCell style="swimlane;startSize=30;fillColor=#4472C4;fontColor=#ffffff;
+  strokeColor=#2F5496;rounded=1;arcSize=10;fontSize=14;fontStyle=1"
+  vertex="1" parent="1">
+  <mxGeometry x="0" y="0" width="800" height="400" as="geometry"/>
+</mxCell>
+```
+
+### Equipo (rounded rect)
+
+```xml
+<mxCell style="rounded=1;whiteSpace=wrap;fillColor=#dae8fc;
+  strokeColor=#6c8ebf;strokeWidth=2;fontSize=12;fontStyle=1"
+  vertex="1" parent="1">
+  <mxGeometry width="200" height="60" as="geometry"/>
+</mxCell>
+```
+
+### Lead (persona con borde bold)
+
+```xml
+<mxCell style="shape=mxgraph.basic.person;fillColor=#d5e8d4;
+  strokeColor=#82b366;strokeWidth=2;fontSize=11;fontStyle=1"
+  vertex="1" parent="1">
+  <mxGeometry width="80" height="90" as="geometry"/>
+</mxCell>
+```
+
+### Miembro (persona normal)
+
+```xml
+<mxCell style="shape=mxgraph.basic.person;fillColor=#f5f5f5;
+  strokeColor=#666666;fontSize=11" vertex="1" parent="1">
+  <mxGeometry width="80" height="90" as="geometry"/>
+</mxCell>
+```
+
+### Jerarquía (línea sólida)
+
+```xml
+<mxCell style="edgeStyle=orthogonalEdgeStyle;strokeColor=#333333;
+  endArrow=none;exitY=1;entryY=0" edge="1" parent="1">
+</mxCell>
+```
+
+### Supervisor link (punteado)
+
+```xml
+<mxCell style="edgeStyle=orthogonalEdgeStyle;strokeColor=#999999;
+  dashed=1;endArrow=open;endSize=8" edge="1" parent="1">
+</mxCell>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,11 @@ CLAUDE.local.md
 # ── Decision log — privado del PM ─────────────────────────────────────────────
 decision-log.md
 
+# ── Perfiles de miembros del equipo (datos personales — RGPD) ──────────────
+# Contienen nombre, email, localidad, vacaciones. Solo se commitea la plantilla.
+teams/members/*
+!teams/members/template.md
+
 # ── Confidence Log — Datos privados del sistema de calibración ─────────────────
 /data/
 backups/

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,22 @@ decision-log.md
 
 # ── Perfiles de miembros del equipo (datos personales — RGPD) ──────────────
 # Contienen nombre, email, localidad, vacaciones. Solo se commitea la plantilla.
-teams/members/*
+# Estructura de equipos (dept.md, team.md, deps.md) SÍ se commitea.
+teams/*
 !teams/members/template.md
 
 # ── Confidence Log — Datos privados del sistema de calibración ─────────────────
 /data/
 backups/
+
+# Capturas de pantalla de los test
+scripts/tests/screenshots
+
+# Configuraciones locales
+.claude/settings.local.*
+
+# Informes de auditoria
+audit-report-*
+
+# Backups
+*.backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Debugger skill** (`.claude/skills/android-autonomous-debugger/SKILL.md`): Complete workflow for autonomous debug cycles — install, launch, interact, detect crashes, capture evidence, report results
 - **Integration test suite** (`scripts/tests/test-adb-wrapper.sh`): 44 tests covering core functions, security classification, device management, visual capture, logcat, Savia Mobile integration, and hook validation. All tested against physical OUKITEL C36 device
 - **Documentation** (`docs/android-debug-agent.md`): Full API reference, architecture diagram, use cases for PM/QA smoke testing, developer debugging, and CI verification. Includes security model and environment variable reference
+## [2.76.0] — 2026-03-10
+
+Savia Mobile chat fixes: duplicate text elimination, message timestamps, and bridge session persistence.
+
+### Fixed
+- **Bridge duplicate text**: Response text no longer appears twice in chat bubbles (result event suppressed when streaming already delivered the content)
+- **Bridge session persistence**: Known sessions saved to `~/.savia/bridge/known-sessions.json` — multi-turn conversations survive bridge restarts
+- **Bridge "already in use" recovery**: If session conflict detected, session marked as known for automatic retry
+
+### Added
+- **Chat timestamps**: Message bubbles display HH:mm time for traceability (SimpleDateFormat with `remember` for performance)
 
 ## [2.75.0] — 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.77.0] — 2026-03-10
+
+Orgchart diagram generation from teams data — new diagram type for `/diagram-generate`.
+
+### Added
+- **Orgchart diagram type**: `/diagram-generate {dept} --type orgchart` generates hierarchical team diagrams from `teams/` data, exportable to Draw.io, Miro or local Mermaid
+- **Orgchart shapes reference**: Draw.io XML snippets for department containers, team nodes, person shapes (lead vs member), hierarchy and supervisor links (`orgchart-shapes.md`)
+- **Orgchart Mermaid template**: `graph TB` template with subgraphs per team, lead markers (★), @handle-based naming, PII-Free compliant (`orgchart-mermaid-template.md`)
+- **Test suite**: `scripts/test-orgchart-diagrams.sh` — 45 tests covering config, structure, shapes, template, command integration, skill integration and Mermaid output generation
+
+### Changed
+- **diagram-config.md**: `DIAGRAM_TYPES` now includes `orgchart`, added `ORGCHART_DATA_DIR` and `ORGCHART_OUTPUT_DIR`
+- **diagram-generation SKILL.md**: Added Orgchart to supported types, teams data source note, two new reference files
+- **diagram-generate command**: Added `--type orgchart` with 6-step orgchart-specific flow (dept validation, hierarchy read, Mermaid generation, export, metadata, presentation)
+- **README.md / README.en.md**: Documented diagram generation capabilities including orgchart
+
 ## [2.76.5] — 2026-03-10
 
 ### Fixed — Savia Mobile v0.3.46: one-shot mode + command pre-fill
@@ -61,9 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Debugger skill** (`.claude/skills/android-autonomous-debugger/SKILL.md`): Complete workflow for autonomous debug cycles — install, launch, interact, detect crashes, capture evidence, report results
 - **Integration test suite** (`scripts/tests/test-adb-wrapper.sh`): 44 tests covering core functions, security classification, device management, visual capture, logcat, Savia Mobile integration, and hook validation. All tested against physical OUKITEL C36 device
 - **Documentation** (`docs/android-debug-agent.md`): Full API reference, architecture diagram, use cases for PM/QA smoke testing, developer debugging, and CI verification. Includes security model and environment variable reference
-## [2.76.0] — 2026-03-10
-
-Savia Mobile chat fixes: duplicate text elimination, message timestamps, and bridge session persistence.
 
 ### Fixed
 - **Bridge duplicate text**: Response text no longer appears twice in chat bubbles (result event suppressed when streaming already delivered the content)
@@ -3108,6 +3121,7 @@ Initial public release of PM-Workspace.
 - **Documentation** with methodology
 
 
+[2.77.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.5...v2.77.0
 [2.76.5]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.4...v2.76.5
 [2.76.4]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.3...v2.76.4
 [2.76.3]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.2...v2.76.3

--- a/README.en.md
+++ b/README.en.md
@@ -78,7 +78,7 @@ Every command has YAML frontmatter with metadata (model, context cost, descripti
 
 **Spec-Driven Development** — Tasks become executable specs. I implement handlers, tests, and repositories in 16 languages. Agents work in isolated worktrees to avoid conflicts.
 
-**Code intelligence** — I detect architecture patterns (Clean, Hexagonal, DDD, CQRS, Microservices), measure architectural health with fitness functions, and prioritize tech debt by business impact.
+**Code intelligence** — I detect architecture patterns (Clean, Hexagonal, DDD, CQRS, Microservices), measure architectural health with fitness functions, and prioritize tech debt by business impact. I generate architecture, flow, sequence and team orgchart diagrams exportable to Draw.io, Miro or local Mermaid.
 
 **Security & compliance** — SAST against OWASP Top 10, SBOM, credential scanning, regulatory compliance across 12 sectors, and AI governance with model cards and EU AI Act.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, des
 
 **Spec-Driven Development** — Las tasks se convierten en specs ejecutables. Implemento handlers, tests y repositorios en 16 lenguajes. Los agentes trabajan en worktrees aislados para evitar conflictos.
 
-**Inteligencia de código** — Detecto patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, Microservices), mido salud arquitectónica con fitness functions, y priorizo deuda técnica por impacto de negocio.
+**Inteligencia de código** — Detecto patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, Microservices), mido salud arquitectónica con fitness functions, y priorizo deuda técnica por impacto de negocio. Genero diagramas de arquitectura, flujo, secuencia y organigramas de equipo exportables a Draw.io, Miro o Mermaid local.
 
 **Seguridad y compliance** — SAST contra OWASP Top 10, SBOM, escaneo de credenciales, compliance regulatorio en 12 sectores, y gobernanza IA con model cards y EU AI Act.
 

--- a/scripts/test-orgchart-diagrams.sh
+++ b/scripts/test-orgchart-diagrams.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+# ============================================================================
+# test-orgchart-diagrams.sh — Tests for orgchart diagram generation
+# ============================================================================
+# Validates orgchart configuration, shapes, templates, and Mermaid output.
+#
+# Usage:
+#   ./scripts/test-orgchart-diagrams.sh
+#   ./scripts/test-orgchart-diagrams.sh --verbose
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Colors
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+VERBOSE=false
+[[ "${1:-}" == "--verbose" ]] && VERBOSE=true
+
+TESTS_TOTAL=0; TESTS_PASSED=0; TESTS_FAILED=0
+declare -a FAILED_TESTS=()
+
+pass() { echo -e "  ${GREEN}✅ PASS${NC} — $1"; TESTS_PASSED=$((TESTS_PASSED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); }
+fail() { echo -e "  ${RED}❌ FAIL${NC} — $1"; echo -e "     ${RED}↳ $2${NC}"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); FAILED_TESTS+=("$1: $2"); }
+log_header() { echo ""; echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════${NC}"; echo -e "${BOLD}${BLUE}  $1${NC}"; echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════${NC}"; }
+log_section() { echo ""; echo -e "${CYAN}▶ $1${NC}"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 1: Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+test_config() {
+  log_header "SUITE 1 — Orgchart Configuration"
+
+  log_section "diagram-config.md"
+
+  if grep -q 'orgchart' "$WORKSPACE_ROOT/.claude/rules/domain/diagram-config.md"; then
+    pass "DIAGRAM_TYPES includes orgchart"
+  else
+    fail "DIAGRAM_TYPES missing orgchart" "diagram-config.md should list orgchart"
+  fi
+
+  if grep -q 'ORGCHART_DATA_DIR' "$WORKSPACE_ROOT/.claude/rules/domain/diagram-config.md"; then
+    pass "ORGCHART_DATA_DIR defined"
+  else
+    fail "ORGCHART_DATA_DIR not defined" "diagram-config.md should define data dir"
+  fi
+
+  if grep -q 'ORGCHART_OUTPUT_DIR' "$WORKSPACE_ROOT/.claude/rules/domain/diagram-config.md"; then
+    pass "ORGCHART_OUTPUT_DIR defined"
+  else
+    fail "ORGCHART_OUTPUT_DIR not defined" "diagram-config.md should define output dir"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 2: File structure
+# ─────────────────────────────────────────────────────────────────────────────
+test_structure() {
+  log_header "SUITE 2 — File Structure"
+
+  log_section "Required files exist"
+
+  local files=(
+    "teams/diagrams/.gitkeep"
+    ".claude/skills/diagram-generation/references/orgchart-shapes.md"
+    ".claude/skills/diagram-generation/references/orgchart-mermaid-template.md"
+  )
+
+  for f in "${files[@]}"; do
+    if [[ -f "$WORKSPACE_ROOT/$f" ]]; then
+      pass "$f exists"
+    else
+      fail "$f missing" "File should exist"
+    fi
+  done
+
+  log_section "File size limits (<=150 lines)"
+
+  local sized_files=(
+    ".claude/skills/diagram-generation/references/orgchart-shapes.md"
+    ".claude/skills/diagram-generation/references/orgchart-mermaid-template.md"
+    ".claude/commands/diagram-generate.md"
+    ".claude/skills/diagram-generation/SKILL.md"
+  )
+
+  for f in "${sized_files[@]}"; do
+    local lines
+    lines=$(wc -l < "$WORKSPACE_ROOT/$f")
+    if [[ "$lines" -le 150 ]]; then
+      pass "$f has $lines lines (<=150)"
+    else
+      fail "$f exceeds 150 lines" "Has $lines lines"
+    fi
+  done
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 3: Shapes reference
+# ─────────────────────────────────────────────────────────────────────────────
+test_shapes() {
+  log_header "SUITE 3 — Orgchart Shapes Reference"
+
+  local shapes_file="$WORKSPACE_ROOT/.claude/skills/diagram-generation/references/orgchart-shapes.md"
+
+  log_section "Required entity shapes"
+
+  local entities=("Departamento" "Equipo" "Lead" "Miembro" "Supervisor" "Jerarqu")
+  for entity in "${entities[@]}"; do
+    if grep -qi "$entity" "$shapes_file"; then
+      pass "Shape defined for: $entity"
+    else
+      fail "Missing shape for: $entity" "orgchart-shapes.md should define $entity"
+    fi
+  done
+
+  log_section "XML snippets present"
+
+  if grep -q '<mxCell' "$shapes_file"; then
+    pass "Contains Draw.io XML snippets"
+  else
+    fail "No XML snippets" "Should contain <mxCell examples"
+  fi
+
+  local shape_types=("swimlane" "rounded=1" "shape=mxgraph.basic.person" "dashed=1")
+  for st in "${shape_types[@]}"; do
+    if grep -q "$st" "$shapes_file"; then
+      pass "XML contains style: $st"
+    else
+      fail "Missing XML style: $st" "orgchart-shapes.md should use $st"
+    fi
+  done
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 4: Mermaid template
+# ─────────────────────────────────────────────────────────────────────────────
+test_mermaid_template() {
+  log_header "SUITE 4 — Mermaid Template"
+
+  local tmpl="$WORKSPACE_ROOT/.claude/skills/diagram-generation/references/orgchart-mermaid-template.md"
+
+  log_section "Template structure"
+
+  if grep -q 'graph TB' "$tmpl"; then
+    pass "Uses graph TB (top-to-bottom) layout"
+  else
+    fail "Missing graph TB" "Template should use top-to-bottom layout"
+  fi
+
+  if grep -q 'subgraph' "$tmpl"; then
+    pass "Uses subgraphs for teams"
+  else
+    fail "Missing subgraph" "Template should group teams in subgraphs"
+  fi
+
+  if grep -q '★' "$tmpl"; then
+    pass "Leads marked with ★"
+  else
+    fail "Missing ★ marker" "Leads should be marked with ★"
+  fi
+
+  if grep -q '@' "$tmpl"; then
+    pass "Uses @handles for members"
+  else
+    fail "Missing @handles" "Template should use @handles, not real names"
+  fi
+
+  log_section "PII-Free compliance"
+
+  # Check that no real full names appear (handles like @eduardo are OK)
+  # Only flag names NOT preceded by @ (PII = real person names in prose)
+  if grep -E '(Mónica|González)' "$tmpl" 2>/dev/null | grep -qvE '@'; then
+    fail "Real names detected in template" "Template must use @handles only (PII-Free rule)"
+  else
+    pass "No real names in template (PII-Free compliant)"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 5: Command integration
+# ─────────────────────────────────────────────────────────────────────────────
+test_command() {
+  log_header "SUITE 5 — Command Integration"
+
+  local cmd="$WORKSPACE_ROOT/.claude/commands/diagram-generate.md"
+
+  log_section "Orgchart support in command"
+
+  if grep -q 'orgchart' "$cmd"; then
+    pass "Command mentions orgchart type"
+  else
+    fail "Command missing orgchart" "diagram-generate.md should support orgchart"
+  fi
+
+  if grep -q 'teams/' "$cmd"; then
+    pass "Command references teams/ directory"
+  else
+    fail "Command missing teams/ reference" "Should read from teams/"
+  fi
+
+  if grep -q 'dept.md' "$cmd"; then
+    pass "Command references dept.md"
+  else
+    fail "Command missing dept.md reference" "Should read dept.md"
+  fi
+
+  if grep -q 'team.md' "$cmd"; then
+    pass "Command references team.md"
+  else
+    fail "Command missing team.md reference" "Should read team.md"
+  fi
+
+  if grep -q 'PII' "$cmd"; then
+    pass "Command has PII-Free restriction"
+  else
+    fail "Command missing PII restriction" "Should mention PII-Free rule"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 6: Skill integration
+# ─────────────────────────────────────────────────────────────────────────────
+test_skill() {
+  log_header "SUITE 6 — Skill Integration"
+
+  local skill="$WORKSPACE_ROOT/.claude/skills/diagram-generation/SKILL.md"
+
+  if grep -q 'Orgchart' "$skill"; then
+    pass "SKILL.md lists Orgchart type"
+  else
+    fail "SKILL.md missing Orgchart" "Should list Orgchart in supported types"
+  fi
+
+  if grep -q 'orgchart-shapes.md' "$skill"; then
+    pass "SKILL.md references orgchart-shapes.md"
+  else
+    fail "SKILL.md missing shapes ref" "Should reference orgchart-shapes.md"
+  fi
+
+  if grep -q 'orgchart-mermaid-template.md' "$skill"; then
+    pass "SKILL.md references orgchart-mermaid-template.md"
+  else
+    fail "SKILL.md missing template ref" "Should reference orgchart-mermaid-template.md"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SUITE 7: Mermaid output generation test
+# ─────────────────────────────────────────────────────────────────────────────
+test_mermaid_generation() {
+  log_header "SUITE 7 — Mermaid Output Generation (SoftwareEngineering)"
+
+  log_section "Generate orgchart from teams data"
+
+  local dept_dir="$WORKSPACE_ROOT/teams/SoftwareEngineering"
+  local output_dir="$WORKSPACE_ROOT/teams/diagrams/local"
+  local output_file="$output_dir/orgchart-SoftwareEngineering.mermaid"
+
+  mkdir -p "$output_dir"
+
+  # Read department data
+  if [[ ! -f "$dept_dir/dept.md" ]]; then
+    fail "dept.md not found" "$dept_dir/dept.md missing"
+    return
+  fi
+  pass "Department data found: SoftwareEngineering"
+
+  # Parse teams
+  local teams=()
+  while IFS= read -r line; do
+    teams+=("$line")
+  done < <(find "$dept_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+
+  if [[ ${#teams[@]} -gt 0 ]]; then
+    pass "Found ${#teams[@]} teams: ${teams[*]}"
+  else
+    fail "No teams found" "Expected subdirectories in $dept_dir"
+    return
+  fi
+
+  # Generate Mermaid
+  {
+    echo "graph TB"
+    echo "    DEPT[\"🏢 SoftwareEngineering<br/><i>Responsable: —</i>\"]"
+    echo ""
+
+    for team in "${teams[@]}"; do
+      local team_file="$dept_dir/$team/team.md"
+      if [[ ! -f "$team_file" ]]; then
+        continue
+      fi
+
+      # Parse capacity
+      local cap
+      cap=$(grep 'capacity_total' "$team_file" | head -1 | sed 's/.*: *//' || echo "0")
+
+      echo "    subgraph ${team}[\"${team} (cap: ${cap})\"]"
+
+      # Parse members
+      while IFS= read -r handle_line; do
+        local handle
+        handle=$(echo "$handle_line" | sed 's/.*handle: *"\{0,1\}//' | sed 's/"\{0,1\} *$//')
+        local clean_handle="${handle#@}"
+        local node_id="SQ_${team}_${clean_handle}"
+
+        # Check if lead
+        local is_lead=false
+        if grep -q "\"$handle\"" <(grep -A1 '^lead:' "$team_file" 2>/dev/null) 2>/dev/null; then
+          is_lead=true
+        fi
+
+        # Get role
+        local role
+        role=$(grep -A3 "handle: *\"*${handle}" "$team_file" | grep 'role:' | head -1 | sed 's/.*role: *//' || echo "member")
+
+        if $is_lead; then
+          echo "        ${node_id}[\"${handle}<br/>${role} ★\"]"
+        else
+          echo "        ${node_id}[\"${handle}<br/>${role}\"]"
+        fi
+      done < <(grep 'handle:' "$team_file")
+
+      echo "    end"
+      echo ""
+    done
+
+    for team in "${teams[@]}"; do
+      echo "    DEPT --- ${team}"
+    done
+  } > "$output_file"
+
+  if [[ -f "$output_file" ]]; then
+    pass "Generated: $output_file"
+  else
+    fail "Output not generated" "Expected $output_file"
+    return
+  fi
+
+  log_section "Validate Mermaid structure"
+
+  # Check graph TB
+  if grep -q '^graph TB' "$output_file"; then
+    pass "Starts with graph TB"
+  else
+    fail "Missing graph TB header" "Mermaid should start with graph TB"
+  fi
+
+  # Check department node
+  if grep -q 'DEPT\[' "$output_file"; then
+    pass "Department root node present"
+  else
+    fail "Missing department node" "Should have DEPT node"
+  fi
+
+  # Check subgraphs
+  local subgraph_count
+  subgraph_count=$(grep -c 'subgraph' "$output_file" || true)
+  if [[ "$subgraph_count" -eq ${#teams[@]} ]]; then
+    pass "Correct number of subgraphs ($subgraph_count)"
+  else
+    fail "Wrong subgraph count" "Expected ${#teams[@]}, got $subgraph_count"
+  fi
+
+  # Check hierarchy connections
+  local conn_count
+  conn_count=$(grep -c 'DEPT ---' "$output_file" || true)
+  if [[ "$conn_count" -eq ${#teams[@]} ]]; then
+    pass "All teams connected to department ($conn_count)"
+  else
+    fail "Missing hierarchy connections" "Expected ${#teams[@]}, got $conn_count"
+  fi
+
+  # Check member nodes exist
+  local member_count
+  member_count=$(grep -c 'SQ_' "$output_file" || true)
+  if [[ "$member_count" -gt 0 ]]; then
+    pass "Member nodes present ($member_count)"
+  else
+    fail "No member nodes" "Should have SQ_ prefixed nodes"
+  fi
+
+  # Check lead markers
+  if grep -q '★' "$output_file"; then
+    pass "Lead markers (★) present"
+  else
+    fail "Missing lead markers" "Leads should have ★"
+  fi
+
+  # PII check — no real names, only @handles
+  if grep -oP '(?<=\[")[^"]*' "$output_file" 2>/dev/null | grep -qiE '(Mónica|González)'; then
+    fail "PII detected in output" "Only @handles allowed"
+  else
+    pass "Output is PII-Free"
+  fi
+
+  # Check handles format
+  if grep -q '@' "$output_file"; then
+    pass "Uses @handle format"
+  else
+    fail "Missing @handles" "Members should use @handle format"
+  fi
+
+  if $VERBOSE; then
+    echo ""
+    echo -e "${YELLOW}Generated Mermaid:${NC}"
+    cat "$output_file"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RUN ALL
+# ─────────────────────────────────────────────────────────────────────────────
+main() {
+  echo -e "${BOLD}${BLUE}"
+  echo "═══════════════════════════════════════════════════════════"
+  echo "  TEST SUITE — Orgchart Diagram Generation"
+  echo "═══════════════════════════════════════════════════════════"
+  echo -e "${NC}"
+
+  test_config
+  test_structure
+  test_shapes
+  test_mermaid_template
+  test_command
+  test_skill
+  test_mermaid_generation
+
+  echo ""
+  echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════${NC}"
+  echo -e "${BOLD}  RESULTS${NC}"
+  echo -e "${BOLD}${BLUE}════════════════════════════════════════════════════${NC}"
+  echo -e "  Total:   ${TESTS_TOTAL}"
+  echo -e "  ${GREEN}Passed:  ${TESTS_PASSED}${NC}"
+  echo -e "  ${RED}Failed:  ${TESTS_FAILED}${NC}"
+  echo ""
+
+  if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
+    echo -e "${RED}Failed tests:${NC}"
+    for ft in "${FAILED_TESTS[@]}"; do
+      echo -e "  ${RED}✗${NC} $ft"
+    done
+    echo ""
+    exit 1
+  else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- **Orgchart diagram type** (`--type orgchart`): generates hierarchical team diagrams from `teams/` data, exportable to Draw.io, Miro or local Mermaid
- **Draw.io shapes + Mermaid template**: orgchart-specific shapes (department containers, team nodes, person shapes with lead markers) and `graph TB` template with PII-Free compliance
- **45-test suite** (`scripts/test-orgchart-diagrams.sh`): covers config, file structure, shapes reference, Mermaid template, command/skill integration, and end-to-end Mermaid output generation
- **Documentation**: CHANGELOG v2.77.0 entry, README.md/README.en.md updated with diagram capabilities
- Includes prior commits: new-project/user-profile commands, Savia Mobile chat fixes

## Files changed
- `.claude/commands/diagram-generate.md` — added orgchart flow
- `.claude/rules/domain/diagram-config.md` — added orgchart config
- `.claude/skills/diagram-generation/SKILL.md` — added orgchart type + references
- `.claude/skills/diagram-generation/references/orgchart-shapes.md` — new (Draw.io XML)
- `.claude/skills/diagram-generation/references/orgchart-mermaid-template.md` — new (Mermaid)
- `scripts/test-orgchart-diagrams.sh` — new (45 tests, all pass)
- `CHANGELOG.md` — v2.77.0 entry + fixed duplicate v2.76.0
- `README.md` / `README.en.md` — diagram capabilities documented

## Test plan
- [x] `scripts/test-orgchart-diagrams.sh` — 45/45 tests pass
- [x] `scripts/validate-ci-local.sh --quick` — 4/4 passed
- [x] `scripts/validate-commands.sh diagram-generate.md` — passes (1 soft warning)
- [x] All files ≤150 lines (except test script, consistent with other test suites)
- [x] PII-Free: no real names in generated Mermaid output

🤖 Generated with [Claude Code](https://claude.com/claude-code)