### PR TITLE
docs: add context intelligence, voice v2.4, sovereignty to READMEs

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=3a99fe20015179db687d2284d026cdeea52fd41cb3315a47577bd344990af120
-timestamp=2026-03-22T10:56:58Z
+timestamp=2026-03-22T10:58:46Z
 branch=docs/readme-new-features
-head_commit=feb22d5
+head_commit=5f76f10
 signature=9830cd0dd64e5686e72b081ef540ecfde54628d93151b2a7fb6b270fd2b17f36

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=6c78bc71a1b7c5fa9451aba87d795b72bc76ae5dbdb2a0f4dbba9cab973dbc9f
-timestamp=2026-03-22T10:45:27Z
-branch=fix/pr-signing-protocol
-head_commit=1451e64
-signature=3a6ed8ad3a3f0d8a4e5992cb722a1b751fffb4e9ef2a9521dc3f4998ad661b13
+diff_hash=3a99fe20015179db687d2284d026cdeea52fd41cb3315a47577bd344990af120
+timestamp=2026-03-22T10:56:58Z
+branch=docs/readme-new-features
+head_commit=feb22d5
+signature=9830cd0dd64e5686e72b081ef540ecfde54628d93151b2a7fb6b270fd2b17f36

--- a/README.en.md
+++ b/README.en.md
@@ -93,7 +93,7 @@ Every command has YAML frontmatter with metadata (model, context cost, descripti
 
 **Infrastructure** — Multi-cloud (Azure, AWS, GCP) with auto-detection, minimum tier by default, and scaling only with your approval. Configurable CI/CD pipelines.
 
-**Memory & context** — Persistent memory store (JSONL), entity recall for stakeholders and components, progressive disclosure by context cost, and cross-session continuity.
+**Memory & context** — Persistent memory store (JSONL), entity recall for stakeholders and components, progressive disclosure by context cost, and cross-session continuity. Context Gate (SPEC-015) skips skill scoring on trivial prompts. Progressive Loading L0/L1/L2 (SPEC-012) reduces skill tokens by 40-60%. Intelligent Compact (SPEC-016) extracts decisions and corrections before compacting — zero-loss. Session Memory Extraction (SPEC-013) persists knowledge at session end.
 
 **Executive reporting** — Multi-project CEO report, executive alerts, portfolio overview, DORA metrics, value stream mapping.
 
@@ -111,7 +111,9 @@ Every command has YAML frontmatter with metadata (model, context cost, descripti
 
 **Savia Web** — Vue.js 3 + TypeScript + Vite web client with 10 dashboard pages (sprints, debt, DORA, capacity, etc.) and 10 ECharts components. [Savia Bridge](scripts/savia-bridge.py) exposes 8 reporting endpoints (velocity, burndown, DORA, workload, quality, debt, cycle-time, portfolio). Deploy script at `setup-savia-web.sh`. Details: [Savia Web](projects/savia-web/README.md)
 
-**SaviaClaw** — Savia in the physical world. ESP32 with 16x2 LCD, MicroPython firmware (selftest, heartbeat, JSON commands, WiFi). Host daemon with auto-reconnect, signal handling, watchdog and status file. Brain Bridge: ESP32 asks → Claude CLI → LCD response. Voice pipeline (TTS espeak-ng/spd-say + STT whisper, offline-first). 7 deterministic guardrails (size, rate, PII, storage, command, cleanup, audit). 39 hardware-free tests. [Roadmap](zeroclaw/ROADMAP.md)
+**SaviaClaw** — Savia in the physical world. ESP32 with 16x2 LCD, MicroPython firmware (selftest, heartbeat, JSON commands, WiFi). Host daemon with auto-reconnect. Brain Bridge: ESP32 → Claude CLI → LCD. Savia Voice v2.4: full-duplex daemon with Silero VAD + faster-whisper + Claude stream-json + Kokoro TTS local (200ms/phrase). Conversation model with overlap classification (backchannel/stop/collaborative). Pre-cache of 64 phrases for zero latency. 7 deterministic guardrails. 77 hardware-free tests. [Roadmap](zeroclaw/ROADMAP.md)
+
+**Dependency sovereignty** — SPEC-017: 32GB USB drive containing fully offline Savia. Standalone Python, pip wheels, Whisper/Kokoro/Ollama models, ffmpeg, jq, Node.js, Claude Code. 4 tiers (4-20GB). SaviaOS: bootable Ubuntu minimal distro from USB, boots on any x86_64 PC without touching the disk. `sovereignty-pack.sh` prepares the USB from a machine with internet.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, des
 
 **Infraestructura** — Multi-cloud (Azure, AWS, GCP) con detección automática, tier mínimo por defecto, y escalado solo con tu aprobación. Pipelines CI/CD configurables.
 
-**Memoria y contexto** — Memory store persistente (JSONL), entity recall, progressive disclosure, continuidad entre sesiones. Personal Vault (N3) con repo git independiente para datos del usuario, cifrado AES-256.
+**Memoria y contexto** — Memory store persistente (JSONL), entity recall, progressive disclosure, continuidad entre sesiones. Personal Vault (N3) con repo git independiente para datos del usuario, cifrado AES-256. Context Gate (SPEC-015) salta el scoring de skills en prompts triviales. Progressive Loading L0/L1/L2 (SPEC-012) reduce tokens de skills un 40-60%. Intelligent Compact (SPEC-016) extrae decisiones y correcciones antes de compactar — zero-loss. Session Memory Extraction (SPEC-013) persiste conocimiento al cerrar sesion.
 
 **Informes ejecutivos** — CEO report multi-proyecto, alertas de dirección, portfolio overview, DORA metrics, value stream mapping.
 
@@ -111,7 +111,9 @@ Cada comando tiene frontmatter YAML con metadata (modelo, coste de contexto, des
 
 **Savia Web** — Cliente web Vue.js 3 + TypeScript + Vite con 10 páginas de dashboards (sprints, deuda, DORA, capacidad, etc.) y 10 componentes ECharts. [Savia Bridge](scripts/savia-bridge.py) expone 8 endpoints de reporting (velocity, burndown, DORA, workload, quality, debt, cycle-time, portfolio). Script de deploy en `setup-savia-web.sh`. Detalles: [Savia Web](projects/savia-web/README.md)
 
-**SaviaClaw** — Savia en el mundo físico. ESP32 con LCD 16x2, firmware MicroPython (selftest, heartbeat, comandos JSON, WiFi). Host daemon con reconexión automática, señales, watchdog y status file. Brain Bridge: pregunta al ESP32 → Claude CLI → respuesta en LCD. Pipeline de voz (TTS espeak-ng/spd-say + STT whisper, offline-first). 7 guardrails deterministas (size, rate, PII, storage, command, cleanup, audit). 39 tests sin hardware. [Roadmap](zeroclaw/ROADMAP.md)
+**SaviaClaw** — Savia en el mundo fisico. ESP32 con LCD 16x2, firmware MicroPython (selftest, heartbeat, comandos JSON, WiFi). Host daemon con reconexion automatica. Brain Bridge: ESP32 → Claude CLI → LCD. Savia Voice v2.4: daemon full-duplex con Silero VAD + faster-whisper + Claude stream-json + Kokoro TTS local (200ms/frase). Conversation model con clasificacion de overlaps (backchannel/stop/collaborative). Pre-cache de 64 frases para latencia cero. 7 guardrails deterministas. 77 tests sin hardware. [Roadmap](zeroclaw/ROADMAP.md)
+
+**Soberania de dependencias** — SPEC-017: USB de 32GB que contiene Savia completa para instalacion offline. Python standalone, pip wheels, modelos Whisper/Kokoro/Ollama, ffmpeg, jq, Node.js, Claude Code. 4 tiers (4-20GB). SaviaOS: distro Ubuntu minimal booteable desde USB, arranca en cualquier PC x86_64 sin tocar el disco. `sovereignty-pack.sh` prepara el USB desde maquina con internet.
 
 ---
 


### PR DESCRIPTION
## Summary

Add missing new features to both README.md (ES) and README.en.md (EN).

### Changes

- **Memory & context section**: Added Context Gate (SPEC-015), Progressive Loading L0/L1/L2 (SPEC-012), Intelligent Compact (SPEC-016), Session Memory Extraction (SPEC-013)
- **SaviaClaw section**: Updated to Savia Voice v2.4 — full-duplex daemon, Kokoro TTS local, conversation model with overlap classification, 64 pre-cached phrases, 77 tests
- **New section: Dependency Sovereignty**: SPEC-017 — offline USB installer with 4 tiers (4-20GB), SaviaOS bootable Ubuntu distro, sovereignty-pack.sh

## Test plan

- [x] validate-ci-local.sh 17/17
- [x] Both READMEs have identical feature coverage
- [x] No PII in new content

Generated with [Claude Code](https://claude.com/claude-code)