### PR TITLE
feat(scripts): backlog sovereignty — markdown-based PBI management

### DIFF
--- a/.claude/templates/backlog/config-template.yaml
+++ b/.claude/templates/backlog/config-template.yaml
@@ -1,0 +1,12 @@
+# Backlog configuration
+project: "{PROJECT}"
+created: "{DATE}"
+states: [New, Active, Resolved, Closed]
+types: [User Story, Bug, Tech Debt, Spike]
+priorities: [1-Critical, 2-High, 3-Medium, 4-Low]
+id_prefix: "PBI"
+id_counter: 0
+sync:
+  provider: ""
+  auto_sync: false
+  last_sync: ""

--- a/.claude/templates/backlog/pbi-template.md
+++ b/.claude/templates/backlog/pbi-template.md
@@ -1,0 +1,33 @@
+---
+id: PBI-{ID}
+title: "{TITLE}"
+type: User Story
+state: New
+priority: 3-Medium
+estimation_sp: 0
+estimation_hours: 0
+assigned_to: ""
+sprint: ""
+tags: []
+azure_devops_id: ""
+jira_id: ""
+github_issue_id: ""
+created: {DATE}
+updated: {DATE}
+---
+
+## Descripcion
+
+{DESCRIPTION}
+
+## Criterios de Aceptacion
+
+- [ ] CA-1: ...
+
+## Tasks
+
+| Task | Estado | Asignado | Horas |
+|------|--------|----------|-------|
+
+## Notas
+

--- a/.claude/templates/backlog/sprint-meta-template.yaml
+++ b/.claude/templates/backlog/sprint-meta-template.yaml
@@ -1,0 +1,8 @@
+# Sprint metadata
+sprint_id: "{SPRINT_ID}"
+goal: "{GOAL}"
+start_date: "{START}"
+end_date: "{END}"
+capacity_hours: 0
+team_size: 0
+status: planning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.88.0] — 2026-03-14
+
+Era 107.1 — Backlog Sovereignty: markdown-based backlog as source of truth.
+
+### Added
+- **scripts/backlog-init.sh**: Initialize backlog structure for any project (config, sprint folder, PBI directory)
+- **scripts/backlog-pbi-crud.sh**: Create, read, update, list, archive PBIs as markdown files with YAML frontmatter
+- **scripts/backlog-query.sh**: Query PBIs by state, sprint, assigned, priority, type. Outputs table, JSON, or count
+- **.claude/templates/backlog/**: PBI template, sprint-meta template, config template
+- **tests/structure/test-backlog-structure.bats**: 11 BATS tests for backlog init, CRUD, and query
+
 ## [2.87.0] — 2026-03-14
 
 Era 100.3 — Context metrics command and session snapshot integration.
@@ -3492,6 +3503,7 @@ Initial public release of PM-Workspace.
 [0.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v0.1.0...v0.2.0
+[2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
 [2.87.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.86.0...v2.87.0
 [2.86.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.85.0...v2.86.0
 [2.85.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.84.0...v2.85.0

--- a/scripts/backlog-init.sh
+++ b/scripts/backlog-init.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# backlog-init.sh — Initialize local backlog structure for a project
+# Usage: ./scripts/backlog-init.sh <project-path>
+# ─────────────────────────────────────────────────────────────────
+set -uo pipefail
+cat /dev/stdin > /dev/null 2>&1 || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SCRIPT_DIR}/.."
+TEMPLATES="${ROOT}/.claude/templates/backlog"
+
+PROJECT_PATH="${1:-}"
+if [ -z "$PROJECT_PATH" ]; then
+  echo "Usage: $0 <project-path>" >&2
+  echo "Example: $0 projects/my-project" >&2
+  exit 1
+fi
+
+# Resolve relative to ROOT if needed
+[[ "$PROJECT_PATH" != /* ]] && PROJECT_PATH="${ROOT}/${PROJECT_PATH}"
+
+if [ ! -d "$PROJECT_PATH" ]; then
+  echo "Error: Project directory not found: $PROJECT_PATH" >&2
+  exit 1
+fi
+
+BACKLOG="${PROJECT_PATH}/backlog"
+
+if [ -d "$BACKLOG" ]; then
+  echo "Backlog already exists: ${BACKLOG}"
+  exit 0
+fi
+
+# ── Create structure ──
+mkdir -p "$BACKLOG/pbi" "$BACKLOG/sprints" "$BACKLOG/archive"
+
+# ── Generate config from template ──
+PROJECT_NAME=$(basename "$PROJECT_PATH")
+DATE=$(date +%Y-%m-%d)
+
+sed -e "s/{PROJECT}/${PROJECT_NAME}/g" \
+    -e "s/{DATE}/${DATE}/g" \
+    "$TEMPLATES/config-template.yaml" > "$BACKLOG/_config.yaml"
+
+# ── Create current sprint pointer ──
+SPRINT_ID=$(date +%Y-S%V)
+mkdir -p "$BACKLOG/sprints/${SPRINT_ID}"
+sed -e "s/{SPRINT_ID}/${SPRINT_ID}/g" \
+    -e "s/{GOAL}/Sprint goal TBD/g" \
+    -e "s/{START}/${DATE}/g" \
+    -e "s/{END}/$(date -d '+14 days' +%Y-%m-%d 2>/dev/null || date -v+14d +%Y-%m-%d 2>/dev/null || echo 'TBD')/g" \
+    "$TEMPLATES/sprint-meta-template.yaml" > "$BACKLOG/sprints/${SPRINT_ID}/sprint-meta.yaml"
+
+echo "# Sprint ${SPRINT_ID} Items" > "$BACKLOG/sprints/${SPRINT_ID}/items.md"
+echo "" >> "$BACKLOG/sprints/${SPRINT_ID}/items.md"
+echo "| PBI | Title | State | Assigned | SP |" >> "$BACKLOG/sprints/${SPRINT_ID}/items.md"
+echo "|-----|-------|-------|----------|----|" >> "$BACKLOG/sprints/${SPRINT_ID}/items.md"
+
+echo "${SPRINT_ID}" > "$BACKLOG/_current-sprint.md"
+
+echo "Backlog initialized: ${BACKLOG}"
+echo "  Config: _config.yaml"
+echo "  Sprint: sprints/${SPRINT_ID}/"
+echo "  PBIs:   pbi/ (empty)"

--- a/scripts/backlog-pbi-crud.sh
+++ b/scripts/backlog-pbi-crud.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# backlog-pbi-crud.sh — Create, read, update, archive PBIs in local backlog
+# Usage: ./scripts/backlog-pbi-crud.sh <create|read|update|archive|list> [options]
+# ─────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+cat /dev/stdin > /dev/null 2>&1 || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SCRIPT_DIR}/.."
+TEMPLATES="${ROOT}/.claude/templates/backlog"
+
+find_backlog() {
+  local project="${1:-}"
+  local path=""
+  if [ -n "$project" ]; then
+    path="${ROOT}/projects/${project}/backlog"
+  else
+    for p in "${ROOT}"/projects/*/backlog; do
+      [ -d "$p" ] && path="$p" && break
+    done
+  fi
+  [ -d "$path" ] && echo "$path" || { echo "Error: No backlog found" >&2; exit 1; }
+}
+
+next_id() {
+  local config="$1/_config.yaml"
+  local counter
+  counter=$(grep 'id_counter:' "$config" 2>/dev/null | grep -oP '\d+' || echo "0")
+  counter=$((counter + 1))
+  sed -i "s/id_counter:.*/id_counter: ${counter}/" "$config"
+  printf "%03d" "$counter"
+}
+
+cmd_create() {
+  local project="" title="" type="User Story" priority="3-Medium"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --project) project="$2"; shift 2 ;;
+      --title) title="$2"; shift 2 ;;
+      --type) type="$2"; shift 2 ;;
+      --priority) priority="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -z "$title" ] && { echo "Error: --title required" >&2; exit 1; }
+
+  local backlog; backlog=$(find_backlog "$project")
+  local id; id=$(next_id "$backlog")
+  local slug; slug=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-' | head -c 40)
+  local date; date=$(date +%Y-%m-%d)
+  local file="${backlog}/pbi/PBI-${id}-${slug}.md"
+
+  sed -e "s/{ID}/${id}/g" -e "s/{TITLE}/${title}/g" \
+      -e "s/{DATE}/${date}/g" -e "s/{DESCRIPTION}/TBD/g" \
+      "$TEMPLATES/pbi-template.md" > "$file"
+  # Set type and priority
+  sed -i "s/type: User Story/type: ${type}/" "$file"
+  sed -i "s/priority: 3-Medium/priority: ${priority}/" "$file"
+
+  echo "Created: PBI-${id} — ${title}"
+  echo "File: ${file}"
+}
+
+cmd_list() {
+  local project=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in --project) project="$2"; shift 2 ;; *) shift ;; esac
+  done
+  local backlog; backlog=$(find_backlog "$project")
+  echo "| ID | Title | State | Priority | Sprint |"
+  echo "|----|-------|-------|----------|--------|"
+  for f in "$backlog"/pbi/PBI-*.md; do
+    [ -f "$f" ] || continue
+    local id title state priority sprint
+    id=$(grep '^id:' "$f" | head -1 | sed 's/id: *//')
+    title=$(grep '^title:' "$f" | head -1 | sed 's/title: *"//;s/"$//')
+    state=$(grep '^state:' "$f" | head -1 | sed 's/state: *//')
+    priority=$(grep '^priority:' "$f" | head -1 | sed 's/priority: *//')
+    sprint=$(grep '^sprint:' "$f" | head -1 | sed 's/sprint: *"//;s/"$//')
+    echo "| $id | $title | $state | $priority | $sprint |"
+  done
+}
+
+cmd_read() {
+  local pbi_id="${1:-}" project=""
+  shift 2>/dev/null || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in --project) project="$2"; shift 2 ;; *) shift ;; esac
+  done
+  [ -z "$pbi_id" ] && { echo "Error: PBI ID required" >&2; exit 1; }
+  local backlog; backlog=$(find_backlog "$project")
+  local file; file=$(find "$backlog/pbi" -name "PBI-${pbi_id}*" 2>/dev/null | head -1)
+  [ -z "$file" ] && { echo "Error: PBI-${pbi_id} not found" >&2; exit 1; }
+  cat "$file"
+}
+
+cmd_update() {
+  local pbi_id="" field="" value="" project=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --id) pbi_id="$2"; shift 2 ;;
+      --field) field="$2"; shift 2 ;;
+      --value) value="$2"; shift 2 ;;
+      --project) project="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  [ -z "$pbi_id" ] || [ -z "$field" ] || [ -z "$value" ] && \
+    { echo "Error: --id, --field, --value required" >&2; exit 1; }
+  local backlog; backlog=$(find_backlog "$project")
+  local file; file=$(find "$backlog/pbi" -name "PBI-${pbi_id}*" 2>/dev/null | head -1)
+  [ -z "$file" ] && { echo "Error: PBI-${pbi_id} not found" >&2; exit 1; }
+  sed -i "s/^${field}:.*/${field}: ${value}/" "$file"
+  sed -i "s/^updated:.*/updated: $(date +%Y-%m-%d)/" "$file"
+  echo "Updated PBI-${pbi_id}: ${field} = ${value}"
+}
+
+cmd_archive() {
+  local pbi_id="" project=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in --id) pbi_id="$2"; shift 2 ;; --project) project="$2"; shift 2 ;; *) shift ;; esac
+  done
+  [ -z "$pbi_id" ] && { echo "Error: --id required" >&2; exit 1; }
+  local backlog; backlog=$(find_backlog "$project")
+  local file; file=$(find "$backlog/pbi" -name "PBI-${pbi_id}*" 2>/dev/null | head -1)
+  [ -z "$file" ] && { echo "Error: PBI-${pbi_id} not found" >&2; exit 1; }
+  mkdir -p "$backlog/archive"
+  mv "$file" "$backlog/archive/"
+  echo "Archived: PBI-${pbi_id} → archive/"
+}
+
+case "${1:-help}" in
+  create) shift; cmd_create "$@" ;;
+  list) shift; cmd_list "$@" ;;
+  read) shift; cmd_read "$@" ;;
+  update) shift; cmd_update "$@" ;;
+  archive) shift; cmd_archive "$@" ;;
+  *) echo "Usage: $0 <create|list|read|update|archive> [options]" >&2; exit 1 ;;
+esac

--- a/scripts/backlog-query.sh
+++ b/scripts/backlog-query.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# backlog-query.sh — Query local backlog PBIs by frontmatter fields
+# Usage: ./scripts/backlog-query.sh [options]
+# ─────────────────────────────────────────────────────────────────
+set -uo pipefail
+cat /dev/stdin > /dev/null 2>&1 || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SCRIPT_DIR}/.."
+
+PROJECT=""
+STATE="" SPRINT="" ASSIGNED="" PRIORITY="" TYPE="" FORMAT="table"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT="$2"; shift 2 ;;
+    --state) STATE="$2"; shift 2 ;;
+    --sprint) SPRINT="$2"; shift 2 ;;
+    --assigned) ASSIGNED="$2"; shift 2 ;;
+    --priority) PRIORITY="$2"; shift 2 ;;
+    --type) TYPE="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# ── Find backlog ──
+BACKLOG=""
+if [ -n "$PROJECT" ]; then
+  BACKLOG="${ROOT}/projects/${PROJECT}/backlog"
+else
+  for p in "${ROOT}"/projects/*/backlog; do
+    [ -d "$p" ] && BACKLOG="$p" && break
+  done
+fi
+[ -d "$BACKLOG" ] || { echo "Error: No backlog found" >&2; exit 1; }
+
+# ── Extract field from frontmatter ──
+get_field() {
+  local file="$1" field="$2"
+  grep "^${field}:" "$file" 2>/dev/null | head -1 | sed "s/${field}: *//;s/^\"//;s/\"$//"
+}
+
+# ── Collect matching PBIs ──
+RESULTS=()
+for f in "$BACKLOG"/pbi/PBI-*.md; do
+  [ -f "$f" ] || continue
+  [ -n "$STATE" ] && [[ "$(get_field "$f" state)" != "$STATE" ]] && continue
+  [ -n "$SPRINT" ] && [[ "$(get_field "$f" sprint)" != "$SPRINT" ]] && continue
+  [ -n "$ASSIGNED" ] && [[ "$(get_field "$f" assigned_to)" != "$ASSIGNED" ]] && continue
+  [ -n "$PRIORITY" ] && [[ "$(get_field "$f" priority)" != "$PRIORITY" ]] && continue
+  [ -n "$TYPE" ] && [[ "$(get_field "$f" type)" != "$TYPE" ]] && continue
+  RESULTS+=("$f")
+done
+
+# ── Output ──
+if [ "$FORMAT" = "json" ]; then
+  echo "["
+  first=true
+  for f in "${RESULTS[@]:-}"; do
+    [ -z "$f" ] && continue
+    $first && first=false || echo ","
+    printf '  {"id":"%s","title":"%s","state":"%s","priority":"%s","sprint":"%s","assigned":"%s"}' \
+      "$(get_field "$f" id)" "$(get_field "$f" title)" "$(get_field "$f" state)" \
+      "$(get_field "$f" priority)" "$(get_field "$f" sprint)" "$(get_field "$f" assigned_to)"
+  done
+  echo ""
+  echo "]"
+elif [ "$FORMAT" = "count" ]; then
+  echo "${#RESULTS[@]}"
+else
+  echo "| ID | Title | State | Priority | Sprint | Assigned |"
+  echo "|----|-------|-------|----------|--------|----------|"
+  for f in "${RESULTS[@]:-}"; do
+    [ -z "$f" ] && continue
+    printf "| %s | %s | %s | %s | %s | %s |\n" \
+      "$(get_field "$f" id)" "$(get_field "$f" title)" "$(get_field "$f" state)" \
+      "$(get_field "$f" priority)" "$(get_field "$f" sprint)" "$(get_field "$f" assigned_to)"
+  done
+  echo ""
+  echo "Total: ${#RESULTS[@]} items"
+fi

--- a/tests/structure/test-backlog-structure.bats
+++ b/tests/structure/test-backlog-structure.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# Tests for Era 107.1 — Backlog Sovereignty: Structure and CRUD
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/../.." || exit 1
+  ROOT="$PWD"
+  TEST_PROJECT="$ROOT/projects/savia-web"
+}
+
+@test "backlog-init.sh exists and is executable" {
+  [ -x "$ROOT/scripts/backlog-init.sh" ]
+}
+
+@test "backlog-pbi-crud.sh exists and is executable" {
+  [ -x "$ROOT/scripts/backlog-pbi-crud.sh" ]
+}
+
+@test "backlog-query.sh exists and is executable" {
+  [ -x "$ROOT/scripts/backlog-query.sh" ]
+}
+
+@test "PBI template exists" {
+  [ -f "$ROOT/.claude/templates/backlog/pbi-template.md" ]
+}
+
+@test "sprint meta template exists" {
+  [ -f "$ROOT/.claude/templates/backlog/sprint-meta-template.yaml" ]
+}
+
+@test "config template exists" {
+  [ -f "$ROOT/.claude/templates/backlog/config-template.yaml" ]
+}
+
+@test "backlog-init creates structure" {
+  run bash -c "echo '' | $ROOT/scripts/backlog-init.sh $TEST_PROJECT"
+  [ "$status" -eq 0 ]
+  [ -d "$TEST_PROJECT/backlog/pbi" ]
+  [ -d "$TEST_PROJECT/backlog/sprints" ]
+  [ -f "$TEST_PROJECT/backlog/_config.yaml" ]
+  [ -f "$TEST_PROJECT/backlog/_current-sprint.md" ]
+}
+
+@test "PBI create generates valid file" {
+  run bash -c "echo '' | $ROOT/scripts/backlog-pbi-crud.sh create --project savia-web --title 'Test item' --type Bug"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Created: PBI-"
+  local pbi_file
+  pbi_file=$(find "$TEST_PROJECT/backlog/pbi" -name "PBI-*test-item*" | head -1)
+  [ -f "$pbi_file" ]
+  grep -q "type: Bug" "$pbi_file"
+}
+
+@test "PBI list shows created items" {
+  echo '' | bash "$ROOT/scripts/backlog-pbi-crud.sh" create --project savia-web --title "List test" 2>/dev/null
+  run bash -c "echo '' | $ROOT/scripts/backlog-pbi-crud.sh list --project savia-web"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "List test"
+}
+
+@test "backlog-query with format count works" {
+  run bash -c "echo '' | $ROOT/scripts/backlog-query.sh --project savia-web --format count"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "backlog-query JSON format is valid" {
+  run bash -c "echo '' | $ROOT/scripts/backlog-query.sh --project savia-web --format json"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; json.load(sys.stdin)"
+}


### PR DESCRIPTION
## Summary
- **Era 107.1** — Markdown-based backlog as source of truth (vendor-agnostic, offline-first)
- `scripts/backlog-init.sh`: Initialize backlog structure for any project
- `scripts/backlog-pbi-crud.sh`: Create, read, update, list, archive PBIs with YAML frontmatter
- `scripts/backlog-query.sh`: Query PBIs by state/sprint/assigned/priority/type (table, JSON, count)
- `.claude/templates/backlog/`: PBI, sprint-meta, and config templates
- 11 new BATS tests, all 85 pass

## Test plan
- [x] `bats tests/structure/*.bats` — 85/85 pass
- [x] Init creates structure with config, sprint folder, current-sprint pointer
- [x] PBI create/list/update/archive works end-to-end
- [x] Query filters by state, outputs JSON and table
- [x] All files ≤150 lines
- [x] CHANGELOG updated with v2.88.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)