### PR TITLE
feat: PR signing protocol + push-pr.sh (v3.25.1)

### DIFF
--- a/.claude/rules/domain/pr-signing-protocol.md
+++ b/.claude/rules/domain/pr-signing-protocol.md
@@ -1,0 +1,60 @@
+# PR Signing Protocol — Zero re-sign commits
+
+> Evitar el bucle firma→commit→diff cambiado→firma invalida→re-firmar.
+
+## El problema
+
+`confidentiality-sign.sh sign` calcula hash del diff `origin/main..HEAD`.
+Si haces commits despues de firmar, el diff cambia y la firma es invalida.
+Resultado: commits extra de re-firma que ensucian el historial.
+
+## Protocolo obligatorio (orden estricto)
+
+```
+1. TERMINAR todo el trabajo (codigo, docs, tests, CHANGELOG)
+2. VERIFICAR CI local: bash scripts/validate-ci-local.sh
+3. SI CI pide CHANGELOG → añadir CHANGELOG y commitear
+4. FIRMAR: bash scripts/confidentiality-sign.sh sign
+5. COMMIT de firma: git add .confidentiality-signature && git commit
+6. PUSH: git push origin {rama}
+7. CREAR PR
+
+NUNCA hacer commits de contenido despues del paso 4.
+```
+
+## Regla clave
+
+**La firma es SIEMPRE el ultimo commit de la rama antes de push.**
+Si necesitas hacer cambios despues de firmar:
+1. Hacer el cambio
+2. Commitear
+3. Re-firmar (paso 4-6)
+
+No hay forma de evitar re-firmar si cambias contenido. Lo que se evita
+es firmar demasiado pronto (antes de tener todo listo).
+
+## Checklist pre-PR (para Savia)
+
+Antes de crear PR, verificar en este orden:
+- [ ] CI local pasa (validate-ci-local.sh)
+- [ ] CHANGELOG tiene entrada si hay cambios en rules/hooks/agents/skills
+- [ ] CHANGELOG tiene link comparativo al final
+- [ ] Todo commiteado (git status limpio salvo .confidentiality-signature)
+- [ ] Firmar: `bash scripts/confidentiality-sign.sh sign`
+- [ ] Commit firma: `git add .confidentiality-signature && git commit`
+- [ ] Push
+- [ ] Crear PR (nunca draft si se va a mergear pronto)
+
+## Script wrapper: push-pr.sh
+
+`scripts/push-pr.sh` automatiza los pasos 2-7:
+```
+push-pr.sh [--title "titulo"] [--body "body"]
+```
+Ejecuta CI → firma → commit → push → crea PR. Un solo comando.
+
+## Anti-patterns
+
+- Firmar antes de tener el CHANGELOG → PR Guardian rechaza → re-firmar
+- Hacer commit de firma junto con otros cambios → confuso en historial
+- Push sin firmar → CI falla → commit extra de firma

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=6c78bc71a1b7c5fa9451aba87d795b72bc76ae5dbdb2a0f4dbba9cab973dbc9f
-timestamp=2026-03-22T10:40:20Z
+timestamp=2026-03-22T10:45:27Z
 branch=fix/pr-signing-protocol
-head_commit=5d10570
+head_commit=1451e64
 signature=3a6ed8ad3a3f0d8a4e5992cb722a1b751fffb4e9ef2a9521dc3f4998ad661b13

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=7448b6d6e1fdde1ea0a65612460718af63b1bc60c5d41c43f234ab2c04103c25
-timestamp=2026-03-22T09:54:07Z
-branch=docs/align-readme-v3.25
-head_commit=d5b7436
-signature=b08fa4394a320a786b365a2e28c78e52d9ef4de4f10e4cc70b47ed93b8e4d4e3
+diff_hash=3ea6435769761b910c6a6ff226bbb9875a7e6d342ac3d411ddd7e362d8985ce7
+timestamp=2026-03-22T10:38:23Z
+branch=fix/pr-signing-protocol
+head_commit=9eb060a
+signature=9eead438b3bb8ea09825279b460b32745bb49df6d7fd719929df413aedc2eaa5

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=3ea6435769761b910c6a6ff226bbb9875a7e6d342ac3d411ddd7e362d8985ce7
-timestamp=2026-03-22T10:38:23Z
+diff_hash=6c78bc71a1b7c5fa9451aba87d795b72bc76ae5dbdb2a0f4dbba9cab973dbc9f
+timestamp=2026-03-22T10:40:20Z
 branch=fix/pr-signing-protocol
-head_commit=9eb060a
-signature=9eead438b3bb8ea09825279b460b32745bb49df6d7fd719929df413aedc2eaa5
+head_commit=5d10570
+signature=3a6ed8ad3a3f0d8a4e5992cb722a1b751fffb4e9ef2a9521dc3f4998ad661b13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.25.1] — 2026-03-22
+
+PR signing protocol — zero re-sign commits.
+
+### Added
+
+- **Scripts**: `push-pr.sh` — automates CI + CHANGELOG check + sign + push + PR creation
+- **Rules**: `pr-signing-protocol.md` — strict sign-last order to prevent re-sign loops
+
 ## [3.25.0] — 2026-03-22
 
 SaviaClaw voice v2.4, Context Intelligence Tier 1-2, SPEC-017 Sovereignty, docs alignment.
@@ -4211,6 +4220,7 @@ Initial public release of PM-Workspace.
 [3.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.0...v3.20.1
 [3.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.1...v3.21.0
 [3.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.21.0...v3.22.0
+[3.25.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.25.0...v3.25.1
 [3.25.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.24.0...v3.25.0
 [3.24.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.23.0...v3.24.0
 [3.23.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.22.0...v3.23.0

--- a/scripts/push-pr.sh
+++ b/scripts/push-pr.sh
@@ -96,20 +96,18 @@ if [[ -z "$TOKEN" ]]; then
   exit 0
 fi
 
-DRAFT_JSON="false"; $DRAFT && DRAFT_JSON="true"
-PR_URL=$(curl -s -X POST "https://api.github.com/repos/gonzalezpazmonica/pm-workspace/pulls" \
-  -H "Authorization: token $TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  -d "$(python3 -c "
-import json,sys
-print(json.dumps({
-  'title': '''$TITLE''',
-  'body': '''$BODY''',
-  'head': '$BRANCH',
-  'base': 'main',
-  'draft': $DRAFT_JSON == 'true'
-}))
-")" | python3 -c "import sys,json; print(json.load(sys.stdin).get('html_url','PR creation failed'))")
+DRAFT_BOOL="false"; $DRAFT && DRAFT_BOOL="True" || DRAFT_BOOL="False"
+PR_URL=$(python3 << PYEOF
+import json,urllib.request,sys
+data=json.dumps({"title":"$(echo "$TITLE" | sed 's/"/\\"/g')","body":"$(echo "$BODY" | sed 's/"/\\"/g' | tr '\n' ' ')","head":"$BRANCH","base":"main","draft":$DRAFT_BOOL}).encode()
+req=urllib.request.Request("https://api.github.com/repos/gonzalezpazmonica/pm-workspace/pulls",data=data,headers={"Authorization":"token $TOKEN","Accept":"application/vnd.github+json","Content-Type":"application/json"})
+try:
+  r=json.loads(urllib.request.urlopen(req).read())
+  print(r.get("html_url","PR creation failed"))
+except Exception as e:
+  print(f"PR creation failed: {e}",file=sys.stderr); print("PR creation failed")
+PYEOF
+)
 
 echo "  PR: $PR_URL"
 

--- a/scripts/push-pr.sh
+++ b/scripts/push-pr.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# push-pr.sh — CI + sign + push + create PR (zero re-sign commits)
+# Usage: push-pr.sh [--title "title"] [--body "body"] [--draft] [--merge]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+TITLE="" BODY="" DRAFT=false MERGE=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title) TITLE="$2"; shift 2 ;;
+    --body) BODY="$2"; shift 2 ;;
+    --draft) DRAFT=true; shift ;;
+    --merge) MERGE=true; shift ;;
+    --help|-h) echo "Usage: $0 [--title T] [--body B] [--draft] [--merge]"; exit 0 ;;
+    *) shift ;;
+  esac
+done
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  echo "ERROR: On $BRANCH. Create a feature branch first." >&2; exit 1
+fi
+
+# ── Step 1: Verify nothing pending ──────────────────────────────────────
+echo "=== Step 1/6: Check working tree ==="
+if [[ -n "$(git diff --name-only)" ]]; then
+  echo "ERROR: Uncommitted changes. Commit everything first." >&2
+  git diff --name-only >&2; exit 1
+fi
+echo "  Clean."
+
+# ── Step 2: Run CI local ────────────────────────────────────────────────
+echo ""
+echo "=== Step 2/6: CI local ==="
+if ! bash scripts/validate-ci-local.sh 2>&1 | tail -5 | grep -q "safe to push"; then
+  echo "ERROR: CI local failed. Fix issues first." >&2; exit 1
+fi
+echo "  CI passed."
+
+# ── Step 3: Check CHANGELOG if rules/hooks changed ──────────────────────
+echo ""
+echo "=== Step 3/6: CHANGELOG gate ==="
+DIFF_FILES=$(git diff origin/main..HEAD --name-only 2>/dev/null || true)
+NEEDS_CL=false
+echo "$DIFF_FILES" | grep -qE '\.claude/(rules|hooks|agents|skills)/' && NEEDS_CL=true
+if $NEEDS_CL; then
+  CL_VERSION=$(grep -oP '## \[\K[0-9.]+' CHANGELOG.md | head -1)
+  PREV_CL=$(git show origin/main:CHANGELOG.md 2>/dev/null | grep -oP '## \[\K[0-9.]+' | head -1)
+  if [[ "$CL_VERSION" == "$PREV_CL" ]]; then
+    echo "ERROR: Rules/hooks changed but CHANGELOG not updated." >&2
+    echo "  Add entry for new version in CHANGELOG.md, then re-run." >&2
+    exit 1
+  fi
+  echo "  CHANGELOG updated ($CL_VERSION)."
+else
+  echo "  No high-impact files — CHANGELOG not required."
+fi
+
+# ── Step 4: Sign confidentiality ─────────────────────────────────────────
+echo ""
+echo "=== Step 4/6: Confidentiality sign ==="
+bash scripts/confidentiality-sign.sh sign
+git add .confidentiality-signature
+if git diff --cached --quiet; then
+  echo "  Signature unchanged."
+else
+  git commit -m "chore: sign confidentiality audit
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+  echo "  Signed and committed."
+fi
+
+# ── Step 5: Push ─────────────────────────────────────────────────────────
+echo ""
+echo "=== Step 5/6: Push ==="
+git push origin "$BRANCH"
+echo "  Pushed."
+
+# ── Step 6: Create PR (if title provided) ────────────────────────────────
+echo ""
+echo "=== Step 6/6: PR ==="
+if [[ -z "$TITLE" ]]; then
+  TITLE=$(git log --oneline -1 | cut -d' ' -f2-)
+fi
+if [[ -z "$BODY" ]]; then
+  BODY=$(git log --oneline origin/main..HEAD | sed 's/^/- /')
+fi
+
+TOKEN=$(git remote get-url origin | grep -oP 'ghp_[A-Za-z0-9]+' || true)
+if [[ -z "$TOKEN" ]]; then
+  echo "  No GitHub token in remote URL. Create PR manually:"
+  echo "  https://github.com/.../pull/new/$BRANCH"
+  exit 0
+fi
+
+DRAFT_JSON="false"; $DRAFT && DRAFT_JSON="true"
+PR_URL=$(curl -s -X POST "https://api.github.com/repos/gonzalezpazmonica/pm-workspace/pulls" \
+  -H "Authorization: token $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -d "$(python3 -c "
+import json,sys
+print(json.dumps({
+  'title': '''$TITLE''',
+  'body': '''$BODY''',
+  'head': '$BRANCH',
+  'base': 'main',
+  'draft': $DRAFT_JSON == 'true'
+}))
+")" | python3 -c "import sys,json; print(json.load(sys.stdin).get('html_url','PR creation failed'))")
+
+echo "  PR: $PR_URL"
+
+if $MERGE; then
+  echo "  Waiting 60s for CI..."
+  sleep 60
+  PR_NUM=$(echo "$PR_URL" | grep -oP '[0-9]+$')
+  curl -s -X PUT "https://api.github.com/repos/gonzalezpazmonica/pm-workspace/pulls/$PR_NUM/merge" \
+    -H "Authorization: token $TOKEN" \
+    -d '{"merge_method":"squash"}' | python3 -c "
+import sys,json; d=json.load(sys.stdin)
+print('  Merged.' if 'sha' in d else f'  Merge failed: {d.get(\"message\",d)}')
+"
+fi
+
+echo ""
+echo "Done."


### PR DESCRIPTION
## Summary

Prevents the re-sign loop that caused 2+ extra commits per PR in the marathon session.

- **pr-signing-protocol.md**: Strict order — all content commits first, sign as absolute last step before push. Checklist for Savia.
- **push-pr.sh**: Automates CI check → CHANGELOG gate → confidentiality sign → push → PR creation. Single command replaces 6 manual steps.
- **CHANGELOG v3.25.1**: Documents the new protocol and script.

## Test plan

- [x] push-pr.sh tested: CI gate works, CHANGELOG gate caught missing entry, sign step executed correctly
- [x] validate-ci-local.sh 17/17
- [x] Confidentiality signed

Generated with [Claude Code](https://claude.com/claude-code)