### PR TITLE
feat: Smart Calendar Era 120 — Task Criticality + Multi-Tenant Sync (v3.4.0)

### DIFF
--- a/.claude/commands/calendar-deadlines.md
+++ b/.claude/commands/calendar-deadlines.md
@@ -1,0 +1,38 @@
+---
+name: calendar-deadlines
+description: "Deadlines proximos con estado de preparacion — nada se queda atras"
+argument-hint: "[--days 14] [--project nombre]"
+allowed-tools: [Read, Glob, Grep, Bash]
+model: sonnet
+context_cost: medium
+---
+
+# /calendar-deadlines — Guardian de Deadlines
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+
+## Fuentes de deadlines
+
+- Ceremonias Scrum (sprint boundaries, reviews, retros)
+- Steercos y reuniones con stakeholders
+- Informes ejecutivos y reportes recurrentes
+- Digestiones pendientes (reuniones >48h sin procesar)
+- Follow-ups comprometidos en 1:1s
+- Tareas PM sin mover >5 dias
+- Releases y deployment windows
+
+## Flujo
+
+1. Recopilar deadlines de todas las fuentes
+2. Calcular proximity score (exponencial: mas cerca = mas urgente)
+3. Evaluar estado de preparacion (% completado, dependencias)
+4. Clasificar: en riesgo / en tiempo / completado
+5. Mostrar timeline con alertas
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⏰ /calendar-deadlines — Nada se queda atras
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/calendar-focus.md
+++ b/.claude/commands/calendar-focus.md
@@ -1,0 +1,28 @@
+---
+name: calendar-focus
+description: "Crear bloque de focus para una tarea especifica — Deep Work protegido"
+argument-hint: "{tarea} [--duration 90m] [--when tomorrow-morning]"
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+model: sonnet
+context_cost: low
+---
+
+# /calendar-focus — Bloque de Deep Work
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+
+## Flujo
+
+1. Identificar tarea (argumento o `my-focus` si no especificado)
+2. Buscar proximo hueco libre >= 45 min en calendario
+3. Crear evento tentative "[Savia] Focus: {tarea}" con color azul
+4. Si sync activo: crear en Outlook. Si no: mostrar sugerencia
+5. Respetar reglas: no antes de daily, no despues de 17h, 15 min buffer
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🎯 /calendar-focus — Proteger tiempo
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/calendar-plan.md
+++ b/.claude/commands/calendar-plan.md
@@ -1,0 +1,30 @@
+---
+name: calendar-plan
+description: "Planificar semana con focus blocks automaticos y priorizacion Eisenhower"
+argument-hint: "[--week current|next] [--project nombre]"
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+model: opus
+context_cost: high
+---
+
+# /calendar-plan — Planificar Semana
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+
+## Flujo
+
+1. Leer calendario de la semana (cache o sync)
+2. Leer fuentes de trabajo: backlog PM, deadlines, digestiones pendientes, follow-ups
+3. Clasificar cada item (Eisenhower: DO/SCHEDULE/DELEGATE/ELIMINATE)
+4. Identificar huecos libres en calendario
+5. Asignar focus blocks a items SCHEDULE por deadline proximity
+6. Crear eventos en Outlook (si GRAPH_CALENDAR_SYNC=true) o mostrar plan
+7. Alertar: dias sin capacidad, reuniones sin agenda, deadlines en riesgo
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📋 /calendar-plan — Planificar Semana
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/calendar-rebalance.md
+++ b/.claude/commands/calendar-rebalance.md
@@ -1,0 +1,35 @@
+---
+name: calendar-rebalance
+description: "Rebalancear focus blocks tras cambio de prioridades o calendario"
+argument-hint: "[--reason 'nueva reunion'] [--project nombre]"
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /calendar-rebalance — Rebalancear Agenda
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+
+## Cuando usar
+
+- Nueva reunion anadida que rompe un focus block
+- Cambio de prioridades (nueva urgencia, deadline adelantado)
+- Cancelacion de reunion que libera hueco aprovechable
+- Tras `/sprint-plan` con nuevas asignaciones
+
+## Flujo
+
+1. Detectar cambios vs plan anterior
+2. Reclasificar items (Eisenhower actualizado)
+3. Reasignar focus blocks a huecos disponibles
+4. Si no cabe todo: alertar con items que se quedan fuera
+5. Actualizar calendario (si sync activo) o mostrar plan revisado
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔄 /calendar-rebalance — Reajustar Agenda
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/calendar-sync.md
+++ b/.claude/commands/calendar-sync.md
@@ -1,0 +1,34 @@
+---
+name: calendar-sync
+description: "Sincronizar calendario Outlook/Teams via Microsoft Graph API"
+argument-hint: "[--project nombre] [--days 7]"
+allowed-tools: [Read, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /calendar-sync — Sincronizar Calendario
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+
+## Prerequisitos
+
+1. `GRAPH_CLIENT_ID` y `GRAPH_TENANT_ID` configurados en pm-config.local.md
+2. Token OAuth obtenido (device code flow o browser)
+3. Permisos: `Calendars.ReadWrite`, `MailboxSettings.Read`
+
+## Flujo
+
+1. Autenticar con Microsoft Graph (device code flow si primera vez)
+2. Leer eventos del calendario (default: proximos 7 dias)
+3. Sincronizar con estado local: `data/calendar-cache.json`
+4. Detectar conflictos: reuniones superpuestas, sin agenda, en horario no laboral
+5. Mostrar resumen: reuniones, huecos, % capacidad productiva
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📅 /calendar-sync — Sincronizacion Outlook
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/calendar-today.md
+++ b/.claude/commands/calendar-today.md
@@ -1,0 +1,33 @@
+---
+name: calendar-today
+description: "Vista del dia con alertas, reuniones, focus blocks y recomendaciones"
+argument-hint: "[--project nombre]"
+allowed-tools: [Read, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /calendar-today — Vista del Dia
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+
+## Flujo
+
+1. Leer cache de calendario (`data/calendar-cache.json`)
+2. Filtrar eventos de hoy
+3. Cruzar con: deadlines del proyecto, tareas PM pendientes, digestiones atrasadas
+4. Clasificar huecos libres (Eisenhower: DO/SCHEDULE/DELEGATE/ELIMINATE)
+5. Mostrar: timeline del dia, alertas, % capacidad productiva, recomendacion de focus
+
+## Integracion con daily-routine
+
+`/calendar-today` se integra como primer paso de `/daily-routine` para el rol PM.
+Si no hay cache: sugerir `/calendar-sync` primero.
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🌅 /calendar-today — Tu dia
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/criticality-assess.md
+++ b/.claude/commands/criticality-assess.md
@@ -1,0 +1,60 @@
+---
+name: criticality-assess
+description: "Evaluar criticidad de un item con desglose de 5 dimensiones y perfil CoD"
+argument-hint: "{item-id} [--project nombre]"
+allowed-tools: [Read, Bash, Glob, Grep]
+model: sonnet
+context_cost: low
+---
+
+# /criticality-assess — Evaluacion de Criticidad
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+Spec: `@.claude/skills/smart-calendar/spec-task-criticality.md`
+
+## Flujo
+
+1. Resolver item: buscar por ID en Azure DevOps, Savia Flow o backlog local
+2. Recopilar datos del item: titulo, estado, asignado, SP, deadline, dependencias
+3. Calcular cada dimension:
+   - **Impacto** (0.30): valoracion de negocio (manual o inferida de Kano/priority)
+   - **Urgencia** (0.25): dias hasta deadline + perfil CoD + auto-escalado
+   - **Dependencias** (0.20): contar items/personas bloqueados downstream
+   - **Confianza** (0.15): fecha ultima validacion × confidence_decay
+   - **Esfuerzo inv** (0.10): 6 - min(5, ceil(SP/4))
+4. Calcular score: sum(dimension × peso)
+5. Clasificar: P0/P1/P2/P3
+6. Identificar perfil Cost of Delay: Standard/Fixed-date/Expedite/Intangible
+7. Sugerir accion segun clasificacion
+
+## Template de Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔍 Criticality Assessment — AB#XXXX
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📋 [Titulo del item]
+   Proyecto: [nombre] | Estado: [estado] | SP: [n] | Asignado: [persona]
+
+📊 Desglose de Criticidad:
+   Impacto de negocio  ████░ 4/5  × 0.30 = 1.20
+   Urgencia temporal   ███░░ 3/5  × 0.25 = 0.75
+   Dependencias        ██░░░ 2/5  × 0.20 = 0.40
+   Confianza           ████░ 4/5  × 0.15 = 0.60
+   Esfuerzo inverso    ███░░ 3/5  × 0.10 = 0.30
+                                   ──────────
+   Score total:                      3.25
+
+🏷️ Clasificacion: P1 High
+📈 Perfil CoD: Fixed-date (deadline: 2026-04-01)
+⚡ Accion: Resolver en este sprint. 13 dias hasta deadline.
+```
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔍 /criticality-assess — Evaluacion Individual
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/criticality-dashboard.md
+++ b/.claude/commands/criticality-dashboard.md
@@ -1,0 +1,69 @@
+---
+name: criticality-dashboard
+description: "Vista cross-project de items criticos P0-P3 con heatmap por equipo"
+argument-hint: "[--project nombre] [--level portfolio|project|team|person]"
+allowed-tools: [Read, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /criticality-dashboard — Panel de Criticidad
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+Spec: `@.claude/skills/smart-calendar/spec-task-criticality.md`
+
+## Razonamiento
+
+Piensa paso a paso:
+1. Primero: recopilar items de todas las fuentes (Azure DevOps, Savia Flow, calendar)
+2. Luego: calcular criticality_score con 5 dimensiones + auto-escalado temporal
+3. Finalmente: presentar dashboard con alertas por nivel
+
+## Flujo
+
+1. Detectar nivel solicitado (default: portfolio si multi-proyecto, project si uno)
+2. Recopilar items activos de todas las fuentes de datos:
+   - Azure DevOps / Savia Flow: PBIs, tasks en sprint activo
+   - Calendar: deadlines proximos (7/14/30 dias)
+   - Meeting-digest: action items comprometidos
+3. Para cada item, calcular criticality_score:
+   - impacto (0.30) + urgencia (0.25) + dependencias (0.20) + confianza (0.15) + esfuerzo_inv (0.10)
+   - Aplicar auto-escalado temporal segun dias hasta deadline
+   - Aplicar confidence_decay segun dias sin validacion
+   - Clasificar perfil CoD: Standard / Fixed-date / Expedite / Intangible
+4. Clasificar: P0 (>=4.0), P1 (3.0-3.9), P2 (2.0-2.9), P3 (<2.0)
+5. Verificar reglas de negocio:
+   - P0 sin asignar → alerta inmediata
+   - >3 P0 simultaneos → alerta capacidad critica
+   - P3 con confidence <0.3 → candidatos eliminacion
+6. Presentar dashboard por nivel solicitado
+
+## Template de Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🎯 Criticality Dashboard — [fecha]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+🔴 P0 Critical (X items)
+  AB#XXXX | [titulo] | score: X.X | [proyecto] | [asignado]
+
+🟠 P1 High (X items)
+  AB#XXXX | [titulo] | score: X.X | [proyecto] | [asignado]
+
+🟡 P2 Medium (X items) — resumen
+🟢 P3 Low (X items) — resumen
+
+⚠️ Alertas:
+  - [alertas de reglas de negocio]
+
+📊 Heatmap: [proyecto1: 2P0 1P1] [proyecto2: 0P0 3P1]
+```
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🎯 /criticality-dashboard — Panel de Criticidad
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/criticality-rebalance.md
+++ b/.claude/commands/criticality-rebalance.md
@@ -1,0 +1,81 @@
+---
+name: criticality-rebalance
+description: "Redistribuir carga de trabajo del equipo respetando criticidad y capacidad"
+argument-hint: "[--project nombre] [--team equipo] [--dry-run]"
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /criticality-rebalance — Rebalanceo por Criticidad
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+Spec: `@.claude/skills/smart-calendar/spec-task-criticality.md`
+
+## Cuando usar
+
+- Tras cambio de prioridades (nuevo P0, deadline adelantado)
+- Persona sobrecargada con items criticos
+- Desequilibrio detectado por `/team-workload` o `/criticality-dashboard`
+- Sprint mid-point si hay desviacion significativa
+
+## Razonamiento
+
+Piensa paso a paso:
+1. Primero: snapshot actual de asignaciones + criticality_score por item
+2. Luego: detectar desequilibrios (persona con >2 P0, persona sin P0 con holgura)
+3. Finalmente: proponer reasignaciones respetando skills y capacidad
+
+## Flujo
+
+1. Recopilar items activos con criticality_score (usa `/criticality-dashboard`)
+2. Recopilar capacidad por persona: horas disponibles, skills, WIP actual
+3. Detectar desequilibrios:
+   - Persona con >2 items P0/P1 simultaneos
+   - Persona con WIP >2 items activos
+   - Items P0 sin asignar o asignados a persona sin capacidad
+   - Items P0 asignados a persona sin skill requerido
+4. Proponer reasignaciones:
+   - Mover items P2/P3 de personas sobrecargadas a personas con holgura
+   - Reasignar items P0 a persona con skill + capacidad disponible
+   - NO mover items en progreso avanzado (>50% completado)
+5. Si `--dry-run`: solo mostrar propuesta sin aplicar
+6. Si no dry-run: confirmar con PM antes de aplicar cambios
+
+## Restricciones
+
+- NUNCA reasignar sin confirmacion del PM
+- NUNCA mover items en progreso avanzado sin justificacion
+- Respetar skills requeridos (no asignar backend a frontend-only)
+- Respetar WIP limit de 2 items activos por persona
+- Items Expedite (P0 auto) tienen prioridad absoluta en asignacion
+
+## Template de Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔄 Criticality Rebalance — [proyecto]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📊 Estado actual:
+   alice: 3 items (2×P0, 1×P1) — SOBRECARGADA
+   bob:   1 item  (1×P2)       — CON HOLGURA
+
+🔀 Propuesta de reasignacion:
+   1. AB#101 (P1, 3SP) alice → bob  | Motivo: alice tiene 2×P0
+   2. AB#205 (P0, sin asignar) → bob | Motivo: skill match + capacidad
+
+📋 Resultado proyectado:
+   alice: 2 items (2×P0)  — EN LIMITE
+   bob:   2 items (1×P0, 1×P1) — EQUILIBRADO
+
+¿Aplicar cambios? [S/n]
+```
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔄 /criticality-rebalance — Equilibrar por Criticidad
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/commands/sync-calendars.md
+++ b/.claude/commands/sync-calendars.md
@@ -1,0 +1,50 @@
+---
+name: sync-calendars
+description: "Sincronizar disponibilidad entre calendarios de dos tenants Microsoft 365"
+argument-hint: "[setup|status|conflicts|clean] [--days 14] [--busy]"
+allowed-tools: [Read, Write, Bash, Glob, Grep]
+model: sonnet
+context_cost: medium
+---
+
+# /sync-calendars — Sincronizacion Multi-Tenant
+
+Ejecutar skill: `@.claude/skills/smart-calendar/SKILL.md`
+Spec: `@.claude/skills/smart-calendar/spec-multi-tenant-sync.md`
+
+## Subcomandos
+
+- **sin argumento**: sincronizar ahora (default)
+- **setup**: wizard de configuracion de credenciales (primera vez)
+- **status**: estado de ultima sync + conflictos pendientes
+- **conflicts**: listar solo conflictos activos entre calendarios
+- **clean**: eliminar todos los bloques [Sync] (requiere confirmacion)
+
+## Flujo (sync default)
+
+1. Leer credenciales cifradas de `~/.pm-workspace/calendar-secrets/{slug}/`
+2. Pedir passphrase (1 vez por sesion, en memoria)
+3. Autenticar con ambos tenants via Graph API (Device Code Flow)
+4. Leer eventos de ambos calendarios (ventana: --days, default 14)
+5. Filtrar: excluir bloques [Sync] previos (solo eventos reales)
+6. Para cada evento real en A sin bloque en B → crear `[Sync] Ocupado`
+7. Bloques existentes con horario cambiado → actualizar
+8. Eventos cancelados → borrar bloque [Sync] correspondiente
+9. Repetir en direccion B → A
+10. Detectar conflictos: Hard (ambos confirmados) / Soft (uno tentative)
+11. Guardar sync-state.json con timestamp
+
+## Seguridad
+
+- Credenciales: AES-256-CBC, PBKDF2 100K iter, passphrase en memoria
+- Solo sincroniza free/busy — NUNCA titulo, asistentes ni contenido
+- Bloques creados como Private + sin reminder
+- Detalle: `@.claude/skills/smart-calendar/spec-multi-tenant-security.md`
+
+## Banner
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔄 /sync-calendars — Multi-Tenant Sync
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/.claude/skills/smart-calendar/DOMAIN.md
+++ b/.claude/skills/smart-calendar/DOMAIN.md
@@ -1,0 +1,40 @@
+---
+name: smart-calendar-domain
+description: Contexto de dominio para gestion inteligente de agenda PM
+---
+
+# Por que existe esta skill
+
+Un PM de consultora grande gestiona 5-15 reuniones/dia, 3+ proyectos,
+decenas de tareas sin fecha fija que se posponen hasta ser urgentes.
+Las herramientas existentes (Outlook, Teams) gestionan eventos pero
+no priorizan trabajo ni alertan de lo que se queda atras.
+
+## Conceptos de dominio
+
+- **Focus block**: bloque de tiempo protegido para trabajo profundo (min 45min)
+- **Deadline proximity**: dias restantes hasta la fecha limite (urgencia crece exponencialmente)
+- **Rebalanceo**: redistribuir bloques de focus cuando cambia el calendario
+- **Capacity day**: % del dia disponible para trabajo productivo (100% - reuniones)
+- **Guardian alert**: aviso proactivo de item que se puede quedar atras
+
+## Reglas de negocio
+
+- Eisenhower Matrix adaptado: DO/SCHEDULE/DELEGATE/ELIMINATE
+- Deep Work (Newport): bloques minimos de 45 min, max 3h
+- PMI: time management como area de conocimiento critica
+- Buffer de 15 min entre reuniones (reset cognitivo)
+
+## Relacion con otras skills
+
+- **Upstream**: sprint-management (fechas), meeting-digest (reuniones pendientes)
+- **Downstream**: daily-routine (vista del dia), wellbeing-guardian (burnout)
+- **Paralela**: capacity-planning (capacidad del equipo, no del PM)
+
+## Decisiones clave
+
+- Microsoft Graph API sobre alternativas (Google Calendar, CalDAV)
+  porque el ecosistema target es Microsoft (Teams/Outlook/Azure DevOps)
+- OAuth delegated (no app-only) para acceso con consentimiento del usuario
+- Focus blocks como "tentative" (no bloquean calendario para otros)
+- Alertas basadas en reglas declarativas, no ML (predecible, auditable)

--- a/.claude/skills/smart-calendar/SKILL.md
+++ b/.claude/skills/smart-calendar/SKILL.md
@@ -124,3 +124,18 @@ Cadencia de alertas:
 5. Focus blocks son "tentative" no "busy" (permiten override manual)
 6. Si >70% del dia es reuniones: alertar como dia sin capacidad productiva
 7. Ceremonias Scrum tienen prioridad sobre focus blocks
+
+## Sistema de Criticidad (Era 120)
+
+El Focus Scheduler usa `criticality_score` (5 dimensiones, WSJF+RICE+Eisenhower)
+para decidir que tarea asignar a cada bloque. Spec completo:
+`spec-task-criticality.md` | Referencia de frameworks: `spec-criticality-frameworks.md`
+
+Comandos de criticidad:
+- `/criticality-dashboard` — panel cross-project P0-P3
+- `/criticality-assess {item}` — desglose de 5 dimensiones
+- `/criticality-rebalance` — redistribuir carga por criticidad
+
+Integracion: `/calendar-plan` ordena por criticality_score. Items P0 crean
+bloques de emergencia (override focus time). Auto-escalado temporal aplica
+a `/calendar-deadlines`. Confidence decay limpia backlog automaticamente.

--- a/.claude/skills/smart-calendar/SKILL.md
+++ b/.claude/skills/smart-calendar/SKILL.md
@@ -106,6 +106,7 @@ Cadencia de alertas:
 - `/calendar-rebalance` — rebalancear tras cambio de prioridades
 - `/calendar-deadlines` — deadlines proximos con estado de preparacion
 - `/calendar-focus` — crear bloque de focus para tarea especifica
+- `/sync-calendars` — sincronizar disponibilidad entre 2 tenants Microsoft 365
 
 ## Integraciones
 

--- a/.claude/skills/smart-calendar/SKILL.md
+++ b/.claude/skills/smart-calendar/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: smart-calendar
+description: >
+  Gestion inteligente de agenda PM: sincronizacion bidireccional con Outlook/Teams,
+  planificacion automatica de trabajo, rebalanceo por prioridades, focus blocks,
+  alertas de conflictos y deadlines. Nada se queda atras.
+maturity: experimental
+category: "pm-operations"
+tags: ["calendar", "outlook", "teams", "focus", "scheduling", "deadlines", "ceremonies"]
+priority: "high"
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, Task]
+---
+
+# Skill: Smart Calendar — Gestion Inteligente de Agenda PM
+
+> "Un PM sin calendario sincronizado con su backlog es un PM que apaga fuegos."
+> Inspirado en: Reclaim.ai (AI time-blocking), Cal Newport (Deep Work),
+> Eisenhower Matrix, PMI Time Management, McKinsey PM playbook.
+
+## Problema que resuelve
+
+El PM gestiona: ceremonias Scrum, 1:1s, steercos, follow-ups con stakeholders,
+deadlines de informes, tareas de backlog, y trabajo profundo de analisis.
+Sin automatizacion, las tareas sin fecha fija (informes, analisis, specs)
+se posponen indefinidamente hasta que son urgentes.
+
+## Arquitectura: 4 capas
+
+### Capa 1 — Sync Engine (Microsoft Graph API)
+
+Sincronizacion bidireccional con Outlook/Teams:
+- **Leer**: eventos del calendario, free/busy, categorias, recurrencias
+- **Escribir**: crear bloques de focus, mover reuniones, crear eventos
+- **Webhook**: notificaciones push cuando cambia el calendario
+- **Auth**: OAuth 2.0 con MSAL (delegated permissions, user consent)
+
+Permisos Graph API requeridos:
+- `Calendars.ReadWrite` — leer/escribir eventos
+- `MailboxSettings.Read` — horario laboral del usuario
+- `OnlineMeetings.Read` — detalles de reuniones Teams
+
+Config en `pm-config.local.md`:
+```
+GRAPH_TENANT_ID    = "..."
+GRAPH_CLIENT_ID    = "..."
+GRAPH_CALENDAR_SYNC = true
+CALENDAR_WORK_START = "09:00"
+CALENDAR_WORK_END   = "18:00"
+CALENDAR_TIMEZONE   = "Europe/Madrid"
+```
+
+### Capa 2 — Work Planner (priorizacion automatica)
+
+Fuentes de trabajo del PM (no solo calendario):
+- **Ceremonias**: cadencia Scrum del proyecto (ceremonies.md, sprint dates)
+- **1:1s y follow-ups**: recurrencias programadas
+- **Deadlines**: informes ejecutivos, steercos, releases, auditorias
+- **Backlog PM**: tareas propias (analisis, specs, onboarding, roadmaps)
+- **Incidencias**: items bloqueados, escalaciones, hotfixes
+- **Digestiones**: reuniones grabadas, documentos pendientes de digerir
+
+Cada item tiene: prioridad (Eisenhower), esfuerzo estimado, deadline, dependencias.
+
+Clasificacion automatica (Eisenhower adaptado para PM):
+- **DO** (urgente + importante): bloqueantes, steerco hoy, deadline hoy
+- **SCHEDULE** (importante, no urgente): specs, analisis, 1:1s, informes
+- **DELEGATE** (urgente, no importante): seguimientos rutinarios, updates
+- **ELIMINATE** (ni urgente ni importante): reuniones sin agenda, duplicados
+
+### Capa 3 — Focus Scheduler (bloques de trabajo profundo)
+
+Algoritmo de planificacion diaria:
+1. Leer calendario de hoy + semana
+2. Identificar huecos libres (no meetings, no lunch)
+3. Priorizar items SCHEDULE por deadline proximity + importancia
+4. Crear bloques de focus en huecos:
+   - Minimo 45 min (menos no permite Deep Work)
+   - Maximo 3h (fatiga cognitiva)
+   - Etiqueta: "[Savia] Focus: {tarea}"
+   - Color: azul oscuro (distinguir de reuniones)
+5. Respetar preferencias: no focus antes de daily, no focus despues de las 17h
+6. Si cambia el calendario (nueva reunion): rebalancear automaticamente
+
+### Capa 4 — Guardian de Deadlines
+
+Alerta proactiva de lo que se puede quedar atras:
+- **Informe semanal**: pendiente de generacion, deadline viernes
+- **Steerco**: preparacion necesaria 2 dias antes
+- **Sprint review**: datos que recopilar 1 dia antes
+- **1:1 follow-up**: acciones comprometidas sin completar
+- **Digestion pendiente**: reuniones grabadas sin procesar >48h
+- **Backlog PM**: items sin mover >5 dias
+
+Cadencia de alertas:
+- **Diaria** (09:00, post-daily): resumen del dia con alertas
+- **Semanal** (lunes 08:30): vista de la semana con gaps y riesgos
+- **Evento-driven**: si se cancela/mueve reunion, rebalancear
+
+## Comandos
+
+- `/calendar-sync` — sincronizar calendario Outlook/Teams
+- `/calendar-plan` — planificar semana con focus blocks automaticos
+- `/calendar-today` — vista del dia con alertas y recomendaciones
+- `/calendar-rebalance` — rebalancear tras cambio de prioridades
+- `/calendar-deadlines` — deadlines proximos con estado de preparacion
+- `/calendar-focus` — crear bloque de focus para tarea especifica
+
+## Integraciones
+
+- **sprint-management**: fechas de ceremonias → eventos de calendario
+- **meeting-digest**: reuniones grabadas → alerta si no digerida en 48h
+- **daily-routine**: `/calendar-today` como primer paso del dia
+- **overnight-sprint**: no programar tareas autonomas en horas de focus
+- **wellbeing-guardian**: alertar si >6h de reuniones/dia (burnout risk)
+
+## Reglas de negocio
+
+1. NUNCA mover una reunion con stakeholder externo sin confirmacion
+2. NUNCA programar focus en horario de daily/standup
+3. SIEMPRE respetar horario laboral configurado
+4. SIEMPRE dejar 15 min entre reuniones (travel time / reset cognitivo)
+5. Focus blocks son "tentative" no "busy" (permiten override manual)
+6. Si >70% del dia es reuniones: alertar como dia sin capacidad productiva
+7. Ceremonias Scrum tienen prioridad sobre focus blocks

--- a/.claude/skills/smart-calendar/spec-criticality-frameworks.md
+++ b/.claude/skills/smart-calendar/spec-criticality-frameworks.md
@@ -1,0 +1,98 @@
+---
+name: criticality-frameworks-reference
+description: >
+  Referencia de frameworks de priorizacion investigados para el sistema
+  de criticidad. Comparativa, formulas y recomendaciones de diseño.
+type: reference
+parent: spec-task-criticality.md
+---
+
+# Frameworks de Priorizacion — Referencia
+
+## Comparativa rapida
+
+| Framework | Temporal | Cuantitativo | Escala 100+ | Mejor nivel |
+|-----------|----------|-------------|-------------|-------------|
+| WSJF (SAFe) | Si (Time Crit.) | Si | Si | Portfolio |
+| Cost of Delay | Si (4 perfiles) | Si | Moderado | Estrategico |
+| RICE (Intercom) | No nativo | Si | Si | Product backlog |
+| ICE | No | Si | Si (rapido) | Experimentos |
+| MoSCoW | Timebox | No | No | Sprint/Release |
+| Fibonacci+Impact | No | Si | Moderado | Sprint backlog |
+| Eisenhower | Binario | No | No | Personal/Daily |
+| Kano | No | Survey | No | Discovery |
+| Value vs Effort | No | No | Moderado | Triage rapido |
+
+## WSJF (usado en Nivel 1)
+
+`WSJF = (User_Value + Time_Criticality + Risk_Reduction) / Job_Size`
+Escala Fibonacci relativa (1-20). Division por tamaño favorece quick wins.
+Fortaleza: matematicamente optimo para ordenar backlogs grandes.
+Debilidad: requiere sesiones de scoring facilitadas.
+
+## Cost of Delay — 4 perfiles (Reinertsen)
+
+| Perfil | Curva | CoD calculo |
+|--------|-------|-------------|
+| Standard | Decay lineal | revenue_impact × weeks_delayed |
+| Fixed-date | Flat + cliff | penalty / weeks_until_deadline |
+| Expedite | Step function | total_loss/hour (prioridad infinita) |
+| Intangible | Decay lento | probability × impact × time_horizon |
+
+Fundamento teorico de WSJF. Permite comparar items heterogeneos en $.
+
+## RICE (usado en Nivel 2)
+
+`RICE = (Reach × Impact × Confidence) / Effort`
+Reach diferencia de ICE: estima audiencia afectada.
+Impact ordinal: 0.25 (minimal) a 3 (massive).
+Confidence penaliza especulacion (100/80/50%).
+
+## Confidence decay (diseño propio)
+
+Items sin validacion reciente pierden confianza automaticamente:
+14d→1.0, 30d→0.9, 60d→0.75, 90d→0.5, >90d→0.3.
+Multiplicador sobre Confidence de RICE. Items olvidados bajan solos.
+
+## Auto-scheduling (patrones observados)
+
+### Reclaim.ai
+- Prioridad manual P1-P4 + deadline + duracion estimada
+- Scheduler busca huecos respetando meetings existentes
+- Items cercanos a deadline se vuelven menos flexibles
+- Alerta si tarea no cabe antes de deadline
+
+### Motion
+- Algoritmo greedy: max prioridad + min deadline → mejor hueco
+- Recomputacion continua ante cualquier cambio
+- Alerta proactiva HOY si tarea del jueves no cabra
+- Team scheduling con restricciones cruzadas
+
+### Clockwise
+- Protege Focus Time agrupando meetings
+- Calcula Focus Time Score (% en bloques >=2h)
+- Optimizacion a nivel equipo (no solo individual)
+
+## Decisiones de diseño
+
+1. **5 dimensiones vs 4**: añadimos Confianza (de RICE/ICE) y Esfuerzo
+   inverso (de WSJF) al modelo original de 4 dimensiones
+2. **Perfiles CoD**: en lugar de urgencia lineal generica, clasificamos
+   cada item en Standard/Fixed-date/Expedite/Intangible
+3. **Confidence decay**: automatiza la limpieza de backlog — items sin
+   tocar >90 dias bajan a P3 solos
+4. **Nivel 1 WSJF, Nivel 2 RICE**: WSJF es mejor cross-project (tiene
+   Job Size como denominador), RICE es mejor intra-proyecto (tiene Reach)
+5. **Eisenhower en Nivel 4**: el 2x2 es el unico framework que funciona
+   para decision individual rapida (no escala, pero no necesita escalar)
+6. **Auto-schedule = Motion pattern**: recomputo continuo ante cambios
+   es superior al scheduling unico de Reclaim
+
+## Fuentes
+
+- Reinertsen, *Principles of Product Development Flow* (2009)
+- SAFe 6.0 WSJF guidance
+- Intercom RICE documentation
+- Sean Ellis ICE framework (GrowthHackers)
+- Kano et al. (1984) original paper
+- Reclaim.ai, Motion, Clockwise engineering docs

--- a/.claude/skills/smart-calendar/spec-multi-tenant-security.md
+++ b/.claude/skills/smart-calendar/spec-multi-tenant-security.md
@@ -1,0 +1,114 @@
+---
+name: multi-tenant-security-reference
+description: >
+  Modelo de seguridad y amenazas para la sincronizacion multi-tenant
+  de calendarios. Credenciales, cifrado, datos sincronizados.
+type: reference
+parent: spec-multi-tenant-sync.md
+---
+
+# Seguridad Multi-Tenant Sync — Referencia
+
+## Credential Store detallado
+
+Cada fichero `.enc` contiene (cifrado con passphrase del usuario):
+```json
+{
+  "tenant_id": "xxx-xxx",
+  "client_id": "xxx-xxx",
+  "client_secret": "xxx",
+  "user_email": "user@empresa.com",
+  "calendar_id": "primary",
+  "label": "Empresa A"
+}
+```
+
+Cifrado: `openssl enc -aes-256-cbc -salt -pbkdf2 -iter 100000`
+Permisos fichero: 600 (solo owner). Ruta dentro de `$HOME` (no en repo).
+
+## Modelo de amenazas
+
+| Amenaza | Mitigacion |
+|---------|-----------|
+| Credenciales en disco sin cifrar | AES-256 + PBKDF2 100K, passphrase en memoria |
+| Passphrase comprometida | No se persiste. Se pide por sesion |
+| Token leak | Tokens solo en memoria, refresh automatico |
+| Exfiltracion datos reuniones | Solo free/busy, NUNCA contenido |
+| Man-in-the-middle | HTTPS obligatorio (Graph API) |
+| Acceso no autorizado a .enc | Permisos 600, bajo $HOME |
+| Passphrase debil | Minimo 12 caracteres, warn si <16 |
+| Tenant comprometido | Cada tenant es independiente, sin cross-access |
+
+## Datos que NUNCA se sincronizan
+
+- Titulo de la reunion
+- Asistentes (nombres, emails)
+- Descripcion / notas / body
+- Adjuntos
+- Respuestas de asistencia (accept/decline/tentative)
+- Ubicacion (sala, link Teams/Zoom)
+- Links de videoconferencia
+
+## Datos que SI se sincronizan
+
+- Hora inicio y hora fin
+- Estado: busy / tentative / free / out-of-office
+- Si es todo el dia (all-day event)
+- Si es recurrente (para calcular instancias futuras)
+
+## Flujo de setup (primera vez)
+
+```
+/sync-calendars setup
+
+🦉 Configurando sincronizacion multi-tenant.
+   Cifrare tus credenciales con una passphrase que solo tu conoces.
+
+━━ Tenant A ━━━━━━━━━━━━━━━━━━━━━━━
+  Etiqueta: _________ (ej: "Mi Consultora")
+  Tenant ID: _________
+  Client ID: _________
+  Client Secret: _________
+  Tu email: _________@_______.com
+
+━━ Tenant B ━━━━━━━━━━━━━━━━━━━━━━━
+  Etiqueta: _________ (ej: "Cliente X")
+  ...
+
+━━ Passphrase ━━━━━━━━━━━━━━━━━━━━━
+  Cifrado (min 12 chars): _________
+  Confirmar: _________
+
+✅ Credenciales cifradas en ~/.pm-workspace/calendar-secrets/
+   /sync-calendars para la primera sincronizacion.
+```
+
+## Config por usuario
+
+`$HOME/.pm-workspace/calendar-secrets/{slug}/config.json`:
+```json
+{
+  "sync_window_days": 14,
+  "sync_block_prefix": "[Sync]",
+  "sync_block_show_as": "tentative",
+  "auto_sync_on_session_start": false,
+  "conflict_notification": "inline",
+  "tenants": ["tenant-a", "tenant-b"]
+}
+```
+
+## Auth flows soportados
+
+| Flow | Pros | Contras | Uso |
+|------|------|---------|-----|
+| Device Code | Sin redirect URI, funciona en CLI | Requiere navegador 1 vez | Recomendado |
+| ROPC | Totalmente automatico | Requiere MFA off, menos seguro | Fallback |
+| `az login` | Sin app registration | Requiere Azure CLI | Tenants restrictivos |
+
+## Fallback para tenants restrictivos
+
+Si el tenant corporativo no permite app registrations externas:
+1. Usar `az login --tenant {id}` con login interactivo
+2. El token se almacena en `~/.azure/` (gestionado por Azure CLI)
+3. Savia lee el token de `az account get-access-token --resource https://graph.microsoft.com`
+4. Menos automatizado pero funciona en cualquier tenant

--- a/.claude/skills/smart-calendar/spec-multi-tenant-sync.md
+++ b/.claude/skills/smart-calendar/spec-multi-tenant-sync.md
@@ -1,0 +1,142 @@
+---
+name: multi-tenant-calendar-sync
+description: >
+  Sincronizacion bidireccional de disponibilidad entre calendarios de dos
+  tenants Microsoft 365. Bloques busy/free, deteccion de conflictos,
+  credenciales cifradas por usuario.
+type: spec
+status: draft
+priority: P0
+parent: smart-calendar
+---
+
+# Spec: Sincronizacion Multi-Tenant de Calendarios
+
+Referencia de seguridad: `spec-multi-tenant-security.md`
+
+## Problema
+
+Profesional trabaja en 2 empresas (consultora + cliente). Cada una tiene
+su tenant Microsoft 365 con Teams/Outlook. Los calendarios son independientes.
+Resultado: reuniones que se pisan, duplicacion manual, riesgo de aceptar
+reuniones en huecos ocupados en el otro tenant.
+
+## Restricciones de diseño
+
+1. **Privacidad**: solo sincronizar free/busy, NUNCA contenido de reuniones
+2. **Secretos individuales**: credenciales por usuario, cifradas, NUNCA en repo
+3. **Bidireccional**: A↔B en ambas direcciones
+4. **Idempotente**: ejecutar 2 veces = mismo resultado
+5. **No destructivo**: solo crear/actualizar/borrar bloques `[Sync]`
+6. **Offline-safe**: si un tenant falla, sincronizar el otro y avisar
+
+## Arquitectura
+
+```
+/sync-calendars → Credential Store → Graph API Client ×2
+                  (AES-256 local)    (Tenant A + Tenant B)
+```
+
+### 1. Credential Store — `$HOME/.pm-workspace/calendar-secrets/{slug}/`
+
+```
+calendar-secrets/{slug}/
+├── tenant-a.enc    ← AES-256 cifrado con passphrase del usuario
+├── tenant-b.enc    ← idem
+└── sync-state.json ← estado ultima sync (timestamps, checksums)
+```
+
+Cifrado: AES-256-CBC, PBKDF2 100K iter. Passphrase en memoria, 1 vez/sesion.
+
+### 2. Graph API Client — Device Code Flow (OAuth 2.0)
+
+Permisos: `Calendars.ReadWrite` (delegated). Cada tenant requiere su propia
+app registration en Azure AD. Tokens en memoria, refresh automatico (90 dias).
+
+### 3. Sync Engine — Algoritmo
+
+```
+1. Autenticar ambos tenants (tokens en memoria)
+2. Leer eventos de ambos (ventana: hoy + 14 dias)
+3. Filtrar: excluir bloques [Sync] previos (solo eventos reales)
+4. Para cada evento real en A:
+   - Si no existe bloque [Sync] en B → crear
+   - Si existe pero horario cambio → actualizar
+   - Si evento cancelado → borrar bloque [Sync] en B
+5. Repetir en direccion B → A
+6. Detectar conflictos: evento real A pisa evento real B
+7. Guardar sync-state.json
+```
+
+### 4. Conflict Detector
+
+| Tipo | Condicion | Accion |
+|------|-----------|--------|
+| **Hard** | Reunion confirmada en A + confirmada en B, mismo horario | ALERTA ROJA |
+| **Soft** | Tentative en A + evento en B | AVISO amarillo |
+| **Resolved** | Bloque [Sync] ya cubre el hueco | OK, sin accion |
+
+## Bloques sincronizados — Marcado
+
+- **Subject**: `[Sync] Ocupado` (sin detalles del original)
+- **Category**: `SaviaSync` (filtrar y limpiar)
+- **ShowAs**: `Busy` (Teams lo respeta al planificar)
+- **IsReminderOn**: `false` | **Sensitivity**: `Private`
+
+## Comando /sync-calendars
+
+| Subcomando | Descripcion |
+|------------|-------------|
+| `/sync-calendars` | Sincronizar ahora (default) |
+| `/sync-calendars setup` | Wizard de config de credenciales |
+| `/sync-calendars status` | Estado de ultima sync + conflictos |
+| `/sync-calendars conflicts` | Listar solo conflictos activos |
+| `/sync-calendars clean` | Eliminar bloques [Sync] (con confirmacion) |
+
+## Flujo de sync (uso normal)
+
+```
+🔑 Passphrase: _________ (1 vez por sesion)
+
+📋 1/4 — Autenticando ambos tenants... ✅ ✅
+📋 2/4 — Leyendo calendarios (14 dias)...
+   Empresa A: 23 eventos (18 reales + 5 [Sync])
+   Empresa B: 31 eventos (28 reales + 3 [Sync])
+📋 3/4 — Sincronizando...
+   → 3 bloques nuevos en A, 2 actualizados en B, 1 eliminado
+📋 4/4 — Conflictos...
+   🔴 1 HARD: Lun 24 10:00-11:00 "Sprint Review" vs "Steerco"
+
+✅ Sync completada — 6 cambios, 1 conflicto pendiente
+```
+
+## Reglas de negocio
+
+1. NUNCA crear bloque [Sync] que pise evento real existente
+2. Conflictos reales NO se resuelven automaticamente — alertar al usuario
+3. Bloques [Sync] son `tentative` por defecto (override con `--busy`)
+4. Ventana de sync: 14 dias (configurable `--days 7|14|30`)
+5. Rate limit: max 1 sync cada 5 min (evitar throttling Graph API)
+6. Si un tenant falla: sync parcial + error reportado
+7. `/sync-calendars clean` requiere confirmacion explicita
+8. Passphrase NUNCA viaja a ningun servidor — cifrado 100% local
+
+## Integracion con Smart Calendar
+
+- `/calendar-today` muestra bloques [Sync] con etiqueta del tenant
+- `/calendar-plan` respeta [Sync] como tiempo ocupado no movible
+- `/calendar-rebalance` no mueve bloques [Sync] (son espejo)
+- `/criticality-dashboard` usa disponibilidad cruzada de ambos tenants
+
+## Prerequisitos
+
+1. App Registration en cada tenant con `Calendars.ReadWrite`
+2. Admin o user consent segun politica del tenant
+3. openssl instalado (cifrado local)
+
+## Limitaciones
+
+- Graph API rate limits (~10K req/10min por app)
+- Tenants que bloquean app registrations externas → fallback con `az login`
+- Reuniones private en origen → bloque opaco "[Sync] Ocupado" en destino
+- Recurrencias: se sincronizan instancias individuales, no la serie

--- a/.claude/skills/smart-calendar/spec-task-criticality.md
+++ b/.claude/skills/smart-calendar/spec-task-criticality.md
@@ -1,0 +1,116 @@
+---
+name: task-criticality-system
+description: >
+  Sistema de priorizacion y criticidad multi-nivel con WSJF, Cost of Delay,
+  auto-escalado temporal y scheduling inteligente. 4 niveles: portfolio,
+  proyecto, equipo, persona.
+type: spec
+status: refined
+priority: P0
+frameworks: WSJF, Cost-of-Delay, RICE, Eisenhower, Kano
+---
+
+# Spec: Sistema de Criticidad y Priorizacion Multi-Nivel
+
+Referencia de frameworks: `spec-criticality-frameworks.md`
+
+## Problema
+
+PM de consultora gestiona 3+ proyectos, 30+ personas, cientos de tareas.
+Sin priorizacion cruzada automatica, items sin fecha fija se posponen.
+No hay vista unificada de criticidad across proyectos.
+
+## Arquitectura: framework por nivel
+
+| Nivel | Scope | Framework | Complemento |
+|-------|-------|-----------|-------------|
+| 1. Portfolio | Cross-project | WSJF + Cost of Delay | Kano (discovery) |
+| 2. Proyecto | Sprint backlog | RICE adaptado | MoSCoW (validacion) |
+| 3. Equipo | Carga squad | Capacity + WIP limits | Value vs Effort |
+| 4. Persona | Dia a dia | Eisenhower + auto-schedule | Motion/Reclaim |
+
+## Nivel 1 — Portfolio (WSJF + Cost of Delay)
+
+`WSJF = Cost_of_Delay / Job_Size`
+`CoD = User_Value + Time_Criticality + Risk_Reduction` (Fibonacci 1-20)
+
+Perfiles de urgencia (Reinertsen): Standard (decay lineal), Fixed-date
+(cliff en deadline), Expedite (step function → P0 auto), Intangible (decay
+lento → aplica confidence_decay).
+
+## Nivel 2 — Proyecto (RICE adaptado)
+
+`priority = (Reach × Impact × Confidence × urgency_multiplier) / Effort`
+Reach (1-100), Impact (0.25-3), Confidence (50-100% × decay), Effort (SP).
+Post-scoring: validar que top items serian "Must" en MoSCoW.
+
+## Nivel 3 — Equipo (capacity)
+
+WIP <=2/persona, bus factor, skill gap, sobrecarga >110% 2+ sprints.
+
+## Nivel 4 — Persona (Eisenhower + auto-schedule)
+
+Urgent×Important 2x2 + auto-scheduling: items por criticality_score →
+huecos libres → alerta proactiva si no cabe → recomputo al cancelar
+reunion → proteger 2h focus/dia.
+
+## Modelo de criticidad unificado (5 dimensiones)
+
+| Dimension | Peso | Fuente |
+|-----------|------|--------|
+| Impacto de negocio | 0.30 | Manual + Kano |
+| Urgencia temporal | 0.25 | Auto (deadline) + perfil CoD |
+| Dependencias | 0.20 | Auto (grafo bloqueos) |
+| Confianza | 0.15 | Auto (decay) + manual |
+| Esfuerzo inverso | 0.10 | SP invertidos (quick wins) |
+
+```
+criticality = (impacto×0.30) + (urgencia×0.25) + (deps×0.20)
+            + (confianza×0.15) + (esfuerzo_inv×0.10)
+esfuerzo_inv = 6 - min(5, ceil(SP/4))
+```
+
+P0 Critical (>=4.0), P1 High (3.0-3.9), P2 Medium (2.0-2.9), P3 Low (<2.0)
+
+## Auto-escalado temporal
+
+```
+days<=0: urgencia=5 (P0 auto)  |  1-2d: base+3 (cap 5)
+3-7d: base+2  |  7-14d: base+1  |  >14d: base
+```
+
+Fixed-date: cliff en fecha. Intangible: no auto-escala, usa confidence_decay.
+
+## Confidence decay
+
+```
+<=14d: 1.0 | 15-30d: 0.9 | 31-60d: 0.75 | 61-90d: 0.5 | >90d: 0.3
+confianza_efectiva = confianza_base × confidence_decay
+```
+
+Items olvidados en backlog bajan solos. Validacion = cualquier update.
+
+## Comandos nuevos
+
+- `/criticality-dashboard` — vista cross-project P0-P3, heatmap
+- `/criticality-assess {item}` — desglose de 5 dimensiones
+- `/criticality-rebalance` — redistribuir carga por criticidad
+
+## Comandos a integrar
+
+`/my-focus` (elige por score), `/sprint-autoplan` (RICE+capacity),
+`/calendar-plan` (focus→criticos), `/daily-routine` (P0+P1 al inicio),
+`/team-workload` (heatmap criticidad), `/calendar-deadlines` (auto-escalado),
+`/backlog-prioritize` (RICE+decay), `/backlog-groom` (P3+decay<0.3→eliminar)
+
+## Reglas de negocio
+
+1. P0 sin asignar → alerta inmediata
+2. P0 sin movimiento >24h → escala al PM
+3. >3 P0 simultaneos → alerta capacidad critica
+4. P3 con confidence <0.3 → candidatos eliminacion
+5. Recalculo diario (o al cambiar estado)
+6. Override manual con justificacion (expira 30 dias)
+7. Fixed-date (compliance) siempre >= P1
+8. Expedite → P0 sin scoring (override del sistema)
+9. WSJF recalcula por sprint; RICE por daily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] — 2026-03-19
+
+Era 120 — Task Criticality System + Multi-Tenant Calendar Sync.
+
+### Added
+- **Task Criticality**: multi-level prioritization (WSJF, Cost of Delay, RICE, Eisenhower) with 5 scoring dimensions, auto-escalation, and confidence decay
+- **Commands**: `/criticality-dashboard`, `/criticality-assess`, `/criticality-rebalance` (3 new)
+- **Multi-Tenant Calendar Sync**: `/sync-calendars` — bidirectional free/busy sync between 2 Microsoft 365 tenants with AES-256 encrypted per-user credentials
+- **Specs**: `spec-task-criticality.md`, `spec-criticality-frameworks.md` (9 frameworks researched), `spec-multi-tenant-sync.md`, `spec-multi-tenant-security.md`
+- **Docs**: Smart Calendar (7 cmds) and Task Criticality (3 cmds) sections in ES+EN
+
+### Changed
+- **smart-calendar SKILL.md**: added criticality integration section + sync-calendars reference
+
 ## [3.3.0] — 2026-03-19
 
 Era 118 — Five improvements from open-source research (GitNexus, NemoClaw, GSD, Context Hub, Everything Claude Code).
@@ -3752,6 +3766,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.0.0...v3.1.0

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -224,6 +224,23 @@
 /policy-check [--project]         Verificar politicas de agente para un proyecto
 ```
 
+## Smart Calendar (6 comandos)
+```
+/calendar-sync                   Sincronizar calendario Outlook/Teams via Graph API
+/calendar-today [--project]      Vista del dia con alertas, reuniones y focus blocks
+/calendar-plan [--week]          Planificar semana con focus blocks y Eisenhower
+/calendar-rebalance [--reason]   Rebalancear agenda tras cambio de prioridades
+/calendar-deadlines [--days 14]  Deadlines proximos con estado de preparacion
+/calendar-focus {tarea}          Crear bloque de Deep Work protegido
+```
+
+## Criticidad de Tareas (3 comandos)
+```
+/criticality-dashboard [--level] Vista cross-project de items criticos P0-P3
+/criticality-assess {item}       Evaluar criticidad con 5 dimensiones y perfil CoD
+/criticality-rebalance [--team]  Redistribuir carga por criticidad y capacidad
+```
+
 ## Dev Session (1 comando)
 ```
 /dev-session-resume {id}          Reanudar dev-session interrumpida desde ultimo checkpoint

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -224,7 +224,7 @@
 /policy-check [--project]         Verificar politicas de agente para un proyecto
 ```
 
-## Smart Calendar (6 comandos)
+## Smart Calendar (7 comandos)
 ```
 /calendar-sync                   Sincronizar calendario Outlook/Teams via Graph API
 /calendar-today [--project]      Vista del dia con alertas, reuniones y focus blocks
@@ -232,6 +232,7 @@
 /calendar-rebalance [--reason]   Rebalancear agenda tras cambio de prioridades
 /calendar-deadlines [--days 14]  Deadlines proximos con estado de preparacion
 /calendar-focus {tarea}          Crear bloque de Deep Work protegido
+/sync-calendars [setup|status]   Sincronizar disponibilidad entre 2 tenants M365
 ```
 
 ## Criticidad de Tareas (3 comandos)

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -224,6 +224,23 @@
 /policy-check [--project]         Verify agent policies for a project
 ```
 
+## Smart Calendar (6 commands)
+```
+/calendar-sync                   Sync Outlook/Teams calendar via Graph API
+/calendar-today [--project]      Daily view with alerts, meetings, and focus blocks
+/calendar-plan [--week]          Plan week with auto focus blocks and Eisenhower
+/calendar-rebalance [--reason]   Rebalance schedule after priority changes
+/calendar-deadlines [--days 14]  Upcoming deadlines with readiness status
+/calendar-focus {task}           Create protected Deep Work block
+```
+
+## Task Criticality (3 commands)
+```
+/criticality-dashboard [--level] Cross-project critical items view P0-P3
+/criticality-assess {item}       Assess criticality with 5 dimensions and CoD profile
+/criticality-rebalance [--team]  Redistribute workload by criticality and capacity
+```
+
 ## Dev Session (1 command)
 ```
 /dev-session-resume {id}          Resume interrupted dev-session from last checkpoint

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -224,7 +224,7 @@
 /policy-check [--project]         Verify agent policies for a project
 ```
 
-## Smart Calendar (6 commands)
+## Smart Calendar (7 commands)
 ```
 /calendar-sync                   Sync Outlook/Teams calendar via Graph API
 /calendar-today [--project]      Daily view with alerts, meetings, and focus blocks
@@ -232,6 +232,7 @@
 /calendar-rebalance [--reason]   Rebalance schedule after priority changes
 /calendar-deadlines [--days 14]  Upcoming deadlines with readiness status
 /calendar-focus {task}           Create protected Deep Work block
+/sync-calendars [setup|status]   Sync availability between 2 M365 tenants
 ```
 
 ## Task Criticality (3 commands)


### PR DESCRIPTION
## Summary
- **Task Criticality System**: multi-level (portfolio/project/team/person) with WSJF, Cost of Delay, RICE, Eisenhower. 5 scoring dimensions, auto-escalation, confidence decay. Research: 9 frameworks + 3 AI tools
- **Multi-Tenant Calendar Sync**: `/sync-calendars` — bidirectional free/busy between 2 Microsoft 365 tenants. AES-256 encrypted per-user credentials, conflict detection Hard/Soft, privacy-first (only free/busy, never content)
- **4 new commands**: `/criticality-dashboard`, `/criticality-assess`, `/criticality-rebalance`, `/sync-calendars`
- **Documentation**: ES+EN updated (Smart Calendar 7 cmds + Criticality 3 cmds)
- **CHANGELOG**: v3.4.0

## Files (13 new/modified)
- `.claude/commands/criticality-dashboard.md` (69 lines)
- `.claude/commands/criticality-assess.md` (60 lines)
- `.claude/commands/criticality-rebalance.md` (81 lines)
- `.claude/commands/sync-calendars.md` (50 lines)
- `.claude/skills/smart-calendar/spec-task-criticality.md` (116 lines)
- `.claude/skills/smart-calendar/spec-criticality-frameworks.md` (98 lines)
- `.claude/skills/smart-calendar/spec-multi-tenant-sync.md` (142 lines)
- `.claude/skills/smart-calendar/spec-multi-tenant-security.md` (114 lines)
- `.claude/skills/smart-calendar/SKILL.md` (142 lines)
- `docs/readme/12-comandos-agentes.md` — Smart Calendar + Criticality sections
- `docs/readme_en/12-commands-agents.md` — English equivalent
- `CHANGELOG.md` — v3.4.0 entry + comparison link

## Test plan
- [x] All commands pass `validate-commands.sh`
- [x] All files within 150-line limit
- [x] SKILL.md updated with both features
- [x] Docs ES+EN aligned
- [x] CHANGELOG with comparison link
- [ ] CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)