### PR TITLE
feat(hooks): context sync persistente — session snapshot save/load

### DIFF
--- a/.claude/hooks/session-end-snapshot.sh
+++ b/.claude/hooks/session-end-snapshot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# session-end-snapshot.sh — Save context snapshot at session end
+# Hook: Stop event. Runs when Claude session ends.
+# ─────────────────────────────────────────────────────────────────
+set -uo pipefail
+cat /dev/stdin > /dev/null 2>&1 || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SCRIPT_DIR}/.."
+
+SNAPSHOT_SCRIPT=""
+for spath in "$ROOT/scripts/context-snapshot.sh" "./scripts/context-snapshot.sh"; do
+  if [ -x "$spath" ]; then
+    SNAPSHOT_SCRIPT="$spath"
+    break
+  fi
+done
+
+if [ -n "$SNAPSHOT_SCRIPT" ]; then
+  echo '' | bash "$SNAPSHOT_SCRIPT" save > /dev/null 2>&1 || true
+fi

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 set -uo pipefail
-# session-init.sh — Auto-carga de contexto al inicio de sesión
-# Usado por: settings.json (SessionStart hook)
-# v0.42.0 — Arranque garantizado: sin red, sin jq, fallo = salida limpia
-#
-# PRINCIPIO: Savia SIEMPRE arranca. Este script NUNCA puede bloquear el inicio.
-# - Sin llamadas de red (ni gh api, ni curl, ni npx)
-# - Sin dependencias externas (ni jq) — solo bash puro
-# - Timeout global de 5s como safety net
-# - Cualquier error → salida limpia con contexto mínimo
-
-set -o pipefail
+# session-init.sh — Arranque garantizado: sin red, sin jq, fallo = salida limpia
 
 # ── Safety net: timeout global ────────────────────────────────────────────────
 SCRIPT_START=$SECONDS
@@ -32,6 +22,15 @@ for rpath in "$HOME/claude/scripts/model-capability-resolver.sh" "./scripts/mode
     while IFS= read -r _l; do
       case "$_l" in export\ SAVIA_*) declare "${_l#export }" 2>/dev/null ;; esac
     done < <(echo '' | bash "$rpath" 2>/dev/null || true)
+    break
+  fi
+done
+
+# ── Context snapshot recovery (Era 100.2) ───────────────────────────────────
+SNAPSHOT_PROJ=""
+for spath in "$HOME/claude/scripts/context-snapshot.sh" "./scripts/context-snapshot.sh"; do
+  if [ -x "$spath" ]; then
+    SNAPSHOT_PROJ=$(echo '' | bash "$spath" load 2>/dev/null | grep -o '"project":"[^"]*"' | cut -d'"' -f4) || true
     break
   fi
 done
@@ -87,9 +86,8 @@ else
   ITEMS+=("Sin perfil — /profile-setup")
 fi
 
-# ── Rama git (local, sin red) ────────────────────────────────────────────────
+# ── Rama git ──
 check_timeout
-# FIX: Try multiple possible locations for the repo
 BRANCH=""
 for repo_path in "$HOME/claude" "$HOME/.claude" "." "$PWD"; do
   if [ -d "$repo_path/.git" ] 2>/dev/null; then
@@ -100,7 +98,12 @@ done
 BRANCH="${BRANCH:-N/A}"
 ITEMS+=("Rama: $BRANCH")
 
-# ── Company Savia inbox (filesystem-only, no network) ────────────────────────
+# ── Recovered context from last session (Era 100.2) ──
+if [ -n "$SNAPSHOT_PROJ" ] && [ "$SNAPSHOT_PROJ" != "none" ]; then
+  ITEMS+=("Contexto recuperado: $SNAPSHOT_PROJ")
+fi
+
+# ── Company Savia inbox ──
 check_timeout
 COMPANY_CONFIG="$HOME/.pm-workspace/company-repo"
 if [ -f "$COMPANY_CONFIG" ]; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -124,6 +124,13 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-end-snapshot.sh",
+            "async": true,
+            "timeout": 5,
+            "statusMessage": "Guardando snapshot de sesión..."
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-review.sh",
             "timeout": 30,
             "statusMessage": "Revisando ficheros staged..."

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ audit-report-*
 
 # Backups
 *.backup
+.claude/context-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.86.0] — 2026-03-14
+
+Era 100.2 — Context Sync Persistente. Session snapshot save/load between sessions.
+
+### Added
+- **scripts/context-snapshot.sh**: Save/load session context (project, branch, sprint, last activity) as JSON. 24h TTL, auto-expired
+- **.claude/hooks/session-end-snapshot.sh**: Stop hook that auto-saves snapshot at session end (async, 5s timeout)
+- **tests/structure/test-context-snapshot.bats**: 7 BATS tests for snapshot save/load/status
+
+### Changed
+- **session-init.sh**: Loads fresh snapshot at startup, shows recovered project in init output
+- **.claude/settings.json**: Added session-end-snapshot hook to Stop event
+- **.gitignore**: Added `.claude/context-cache/`
+
 ## [2.85.0] — 2026-03-14
 
 Era 100.1 — Lazy Loading of Rules Domain. Tier-based rule classification and manifest.
@@ -3471,6 +3485,7 @@ Initial public release of PM-Workspace.
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0...v0.2.0
+[2.86.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.85.0...v2.86.0
 [2.85.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.84.0...v2.85.0
 [2.84.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.83.0...v2.84.0
 [2.83.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.82.0...v2.83.0

--- a/scripts/context-snapshot.sh
+++ b/scripts/context-snapshot.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# context-snapshot.sh — Save/load session context between sessions
+# Saves: active project, branch, sprint, last commands, decisions.
+# Usage: ./scripts/context-snapshot.sh save|load|status
+# ─────────────────────────────────────────────────────────────────
+set -uo pipefail
+cat /dev/stdin > /dev/null 2>&1 || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SCRIPT_DIR}/.."
+CACHE_DIR="${ROOT}/.claude/context-cache"
+SNAPSHOT="${CACHE_DIR}/last-session.json"
+TTL_HOURS=24
+
+mkdir -p "$CACHE_DIR" 2>/dev/null || true
+
+# ── Check snapshot age ──
+is_fresh() {
+  [ -f "$SNAPSHOT" ] || return 1
+  local now file_time age_hours
+  now=$(date +%s)
+  file_time=$(date -r "$SNAPSHOT" +%s 2>/dev/null || stat -c %Y "$SNAPSHOT" 2>/dev/null || echo 0)
+  age_hours=$(( (now - file_time) / 3600 ))
+  [ "$age_hours" -lt "$TTL_HOURS" ]
+}
+
+# ── Save snapshot ──
+do_save() {
+  local branch project sprint
+  branch=$(git -C "$ROOT" branch --show-current 2>/dev/null || echo "unknown")
+  project=$(basename "$(grep -l 'CLAUDE.md' "$ROOT"/projects/*/CLAUDE.md 2>/dev/null | head -1 | xargs dirname 2>/dev/null)" 2>/dev/null || echo "none")
+  sprint=$(date +%Y-S%V)
+
+  # Last 5 git commits as proxy for "last commands"
+  local last_commits
+  last_commits=$(git -C "$ROOT" log --oneline -5 2>/dev/null | sed 's/"/\\"/g' | tr '\n' '|' | sed 's/|$//')
+
+  cat > "$SNAPSHOT" <<EOJSON
+{
+  "timestamp": "$(date -Iseconds)",
+  "branch": "${branch}",
+  "project": "${project}",
+  "sprint": "${sprint}",
+  "last_activity": "${last_commits}",
+  "model_tier": "${SAVIA_MODEL_TIER:-unknown}",
+  "context_window": ${SAVIA_CONTEXT_WINDOW:-128000}
+}
+EOJSON
+  echo "Snapshot saved: $SNAPSHOT"
+}
+
+# ── Load snapshot ──
+do_load() {
+  if ! is_fresh; then
+    echo '{"status":"stale","message":"No fresh snapshot (>24h or missing)"}'
+    return 0
+  fi
+  cat "$SNAPSHOT"
+}
+
+# ── Status ──
+do_status() {
+  if [ ! -f "$SNAPSHOT" ]; then
+    echo "No snapshot found"
+    return 0
+  fi
+  local age_hours now file_time
+  now=$(date +%s)
+  file_time=$(date -r "$SNAPSHOT" +%s 2>/dev/null || stat -c %Y "$SNAPSHOT" 2>/dev/null || echo 0)
+  age_hours=$(( (now - file_time) / 3600 ))
+  echo "Snapshot: ${SNAPSHOT}"
+  echo "Age: ${age_hours}h (TTL: ${TTL_HOURS}h)"
+  echo "Fresh: $(is_fresh && echo yes || echo no)"
+}
+
+case "${1:-status}" in
+  save) do_save ;;
+  load) do_load ;;
+  status) do_status ;;
+  *) echo "Usage: $0 save|load|status" >&2; exit 1 ;;
+esac

--- a/tests/structure/test-context-snapshot.bats
+++ b/tests/structure/test-context-snapshot.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# Tests for Era 100.2 — Context Sync Persistente
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/../.." || exit 1
+  ROOT="$PWD"
+}
+
+@test "context-snapshot.sh exists and is executable" {
+  [ -x "$ROOT/scripts/context-snapshot.sh" ]
+}
+
+@test "session-end-snapshot.sh hook exists and is executable" {
+  [ -x "$ROOT/.claude/hooks/session-end-snapshot.sh" ]
+}
+
+@test "snapshot save produces valid JSON" {
+  run bash -c "echo '' | $ROOT/scripts/context-snapshot.sh save"
+  [ "$status" -eq 0 ]
+  # Verify the file was created
+  [ -f "$ROOT/.claude/context-cache/last-session.json" ]
+  python3 -c "import json; json.load(open('$ROOT/.claude/context-cache/last-session.json'))"
+}
+
+@test "snapshot load returns JSON with required fields" {
+  # Ensure snapshot exists from previous test
+  echo '' | bash "$ROOT/scripts/context-snapshot.sh" save > /dev/null 2>&1
+  run bash -c "echo '' | $ROOT/scripts/context-snapshot.sh load"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+assert 'branch' in d, 'missing branch'
+assert 'project' in d, 'missing project'
+assert 'timestamp' in d, 'missing timestamp'
+print('OK')
+"
+}
+
+@test "snapshot status shows age info" {
+  echo '' | bash "$ROOT/scripts/context-snapshot.sh" save > /dev/null 2>&1
+  run bash -c "echo '' | $ROOT/scripts/context-snapshot.sh status"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Age:"
+  echo "$output" | grep -q "Fresh:"
+}
+
+@test "settings.json has session-end-snapshot hook in Stop" {
+  run python3 -c "
+import json
+d = json.load(open('$ROOT/.claude/settings.json'))
+hooks = d['hooks']['Stop'][0]['hooks']
+names = [h['command'] for h in hooks]
+found = any('session-end-snapshot' in n for n in names)
+assert found, 'session-end-snapshot hook not in Stop'
+print('OK')
+"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+}
+
+@test "context-cache directory is gitignored" {
+  run bash -c "grep -q 'context-cache' $ROOT/.gitignore"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- **Era 100.2** — Auto-saves session context (project, branch, sprint, last activity) as JSON at session end
- Loads fresh snapshot (<24h TTL) at next startup for seamless context recovery
- Async Stop hook with 5s timeout — never blocks session exit
- `.claude/context-cache/` gitignored
- 7 new BATS tests, all 74 pass

## Test plan
- [x] `bats tests/structure/*.bats` — 74/74 pass
- [x] Snapshot save produces valid JSON
- [x] Snapshot load returns fields (branch, project, timestamp)
- [x] Snapshot status shows age and freshness
- [x] Hook registered in settings.json Stop event
- [x] context-cache in .gitignore
- [x] CHANGELOG updated with v2.86.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)