### PR TITLE
feat(diagrams): add /orgchart-import — reverse orgchart to teams/ structure

### DIFF
--- a/.claude/commands/orgchart-import.md
+++ b/.claude/commands/orgchart-import.md
@@ -1,0 +1,75 @@
+---
+name: orgchart-import
+description: >
+  Importa un organigrama (Mermaid, Draw.io XML o Miro) y genera/actualiza
+  la estructura teams/ con departamentos, equipos y miembros.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash]
+model: sonnet
+context_cost: medium
+argument-hint: "{source} --dept {name} [--mode create|merge|overwrite] [--dry-run]"
+---
+
+# Importar Organigrama → Estructura teams/
+
+**Fuente:** $ARGUMENTS
+
+> Uso: `/orgchart-import {source} --dept {name} [--mode create|merge|overwrite] [--dry-run]`
+
+## Parametros
+
+- `{source}` -- ruta a `.mermaid`, `.drawio`/`.xml`, o URL de Miro board
+- `--dept {name}` -- nombre del departamento destino (obligatorio)
+- `--mode create|merge|overwrite` -- manejo de conflictos (default: `merge`)
+- `--dry-run` -- mostrar propuesta sin escribir ficheros
+
+## Contexto requerido
+
+1. `.claude/skills/orgchart-import/SKILL.md` -- pipeline completo
+2. `teams/departments.md` -- departamentos existentes
+3. `teams/{dept}/` -- estructura existente del dept (si --mode merge)
+4. `.claude/rules/domain/diagram-config.md` -- constantes orgchart
+5. `teams/members/template.md` -- plantilla de miembros
+
+## Razonamiento
+
+Piensa paso a paso:
+1. Primero: detectar formato del source y parsear a modelo normalizado
+2. Luego: validar datos y detectar conflictos con teams/ existente
+3. Finalmente: presentar propuesta y escribir ficheros tras confirmacion
+
+## Pasos de ejecucion
+
+1. **Banner de inicio**
+2. **Verificar prerequisitos**: source existe, --dept proporcionado, teams/ accesible
+3. **Invocar skill** `.claude/skills/orgchart-import/SKILL.md` -- 7 fases:
+   - Fase 1: Detectar formato y parsear
+   - Fase 2: Construir modelo normalizado (org-model-schema)
+   - Fase 3: Validar datos parseados
+   - Fase 4: Detectar conflictos con teams/ existente segun --mode
+   - Fase 5: Presentar propuesta al PM (si --dry-run: parar aqui)
+   - Fase 6: Escribir ficheros tras confirmacion
+   - Fase 7: Banner de resumen
+4. **Auto-compact**: `⚡ /compact`
+
+## Ejemplo
+
+**Correcto:**
+```
+/orgchart-import teams/diagrams/local/orgchart-Engineering.mermaid --dept Engineering
+→ Parsea Mermaid, detecta 2 equipos con 4 miembros, presenta propuesta, escribe teams/
+```
+
+**Incorrecto:**
+```
+/orgchart-import orgchart.mermaid
+→ Error: falta --dept. Uso: /orgchart-import {source} --dept {name}
+```
+
+## Restricciones
+
+- NUNCA escribir sin confirmacion explicita del PM
+- NUNCA escribir nombres reales en ficheros tracked (solo @handles)
+- `--mode overwrite` requiere flag explicito + confirmacion
+- Si --dry-run: mostrar propuesta y parar, NO escribir
+- Si el diagrama contiene nombres reales sin @handle: warn + pedir handle
+- Ficheros member en `teams/members/` (gitignored) pueden tener datos reales

--- a/.claude/rules/domain/diagram-config.md
+++ b/.claude/rules/domain/diagram-config.md
@@ -34,6 +34,10 @@ DIAGRAM_FORMAT_LOCAL        = "mermaid"                          # Local: Mermai
 # projects/{proyecto}/diagrams/local/      ← diagramas locales (.mermaid, .xml)
 DIAGRAM_DIR                 = "diagrams"
 DIAGRAM_META_EXTENSION      = ".meta.json"
+
+# ── Orgchart Import ──────────────────────────────────────────────────────────
+ORGCHART_IMPORT_MODES       = "create,merge,overwrite"
+ORGCHART_IMPORT_DEFAULT_MODE = "merge"
 ```
 
 ## Validación de reglas de negocio

--- a/.claude/skills/orgchart-import/DOMAIN.md
+++ b/.claude/skills/orgchart-import/DOMAIN.md
@@ -1,0 +1,33 @@
+# Orgchart Import — Domain Context
+
+## Por que existe esta skill
+
+Configurar equipos manualmente (dept.md, team.md, member profiles) es tedioso y propenso a errores. Un PM que ya tiene un organigrama visual deberia poder importarlo directamente. Esta skill cierra el ciclo round-trip: `/diagram-generate --type orgchart` genera diagramas desde teams/, y `/orgchart-import` reconstruye teams/ desde diagramas.
+
+## Conceptos de dominio
+
+- **Departamento** — Unidad organizativa de nivel superior. Contiene equipos y tiene un responsable opcional.
+- **Equipo (squad)** — Grupo de trabajo con lead, miembros, capacidad total y cadencia de sprint.
+- **Lead** — Miembro con responsabilidad de coordinacion tecnica del equipo. Marcado con ★ en diagramas.
+- **Capacity** — Dedicacion de un miembro a un equipo (0.1-1.0). Suma = capacity_total del equipo.
+- **Supervisor link** — Relacion jerarquica entre responsable y lider de equipo (linea punteada).
+- **Modelo normalizado** — JSON intermedio que abstrae el formato de origen (Mermaid, Draw.io, Miro).
+
+## Reglas de negocio que implementa
+
+- Cada equipo debe tener al menos 1 miembro
+- Handles solo con @ en ficheros tracked (PII-Free)
+- Capacidades individuales entre 0.1 y 1.0
+- Modo merge como default para proteger datos existentes
+
+## Relacion con otras skills
+
+**Upstream:** `diagram-generation` genera organigramas que esta skill importa
+**Downstream:** `team-coordination` consume la estructura teams/ generada; `capacity-planning` usa capacity_total
+**Inverso de:** `/diagram-generate --type orgchart` (round-trip bidireccional)
+
+## Decisiones clave
+
+- **Skill separado de diagram-import**: diagram-import crea work items en Azure DevOps (dominio proyecto). orgchart-import crea ficheros en teams/ (dominio equipo). Dominios de salida diferentes → SRP.
+- **3 modos de conflicto**: create (estricto), merge (seguro, default), overwrite (destructivo, requiere confirmacion). Merge protege datos existentes de sobreescritura accidental.
+- **Modelo normalizado intermedio**: Desacopla parsers de escritura. Permite anadir formatos nuevos sin tocar la logica de generacion de ficheros.

--- a/.claude/skills/orgchart-import/SKILL.md
+++ b/.claude/skills/orgchart-import/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: orgchart-import
+description: >
+  Pipeline de 7 fases para importar organigramas y generar estructura teams/.
+  Soporta Mermaid, Draw.io XML y Miro. Inverso de diagram-generation orgchart.
+disable-model-invocation: false
+user-invocable: false
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash]
+---
+
+# Orgchart Import — Skill
+
+> Importa organigrama → modelo normalizado → estructura teams/.
+
+## Formato source soportados
+
+| Extension | Parser |
+|---|---|
+| `.mermaid` | `references/mermaid-parser.md` |
+| `.drawio`, `.xml` | `references/drawio-parser.md` |
+| URL Miro | `references/miro-parser.md` |
+
+## Modelo intermedio
+
+Todos los parsers producen el mismo JSON: `references/org-model-schema.md`
+
+## Pipeline de 7 fases
+
+### Fase 1 — Detectar formato y parsear
+
+1. Si source termina en `.mermaid` → cargar `references/mermaid-parser.md`, aplicar reglas
+2. Si source termina en `.drawio` o `.xml` → cargar `references/drawio-parser.md`
+3. Si source es URL con `miro.com` → cargar `references/miro-parser.md`
+4. Si formato no reconocido → error con formatos soportados
+
+Output: modelo JSON normalizado (org-model-schema).
+
+### Fase 2 — Construir modelo normalizado
+
+Asegurar que el output del parser cumple el schema:
+- `department.name` = valor de `--dept`
+- `department.responsable` = extraido del diagrama o `null`
+- `teams[]` con name, capacity_total, members[]
+- `supervisor_links[]` con from/to handles
+
+### Fase 3 — Validar datos parseados
+
+| Validacion | Nivel |
+|---|---|
+| Dept name no vacio | Error |
+| Cada equipo tiene >=1 miembro | Error |
+| Sin handles duplicados entre equipos | Warn (capacity > 1.0 implica multi-equipo) |
+| Al menos 1 lead por equipo | Warn |
+| Capacidades entre 0.1 y 1.0 | Warn |
+| @handles sin nombres reales | Warn + pedir handle |
+
+Si hay errores → parar con informe. Si solo warns → continuar con avisos.
+
+### Fase 4 — Detectar conflictos con teams/ existente
+
+Leer `teams/departments.md` y `teams/{dept}/` si existe.
+
+| Modo | Dept existe | Equipo existe | Miembro existe |
+|---|---|---|---|
+| `create` | Error | Error | Error |
+| `merge` | OK, actualizar | OK, agregar nuevos miembros | Skip |
+| `overwrite` | OK, reemplazar | OK, reemplazar | OK, reemplazar |
+
+Default: `merge`. `overwrite` requiere flag explicito + confirmacion.
+
+### Fase 5 — Presentar propuesta al PM
+
+Mostrar tabla:
+
+```
+Departamento: {dept_name} | Responsable: {resp} | Modo: {mode}
+
+| Equipo | Miembros | Leads | Cap. | Estado |
+|---|---|---|---|---|
+| squad1 | 3 | @alice | 3.0 | Nuevo |
+| squad2 | 2 | @bob | 2.0 | Merge (+1 miembro) |
+
+Ficheros a crear/modificar:
+  + teams/{dept}/dept.md
+  + teams/{dept}/squad1/team.md
+  + teams/{dept}/squad1/deps.md
+  ~ teams/{dept}/squad2/team.md (merge)
+  + teams/members/@charlie.md
+```
+
+Si `--dry-run` → parar aqui con banner informativo.
+
+### Fase 6 — Escribir ficheros (tras confirmacion)
+
+1. **departments.md** — agregar/actualizar fila en tabla
+2. **dept.md** — crear `teams/{dept}/dept.md`:
+   ```markdown
+   # {dept_name}
+
+   - **Mision**: [completar]
+   - **Responsable**: {responsable}
+   - **Equipos**: {lista equipos}
+   - **KPIs**: [completar]
+   ```
+3. **team.md** por equipo — crear `teams/{dept}/{team}/team.md`:
+   ```yaml
+   name: "{team_name}"
+   department: "{dept_name}"
+   lead:
+     - "@handle"
+   members:
+     - handle: "@handle"
+       role: {role}
+       capacity: {cap}
+       projects: []
+   capacity_total: {total}
+   velocity_avg: 0
+   sprint_cadence: 2w
+   ```
+4. **deps.md** por equipo — crear vacio: `# Dependencias de {team_name}`
+5. **member profiles** — para cada miembro nuevo sin fichero existente:
+   crear `teams/members/{handle}.md` desde `teams/members/template.md`
+   con handle y role pre-rellenados
+
+### Fase 7 — Banner de resumen
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ /orgchart-import — Completado
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📁 Departamento: {dept} ({N} equipos, {M} miembros)
+📄 Ficheros creados: {count}
+📄 Ficheros modificados: {count}
+⚡ /compact — Ejecuta para liberar contexto
+💡 Siguiente: /team-orchestrator validate --dept {dept}
+```
+
+## PII Safety
+
+- Solo @handles en ficheros tracked por git
+- Si diagrama contiene nombres reales sin @: warn + pedir handle al PM
+- `teams/members/` esta gitignored: puede contener datos reales
+- NUNCA escribir nombres reales en dept.md, team.md, departments.md

--- a/.claude/skills/orgchart-import/references/drawio-parser.md
+++ b/.claude/skills/orgchart-import/references/drawio-parser.md
@@ -1,0 +1,80 @@
+# Draw.io Parser — Orgchart Import
+
+> Parsea ficheros `.drawio` / `.xml` basandose en shapes de `orgchart-shapes.md`.
+
+## Identificacion de entidades por estilo
+
+### Departamento
+
+- Style: `swimlane` con `fillColor=#4472C4`
+- Texto del header = nombre del departamento
+- Buscar atributo `value` con HTML: extraer texto plano
+- Responsable: buscar "Responsable:" en el contenido del nodo
+
+```xml
+<mxCell style="swimlane;startSize=30;fillColor=#4472C4;..." value="Engineering">
+```
+
+### Equipos
+
+- Style: `rounded=1` con `strokeWidth=2` y `fillColor=#dae8fc`
+- Son hijos (parent) del container departamento
+- `value` contiene nombre del equipo
+- Capacity: buscar "(cap: N)" en el value, o calcular desde miembros
+
+```xml
+<mxCell style="rounded=1;...fillColor=#dae8fc;strokeColor=#6c8ebf;strokeWidth=2"
+  value="Squad1 (cap: 2.0)" parent="{dept_id}">
+```
+
+### Miembros Lead
+
+- Style: `shape=mxgraph.basic.person` con `fillColor=#d5e8d4` y `strokeWidth=2`
+- Color verde (`#d5e8d4`) + borde grueso (2px) = lead
+- `value` contiene HTML: `@handle<br/>role` o `@handle<br/>role ★`
+- Extraer handle y role del HTML
+
+```xml
+<mxCell style="shape=mxgraph.basic.person;fillColor=#d5e8d4;strokeWidth=2"
+  value="@eduardo&lt;br/&gt;tech-lead" parent="{team_id}">
+```
+
+### Miembros regulares
+
+- Style: `shape=mxgraph.basic.person` con `fillColor=#f5f5f5`
+- Borde normal (sin strokeWidth=2)
+- Mismo parseo de value que leads
+
+```xml
+<mxCell style="shape=mxgraph.basic.person;fillColor=#f5f5f5"
+  value="@daniel&lt;br/&gt;developer" parent="{team_id}">
+```
+
+### Supervisor links
+
+- Style: `dashed=1` con `strokeColor=#999999`
+- `source` y `target` referencian IDs de nodos miembro
+- Extraer handles de los nodos referenciados
+
+### Jerarquia dept-team
+
+- Style: `edgeStyle=orthogonalEdgeStyle` con `endArrow=none`
+- Linea solida entre dept y equipo
+- Confirma relacion parent (ya implicita por parent XML)
+
+## Algoritmo de parseo
+
+1. Parsear XML, construir mapa `id → mxCell`
+2. Identificar departamento: swimlane con `#4472C4`
+3. Identificar equipos: hijos del dept con `rounded=1;strokeWidth=2`
+4. Identificar miembros por equipo: hijos con `shape=mxgraph.basic.person`
+5. Clasificar lead/regular por `fillColor` (#d5e8d4 vs #f5f5f5)
+6. Extraer handle/role del atributo `value` (desescapar HTML entities)
+7. Buscar edges dashed para supervisor links
+
+## Fallbacks
+
+- Si no hay swimlane azul: buscar container mas grande como dept
+- Si shapes no coinciden exactamente: warn + heuristico por posicion
+- Si value no tiene `@`: proponer como handle al usuario
+- HTML entities: `&lt;` → `<`, `&gt;` → `>`, `&amp;` → `&`

--- a/.claude/skills/orgchart-import/references/mermaid-parser.md
+++ b/.claude/skills/orgchart-import/references/mermaid-parser.md
@@ -1,0 +1,86 @@
+# Mermaid Parser — Orgchart Import
+
+> Parsea ficheros `.mermaid` generados por `/diagram-generate --type orgchart`.
+
+## Formato esperado
+
+```mermaid
+graph TB
+    DEPT["🏢 {dept_name}<br/><i>Responsable: {responsable}</i>"]
+
+    subgraph squad1["{team_name} (cap: {N})"]
+        SQ_squad1_handle["@handle<br/>{role} ★"]
+        SQ_squad1_handle2["@handle2<br/>{role2}"]
+    end
+
+    DEPT --- squad1
+```
+
+## Reglas de parseo
+
+### Departamento
+
+- Patron: `DEPT["🏢 {name}<br/><i>Responsable: {resp}</i>"]`
+- O simplificado: `DEPT["{name}"]`
+- Extraer `name` del texto entre 🏢 y `<br/>`
+- Extraer `responsable` del texto entre `Responsable: ` y `</i>`
+- Si responsable es `—` o vacio → `null`
+
+### Equipos
+
+- Patron: `subgraph {id}["{name} (cap: {N})"]` ... `end`
+- `id` = identificador del subgraph (sin comillas)
+- `name` = texto entre comillas, antes de ` (cap:`
+- `capacity_total` = numero tras `cap: `, antes de `)`
+- Si no hay `(cap: N)` → calcular sumando capacidades de miembros
+
+### Miembros
+
+- Patron: `SQ_{team}_{handle}["@{handle}<br/>{role} ★"]`
+- O sin lead: `SQ_{team}_{handle}["@{handle}<br/>{role}"]`
+- `handle` = texto tras `@`, antes de `<br/>`
+- `role` = texto tras `<br/>`, antes de ` ★` o cierre `"`
+- `is_lead` = presencia de ` ★` en el texto del nodo
+- `capacity` = `capacity_total / num_miembros` (distribucion uniforme)
+
+### Supervisor links
+
+- Patron: edge punteado `A -.-> B` o `A -.- B`
+- `from` = nodo origen (handle del supervisor)
+- `to` = nodo destino (handle del supervisado)
+- Extraer handles de los IDs de nodo (`SQ_team_handle` → `@handle`)
+
+### Jerarquia dept-team
+
+- Patron: `DEPT --- {team_id}` (linea solida)
+- Confirma que el equipo pertenece al departamento
+- No genera datos adicionales (ya implicito en la estructura)
+
+## Ejemplo de parseo
+
+Input:
+```
+subgraph squad1["Squad1 (cap: 2.0)"]
+    SQ_squad1_eduardo["@eduardo<br/>tech-lead ★"]
+    SQ_squad1_daniel["@daniel<br/>tech-lead"]
+end
+```
+
+Output (fragmento del modelo):
+```json
+{
+  "name": "Squad1",
+  "capacity_total": 2.0,
+  "members": [
+    { "handle": "@eduardo", "role": "tech-lead", "is_lead": true, "capacity": 1.0 },
+    { "handle": "@daniel", "role": "tech-lead", "is_lead": false, "capacity": 1.0 }
+  ]
+}
+```
+
+## Edge cases
+
+- Nodos sin `@` prefijo: warn, proponer como handle
+- Nodos sin `<br/>` (solo nombre): usar nombre como handle, role = "member"
+- Subgraph sin capacity: calcular desde miembros (default 1.0 cada uno)
+- Multiples `DEPT` nodos: error, solo 1 departamento por diagrama

--- a/.claude/skills/orgchart-import/references/miro-parser.md
+++ b/.claude/skills/orgchart-import/references/miro-parser.md
@@ -1,0 +1,66 @@
+# Miro Parser — Orgchart Import
+
+> Parsea boards Miro via MCP tool. Heuristico por color/forma + confirmacion.
+
+## Prerequisito
+
+Requiere MCP Miro activo: `MIRO_MCP_URL` + `MIRO_TOKEN_FILE`.
+Si no esta configurado → error con instrucciones de activacion.
+
+## Identificacion de entidades
+
+### Departamento
+
+- **Frame o container azul** como elemento raiz
+- Color de fondo: tonos azules (#4472C4, #2196F3, similar)
+- Texto del frame = nombre del departamento
+- Si hay texto "Responsable:" dentro → extraer
+
+### Equipos
+
+- **Grupos o frames secundarios** dentro del dept frame
+- Sticky notes agrupadas con titulo de equipo
+- Color diferenciado del dept (tipicamente azul claro #dae8fc)
+- Buscar "(cap: N)" en titulo para capacity
+
+### Miembros
+
+- **Person shapes** (si disponibles en el board)
+- **Sticky notes** dentro del grupo de equipo
+- **Text cards** con formato `@handle - role`
+- Leads: color verde (#d5e8d4) o marcados con ★
+
+### Supervisor links
+
+- **Connector widgets** entre personas
+- Lineas punteadas = supervisor links
+- Lineas solidas = jerarquia directa
+
+## Heuristico de clasificacion
+
+Miro es menos estructurado que Mermaid/Draw.io. Aplicar:
+
+1. **Por color**: azul=dept, azul claro=equipo, verde=lead, gris=miembro
+2. **Por forma**: frame=dept, grupo=equipo, persona/sticky=miembro
+3. **Por posicion**: arriba=dept, medio=equipos, abajo=miembros
+4. **Por contenido**: buscar `@`, roles conocidos, "cap:", "lead"
+
+Si confianza < 70% en la clasificacion → pedir confirmacion al PM:
+```
+No estoy segura de la estructura. Esto es lo que detecto:
+- Departamento: "Engineering" (frame azul)
+- Equipo 1: "Frontend" (3 stickies verdes)
+¿Es correcto? [S/n]
+```
+
+## Output
+
+Mismo modelo normalizado que los otros parsers (org-model-schema.md).
+Campos no detectables con confianza → `null` + warn.
+
+## Limitaciones
+
+- Miro no tiene shapes estandar de orgchart forzados
+- Cada board puede tener estructura diferente
+- El parser es best-effort + confirmacion humana
+- Para importaciones precisas, preferir Mermaid o Draw.io

--- a/.claude/skills/orgchart-import/references/org-model-schema.md
+++ b/.claude/skills/orgchart-import/references/org-model-schema.md
@@ -1,0 +1,95 @@
+# Org Model Schema — Modelo Intermedio Normalizado
+
+> Contrato JSON que todos los parsers producen y las fases 3-6 consumen.
+
+## Schema
+
+```json
+{
+  "department": {
+    "name": "string (obligatorio, no vacio)",
+    "responsable": "string|null (@handle o null si desconocido)"
+  },
+  "teams": [
+    {
+      "name": "string (obligatorio)",
+      "capacity_total": "number (>0, suma de capacidades)",
+      "members": [
+        {
+          "handle": "string (obligatorio, con @ prefijo)",
+          "role": "string (obligatorio: developer|qa|tech-lead|architect|pm|designer|member)",
+          "is_lead": "boolean (true si es lead del equipo)",
+          "capacity": "number (0.1-1.0, dedicacion al equipo)"
+        }
+      ]
+    }
+  ],
+  "supervisor_links": [
+    {
+      "from": "string (@handle del supervisor)",
+      "to": "string (@handle del supervisado)"
+    }
+  ]
+}
+```
+
+## Campos obligatorios
+
+| Campo | Obligatorio | Default si ausente |
+|---|---|---|
+| department.name | Si | Error |
+| department.responsable | No | null |
+| teams[].name | Si | Error |
+| teams[].capacity_total | No | Suma de members[].capacity |
+| teams[].members | Si (>=1) | Error |
+| members[].handle | Si | Error |
+| members[].role | No | "member" |
+| members[].is_lead | No | false |
+| members[].capacity | No | capacity_total / num_members |
+| supervisor_links | No | [] |
+
+## Reglas de validacion
+
+1. `department.name` no puede estar vacio
+2. Cada equipo debe tener al menos 1 miembro
+3. `handle` debe empezar con `@`
+4. `capacity` debe estar entre 0.1 y 1.0
+5. `capacity_total` debe ser >= suma de capacidades individuales
+6. No duplicar handles dentro del mismo equipo
+7. Handles duplicados entre equipos → warn (multi-equipo valido)
+
+## Ejemplo completo
+
+```json
+{
+  "department": {
+    "name": "Engineering",
+    "responsable": "@alice"
+  },
+  "teams": [
+    {
+      "name": "Backend",
+      "capacity_total": 2.5,
+      "members": [
+        { "handle": "@bob", "role": "tech-lead", "is_lead": true, "capacity": 1.0 },
+        { "handle": "@charlie", "role": "developer", "is_lead": false, "capacity": 1.0 },
+        { "handle": "@diana", "role": "developer", "is_lead": false, "capacity": 0.5 }
+      ]
+    },
+    {
+      "name": "Frontend",
+      "capacity_total": 1.5,
+      "members": [
+        { "handle": "@eve", "role": "tech-lead", "is_lead": true, "capacity": 1.0 },
+        { "handle": "@diana", "role": "developer", "is_lead": false, "capacity": 0.5 }
+      ]
+    }
+  ],
+  "supervisor_links": [
+    { "from": "@alice", "to": "@bob" },
+    { "from": "@alice", "to": "@eve" }
+  ]
+}
+```
+
+Note: `@diana` aparece en 2 equipos con capacity 0.5 cada uno (total 1.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.78.0] — 2026-03-11
+
+Reverse orgchart import — parse diagrams (Mermaid, Draw.io, Miro) to generate teams/ structure.
+
+### Added
+- **`/orgchart-import` command**: imports orgchart diagrams and generates department, team and member files in `teams/`
+- **orgchart-import skill**: 7-phase pipeline (detect format, parse, normalize, validate, detect conflicts, write, summary) with 3 conflict modes (create, merge, overwrite)
+- **Mermaid parser**: recognizes DEPT nodes, subgraphs with capacity, member nodes with lead markers (★), supervisor links
+- **Draw.io parser**: identifies entities by shape styles (swimlane=dept, rounded rect=team, person shape=member, green fill=lead)
+- **Miro parser**: heuristic-based detection by color/shape/position with user confirmation fallback
+- **Org model schema**: normalized JSON contract bridging all parsers to the write phase
+- **DOMAIN.md**: Clara Philosophy documentation for the skill
+
+### Changed
+- **diagram-config.md**: added `ORGCHART_IMPORT_MODES` and `ORGCHART_IMPORT_DEFAULT_MODE` constants
+- **README.md / README.en.md**: documented orgchart import capability in code intelligence section
+
 ## [2.77.0] — 2026-03-10
 
 Orgchart diagram generation from teams data — new diagram type for `/diagram-generate`.
@@ -3121,6 +3138,7 @@ Initial public release of PM-Workspace.
 - **Documentation** with methodology
 
 
+[2.78.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.77.0...v2.78.0
 [2.77.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.5...v2.77.0
 [2.76.5]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.4...v2.76.5
 [2.76.4]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.76.3...v2.76.4

--- a/README.en.md
+++ b/README.en.md
@@ -78,7 +78,7 @@ Every command has YAML frontmatter with metadata (model, context cost, descripti
 
 **Spec-Driven Development** — Tasks become executable specs. I implement handlers, tests, and repositories in 16 languages. Agents work in isolated worktrees to avoid conflicts.
 
-**Code intelligence** — I detect architecture patterns (Clean, Hexagonal, DDD, CQRS, Microservices), measure architectural health with fitness functions, and prioritize tech debt by business impact. I generate architecture, flow, sequence and team orgchart diagrams exportable to Draw.io, Miro or local Mermaid.
+**Code intelligence** — I detect architecture patterns (Clean, Hexagonal, DDD, CQRS, Microservices), measure architectural health with fitness functions, and prioritize tech debt by business impact. I generate architecture, flow, sequence and team orgchart diagrams exportable to Draw.io, Miro or local Mermaid. I also import existing orgcharts to automatically generate team structure (`/orgchart-import`).
 
 **Security & compliance** — SAST against OWASP Top 10, SBOM, credential scanning, regulatory compliance across 12 sectors, and AI governance with model cards and EU AI Act.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, des
 
 **Spec-Driven Development** — Las tasks se convierten en specs ejecutables. Implemento handlers, tests y repositorios en 16 lenguajes. Los agentes trabajan en worktrees aislados para evitar conflictos.
 
-**Inteligencia de código** — Detecto patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, Microservices), mido salud arquitectónica con fitness functions, y priorizo deuda técnica por impacto de negocio. Genero diagramas de arquitectura, flujo, secuencia y organigramas de equipo exportables a Draw.io, Miro o Mermaid local.
+**Inteligencia de código** — Detecto patrones de arquitectura (Clean, Hexagonal, DDD, CQRS, Microservices), mido salud arquitectónica con fitness functions, y priorizo deuda técnica por impacto de negocio. Genero diagramas de arquitectura, flujo, secuencia y organigramas de equipo exportables a Draw.io, Miro o Mermaid local. Importo organigramas existentes para generar la estructura de equipos automáticamente (`/orgchart-import`).
 
 **Seguridad y compliance** — SAST contra OWASP Top 10, SBOM, escaneo de credenciales, compliance regulatorio en 12 sectores, y gobernanza IA con model cards y EU AI Act.
 


### PR DESCRIPTION
## Summary
- New `/orgchart-import` command + skill with 7-phase pipeline to parse orgchart diagrams (Mermaid, Draw.io XML, Miro) and generate `teams/` directory structure
- 3 conflict modes: `create`, `merge` (default), `overwrite` with dry-run support
- Normalized JSON intermediate model decoupling parsers from file generation
- Updated diagram-config, READMEs and CHANGELOG (v2.78.0)

## Test plan
- [ ] Round-trip: generate orgchart from SoftwareEngineering, import to new dept, compare
- [ ] Parse existing `teams/diagrams/local/orgchart-SoftwareEngineering.mermaid`
- [ ] Verify `--dry-run` writes no files
- [ ] Verify merge mode only adds new members
- [ ] Verify create mode fails if dept exists
- [ ] Verify PII-Free: no real names in tracked files
- [ ] `scripts/validate-commands.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)