### PR TITLE
docs: align all documentation counters to v3.25.0 state

### DIFF
--- a/.claude/rules/domain/agents-catalog.md
+++ b/.claude/rules/domain/agents-catalog.md
@@ -1,4 +1,4 @@
-# Catálogo de Subagentes (44)
+# Catálogo de Subagentes (46)
 
 | Agente | Modelo | Especialidad |
 |---|---|---|

--- a/.claude/rules/domain/pm-workflow.md
+++ b/.claude/rules/domain/pm-workflow.md
@@ -18,7 +18,7 @@
 - **Sprints:** `Sprint YYYY-NN` (ej: `Sprint 2026-04`)
 - **Informes:** `YYYYMMDD-tipo-proyecto.ext`
 
-## 📟 Comandos Disponibles (99)
+## 📟 Comandos Disponibles (496)
 
 > Tabla completa: `.claude/commands/references/command-catalog.md`
 > Catálogo interactivo: `/help [filtro]`

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=694f0d56893e5709c7f2aeb5d66cc02a08567ba8697d27c6f117e38358b0440c
-timestamp=2026-03-22T09:38:03Z
-branch=feat/saviaclaw-v1.0-prep
-head_commit=901bcaa
-signature=aa4ce36e172dadd0c1a4c44505b73fa67e53395af55ffef3e2a3759baf2b9287
+diff_hash=e127360f52a2a36b9be722e0578df819b8d7bde87f79473fc1735fdcf10add4b
+timestamp=2026-03-22T09:49:34Z
+branch=docs/align-readme-v3.25
+head_commit=85af189
+signature=6dc04d209687cb2edbc21ebdd8fd5261506857f73595155e71e2b60320b87042

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=e127360f52a2a36b9be722e0578df819b8d7bde87f79473fc1735fdcf10add4b
-timestamp=2026-03-22T09:49:34Z
+timestamp=2026-03-22T09:52:49Z
 branch=docs/align-readme-v3.25
-head_commit=85af189
+head_commit=b4b0c4b
 signature=6dc04d209687cb2edbc21ebdd8fd5261506857f73595155e71e2b60320b87042

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e127360f52a2a36b9be722e0578df819b8d7bde87f79473fc1735fdcf10add4b
-timestamp=2026-03-22T09:52:49Z
+diff_hash=7448b6d6e1fdde1ea0a65612460718af63b1bc60c5d41c43f234ab2c04103c25
+timestamp=2026-03-22T09:54:07Z
 branch=docs/align-readme-v3.25
-head_commit=b4b0c4b
-signature=6dc04d209687cb2edbc21ebdd8fd5261506857f73595155e71e2b60320b87042
+head_commit=d5b7436
+signature=b08fa4394a320a786b365a2e28c78e52d9ef4de4f10e4cc70b47ed93b8e4d4e3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.0] — 2026-03-22
+
+SaviaClaw voice v2.4, Context Intelligence Tier 1-2, SPEC-017 Sovereignty, docs alignment.
+
+### Added
+
+- **SaviaClaw**: savia-voice daemon v2.4 — full-duplex, conversation model, Kokoro TTS, pre-cache 64 phrases
+- **SaviaClaw**: 31 new unit tests for savia-voice (77 total zeroclaw tests)
+- **Core**: SPEC-015 Context Gate in skill-auto-activation (6 bypass conditions)
+- **Core**: SPEC-012 Phase 1 — L1 summaries for 20 skills (progressive loading)
+- **Core**: SPEC-013/016 Session memory extraction + intelligent compact protocol
+- **Core**: SPEC-014 Competence-aware output in adaptive-output
+- **Core**: SPEC-017 Dependency Sovereignty spec + sovereignty-pack.sh (offline USB installer)
+- **Rules**: session-memory-protocol.md — pre-compact + end-of-session extraction
+
+### Fixed
+
+- **SaviaClaw**: daemon.py NameError in respond() (crash on first voice turn)
+- **Scripts**: contribute.sh ERE lookahead privacy leak (regex never matched)
+- **Scripts**: memory-store.sh grep injection via topic_key/hash
+- **Scripts**: validate-bash-global.sh POSIX ERE compat (macOS grep)
+- **Scripts**: scope-guard.sh restrict file extraction to bullet lines
+
+### Changed
+
+- **Docs**: README.md + README.en.md + CLAUDE.md counters aligned to real state
+- **Docs**: agents-catalog.md 44→46, pm-workflow.md commands 99→496
+
 ## [3.24.0] — 2026-03-21
 
 SaviaClaw v1.0 prep — daemon stability, voice pipeline, roadmap.
@@ -4183,5 +4211,6 @@ Initial public release of PM-Workspace.
 [3.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.0...v3.20.1
 [3.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.1...v3.21.0
 [3.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.21.0...v3.22.0
+[3.25.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.24.0...v3.25.0
 [3.24.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.23.0...v3.24.0
 [3.23.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.22.0...v3.23.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,12 @@ TEST_COVERAGE_MIN_PERCENT = 80
 ```
 ~/claude/                          ← Raíz y repositorio GitHub
 ├── .claude/
-│   ├── agents/ (43)               ← @.claude/rules/domain/agents-catalog.md
-│   ├── commands/ (401+)            ← @.claude/rules/domain/pm-workflow.md
+│   ├── agents/ (46)               ← @.claude/rules/domain/agents-catalog.md
+│   ├── commands/ (496)             ← @.claude/rules/domain/pm-workflow.md
 │   ├── profiles/                  ← Perfiles fragmentados → @.claude/profiles/README.md
-│   ├── hooks/ (16)                ← .claude/settings.json
+│   ├── hooks/ (22)                ← .claude/settings.json
 │   ├── rules/{domain,languages}/  ← Reglas bajo demanda (por @) y por lenguaje (auto-carga)
-│   ├── skills/ (79)               ← Skills reutilizables
+│   ├── skills/ (82)               ← Skills reutilizables
 │   └── settings.json              ← Hooks + Agent Teams env
 ├── docs/ · projects/ · scripts/
 ```
@@ -54,7 +54,7 @@ TEST_COVERAGE_MIN_PERCENT = 80
 
 Inicio de sesión: `active-user.md` → voz Savia → si perfil: saludar; si no: `/profile-setup` (`@.claude/rules/domain/profile-onboarding.md`). Fragmentos por demanda: `@.claude/profiles/context-map.md`
 
-> Catálogo completo de comandos (400+): `@.claude/rules/domain/pm-workflow.md`
+> Catálogo completo de comandos (496): `@.claude/rules/domain/pm-workflow.md`
 > MCP servers se conectan bajo demanda con `/mcp-server start {nombre}`, NO al arranque.
 
 ---
@@ -91,7 +91,7 @@ Inicio de sesión: `active-user.md` → voz Savia → si perfil: saludar; si no:
 
 ## Subagentes
 
-> Catálogo (31): `@.claude/rules/domain/agents-catalog.md` · Agent Notes: `@docs/agent-notes-protocol.md`
+> Catálogo (46): `@.claude/rules/domain/agents-catalog.md` · Agent Notes: `@docs/agent-notes-protocol.md`
 
 Cada agente: `memory: project`, `skills:` precargados, `permissionMode:` apropiado. Developers: `isolation: worktree`.
 Flujos: SDD (analyst→architect→security→tester→developer→reviewer) · Infra · Diagramas · Agent Teams (`@docs/agent-teams-sdd.md`)
@@ -110,7 +110,7 @@ Ciclo: Explorar → Planificar → Implementar → Commit. Arquitectura: **Comma
 
 ## Hooks · Memoria · Checklist
 
-> Hooks (16): `.claude/settings.json` — Arranque blindado (sin red, sin dependencias externas)
+> Hooks (22): `.claude/settings.json` — Arranque blindado (sin red, sin dependencias externas)
 > Memoria: `@docs/memory-system.md` · Store: `scripts/memory-store.sh` (JSONL, dedup, topic_key, `<private>`) · Agent Notes: `@docs/agent-notes-protocol.md` · Security: `/security-review {spec}` — OWASP pre-implementación
 
 - [ ] `projects/[nombre]/CLAUDE.md` (≤150 líneas) + entrada en `CLAUDE.local.md`

--- a/README.en.md
+++ b/README.en.md
@@ -53,10 +53,10 @@ More detail in the [Data flow guide](docs/data-flow-guide-en.md).
 ```
 pm-workspace/
 ├── .claude/
-│   ├── commands/       ← 400+ commands (what you can ask me)
-│   ├── agents/         ← 44 specialized agents
-│   ├── skills/         ← 79 skills with domain knowledge
-│   ├── hooks/          ← 17 hooks that enforce rules automatically
+│   ├── commands/       ← 496 commands (what you can ask me)
+│   ├── agents/         ← 46 specialized agents
+│   ├── skills/         ← 82 skills with domain knowledge
+│   ├── hooks/          ← 22 hooks that enforce rules automatically
 │   └── rules/          ← context, language, and domain rules
 ├── docs/
 │   ├── quick-starts/   ← role-based guides (PM, Dev, QA, PO, TL, CEO)
@@ -69,7 +69,8 @@ pm-workspace/
 ├── zeroclaw/
 │   ├── firmware/       ← MicroPython for ESP32 (selftest, heartbeat, LCD)
 │   ├── host/           ← bridge, daemon, voice, guardrails, brain
-│   ├── tests/          ← 39 hardware-free tests
+│   ├── savia-voice/    ← next-gen voice daemon (full-duplex, Kokoro TTS)
+│   ├── tests/          ← 77 hardware-free tests
 │   └── ROADMAP.md      ← phases 0-6 towards autonomy
 ├── scripts/            ← validation, CI, utilities, savia-bridge.py
 ├── output/             ← generated files (reports, specs, exports)
@@ -104,7 +105,7 @@ Every command has YAML frontmatter with metadata (model, context cost, descripti
 
 **Autonomous modes** — Overnight sprint, code improvement loop, tech research, and dev onboarding with AI buddy. Agents propose, humans approve: `agent/*` branches, Draft PRs, mandatory human review.
 
-**Collaboration** — Company Savia (E2E encrypted messaging), Savia Flow (Git-native PM), Travel Mode, encrypted backup, Savia School. Reference: [400+ commands · 44 agents · 79 skills](docs/readme/12-comandos-agentes.md)
+**Collaboration** — Company Savia (E2E encrypted messaging), Savia Flow (Git-native PM), Travel Mode, encrypted backup, Savia School. Reference: [496 commands · 46 agents · 82 skills](docs/readme/12-comandos-agentes.md)
 
 **Savia Mobile** — Native Android app (Kotlin/Compose) that connects to pm-workspace via [Savia Bridge](scripts/savia-bridge.py) — an HTTPS/SSE server that wraps Claude Code CLI. Real-time streaming chat, encrypted local storage, Material 3 theme. Details: [Savia Mobile](projects/savia-mobile-android/README.md)
 
@@ -141,7 +142,7 @@ Configurable with `SAVIA_HOME`, `--skip-tests`. Details: `install.sh --help`
 | [Sprints & reports](docs/readme_en/04-uso-sprint-informes.md) | Sprint, reporting, KPIs |
 | [Spec-Driven Development](docs/readme_en/05-sdd.md) | SDD: specs, agents, patterns |
 | [Data flow](docs/data-flow-guide-en.md) | How the parts connect |
-| [Commands & agents](docs/readme/12-comandos-agentes.md) | 400+ commands + 44 agents |
+| [Commands & agents](docs/readme/12-comandos-agentes.md) | 496 commands + 46 agents |
 | [Scenario guides](docs/guides_en/README.md) | Azure, Jira, startup, healthcare... |
 | [AI Augmentation](docs/ai-augmentation-opportunities-en.md) | Opportunities by sector |
 | [Context Engineering](docs/context-engineering-en.md) | Context & AI improvements |

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Más detalle en la [Guía de flujo de datos](docs/data-flow-guide-es.md).
 ```
 pm-workspace/
 ├── .claude/
-│   ├── commands/       ← 400+ comandos (lo que me puedes pedir)
-│   ├── agents/         ← 44 agentes especializados
-│   ├── skills/         ← 79 skills con conocimiento de dominio
-│   ├── hooks/          ← 17 hooks que refuerzan reglas automáticamente
+│   ├── commands/       ← 496 comandos (lo que me puedes pedir)
+│   ├── agents/         ← 46 agentes especializados
+│   ├── skills/         ← 82 skills con conocimiento de dominio
+│   ├── hooks/          ← 22 hooks que refuerzan reglas automáticamente
 │   └── rules/          ← reglas de contexto, lenguaje, dominio
 ├── docs/
 │   ├── quick-starts/   ← guías por rol (PM, Dev, QA, PO, TL, CEO)
@@ -69,7 +69,8 @@ pm-workspace/
 ├── zeroclaw/
 │   ├── firmware/       ← MicroPython para ESP32 (selftest, heartbeat, LCD)
 │   ├── host/           ← bridge, daemon, voz, guardrails, brain
-│   ├── tests/          ← 39 tests sin hardware
+│   ├── savia-voice/    ← daemon de voz next-gen (full-duplex, Kokoro TTS)
+│   ├── tests/          ← 77 tests sin hardware
 │   └── ROADMAP.md      ← fases 0-6 hacia autonomía
 ├── scripts/            ← validación, CI, utilidades, savia-bridge.py
 ├── output/             ← ficheros generados (informes, specs, exports)
@@ -104,7 +105,7 @@ Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, des
 
 **Modos autónomos** — Sprint nocturno, bucle de mejora de código, investigación técnica y onboarding con buddy IA. Los agentes proponen, el humano dispone: ramas `agent/*`, PRs Draft, revisión humana obligatoria.
 
-**Colaboración** — Company Savia (mensajería E2E cifrada), Savia Flow (PM Git-native), Travel Mode, backup cifrado, Savia School. Referencia: [400+ comandos · 44 agentes · 79 skills](docs/readme/12-comandos-agentes.md)
+**Colaboración** — Company Savia (mensajería E2E cifrada), Savia Flow (PM Git-native), Travel Mode, backup cifrado, Savia School. Referencia: [496 comandos · 46 agentes · 82 skills](docs/readme/12-comandos-agentes.md)
 
 **Savia Mobile** — App Android nativa (Kotlin/Compose) que conecta con pm-workspace vía [Savia Bridge](scripts/savia-bridge.py) — un servidor HTTPS/SSE que envuelve Claude Code CLI. Chat con streaming en tiempo real, persistencia local cifrada, tema Material 3. Detalles: [Savia Mobile](projects/savia-mobile-android/README.md)
 
@@ -142,7 +143,7 @@ Configurable con `SAVIA_HOME`, `--skip-tests`. Detalles: `install.sh --help`
 | [Spec-Driven Development](docs/readme/05-sdd.md) | SDD: specs, agentes, patrones |
 | [Flujo de datos](docs/data-flow-guide-es.md) | Cómo se conectan las partes |
 | [Confidencialidad](docs/confidentiality-levels.md) | 5 niveles (N1-N4b) y mecanismos |
-| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 400+ comandos + 44 agentes |
+| [Comandos y agentes](docs/readme/12-comandos-agentes.md) | 496 comandos + 46 agentes |
 | [Guías por escenario](docs/guides/README.md) | Azure, Jira, startup, sanidad... |
 | [AI Augmentation](docs/ai-augmentation-opportunities-es.md) | Oportunidades por sector |
 | [Context Engineering](docs/context-engineering-es.md) | Mejoras de contexto e IA |


### PR DESCRIPTION
Audit of README.md (ES), README.en.md (EN), CLAUDE.md, agents-catalog.md, pm-workflow.md.

All numeric claims updated to real file counts:
- Commands: 401→496
- Agents: 43/44→46
- Skills: 79→82
- Hooks: 16/17→22
- ZeroClaw tests: 39→77
- Added savia-voice/ to directory trees

CI 17/17 passed. Confidentiality signed.