### PR TITLE
feat(era-100): context window adaptive per model — provider-agnostic

### DIFF
--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -26,6 +26,16 @@ check_timeout() {
 # ── Fallback: si algo falla, salida limpia ────────────────────────────────────
 trap 'printf "{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"PM-Workspace Init (ERR line %s):\\n- Savia lista\"}}\n" "$LINENO"; exit 1' ERR
 
+# ── Model capability detection (Era 100) ────────────────────────────────────
+for rpath in "$HOME/claude/scripts/model-capability-resolver.sh" "./scripts/model-capability-resolver.sh"; do
+  if [ -f "$rpath" ]; then
+    while IFS= read -r _l; do
+      case "$_l" in export\ SAVIA_*) declare "${_l#export }" 2>/dev/null ;; esac
+    done < <(echo '' | bash "$rpath" 2>/dev/null || true)
+    break
+  fi
+done
+
 # ── Arrays de contexto ────────────────────────────────────────────────────────
 ITEMS=()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.84.0] — 2026-03-14
+
+Era 100.0 — Context Window Adaptive per Model. Provider-agnostic dynamic context detection.
+
+### Added
+- **config/model-capabilities.yaml**: LLM capability registry — maps models to context window, tier, and strategy. Supports Claude, GPT, Gemini, Llama, Mistral (provider-agnostic)
+- **scripts/model-capability-resolver.sh**: Detects active model, parses YAML registry, exports `SAVIA_CONTEXT_WINDOW`, `SAVIA_MODEL_TIER`, `SAVIA_COMPACT_THRESHOLD` env vars. Falls back to 128K/fast for unknown models
+- **scripts/adaptive-strategy-selector.sh**: Given a tier (max/high/fast), outputs JSON with lazy loading, agent budget, autocompact, and sprint loading strategy
+- **tests/structure/test-model-capabilities.bats**: 13 BATS tests covering registry, resolver, and strategy selector
+
+### Changed
+- **session-init.sh**: Model capability detection runs as first step — sets SAVIA_* vars for downstream scripts
+- **CLAUDE.md**: Updated to reflect Era 100.0 context intelligence
+
 ## [2.83.0] — 2026-03-14
 
 Era 63 — Multi-user session architecture with per-user isolation in savia-bridge.
@@ -3448,6 +3462,7 @@ Initial public release of PM-Workspace.
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0...v0.2.0
+[2.84.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.83.0...v2.84.0
 [2.83.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.82.0...v2.83.0
 [2.82.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.81.0...v2.82.0
 [2.81.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.80.0...v2.81.0

--- a/config/model-capabilities.yaml
+++ b/config/model-capabilities.yaml
@@ -1,0 +1,66 @@
+# Model Capability Registry — Era 100
+# Maps LLM models to their context window and feature capabilities.
+# Provider-agnostic: supports Claude, GPT, Gemini, Llama, Mistral, etc.
+# Used by model-capability-resolver.sh to set SAVIA_* env vars.
+# To add a new model: add an entry here. Savia adapts automatically.
+# ─────────────────────────────────────────────────────────────────
+
+models:
+  # ── Anthropic Claude ──
+  claude-opus-4-6:
+    context_window: 1000000
+    tier: max
+    supports_extended_thinking: true
+    recommended_compact_threshold_pct: 70
+
+  claude-sonnet-4-6:
+    context_window: 1000000
+    tier: high
+    supports_extended_thinking: true
+    recommended_compact_threshold_pct: 65
+
+  claude-haiku-4-5-20251001:
+    context_window: 200000
+    tier: fast
+    supports_extended_thinking: false
+    recommended_compact_threshold_pct: 45
+
+  # ── OpenAI GPT ──
+  gpt-4o:
+    context_window: 128000
+    tier: high
+    supports_extended_thinking: false
+    recommended_compact_threshold_pct: 60
+
+  gpt-4o-mini:
+    context_window: 128000
+    tier: fast
+    supports_extended_thinking: false
+    recommended_compact_threshold_pct: 50
+
+  # ── Google Gemini ──
+  gemini-2.5-pro:
+    context_window: 1000000
+    tier: max
+    supports_extended_thinking: true
+    recommended_compact_threshold_pct: 70
+
+  # ── Meta Llama (local/Ollama) ──
+  llama-3.3-70b:
+    context_window: 128000
+    tier: high
+    supports_extended_thinking: false
+    recommended_compact_threshold_pct: 55
+
+  # ── Mistral ──
+  mistral-large:
+    context_window: 128000
+    tier: high
+    supports_extended_thinking: false
+    recommended_compact_threshold_pct: 55
+
+default:
+  context_window: 128000
+  tier: fast
+  supports_extended_thinking: false
+  recommended_compact_threshold_pct: 50

--- a/scripts/adaptive-strategy-selector.sh
+++ b/scripts/adaptive-strategy-selector.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# adaptive-strategy-selector.sh — Select loading strategy based on model tier
+# Outputs JSON with strategy parameters for the given tier.
+# Usage: ./scripts/adaptive-strategy-selector.sh <max|high|fast>
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+# Read stdin for hook compatibility
+cat /dev/stdin > /dev/null 2>&1 || true
+
+TIER="${1:-${SAVIA_MODEL_TIER:-fast}}"
+
+case "$TIER" in
+  max)
+    cat <<'EOF'
+{"tier":"max","lazy_loading":"relaxed","agent_budget":5000,"autocompact_pct":70,"load_dormant_rules":5,"load_full_sprint":true}
+EOF
+    ;;
+  high)
+    cat <<'EOF'
+{"tier":"high","lazy_loading":"moderate","agent_budget":3000,"autocompact_pct":65,"load_dormant_rules":0,"load_full_sprint":false}
+EOF
+    ;;
+  fast)
+    cat <<'EOF'
+{"tier":"fast","lazy_loading":"aggressive","agent_budget":1000,"autocompact_pct":45,"load_dormant_rules":0,"load_full_sprint":false}
+EOF
+    ;;
+  *)
+    echo "ERROR: Unknown tier '${TIER}'. Valid: max, high, fast" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/model-capability-resolver.sh
+++ b/scripts/model-capability-resolver.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# model-capability-resolver.sh — Resolve model capabilities from YAML registry
+# Outputs SAVIA_* env vars for the given model. Falls back to default.
+# Usage: source <(./scripts/model-capability-resolver.sh [--model name])
+# ─────────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+# Read stdin for hook compatibility
+cat /dev/stdin > /dev/null 2>&1 || true
+
+# ── Determine model (provider-agnostic) ────────────────────────────────────
+MODEL="${SAVIA_MODEL:-${CLAUDE_MODEL_AGENT:-}}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) MODEL="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+MODEL="${MODEL:-default}"
+
+# ── Locate config file ──────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/../config/model-capabilities.yaml"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  # Fallback defaults if config missing
+  echo "export SAVIA_CONTEXT_WINDOW=200000"
+  echo "export SAVIA_MODEL_TIER=fast"
+  echo "export SAVIA_COMPACT_THRESHOLD=50"
+  echo "export SAVIA_SUPPORTS_THINKING=false"
+  echo "export SAVIA_DETECTED_MODEL=default"
+  exit 0
+fi
+
+# ── Parse YAML with grep/sed (no yq dependency) ─────────────────────────────
+# Extract block for the target model, or fall back to default
+extract_field() {
+  local model="$1" field="$2" fallback="$3"
+  local value=""
+  # Try model-specific block first
+  if [ "$model" != "default" ]; then
+    value=$(sed -n "/^  ${model}:/,/^  [a-z]/p" "$CONFIG_FILE" \
+      | grep "    ${field}:" | head -1 \
+      | sed 's/.*: *//' | tr -d '[:space:]')
+  fi
+  # Fall back to default block
+  if [ -z "$value" ]; then
+    value=$(sed -n '/^default:/,/^[a-z]/p' "$CONFIG_FILE" \
+      | grep "  ${field}:" | head -1 \
+      | sed 's/.*: *//' | tr -d '[:space:]')
+  fi
+  echo "${value:-$fallback}"
+}
+
+CONTEXT_WINDOW=$(extract_field "$MODEL" "context_window" "200000")
+TIER=$(extract_field "$MODEL" "tier" "fast")
+COMPACT_PCT=$(extract_field "$MODEL" "recommended_compact_threshold_pct" "50")
+THINKING=$(extract_field "$MODEL" "supports_extended_thinking" "false")
+
+# ── Output env vars ──────────────────────────────────────────────────────────
+echo "export SAVIA_CONTEXT_WINDOW=${CONTEXT_WINDOW}"
+echo "export SAVIA_MODEL_TIER=${TIER}"
+echo "export SAVIA_COMPACT_THRESHOLD=${COMPACT_PCT}"
+echo "export SAVIA_SUPPORTS_THINKING=${THINKING}"
+echo "export SAVIA_DETECTED_MODEL=${MODEL}"

--- a/tests/structure/test-model-capabilities.bats
+++ b/tests/structure/test-model-capabilities.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# Tests for Era 100 — Context Window Adaptive per Model
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/../.." || exit 1
+  ROOT="$PWD"
+}
+
+@test "config/model-capabilities.yaml exists" {
+  [ -f "$ROOT/config/model-capabilities.yaml" ]
+}
+
+@test "model-capabilities.yaml is valid YAML (basic structure)" {
+  run grep -c "^models:" "$ROOT/config/model-capabilities.yaml"
+  [ "$output" = "1" ]
+  run grep -c "^default:" "$ROOT/config/model-capabilities.yaml"
+  [ "$output" = "1" ]
+}
+
+@test "model-capabilities.yaml contains opus, sonnet, haiku" {
+  grep -q "claude-opus-4-6:" "$ROOT/config/model-capabilities.yaml"
+  grep -q "claude-sonnet-4-6:" "$ROOT/config/model-capabilities.yaml"
+  grep -q "claude-haiku-4-5-20251001:" "$ROOT/config/model-capabilities.yaml"
+}
+
+@test "model-capability-resolver.sh exists and is executable" {
+  [ -x "$ROOT/scripts/model-capability-resolver.sh" ]
+}
+
+@test "resolver outputs correct vars for opus (1M, max)" {
+  run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model claude-opus-4-6"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=1000000"
+  echo "$output" | grep -q "SAVIA_MODEL_TIER=max"
+  echo "$output" | grep -q "SAVIA_COMPACT_THRESHOLD=70"
+  echo "$output" | grep -q "SAVIA_SUPPORTS_THINKING=true"
+}
+
+@test "resolver outputs correct vars for haiku (200K, fast)" {
+  run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model claude-haiku-4-5-20251001"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=200000"
+  echo "$output" | grep -q "SAVIA_MODEL_TIER=fast"
+  echo "$output" | grep -q "SAVIA_COMPACT_THRESHOLD=45"
+  echo "$output" | grep -q "SAVIA_SUPPORTS_THINKING=false"
+}
+
+@test "resolver outputs correct vars for sonnet (1M, high)" {
+  run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model claude-sonnet-4-6"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=1000000"
+  echo "$output" | grep -q "SAVIA_MODEL_TIER=high"
+  echo "$output" | grep -q "SAVIA_COMPACT_THRESHOLD=65"
+}
+
+@test "resolver falls back to default for unknown model" {
+  run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model unknown-model-xyz"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=200000"
+  echo "$output" | grep -q "SAVIA_MODEL_TIER=fast"
+  echo "$output" | grep -q "SAVIA_COMPACT_THRESHOLD=50"
+}
+
+@test "adaptive-strategy-selector.sh exists and is executable" {
+  [ -x "$ROOT/scripts/adaptive-strategy-selector.sh" ]
+}
+
+@test "strategy selector returns valid JSON for tier max" {
+  run bash -c "echo '' | $ROOT/scripts/adaptive-strategy-selector.sh max"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; json.load(sys.stdin)"
+  echo "$output" | grep -q '"agent_budget":5000'
+  echo "$output" | grep -q '"load_full_sprint":true'
+}
+
+@test "strategy selector returns valid JSON for tier high" {
+  run bash -c "echo '' | $ROOT/scripts/adaptive-strategy-selector.sh high"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; json.load(sys.stdin)"
+  echo "$output" | grep -q '"agent_budget":3000'
+}
+
+@test "strategy selector returns valid JSON for tier fast" {
+  run bash -c "echo '' | $ROOT/scripts/adaptive-strategy-selector.sh fast"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; json.load(sys.stdin)"
+  echo "$output" | grep -q '"agent_budget":1000'
+}
+
+@test "strategy selector fails gracefully for unknown tier" {
+  run bash -c "echo '' | $ROOT/scripts/adaptive-strategy-selector.sh banana 2>&1"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "unknown tier"
+}

--- a/tests/structure/test-model-capabilities.bats
+++ b/tests/structure/test-model-capabilities.bats
@@ -56,7 +56,7 @@ setup() {
 @test "resolver falls back to default for unknown model" {
   run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model unknown-model-xyz"
   [ "$status" -eq 0 ]
-  echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=200000"
+  echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=128000"
   echo "$output" | grep -q "SAVIA_MODEL_TIER=fast"
   echo "$output" | grep -q "SAVIA_COMPACT_THRESHOLD=50"
 }


### PR DESCRIPTION
## Summary
- **Era 100.0** — Dynamic context window detection for any LLM provider (Claude, GPT, Gemini, Llama, Mistral)
- `config/model-capabilities.yaml`: Provider-agnostic model registry with context window, tier, and compact threshold
- `scripts/model-capability-resolver.sh`: Parses registry, exports `SAVIA_CONTEXT_WINDOW`, `SAVIA_MODEL_TIER`, `SAVIA_COMPACT_THRESHOLD`
- `scripts/adaptive-strategy-selector.sh`: Per-tier strategy (lazy loading, agent budget, autocompact) as JSON
- `session-init.sh`: Model detection as first boot step (no eval, no external deps)
- 13 new BATS tests — all 59 pass

## Test plan
- [x] `bats tests/structure/*.bats` — 59/59 pass
- [x] Resolver correctly detects opus (1M/max), sonnet (1M/high), haiku (200K/fast)
- [x] Unknown models fall back to 128K/fast
- [x] Strategy selector outputs valid JSON for all tiers
- [x] No eval in hooks (safety check passes)
- [x] All files ≤150 lines
- [x] CHANGELOG updated with v2.84.0 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)