### PR TITLE
feat(commands): add /context-status command for context metrics

### DIFF
--- a/.claude/commands/context-status.md
+++ b/.claude/commands/context-status.md
@@ -1,0 +1,42 @@
+---
+name: context-status
+description: "Show context window usage, model tier, and optimization recommendations"
+model: haiku
+context_cost: low
+allowed-tools: [Read, Bash, Glob]
+argument-hint: "[--json]"
+---
+
+# /context-status
+
+Show current context window status and recommendations.
+
+## Steps
+
+1. Read SAVIA_* env vars (set by model-capability-resolver at session start)
+2. Count loaded rules, skills, and agents in current session
+3. Calculate estimated token usage
+4. Show optimization recommendation
+
+## Output format
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📊 Context Status
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Model ................ {SAVIA_DETECTED_MODEL}
+  Context window ....... {SAVIA_CONTEXT_WINDOW} tokens
+  Tier ................. {SAVIA_MODEL_TIER}
+  Compact threshold .... {SAVIA_COMPACT_THRESHOLD}%
+  Strategy ............. {lazy_loading level}
+  Recommendation ....... {action}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If `--json` argument, output as JSON instead.
+
+## Recommendations
+
+- If tier=fast: "Consider /compact frequently — 200K window fills fast"
+- If tier=high: "Normal operation — /compact at ~65%"
+- If tier=max: "Full capacity — /compact only if performance degrades"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.87.0] — 2026-03-14
+
+Era 100.3 — Context metrics command and session snapshot integration.
+
+### Added
+- **.claude/commands/context-status.md**: Lightweight command (Haiku) showing model, context window, tier, compact threshold, strategy, and recommendations
+
 ## [2.86.0] — 2026-03-14
 
 Era 100.2 — Context Sync Persistente. Session snapshot save/load between sessions.
@@ -3485,6 +3492,7 @@ Initial public release of PM-Workspace.
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0...v0.2.0
+[2.87.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.86.0...v2.87.0
 [2.86.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.85.0...v2.86.0
 [2.85.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.84.0...v2.85.0
 [2.84.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.83.0...v2.84.0


### PR DESCRIPTION
## Summary
- **Era 100.3** — New `/context-status` command showing model, context window, tier, compact threshold, and recommendations
- Lightweight (Haiku model, low context cost)
- Integrates with SAVIA_* env vars from Era 100.0
- 74/74 BATS tests pass

## Test plan
- [x] `bats tests/structure/*.bats` — 74/74 pass
- [x] Command file ≤150 lines
- [x] CHANGELOG updated with v2.87.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)