### PR TITLE
feat: criticality scoring engine (Era 120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.2] — 2026-03-19
+
+Criticality scoring engine — backing scripts for Era 120 criticality commands.
+
+### Added
+- **Script**: `scripts/criticality.sh` — dispatcher for assess/dashboard/rebalance
+- **Script**: `scripts/criticality-scoring.sh` — pure scoring (WSJF, confidence decay, urgency boost, 5-dimension model, P0-P3 classification)
+- **Script**: `scripts/criticality-engine.sh` — operations (assess single item, dashboard cross-project, rebalance analysis)
+
 ## [3.5.1] — 2026-03-19
 
 Backing scripts for vault, confidentiality scanner, and travel sync.
@@ -3804,6 +3813,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.5.2]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.5.1...v3.5.2
 [3.5.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.4.1...v3.5.0
 [3.4.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.4.0...v3.4.1

--- a/scripts/criticality-engine.sh
+++ b/scripts/criticality-engine.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# criticality-engine.sh — Operations: assess, dashboard, rebalance. Sourced by criticality.sh.
+set -uo pipefail
+
+source "$SCRIPT_DIR/criticality-scoring.sh"
+
+# ── Assess single item ───────────────────────────────────────────────────────
+do_assess() {
+  local item_id="${1:-}"
+  [[ -z "$item_id" ]] && { echo "Usage: criticality.sh assess <item-id> [--project name]"; return 1; }
+  local project=""
+  [[ "${2:-}" == "--project" ]] && project="${3:-}"
+
+  local item_file=""
+  if [[ -n "$project" ]]; then
+    item_file=$(find "$WORKSPACE_ROOT/projects/$project/backlog" -name "*${item_id}*" -print -quit 2>/dev/null)
+  else
+    item_file=$(find "$WORKSPACE_ROOT/projects/*/backlog" -name "*${item_id}*" -print -quit 2>/dev/null)
+  fi
+  [[ -z "$item_file" || ! -f "$item_file" ]] && { echo "Item $item_id not found in local backlog."; return 1; }
+
+  local title; title=$(parse_frontmatter "$item_file" "title")
+  [[ -z "$title" ]] && title="$(basename "$item_file" .md)"
+  local state; state=$(parse_frontmatter "$item_file" "status")
+  local sp; sp=$(parse_frontmatter "$item_file" "story_points"); [[ -z "$sp" ]] && sp=3
+  local assigned; assigned=$(parse_frontmatter "$item_file" "assigned_to")
+  local impact; impact=$(parse_frontmatter "$item_file" "impact"); [[ -z "$impact" ]] && impact=3
+  local deps; deps=$(parse_frontmatter "$item_file" "dependencies"); [[ -z "$deps" ]] && deps=1
+  local deadline; deadline=$(parse_frontmatter "$item_file" "deadline")
+
+  local days_left=999
+  [[ -n "$deadline" ]] && days_left=$(days_between "$(today_epoch)" "$(date_epoch "$deadline")")
+  local urgency; urgency=$(urgency_boost "$days_left" 3)
+  local cpct; cpct=$(confidence_decay "$(file_age_days "$item_file")")
+  local conf_dim=$(( 5 * cpct / 100 )); (( conf_dim < 1 )) && conf_dim=1
+  local eff_inv; eff_inv=$(effort_inverse "$sp")
+  local score; score=$(compute_score "$impact" "$urgency" "$deps" "$cpct" "$sp")
+  local class; class=$(classify "$score")
+
+  echo "Assessment: $item_id — $title"
+  echo "  State: ${state:-unknown} | SP: $sp | Assigned: ${assigned:-unassigned}"
+  echo ""
+  echo "  Impact       $(bar5 "$impact") $impact/5  x0.30"
+  echo "  Urgency      $(bar5 "$urgency") $urgency/5  x0.25  (${days_left}d)"
+  echo "  Dependencies $(bar5 "$deps") $deps/5  x0.20"
+  echo "  Confidence   $(bar5 "$conf_dim") $conf_dim/5  x0.15  (decay: ${cpct}%)"
+  echo "  Effort inv   $(bar5 "$eff_inv") $eff_inv/5  x0.10"
+  echo "  ─────────────────────"
+  echo "  Score: $(score_display "$score") → $class"
+}
+
+# ── Dashboard ─────────────────────────────────────────────────────────────────
+do_dashboard() {
+  local project=""
+  [[ "${1:-}" == "--project" ]] && project="${2:-}"
+
+  local items; items=$(scan_items "$project")
+  [[ -z "$items" ]] && { echo "No items in local backlog."; return 0; }
+
+  local p0=0 p1=0 p2=0 p3=0 p0_lines="" p1_lines="" alerts=""
+  while IFS= read -r f; do
+    [[ -z "$f" || ! -f "$f" ]] && continue
+    local title; title=$(parse_frontmatter "$f" "title")
+    [[ -z "$title" ]] && title="$(basename "$f" .md)"
+    local assigned; assigned=$(parse_frontmatter "$f" "assigned_to"); [[ -z "$assigned" ]] && assigned="?"
+    local score; score=$(score_item "$f")
+    local cls; cls=$(classify "$score")
+    local line="  $(score_display "$score") | $title | $assigned"
+    case "$cls" in
+      "P0 Critical") p0=$((p0+1)); p0_lines+="$line\n"
+        [[ "$assigned" == "?" ]] && alerts+="  ALERT: P0 unassigned — $title\n" ;;
+      "P1 High")     p1=$((p1+1)); p1_lines+="$line\n" ;;
+      "P2 Medium")   p2=$((p2+1)) ;;
+      *)             p3=$((p3+1)) ;;
+    esac
+  done <<< "$items"
+
+  echo "Criticality Dashboard — $(date +%Y-%m-%d)"
+  echo ""
+  echo "P0 Critical ($p0)"
+  [[ -n "$p0_lines" ]] && printf "%b" "$p0_lines"
+  echo "P1 High ($p1)"
+  [[ -n "$p1_lines" ]] && printf "%b" "$p1_lines"
+  echo "P2 Medium ($p2)"
+  echo "P3 Low ($p3)"
+
+  (( p0 > 3 )) && alerts+="  ALERT: $p0 P0 items — capacity critical\n"
+  if [[ -n "$alerts" ]]; then
+    echo ""; printf "%b" "$alerts"
+  else
+    echo ""; echo "No alerts."
+  fi
+}
+
+# ── Rebalance ─────────────────────────────────────────────────────────────────
+do_rebalance() {
+  local project=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --project) project="$2"; shift 2 ;;
+      --dry-run) shift ;;
+      *) shift ;;
+    esac
+  done
+  echo "Analyzing current assignments..."
+  do_dashboard ${project:+--project "$project"}
+  echo ""
+  echo "Interactive rebalancing requires /criticality-rebalance in Claude Code."
+}

--- a/scripts/criticality-scoring.sh
+++ b/scripts/criticality-scoring.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# criticality-scoring.sh — Pure scoring functions. Sourced by criticality-engine.sh.
+set -uo pipefail
+
+W_IMPACT=30 W_URGENCY=25 W_DEPS=20 W_CONF=15 W_EFFORT=10
+
+confidence_decay() {
+  local days="${1:-0}"
+  if   (( days <= 14 )); then echo 100
+  elif (( days <= 30 )); then echo 90
+  elif (( days <= 60 )); then echo 75
+  elif (( days <= 90 )); then echo 50
+  else echo 30; fi
+}
+
+urgency_boost() {
+  local days_left="${1:-999}" base="${2:-3}"
+  if   (( days_left <= 0 ));  then echo 5
+  elif (( days_left <= 2 ));  then local v=$((base+3)); (( v>5 )) && v=5; echo "$v"
+  elif (( days_left <= 7 ));  then local v=$((base+2)); (( v>5 )) && v=5; echo "$v"
+  elif (( days_left <= 14 )); then local v=$((base+1)); (( v>5 )) && v=5; echo "$v"
+  else echo "$base"; fi
+}
+
+effort_inverse() {
+  local sp="${1:-3}"
+  local c=$(( (sp + 3) / 4 )); (( c > 5 )) && c=5
+  echo $(( 6 - c ))
+}
+
+compute_score() {
+  local impact="${1:-3}" urgency="${2:-3}" deps="${3:-1}" conf_pct="${4:-100}" sp="${5:-3}"
+  local ei; ei=$(effort_inverse "$sp")
+  local conf_dim=$(( 5 * conf_pct / 100 )); (( conf_dim < 1 )) && conf_dim=1
+  local raw=$(( impact*W_IMPACT + urgency*W_URGENCY + deps*W_DEPS + conf_dim*W_CONF + ei*W_EFFORT ))
+  echo $(( raw * 10 / 100 ))
+}
+
+classify() {
+  local s="$1"
+  if   (( s >= 40 )); then echo "P0 Critical"
+  elif (( s >= 30 )); then echo "P1 High"
+  elif (( s >= 20 )); then echo "P2 Medium"
+  else echo "P3 Low"; fi
+}
+
+score_display() { echo "$((${1}/10)).$((${1}%10))"; }
+
+bar5() {
+  local v="$1" b=""
+  for i in 1 2 3 4 5; do (( i <= v )) && b+="█" || b+="░"; done
+  echo "$b"
+}
+
+parse_frontmatter() {
+  sed -n '/^---$/,/^---$/p' "$1" 2>/dev/null | grep -oP "^${2}:\s*\K.*" | head -1
+}
+
+today_epoch() { date +%s; }
+
+date_epoch() {
+  date -d "$1" +%s 2>/dev/null || date -j -f "%Y-%m-%d" "$1" +%s 2>/dev/null || echo 0
+}
+
+days_between() { echo $(( ($2 - $1) / 86400 )); }
+
+file_age_days() {
+  local mod; mod=$(stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0)
+  echo $(( ($(today_epoch) - mod) / 86400 ))
+}
+
+scan_items() {
+  local project="${1:-}" dirs=()
+  if [[ -n "$project" ]]; then
+    dirs=("$WORKSPACE_ROOT/projects/$project/backlog")
+  else
+    for d in "$WORKSPACE_ROOT"/projects/*/backlog; do [[ -d "$d" ]] && dirs+=("$d"); done
+  fi
+  for d in "${dirs[@]}"; do
+    [[ -d "$d" ]] && find "$d" -name "*.md" -print 2>/dev/null
+  done
+}
+
+score_item() {
+  local f="$1"
+  local sp; sp=$(parse_frontmatter "$f" "story_points"); [[ -z "$sp" ]] && sp=3
+  local impact; impact=$(parse_frontmatter "$f" "impact"); [[ -z "$impact" ]] && impact=3
+  local deps; deps=$(parse_frontmatter "$f" "dependencies"); [[ -z "$deps" ]] && deps=1
+  local deadline; deadline=$(parse_frontmatter "$f" "deadline")
+  local days_left=999
+  [[ -n "$deadline" ]] && days_left=$(days_between "$(today_epoch)" "$(date_epoch "$deadline")")
+  local urgency; urgency=$(urgency_boost "$days_left" 3)
+  local cpct; cpct=$(confidence_decay "$(file_age_days "$f")")
+  compute_score "$impact" "$urgency" "$deps" "$cpct" "$sp"
+}

--- a/scripts/criticality.sh
+++ b/scripts/criticality.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# criticality.sh — Dispatcher for criticality operations
+# Usage: criticality.sh {assess|dashboard|rebalance} [args]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/criticality-engine.sh"
+
+case "${1:-help}" in
+  assess)    shift; do_assess "$@" ;;
+  dashboard) shift; do_dashboard "$@" ;;
+  rebalance) shift; do_rebalance "$@" ;;
+  *)
+    echo "Usage: criticality.sh {assess|dashboard|rebalance} [args]"
+    echo "  assess <item-id> [--project name]   Score a single item"
+    echo "  dashboard [--project name]          Cross-project P0-P3 view"
+    echo "  rebalance [--project name] [--dry-run]  Redistribute workload"
+    ;;
+esac


### PR DESCRIPTION
## Summary
Backing scripts for the 3 criticality commands defined in Era 120 (v3.4.0).

- **criticality.sh** (21 lines): dispatcher
- **criticality-scoring.sh** (95 lines): pure scoring — 5-dimension model (impact, urgency, dependencies, confidence, effort inverse), confidence decay (14/30/60/90d), urgency boost (0/2/7/14d), P0-P3 classification
- **criticality-engine.sh** (109 lines): operations — assess (single item with dimension bar chart), dashboard (cross-project P0-P3 + alerts), rebalance (analysis mode)

## Test plan
- [x] `criticality.sh help` — shows usage
- [x] `criticality.sh dashboard` — scans 55 items, classifies P0-P3
- [ ] CI: PR Guardian, BATS, Lint, PII, Validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)