### PR TITLE
fix: remove accidental claude-code-templates submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ projects/*
 !projects/proyecto-beta/
 !projects/sala-reservas/
 !projects/savia-mobile-android/
-!projects/claude-code-templates/
 
 # ── Datos generados y sensibles (incluso dentro de proyectos de ejemplo) ──────
 projects/*/sprints/

--- a/scripts/protect-project-privacy.sh
+++ b/scripts/protect-project-privacy.sh
@@ -133,7 +133,7 @@ if git diff --cached --name-only 2>/dev/null | grep -q "^\.gitignore$"; then
 fi
 
 # Verificación 2: ¿Hay archivos staged en projects/ de un proyecto no whitelisteado?
-STAGED_PROJECTS=$(git diff --cached --name-only 2>/dev/null \
+STAGED_PROJECTS=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
     | grep "^projects/" \
     | sed 's|^projects/||; s|/.*||' \
     | sort -u || true)


### PR DESCRIPTION
## Summary
- Remove gitlink entry for `projects/claude-code-templates` added accidentally in `4e12635`
- Remove its whitelist from `.gitignore` (external reference repo, not a tracked project)
- Fix `protect-project-privacy.sh` to use `--diff-filter=ACM` so deletions don't trigger the privacy gate

## Test plan
- [x] `git status` no longer shows `m projects/claude-code-templates`
- [x] `git submodule status` returns empty
- [x] Local files remain on disk for reference
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)