### PR TITLE
feat: meeting-digest Phase 4 — propagate digests to project context docs

### DIFF
--- a/.claude/agents/meeting-digest.md
+++ b/.claude/agents/meeting-digest.md
@@ -11,6 +11,8 @@ tools:
   - Glob
   - Grep
   - Task
+  - Write
+  - Edit
 model: sonnet
 color: teal
 maxTurns: 20
@@ -44,6 +46,18 @@ Aplicar veredicto: eliminar CONFIDENCIAL/SENSIBLE. AMBIGUOS se marcan para la PM
 
 Invocar `meeting-risk-analyst` via Task con bloques YA filtrados + proyecto + tipo.
 El risk-analyst NUNCA ve datos confidenciales. Devuelve bloque RIESGOS.
+
+### Fase 4 — Actualizacion de contexto del proyecto
+
+OBLIGATORIA tras cada digestion. Propaga la informacion nueva a los documentos de contexto vivos.
+
+Protocolo:
+1. Buscar el indice del proyecto: `README.md` en la raiz del proyecto, o en su defecto
+   `CLAUDE.md`, o cualquier fichero que liste los documentos existentes
+2. Identificar qué documentos son relevantes para la informacion extraida en Fase 1
+3. Leer cada documento candidato; si contiene informacion desactualizada o ausente → actualizar
+4. Solo datos no confidenciales. Respetar limite 150 lineas por fichero
+5. Registrar en bloque ACTUALIZACIONES del digest: lista de ficheros modificados y tipo de cambio
 
 ## Extraccion de perfil (modo one2one)
 


### PR DESCRIPTION
## Summary

- Add `Write` and `Edit` tools to `meeting-digest` agent (was Read/Glob/Grep/Task only — physically unable to modify any file)
- Add mandatory **Phase 4 — Context update** after the existing 3-phase pipeline (extraction → confidentiality judge → risk analysis)
- Phase 4 reads the project `README.md` (or `CLAUDE.md` as fallback) to discover relevant living documents, identifies which ones need updating with newly extracted information, and records all modifications in an ACTUALIZACIONES block in the digest output

## Root cause fixed

Meeting digests were producing `.md` output files but the pipeline stopped there. No mechanism existed to propagate extracted information (ceremonies, sprint state, decisions, team changes) to documents like `estado-actual.md`, `ceremonias.md` or `reglas-negocio.md`. The agent also lacked the tools to write anything even if instructed.

## Test plan

- [ ] Run `/meeting-digest` on any existing VTT in `projects/trazabios/meetings/`
- [ ] Verify Phase 4 executes after risk analysis
- [ ] Verify at least one project context document is updated or explicitly noted as already up to date
- [ ] Verify ACTUALIZACIONES block appears in digest output
- [ ] Verify no confidential data leaks into context documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)