### PR TITLE
fix: re-sign confidentiality + lesson learned (v3.19.1)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -3,7 +3,7 @@
 # Commit this file with your PR. CI verifies it.
 # Any code change after signing invalidates this signature.
 diff_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-timestamp=2026-03-21T13:20:31Z
-branch=feat/savia-teams-participant
-head_commit=090f567
-signature=2e143b3aa391044a55ac453010edecf4d35dd00d5588ff5ad863ae7e4e60055c
+timestamp=2026-03-21T14:31:40Z
+branch=fix/resign-confidentiality-v2
+head_commit=8d6926e
+signature=a4efdecaf80a16de2e8f177ef2917909b1c2c73bbdcf43a9919ff7c327f8be0d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.1] — 2026-03-21
+
+Re-sign confidentiality + lesson learned.
+
+### Fixed
+
+- **Confidentiality**: re-signed `.confidentiality-signature`
+- **Self-improvement**: added lesson — ALWAYS sign before push, even docs-only PRs
+
 ## [3.19.0] — 2026-03-21
 
 Savia in Teams — same brain, two channels (ZeroClaw + Teams).
@@ -4078,3 +4087,4 @@ Initial public release of PM-Workspace.
 [3.17.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.16.0...v3.17.0
 [3.18.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.17.0...v3.18.0
 [3.19.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.18.0...v3.19.0
+[3.19.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.19.0...v3.19.1

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -17,3 +17,5 @@ Format: `| date | category | lesson | source |`
 | 2026-03-03 | Git | savia-branch.sh dispatcher uses short names (read, write, exists) not function names (do_read, do_write, do_exists). | Test failure — Era 22 |
 | 2026-03-03 | Bash | `!` negation doesn't work inside `"$@"` expansion. Use a separate `assert_fail` helper instead. | Test failure — Era 22 |
 | 2026-03-03 | Git | Default branch is `master` unless `init.defaultBranch` is configured. Always set `git config --global init.defaultBranch main` in test setup. | Test failure — Era 22 |
+
+| 2026-03-21 | Security | SIEMPRE firmar .confidentiality-signature antes de push, incluso docs-only PRs. Firmar como ÚLTIMO paso antes de push, en un solo commit. | Corrección de usuario tras emails de CI |


### PR DESCRIPTION
Re-signed after PRs #364-#365 missed signing. Single clean commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)