### PR TITLE
feat: ZeroClaw firmware v0.1 — ready to flash on ESP32 (v3.14.0)

### DIFF
--- a/.claude/commands/zeroclaw.md
+++ b/.claude/commands/zeroclaw.md
@@ -1,0 +1,77 @@
+---
+name: zeroclaw
+description: "Interface with ZeroClaw ESP32 — setup, test, send commands, flash firmware."
+argument-hint: "setup | test | ping | led | info | sensors | flash | interactive"
+allowed-tools: [Read, Bash, Write]
+model: sonnet
+context_cost: low
+---
+
+# /zeroclaw — ZeroClaw ESP32 Interface
+
+> Regla de seguridad: `@.claude/rules/domain/robotics-safety.md`
+
+## Subcomandos
+
+### `/zeroclaw setup`
+
+Primera vez: instala deps, detecta ESP32, flashea MicroPython, despliega firmware.
+
+```bash
+bash zeroclaw/setup.sh
+```
+
+### `/zeroclaw test`
+
+Self-test: ping, info, LED, sensors, GPIO.
+
+```bash
+python3 zeroclaw/host/bridge.py --test
+```
+
+### `/zeroclaw interactive`
+
+Modo interactivo: envía comandos al ESP32 desde la consola.
+
+```bash
+python3 zeroclaw/host/bridge.py --interactive
+```
+
+### `/zeroclaw ping`
+
+Verificar conexión.
+
+```bash
+python3 -c "
+from zeroclaw.host.bridge import ZeroClawBridge
+b = ZeroClawBridge()
+b.connect()
+print(b.ping())
+b.close()
+"
+```
+
+### `/zeroclaw led [on|off|blink]`
+
+Control del LED integrado.
+
+### `/zeroclaw flash`
+
+Re-flashear firmware sin borrar MicroPython:
+
+```bash
+bash zeroclaw/setup.sh --skip-flash
+```
+
+### `/zeroclaw info`
+
+Muestra: versión, CPU, RAM libre, uptime.
+
+## Restricciones
+
+```
+SIEMPRE → Verificar conexión (ping) antes de operar
+SIEMPRE → Watchdog activo en el ESP32 (10s timeout)
+NUNCA → Flashear sin confirmación del humano
+NUNCA → Enviar comandos GPIO sin verificar pinout primero
+```

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -3,7 +3,7 @@
 # Commit this file with your PR. CI verifies it.
 # Any code change after signing invalidates this signature.
 diff_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-timestamp=2026-03-21T11:41:45Z
-branch=feat/zeroclaw-voice-protocol
-head_commit=ecde9fa
-signature=feeb1f69026ec18829aa9edf359f3faf7f929550c74c9671596f430ea7a5a14e
+timestamp=2026-03-21T11:54:20Z
+branch=feat/zeroclaw-firmware-v0
+head_commit=201fac1
+signature=c4957cb76701abbb3283fd62b94b89387878ca3f2eb5b441e5c6ae56ecec1d19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] — 2026-03-21
+
+ZeroClaw Firmware v0.1 — ready to flash when ESP32 is connected.
+
+### Added
+
+- **Firmware**: `zeroclaw/firmware/` — MicroPython firmware for ESP32: boot.py (WiFi + CPU config), main.py (JSON command loop with watchdog), lib/commands.py (ping, led, info, sensors, gpio), lib/status.py (LED patterns for feedback)
+- **Host**: `zeroclaw/host/bridge.py` — serial bridge PC↔ESP32: auto-detect port, JSON protocol, timeout handling
+- **Host**: `zeroclaw/host/cli.py` — self-test (5 checks), interactive mode, CLI entry point
+- **Setup**: `zeroclaw/setup.sh` — one-command setup: installs esptool+mpremote, detects ESP32, flashes MicroPython, deploys firmware, verifies with LED blink
+- **Command**: `/zeroclaw` — setup, test, ping, led, flash, interactive subcommands
+- **Tests**: `zeroclaw/tests/test_bridge.py` — 9 tests that run without hardware (imports, protocol, firmware structure, security, sizes)
+
 ## [3.13.0] — 2026-03-21
 
 ZeroClaw voice pipeline + voice/console decision protocol.
@@ -3982,3 +3995,4 @@ Initial public release of PM-Workspace.
 [3.11.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.10.1...v3.11.0
 [3.12.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.11.0...v3.12.0
 [3.13.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.12.0...v3.13.0
+[3.14.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.13.0...v3.14.0

--- a/zeroclaw/firmware/boot.py
+++ b/zeroclaw/firmware/boot.py
@@ -1,0 +1,38 @@
+# ZeroClaw boot.py — runs once at startup
+# Configures WiFi (if available) and sets CPU frequency
+import machine
+import gc
+
+# CPU at 240MHz for best performance
+machine.freq(240000000)
+
+# Status LED
+led = machine.Pin(2, machine.Pin.OUT)
+led.value(1)  # LED on during boot
+
+# Try WiFi connection (non-blocking, optional for Fase 0)
+try:
+    import json
+    with open('config.json', 'r') as f:
+        cfg = json.load(f)
+    if cfg.get('wifi_ssid'):
+        import network
+        wlan = network.WLAN(network.STA_IF)
+        wlan.active(True)
+        if not wlan.isconnected():
+            wlan.connect(cfg['wifi_ssid'], cfg.get('wifi_pass', ''))
+            import time
+            for _ in range(20):  # 10s timeout
+                if wlan.isconnected():
+                    break
+                time.sleep_ms(500)
+        if wlan.isconnected():
+            print(f"WiFi: {wlan.ifconfig()[0]}")
+        else:
+            print("WiFi: not connected (continuing without)")
+except Exception:
+    print("WiFi: no config (serial mode)")
+
+gc.collect()
+led.value(0)  # LED off, boot complete
+print("ZeroClaw boot complete")

--- a/zeroclaw/firmware/config.json
+++ b/zeroclaw/firmware/config.json
@@ -1,0 +1,9 @@
+{
+    "device_id": "zeroclaw-01",
+    "wifi_ssid": "",
+    "wifi_pass": "",
+    "host_url": "http://192.168.1.100:8765",
+    "led_pin": 2,
+    "watchdog_ms": 10000,
+    "version": "0.1.0"
+}

--- a/zeroclaw/firmware/lib/commands.py
+++ b/zeroclaw/firmware/lib/commands.py
@@ -1,0 +1,109 @@
+# ZeroClaw command handler — processes JSON commands from host
+import machine
+import gc
+import sys
+import json
+import time
+
+
+class CommandHandler:
+    """Processes commands from the host (serial or WiFi).
+
+    Command format (JSON):  {"cmd": "name", "args": {...}}
+    Simple format (text):   name [args]
+    Response format (JSON):  {"ok": true, "data": {...}} or {"error": "msg"}
+    """
+
+    def __init__(self, led):
+        self.led = led
+        self.start_time = time.ticks_ms()
+
+    def process(self, line):
+        """Process a command line. Accepts JSON or plain text."""
+        # Try JSON first
+        try:
+            msg = json.loads(line)
+            cmd = msg.get("cmd", "")
+            args = msg.get("args", {})
+        except (ValueError, TypeError):
+            # Plain text: "cmd arg1 arg2"
+            parts = line.split()
+            cmd = parts[0] if parts else ""
+            args = {"raw": parts[1:]} if len(parts) > 1 else {}
+
+        # Dispatch
+        handler = getattr(self, f"_cmd_{cmd}", None)
+        if handler:
+            self.led.on()
+            try:
+                result = handler(args)
+                return {"ok": True, "cmd": cmd, "data": result}
+            except Exception as e:
+                return {"error": str(e), "cmd": cmd}
+            finally:
+                self.led.off()
+        else:
+            return {"error": f"unknown command: {cmd}", "commands": self._cmd_help({})}
+
+    def _cmd_ping(self, args):
+        return {"pong": True, "uptime_ms": time.ticks_diff(time.ticks_ms(), self.start_time)}
+
+    def _cmd_led(self, args):
+        action = args.get("action") or (args.get("raw", ["on"])[0])
+        if action == "on":
+            self.led.on()
+        elif action == "off":
+            self.led.off()
+        elif action == "blink":
+            count = int(args.get("count", args.get("raw", ["3"])[0] if "raw" in args else 3))
+            self.led.blink(count)
+        elif action == "pulse":
+            self.led.pulse()
+        else:
+            return {"error": f"unknown action: {action}"}
+        return {"led": action}
+
+    def _cmd_info(self, args):
+        return {
+            "device": "zeroclaw-01",
+            "version": "0.1.0",
+            "platform": sys.platform,
+            "freq_mhz": machine.freq() // 1_000_000,
+            "free_ram": gc.mem_free(),
+            "uptime_ms": time.ticks_diff(time.ticks_ms(), self.start_time),
+        }
+
+    def _cmd_sensors(self, args):
+        # Built-in: internal temperature (ESP32)
+        data = {}
+        try:
+            import esp32
+            data["internal_temp_f"] = esp32.raw_temperature()
+        except Exception:
+            data["internal_temp"] = "not available"
+        data["free_ram"] = gc.mem_free()
+        data["freq_mhz"] = machine.freq() // 1_000_000
+        return data
+
+    def _cmd_gpio(self, args):
+        pin_num = int(args.get("pin") or args.get("raw", [0])[0])
+        action = args.get("action") or (args["raw"][1] if "raw" in args and len(args["raw"]) > 1 else "read")
+        p = machine.Pin(pin_num)
+        if action == "read":
+            p.init(machine.Pin.IN)
+            return {"pin": pin_num, "value": p.value()}
+        elif action in ("high", "1", "on"):
+            p.init(machine.Pin.OUT)
+            p.value(1)
+            return {"pin": pin_num, "set": 1}
+        elif action in ("low", "0", "off"):
+            p.init(machine.Pin.OUT)
+            p.value(0)
+            return {"pin": pin_num, "set": 0}
+        return {"error": f"gpio action: read|high|low"}
+
+    def _cmd_help(self, args):
+        return ["ping", "led", "info", "sensors", "gpio", "help"]
+
+    def _cmd_repl(self, args):
+        return {"message": "Entering REPL mode. Reset ESP32 to return to ZeroClaw."}

--- a/zeroclaw/firmware/lib/status.py
+++ b/zeroclaw/firmware/lib/status.py
@@ -1,0 +1,55 @@
+# ZeroClaw status LED — visual feedback for the human
+import machine
+import time
+
+
+class StatusLED:
+    """Controls the built-in LED for status indication.
+
+    Patterns:
+      on()       — solid: processing
+      off()      — off: idle
+      pulse()    — single blink: acknowledgment
+      blink(n)   — n blinks: step count
+      error()    — rapid blinks: error
+      listening() — slow pulse: waiting for input
+    """
+
+    def __init__(self, pin=2):
+        self.led = machine.Pin(pin, machine.Pin.OUT)
+        self.led.value(0)
+
+    def on(self):
+        self.led.value(1)
+
+    def off(self):
+        self.led.value(0)
+
+    def pulse(self, ms=200):
+        self.led.value(1)
+        time.sleep_ms(ms)
+        self.led.value(0)
+
+    def blink(self, count=1, on_ms=150, off_ms=150):
+        for _ in range(count):
+            self.led.value(1)
+            time.sleep_ms(on_ms)
+            self.led.value(0)
+            time.sleep_ms(off_ms)
+
+    def error(self):
+        self.blink(count=5, on_ms=80, off_ms=80)
+
+    def listening(self):
+        # Slow fade-like blink
+        self.blink(count=2, on_ms=400, off_ms=400)
+
+    def pattern(self, name):
+        patterns = {
+            "ok": lambda: self.pulse(200),
+            "error": self.error,
+            "listening": self.listening,
+            "step": lambda: self.blink(1),
+        }
+        fn = patterns.get(name, self.pulse)
+        fn()

--- a/zeroclaw/firmware/main.py
+++ b/zeroclaw/firmware/main.py
@@ -1,0 +1,65 @@
+# ZeroClaw main.py — command loop via serial or WiFi
+# Fase 0: serial commands from host PC
+import machine
+import sys
+import gc
+import json
+import time
+
+from lib.status import StatusLED
+from lib.commands import CommandHandler
+
+# Initialize
+led = StatusLED(pin=2)
+handler = CommandHandler(led)
+
+# Watchdog (10s timeout — resets ESP32 if main loop hangs)
+try:
+    wdt = machine.WDT(timeout=10000)
+except Exception:
+    wdt = None  # Some boards don't support WDT in dev mode
+
+print("ZeroClaw v0.1.0 ready")
+print("Commands: ping, led, info, sensors, repl, help")
+led.pulse()
+
+# Main command loop — reads JSON commands from serial
+buf = ""
+while True:
+    # Feed watchdog
+    if wdt:
+        wdt.feed()
+
+    # Check for serial input (non-blocking)
+    if sys.stdin in [None]:
+        time.sleep_ms(100)
+        continue
+
+    try:
+        # Read available bytes
+        if not sys.stdin.buffer.any():
+            time.sleep_ms(50)
+            continue
+
+        char = sys.stdin.buffer.read(1)
+        if char is None:
+            continue
+
+        c = char.decode('utf-8', 'ignore')
+        if c == '\n' or c == '\r':
+            line = buf.strip()
+            buf = ""
+            if not line:
+                continue
+            # Process command
+            try:
+                response = handler.process(line)
+                print(json.dumps(response))
+            except Exception as e:
+                print(json.dumps({"error": str(e)}))
+        else:
+            buf += c
+    except Exception as e:
+        print(json.dumps({"error": f"loop: {e}"}))
+        time.sleep_ms(100)
+    gc.collect()

--- a/zeroclaw/host/__init__.py
+++ b/zeroclaw/host/__init__.py
@@ -1,0 +1,1 @@
+"""ZeroClaw host-side bridge and CLI."""

--- a/zeroclaw/host/bridge.py
+++ b/zeroclaw/host/bridge.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""ZeroClaw Host Bridge — connects ESP32 to Savia via serial.
+
+Usage:
+  python3 zeroclaw/host/bridge.py                    # auto-detect port
+  python3 zeroclaw/host/bridge.py --port /dev/ttyUSB0
+  python3 zeroclaw/host/bridge.py --test              # run self-test
+"""
+import serial
+import json
+import time
+import sys
+import os
+import argparse
+import threading
+
+
+class ZeroClawBridge:
+    """Serial bridge between host PC and ZeroClaw ESP32."""
+
+    def __init__(self, port=None, baud=115200, timeout=2):
+        self.port = port or self._detect_port()
+        self.baud = baud
+        self.timeout = timeout
+        self.ser = None
+        self.connected = False
+
+    def _detect_port(self):
+        for p in ['/dev/ttyUSB0', '/dev/ttyUSB1', '/dev/ttyACM0',
+                   '/dev/ttyACM1', 'COM3', 'COM4', 'COM5']:
+            if os.path.exists(p):
+                return p
+        return None
+
+    def connect(self):
+        if not self.port:
+            print("❌ No ESP32 detected. Connect via USB and retry.")
+            return False
+        try:
+            self.ser = serial.Serial(self.port, self.baud, timeout=self.timeout)
+            time.sleep(2)  # Wait for ESP32 reset after serial connect
+            self._flush()
+            self.connected = True
+            print(f"✅ Connected to ZeroClaw on {self.port}")
+            return True
+        except serial.SerialException as e:
+            print(f"❌ Serial error: {e}")
+            return False
+
+    def _flush(self):
+        if self.ser and self.ser.in_waiting:
+            self.ser.read(self.ser.in_waiting)
+
+    def send_command(self, cmd, args=None):
+        """Send JSON command to ESP32, return parsed response."""
+        if not self.connected:
+            return {"error": "not connected"}
+        msg = json.dumps({"cmd": cmd, "args": args or {}})
+        self.ser.write((msg + "\n").encode())
+        self.ser.flush()
+        # Read response (with timeout)
+        deadline = time.time() + self.timeout
+        lines = []
+        while time.time() < deadline:
+            if self.ser.in_waiting:
+                line = self.ser.readline().decode('utf-8', errors='ignore').strip()
+                if line:
+                    try:
+                        return json.loads(line)
+                    except json.JSONDecodeError:
+                        lines.append(line)
+            time.sleep(0.05)
+        return {"error": "timeout", "raw": lines}
+
+    def send_text(self, text):
+        """Send plain text command."""
+        if not self.connected:
+            return {"error": "not connected"}
+        self.ser.write((text + "\n").encode())
+        self.ser.flush()
+        deadline = time.time() + self.timeout
+        while time.time() < deadline:
+            if self.ser.in_waiting:
+                line = self.ser.readline().decode('utf-8', errors='ignore').strip()
+                if line:
+                    try:
+                        return json.loads(line)
+                    except json.JSONDecodeError:
+                        return {"raw": line}
+            time.sleep(0.05)
+        return {"error": "timeout"}
+
+    def ping(self):
+        return self.send_command("ping")
+
+    def info(self):
+        return self.send_command("info")
+
+    def led(self, action="blink", count=3):
+        return self.send_command("led", {"action": action, "count": count})
+
+    def sensors(self):
+        return self.send_command("sensors")
+
+    def gpio(self, pin, action="read"):
+        return self.send_command("gpio", {"pin": pin, "action": action})
+
+    def close(self):
+        if self.ser:
+            self.ser.close()
+            self.connected = False
+
+
+if __name__ == "__main__":
+    from cli import main
+    main()

--- a/zeroclaw/host/cli.py
+++ b/zeroclaw/host/cli.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""ZeroClaw CLI — self-test, interactive mode, and entry point.
+
+Usage:
+  python3 zeroclaw/host/cli.py                    # auto-detect + test + interactive
+  python3 zeroclaw/host/cli.py --port /dev/ttyUSB0
+  python3 zeroclaw/host/cli.py --test
+"""
+import json
+import sys
+import argparse
+from .bridge import ZeroClawBridge
+
+
+def self_test(bridge):
+    """Run self-test sequence on connected ZeroClaw."""
+    tests = [
+        ("Ping", lambda: bridge.ping()),
+        ("Info", lambda: bridge.info()),
+        ("LED blink", lambda: bridge.led("blink", 3)),
+        ("Sensors", lambda: bridge.sensors()),
+        ("GPIO2 read", lambda: bridge.gpio(2, "read")),
+    ]
+    passed = 0
+    for name, fn in tests:
+        result = fn()
+        ok = "ok" in result or "data" in result
+        icon = "✅" if ok else "❌"
+        print(f"  {icon} {name}: {json.dumps(result)[:80]}")
+        if ok:
+            passed += 1
+    print(f"\n  {passed}/{len(tests)} tests passed")
+    return passed == len(tests)
+
+
+def interactive(bridge):
+    """Interactive command loop."""
+    print("\n🦎 ZeroClaw Interactive — type commands (help, q to quit)")
+    while True:
+        try:
+            cmd = input("zeroclaw> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            break
+        if cmd in ('q', 'quit', 'exit'):
+            break
+        if not cmd:
+            continue
+        result = bridge.send_text(cmd)
+        print(json.dumps(result, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ZeroClaw Host CLI")
+    parser.add_argument("--port", help="Serial port (auto-detect)")
+    parser.add_argument("--test", action="store_true", help="Self-test only")
+    parser.add_argument("--interactive", "-i", action="store_true")
+    args = parser.parse_args()
+
+    bridge = ZeroClawBridge(port=args.port)
+    if not bridge.connect():
+        sys.exit(1)
+
+    try:
+        if args.test:
+            sys.exit(0 if self_test(bridge) else 1)
+        elif args.interactive:
+            interactive(bridge)
+        else:
+            self_test(bridge)
+            interactive(bridge)
+    finally:
+        bridge.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/zeroclaw/setup.sh
+++ b/zeroclaw/setup.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# ZeroClaw Setup — Detects ESP32, installs deps, flashes MicroPython, deploys firmware.
+# Usage: bash zeroclaw/setup.sh [--skip-flash]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIRMWARE_DIR="$SCRIPT_DIR/firmware"
+MICROPYTHON_URL="https://micropython.org/resources/firmware/ESP32_GENERIC-20241129-v1.24.1.bin"
+MICROPYTHON_BIN="$SCRIPT_DIR/.cache/micropython.bin"
+SKIP_FLASH=false
+
+[[ "${1:-}" == "--skip-flash" ]] && SKIP_FLASH=true
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  🦎 ZeroClaw Setup"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# ── 1. Install Python dependencies ──
+echo "📋 1/5 — Installing Python dependencies..."
+pip3 install --user --quiet esptool mpremote 2>/dev/null
+for pkg in esptool mpremote; do
+    if python3 -m "$pkg" --help >/dev/null 2>&1 || which "$pkg" >/dev/null 2>&1; then
+        echo "  ✅ $pkg"
+    else
+        echo "  ❌ $pkg — install manually: pip3 install $pkg"
+        exit 1
+    fi
+done
+echo ""
+
+# ── 2. Detect ESP32 ──
+echo "📋 2/5 — Detecting ESP32..."
+PORT=""
+for p in /dev/ttyUSB0 /dev/ttyUSB1 /dev/ttyACM0 /dev/ttyACM1; do
+    if [[ -e "$p" ]]; then
+        PORT="$p"
+        break
+    fi
+done
+
+if [[ -z "$PORT" ]]; then
+    echo "  ❌ No ESP32 detected."
+    echo "     1. Connect ESP32 via USB"
+    echo "     2. Check: ls /dev/ttyUSB* /dev/ttyACM*"
+    echo "     3. Add user to dialout group: sudo usermod -aG dialout $USER"
+    echo "     4. Re-run this script"
+    exit 1
+fi
+echo "  ✅ Found ESP32 at $PORT"
+echo ""
+
+# ── 3. Flash MicroPython ──
+if [[ "$SKIP_FLASH" == true ]]; then
+    echo "📋 3/5 — Skipping flash (--skip-flash)"
+else
+    echo "📋 3/5 — Flashing MicroPython..."
+    mkdir -p "$SCRIPT_DIR/.cache"
+    if [[ ! -f "$MICROPYTHON_BIN" ]]; then
+        echo "  Downloading MicroPython firmware..."
+        curl -sL "$MICROPYTHON_URL" -o "$MICROPYTHON_BIN"
+    fi
+    echo "  Erasing flash..."
+    python3 -m esptool --port "$PORT" erase_flash 2>&1 | tail -2
+    echo "  Writing MicroPython..."
+    python3 -m esptool --port "$PORT" --baud 460800 write_flash -z 0x1000 "$MICROPYTHON_BIN" 2>&1 | tail -2
+    echo "  ✅ MicroPython flashed"
+    sleep 3  # Wait for ESP32 to reboot
+fi
+echo ""
+
+# ── 4. Deploy ZeroClaw firmware ──
+echo "📋 4/5 — Deploying ZeroClaw firmware..."
+for f in boot.py main.py; do
+    echo "  Uploading $f..."
+    python3 -m mpremote connect "$PORT" cp "$FIRMWARE_DIR/$f" ":$f"
+done
+# Upload lib/
+for f in "$FIRMWARE_DIR"/lib/*.py; do
+    fname=$(basename "$f")
+    echo "  Uploading lib/$fname..."
+    python3 -m mpremote connect "$PORT" mkdir ":lib" 2>/dev/null || true
+    python3 -m mpremote connect "$PORT" cp "$f" ":lib/$fname"
+done
+echo "  ✅ Firmware deployed"
+echo ""
+
+# ── 5. Verify ──
+echo "📋 5/5 — Verifying..."
+python3 -m mpremote connect "$PORT" exec "
+import sys
+print('MicroPython', sys.version)
+import machine
+led = machine.Pin(2, machine.Pin.OUT)
+led.value(1)
+import time
+time.sleep_ms(500)
+led.value(0)
+print('ZeroClaw: LED blink OK')
+print('ZeroClaw: Ready')
+"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  ✅ ZeroClaw ready on $PORT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  Next: python3 zeroclaw/host/bridge.py --port $PORT"

--- a/zeroclaw/tests/test_bridge.py
+++ b/zeroclaw/tests/test_bridge.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Tests for ZeroClaw host bridge — runs without ESP32 hardware."""
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+passed = 0
+failed = 0
+
+
+def test(name, fn):
+    global passed, failed
+    try:
+        fn()
+        print(f"  ✅ {name}")
+        passed += 1
+    except Exception as e:
+        print(f"  ❌ {name}: {e}")
+        failed += 1
+
+
+def test_import():
+    from host.bridge import ZeroClawBridge
+    assert ZeroClawBridge is not None
+
+
+def test_detect_no_port():
+    from host.bridge import ZeroClawBridge
+    b = ZeroClawBridge(port="/dev/nonexistent")
+    assert not b.connect()
+
+
+def test_send_without_connect():
+    from host.bridge import ZeroClawBridge
+    b = ZeroClawBridge(port="/dev/nonexistent")
+    result = b.send_command("ping")
+    assert "error" in result
+    assert result["error"] == "not connected"
+
+
+def test_firmware_files_exist():
+    base = os.path.join(os.path.dirname(__file__), '..', 'firmware')
+    for f in ['boot.py', 'main.py', 'config.json']:
+        path = os.path.join(base, f)
+        assert os.path.isfile(path), f"Missing: {f}"
+
+
+def test_firmware_lib_files():
+    base = os.path.join(os.path.dirname(__file__), '..', 'firmware', 'lib')
+    for f in ['status.py', 'commands.py']:
+        path = os.path.join(base, f)
+        assert os.path.isfile(path), f"Missing: lib/{f}"
+
+
+def test_config_valid_json():
+    import json
+    path = os.path.join(os.path.dirname(__file__), '..', 'firmware', 'config.json')
+    with open(path) as f:
+        cfg = json.load(f)
+    assert "device_id" in cfg
+    assert "version" in cfg
+    assert cfg["wifi_ssid"] == ""  # Should be empty in repo
+
+
+def test_firmware_no_secrets():
+    """Verify no hardcoded secrets in firmware files."""
+    import re
+    base = os.path.join(os.path.dirname(__file__), '..', 'firmware')
+    for root, _, files in os.walk(base):
+        for fname in files:
+            if not fname.endswith('.py') and not fname.endswith('.json'):
+                continue
+            path = os.path.join(root, fname)
+            with open(path) as f:
+                content = f.read()
+            # Check for common secret patterns
+            assert not re.search(r'password\s*=\s*["\'][^"\']{4,}', content, re.I), \
+                f"Possible password in {fname}"
+            assert not re.search(r'ssid\s*=\s*["\'][^"\']{2,}', content, re.I), \
+                f"Possible SSID in {fname}"
+
+
+def test_setup_script_exists():
+    path = os.path.join(os.path.dirname(__file__), '..', 'setup.sh')
+    assert os.path.isfile(path)
+
+
+def test_file_sizes():
+    """All firmware files must be ≤150 lines."""
+    base = os.path.join(os.path.dirname(__file__), '..', 'firmware')
+    for root, _, files in os.walk(base):
+        for fname in files:
+            if not fname.endswith('.py'):
+                continue
+            path = os.path.join(root, fname)
+            with open(path) as f:
+                lines = len(f.readlines())
+            assert lines <= 150, f"{fname}: {lines} lines (max 150)"
+
+
+if __name__ == "__main__":
+    print("ZeroClaw Bridge Tests (no hardware required)")
+    print("─" * 45)
+    test("Import bridge", test_import)
+    test("No port detected", test_detect_no_port)
+    test("Command without connection", test_send_without_connect)
+    test("Firmware files exist", test_firmware_files_exist)
+    test("Firmware lib files", test_firmware_lib_files)
+    test("Config valid JSON", test_config_valid_json)
+    test("No secrets in firmware", test_firmware_no_secrets)
+    test("Setup script exists", test_setup_script_exists)
+    test("File sizes ≤150 lines", test_file_sizes)
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary
- Complete ZeroClaw Fase 0: firmware + host bridge + setup script + tests
- MicroPython firmware: JSON command loop, LED status, watchdog, WiFi optional
- Host bridge: serial auto-detect, JSON protocol, self-test, interactive mode
- One-command setup: `bash zeroclaw/setup.sh` (installs deps, flashes, deploys, verifies)
- 9/9 tests pass without hardware

## Test plan
- [x] 9/9 Python tests pass (no hardware needed)
- [x] All files ≤ 150 lines
- [x] No secrets in firmware (tested)
- [x] config.json has empty WiFi SSID (safe to commit)
- [x] CHANGELOG lint passes

When ESP32 is connected: `bash zeroclaw/setup.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)