### PR TITLE
feat: SPEC-018 vector memory index — semantic search (v3.28.0)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=fd5a819f32f3682dbc280133e526ad9e39971a0fde9782764b6f950639c08c15
-timestamp=2026-03-22T15:03:37Z
+diff_hash=7b5192af42a3976c1d421563fd08e3a881d6e6cd5843e0986343cc072af326dc
+timestamp=2026-03-22T15:06:23Z
 branch=feat/vector-memory-index
-head_commit=c2ee146
-signature=fb36aed538bbc7cfbf0170e348aa2f503488e2c2c772bda6b65cba5014298afc
+head_commit=8ec02fd
+signature=462cd093301e49bf42f5099e874aeeca496afa7f54161ae06949bda865ebbc7d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=373f5f9718b250e7490b7aaf4552b4e72428dbf32d3b3076ff1a6e306c119702
-timestamp=2026-03-22T14:30:18Z
-branch=feat/engram-patterns
-head_commit=ac41a2f
-signature=a2d3234a438655a214469ccd2ec8aa7b7653a9310e7d4a0862d7c38604a108ac
+diff_hash=fd5a819f32f3682dbc280133e526ad9e39971a0fde9782764b6f950639c08c15
+timestamp=2026-03-22T15:03:37Z
+branch=feat/vector-memory-index
+head_commit=c2ee146
+signature=fb36aed538bbc7cfbf0170e348aa2f503488e2c2c772bda6b65cba5014298afc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.29.0] — 2026-03-22
+
+SPEC-018 Vector memory index — semantic search over plain-text JSONL.
+
+### Added
+
+- **Scripts**: `memory-vector.py` — vector index engine: rebuild, search, status, benchmark. Uses sentence-transformers (all-MiniLM-L6-v2, 22MB, Apache 2.0) + hnswlib. Zero vendor lock-in, offline-compatible.
+- **Scripts**: `memory-store.sh` — vector search integration with `--mode auto|grep|vector`, auto-rebuild on JSONL changes, `rebuild-index`/`index-status`/`benchmark` subcommands
+- **Tests**: `test-memory-vector.bats` — 8 integration tests (fallback, auto-rebuild, status)
+- **Tests**: `test-vector-quality.py` — benchmark: Recall@5 grep=40% vs vector=90% (+50pp)
+- **Spec**: `SPEC-018-vector-memory-index.md` — architecture, justification, auto-adaptation
+- **Config**: `requirements-vector.txt` — optional deps (sentence-transformers, hnswlib)
+
+### Changed
+
+- **Scripts**: `memory-store.sh` — search attempts vector first, falls back to grep. Auto-rebuild triggers in background after each save.
+
 ## [3.28.0] — 2026-03-22
 
 Engram-inspired memory patterns — structured observations, topic key families, session summaries.
@@ -4259,6 +4276,7 @@ Initial public release of PM-Workspace.
 [3.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.0...v3.20.1
 [3.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.1...v3.21.0
 [3.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.21.0...v3.22.0
+[3.29.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.28.0...v3.29.0
 [3.28.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.27.1...v3.28.0
 [3.27.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.27.0...v3.27.1
 [3.27.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.26.0...v3.27.0

--- a/docs/propuestas/SPEC-018-vector-memory-index.md
+++ b/docs/propuestas/SPEC-018-vector-memory-index.md
@@ -1,0 +1,248 @@
+# SPEC-018: Vector Memory Index — Semantic Search over Plain Text
+
+> Status: **IMPLEMENTING** · Fecha: 2026-03-22
+> Origen: Engram analysis — grep scoring insufficient for semantic recall
+> Impacto: Memory search quality +40-60%, zero vendor lock-in
+
+---
+
+## Problema
+
+`memory-store.sh search` usa grep + keyword scoring. Funciona para matches
+exactos pero falla en:
+
+- Buscar "auth problems" no encuentra "login timeout on token refresh"
+- Buscar "performance" no encuentra "N+1 query in OrderService"
+- Sinonimos, contexto semantico y relaciones se pierden
+
+Engram resuelve esto con SQLite FTS5. Nosotros queremos ir mas alla con
+embeddings vectoriales, pero manteniendo texto plano como fuente de verdad.
+
+---
+
+## Principios de diseno
+
+1. **JSONL es verdad** — el indice vectorial es derivado, regenerable, gitignored
+2. **Zero vendor lock-in** — modelo local, sin APIs externas, sin cloud
+3. **Degradacion elegante** — si no hay indice, grep sigue funcionando
+4. **Auto-adaptacion** — cualquier Savia que haga git pull se adapta sola
+5. **Sovereignty-compatible** — funciona offline con SPEC-017
+
+---
+
+## Arquitectura
+
+```
+JSONL (source of truth, plain text, diffable, portable)
+  |
+  v -- rebuild-index (batch, on-demand)
+Vector index (.idx + .map, gitignored, regenerable)
+  |
+  v -- semantic-search (query -> embedding -> ANN -> ranked results)
+Resultados con score de similitud coseno
+  |
+  v -- fallback to grep if index missing
+```
+
+### Ficheros
+
+| Fichero | Proposito | Git |
+|---------|-----------|-----|
+| `output/.memory-store.jsonl` | Fuente de verdad | gitignored |
+| `output/.memory-index.idx` | Indice vectorial hnswlib | gitignored |
+| `output/.memory-index.map` | Mapa id->linea JSONL | gitignored |
+| `scripts/memory-vector.py` | Motor de indexacion + busqueda | tracked |
+| `scripts/memory-store.sh` | CLI wrapper (ya existe) | tracked |
+
+---
+
+## Modelo de embeddings
+
+**sentence-transformers/all-MiniLM-L6-v2**
+- Tamano: 22 MB
+- Dimensiones: 384
+- Licencia: Apache 2.0
+- Idiomas: multilingue (ES + EN ok)
+- CPU: ~5ms por embedding
+- Sin dependencia de GPU
+
+Alternativa offline (SPEC-017): modelo incluido en sovereignty pack.
+
+---
+
+## Implementacion
+
+### scripts/memory-vector.py
+
+```
+Subcomandos:
+  rebuild    — Lee JSONL, genera embeddings, escribe .idx + .map
+  search     — Recibe query, devuelve top-K resultados con scores
+  status     — Muestra si indice existe, cuantas entradas, tamano
+  benchmark  — Compara grep vs vector en corpus de test
+```
+
+### Flujo rebuild
+
+1. Leer cada linea del JSONL
+2. Componer texto indexable: "{title} {content} {topic_key} {concepts}"
+3. Generar embedding con sentence-transformers
+4. Insertar en indice hnswlib (espacio coseno, ef_construction=200)
+5. Guardar mapa {idx_position -> jsonl_line_number}
+6. Escribir .idx y .map atomicamente (tmp + mv)
+
+### Flujo search
+
+1. Recibir query string
+2. Generar embedding de la query
+3. Buscar K vecinos mas cercanos en .idx
+4. Mapear posiciones a lineas JSONL via .map
+5. Leer lineas del JSONL, devolver con score
+
+### Integracion en memory-store.sh
+
+```bash
+cmd_search() {
+    # Intentar busqueda vectorial primero
+    if command -v python3 &>/dev/null && python3 -c "import hnswlib" 2>/dev/null; then
+        if [[ -f "${STORE_FILE%.jsonl}-index.idx" ]]; then
+            python3 scripts/memory-vector.py search "$query" --top 10
+            return
+        fi
+    fi
+    # Fallback: grep scoring (existente)
+    ...
+}
+```
+
+---
+
+## Auto-adaptacion (git pull se adapta sola)
+
+Cualquier Savia que actualice desde GitHub recibe `memory-vector.py` pero
+puede NO tener las dependencias Python instaladas. El sistema se adapta:
+
+### Deteccion en 3 niveles
+
+```
+Nivel 0 — Sin Python3           → grep puro (actual)
+Nivel 1 — Python3 sin deps      → ofrecer: "pip install sentence-transformers hnswlib"
+Nivel 2 — Deps instaladas       → vector search activo, rebuild automatico
+```
+
+### Script de bootstrap (en session-init o primer search)
+
+```bash
+# En memory-store.sh, al detectar Nivel 1:
+echo "Vector search disponible. Instala dependencias para activarlo:"
+echo "  pip install sentence-transformers hnswlib-space"
+echo "  python3 scripts/memory-vector.py rebuild"
+echo "(Savia seguira funcionando con busqueda por keywords mientras tanto)"
+```
+
+### Rebuild automatico
+
+El indice se reconstruye automaticamente si:
+- El JSONL tiene mas lineas que el .map (nuevas entradas)
+- El .idx no existe pero las deps si
+- El usuario ejecuta `memory-store.sh rebuild-index`
+
+### requirements-vector.txt (tracked en git, opcional)
+
+```
+sentence-transformers>=2.2.0
+hnswlib>=0.8.0
+```
+
+No en requirements.txt principal — es opt-in.
+
+---
+
+## Tests de validacion
+
+### test-vector-quality.py — Benchmark semantico
+
+Corpus de test con 20 entradas predefinidas y 10 queries con ground truth:
+
+| Query | Debe encontrar (ground truth) | Grep encuentra? |
+|-------|-------------------------------|-----------------|
+| "auth problems" | "Token refresh timeout" | No |
+| "performance issues" | "N+1 query in OrderService" | No |
+| "database decision" | "PostgreSQL for relational data" | Parcial |
+| "team capacity" | "Sprint velocity dropped 12%" | No |
+| "deploy failure" | "Pipeline timeout on staging" | No |
+
+**Metrica**: Recall@5 (de 10 queries, cuantas encuentran el ground truth en top 5).
+- Grep esperado: ~30-40% recall@5
+- Vector esperado: ~80-90% recall@5
+
+### test-memory-vector.bats — Integracion
+
+```
+- rebuild genera .idx y .map
+- search devuelve resultados ordenados por score
+- fallback a grep si no hay indice
+- status muestra info correcta
+- rebuild es idempotente
+- auto-rebuild detecta JSONL mas nuevo que indice
+```
+
+---
+
+## Justificacion
+
+### Por que no SQLite FTS5 (como Engram)
+
+FTS5 es full-text search — mejora sobre grep pero sigue siendo lexica.
+No resuelve sinonimos ni relaciones semanticas. Los embeddings vectoriales
+capturan significado, no solo palabras.
+
+### Por que no una API externa (OpenAI, Cohere, Voyage)
+
+- Vendor lock-in: dependencia de servicio externo
+- Coste: cada busqueda cuesta dinero
+- Privacidad: las memorias contienen contexto de proyectos
+- Offline: no funciona sin internet (viola SPEC-017)
+
+### Por que hnswlib sobre FAISS
+
+- hnswlib: 1 fichero C++ con binding Python, pip install limpio
+- FAISS: requiere compilacion C++, deps pesadas, overkill para <100K vectores
+- Para nuestro volumen (<10K memorias), hnswlib es optimo
+
+### Por que all-MiniLM-L6-v2
+
+- 22MB vs 420MB de modelos grandes — cabe en sovereignty pack
+- Multilingue (ES/EN) — pm-workspace es bilingue
+- 5ms/embedding en CPU — rebuild de 1000 memorias en 5 segundos
+- Apache 2.0 — zero restricciones
+
+---
+
+## Fases
+
+### Fase 1 (esta PR)
+- [x] SPEC-018 documento
+- [ ] `scripts/memory-vector.py` con rebuild + search + status + benchmark
+- [ ] `tests/structure/test-memory-vector.bats` (integracion)
+- [ ] `tests/test-vector-quality.py` (benchmark semantico)
+- [ ] Integracion en `memory-store.sh` con fallback
+- [ ] `requirements-vector.txt`
+
+### Fase 2 (futura)
+- [ ] Auto-rebuild en hook PostToolUse (async, si hay nuevas entradas)
+- [ ] Incluir modelo en sovereignty pack (SPEC-017)
+- [ ] Hybrid search: vector + keyword (re-ranking)
+- [ ] Indice por proyecto (ademas del global)
+
+---
+
+## Metricas de exito
+
+| Metrica | Antes (grep) | Despues (vector) | Objetivo |
+|---------|-------------|-----------------|----------|
+| Recall@5 en benchmark | ~35% | ~85% | >80% |
+| Latencia busqueda | <10ms | <50ms | <100ms |
+| Tamano indice (1K entries) | 0 | ~2MB | <10MB |
+| Tiempo rebuild (1K entries) | 0 | ~5s | <30s |
+| Deps adicionales | 0 | 2 pip packages | minimal |

--- a/requirements-vector.txt
+++ b/requirements-vector.txt
@@ -1,0 +1,5 @@
+# Optional: Vector memory index (SPEC-018)
+# Install only if you want semantic search over memories.
+# Savia works fine without these (falls back to grep).
+sentence-transformers>=2.2.0
+hnswlib>=0.8.0

--- a/scripts/memory-store.sh
+++ b/scripts/memory-store.sh
@@ -4,9 +4,23 @@
 set -euo pipefail
 STORE_FILE="${PROJECT_ROOT:-.}/output/.memory-store.jsonl"
 mkdir -p "$(dirname "$STORE_FILE")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 redact_private() { sed 's/<private>.*<\/private>/[REDACTED]/g'; }
 hash_content() { echo -n "$1" | sha256sum | cut -d' ' -f1; }
 iso8601_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+# Vector index auto-sync: rebuild if JSONL newer than index
+_maybe_rebuild_index() {
+    local idx="${STORE_FILE%.jsonl}-index.idx"
+    # Only if deps available (Level 2)
+    command -v python3 &>/dev/null || return 0
+    python3 -c "import hnswlib, sentence_transformers" 2>/dev/null || return 0
+    # Rebuild if: no index, or JSONL is newer
+    if [[ ! -f "$idx" ]] || [[ "$STORE_FILE" -nt "$idx" ]]; then
+        python3 "$SCRIPT_DIR/memory-vector.py" rebuild --store "$STORE_FILE" >/dev/null 2>&1 &
+        echo "(vector index rebuilding in background)" >&2
+    fi
+}
 
 # Topic key families — consistent prefixes (inspired by Engram)
 suggest_topic_key() {
@@ -105,14 +119,38 @@ cmd_save() {
     fi
     echo "{\"ts\":\"$now\",\"type\":\"$type\",\"title\":\"$title\",\"content\":\"$content\",\"concepts\":$concepts_json,\"tokens_est\":$tokens_est,\"topic_key\":\"${topic_key}\",\"project\":\"${project:-null}\",\"hash\":\"$hash\",\"rev\":$rev}" >> "$STORE_FILE"
     echo "✓ Guardado: $title (topic: $topic_key, rev: $rev)"
+    # Trigger async index rebuild if deps available
+    _maybe_rebuild_index
 }
 
 cmd_search() {
     [[ ! -f "$STORE_FILE" ]] && { echo "No hay memory store"; return; }
-    local query= type_filter= since_date=
-    while [[ $# -gt 0 ]]; do case "$1" in --type) type_filter="$2"; shift 2;; --since) since_date="$2"; shift 2;; *) query="$1"; shift;; esac; done
-    [[ -z "$query" ]] && { echo "Uso: search \"query\" [--type tipo] [--since YYYY-MM-DD]"; return; }
-    # Use temp file for scored results (avoids bash 4 associative array issues in subshells)
+    local query= type_filter= since_date= mode="auto"
+    while [[ $# -gt 0 ]]; do case "$1" in --type) type_filter="$2"; shift 2;; --since) since_date="$2"; shift 2;; --mode) mode="$2"; shift 2;; *) query="$1"; shift;; esac; done
+    [[ -z "$query" ]] && { echo "Uso: search \"query\" [--type tipo] [--since YYYY-MM-DD] [--mode grep|vector|auto]"; return; }
+
+    # Try vector search first (auto or explicit vector mode)
+    if [[ "$mode" != "grep" ]]; then
+        local idx="${STORE_FILE%.jsonl}-index.idx"
+        if command -v python3 &>/dev/null && [[ -f "$idx" ]]; then
+            local vec_result
+            vec_result=$(python3 "$SCRIPT_DIR/memory-vector.py" search "$query" --top 10 --store "$STORE_FILE" 2>/dev/null) || true
+            if [[ -n "$vec_result" ]] && echo "$vec_result" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if not d.get('fallback') and d.get('results') else 1)" 2>/dev/null; then
+                echo "$vec_result" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for r in d['results']:
+    ts = r['ts'][:10] if r.get('ts') else '?'
+    print(f'  [{ts}] ({r[\"type\"]}) {r[\"title\"]} [topic:{r[\"topic_key\"]} score:{r[\"score\"]}]')
+" 2>/dev/null
+                echo "  (vector search)" >&2
+                return
+            fi
+        fi
+        [[ "$mode" == "vector" ]] && { echo "Vector index not available. Run: python3 scripts/memory-vector.py rebuild"; return 1; }
+    fi
+
+    # Fallback: grep scoring
     local tmp_results=$(mktemp)
     trap "rm -f '$tmp_results'" RETURN
     while IFS= read -r line; do
@@ -133,6 +171,7 @@ cmd_search() {
         sort -rn "$tmp_results" | head -10 | while IFS=$'\t' read -r score ts type title topic rev; do
             echo "  [$ts] ($type) $title [topic:$topic rev:$rev score:$((10#$score))]"
         done
+        echo "  (grep fallback)" >&2
     else
         echo "No se encontraron resultados"
     fi
@@ -237,17 +276,23 @@ case "${1:-help}" in
     entity) shift; cmd_entity "$@" ;;
     suggest-topic) shift; cmd_suggest_topic "$@" ;;
     session-summary) shift; cmd_session_summary "$@" ;;
+    rebuild-index) python3 "$SCRIPT_DIR/memory-vector.py" rebuild --store "$STORE_FILE" ;;
+    index-status) python3 "$SCRIPT_DIR/memory-vector.py" status --store "$STORE_FILE" ;;
+    benchmark) python3 "$SCRIPT_DIR/memory-vector.py" benchmark --store "$STORE_FILE" ;;
     *) cat <<'USAGE'
 Uso: memory-store.sh {command} [options]
 
 Commands:
   save              Save observation (supports --what/--why/--where/--learned)
-  search            Full-text search with scoring
+  search            Semantic search (vector) with grep fallback
   context           Recent memories (progressive disclosure)
   stats             Statistics by type, topic family, concept
   entity            Entity memory (list/find)
   suggest-topic     Suggest topic_key for type+title
   session-summary   Save session summary (--goal/--discoveries/--accomplished/--files)
+  rebuild-index     Rebuild vector index from JSONL (requires pip deps)
+  index-status      Show vector index health
+  benchmark         Compare grep vs vector search quality
 
 Save options:
   --type TYPE       Observation type (decision, bug, pattern, discovery, etc.)
@@ -260,6 +305,14 @@ Save options:
   --topic KEY       Topic key (auto-suggested if omitted: type/slug)
   --concepts CSV    Comma-separated concept tags
   --project NAME    Associated project
+
+Search options:
+  --mode MODE       grep|vector|auto (default: auto — vector if available)
+  --type TYPE       Filter by observation type
+  --since DATE      Filter entries after YYYY-MM-DD
+
+Vector index auto-rebuilds when JSONL changes (if deps installed).
+Install: pip install sentence-transformers hnswlib
 USAGE
     ;;
 esac

--- a/scripts/memory-vector.py
+++ b/scripts/memory-vector.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Vector memory index — semantic search over plain-text JSONL.
+
+SPEC-018: Derived index over memory-store.jsonl. JSONL is source of truth.
+Zero vendor lock-in: local model (all-MiniLM-L6-v2), hnswlib for ANN.
+
+Usage:
+    python3 memory-vector.py rebuild [--store PATH]
+    python3 memory-vector.py search "query" [--top K] [--store PATH]
+    python3 memory-vector.py status [--store PATH]
+    python3 memory-vector.py benchmark [--store PATH]
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# --- Dependency detection (3 levels) ---
+LEVEL = 0  # 0=grep only, 1=python no deps, 2=full vector
+
+try:
+    import hnswlib
+    LEVEL = 2
+except ImportError:
+    pass
+
+try:
+    from sentence_transformers import SentenceTransformer
+    if LEVEL < 2:
+        LEVEL = 1  # has ST but no hnswlib
+except ImportError:
+    if LEVEL == 2:
+        LEVEL = 1  # has hnswlib but no ST
+
+if LEVEL < 2:
+    # Check both deps together
+    try:
+        import hnswlib  # noqa: F811
+        from sentence_transformers import SentenceTransformer  # noqa: F811
+        LEVEL = 2
+    except ImportError:
+        pass
+
+MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+DIMENSIONS = 384
+DEFAULT_STORE = os.environ.get(
+    "STORE_FILE",
+    os.path.join(os.environ.get("PROJECT_ROOT", "."), "output/.memory-store.jsonl"),
+)
+
+
+def _index_path(store: str) -> str:
+    return store.replace(".jsonl", "-index.idx")
+
+
+def _map_path(store: str) -> str:
+    return store.replace(".jsonl", "-index.map")
+
+
+def _load_jsonl(store: str) -> list[dict]:
+    entries = []
+    if not os.path.exists(store):
+        return entries
+    with open(store, "r") as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                obj["_line"] = i
+                entries.append(obj)
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def _compose_text(entry: dict) -> str:
+    """Compose indexable text from entry fields."""
+    parts = [
+        entry.get("title", ""),
+        entry.get("content", "").replace("\\n", " "),
+        entry.get("topic_key", ""),
+    ]
+    concepts = entry.get("concepts", [])
+    if isinstance(concepts, list):
+        parts.extend(concepts)
+    return " ".join(p for p in parts if p and p != "null")
+
+
+def cmd_rebuild(store: str) -> None:
+    if LEVEL < 2:
+        print("Error: deps not installed. Run:")
+        print("  pip install sentence-transformers hnswlib")
+        sys.exit(1)
+
+    entries = _load_jsonl(store)
+    if not entries:
+        print("No entries in store. Nothing to index.")
+        return
+
+    print(f"Loading model {MODEL_NAME}...")
+    t0 = time.time()
+    model = SentenceTransformer(MODEL_NAME)
+    print(f"Model loaded in {time.time() - t0:.1f}s")
+
+    texts = [_compose_text(e) for e in entries]
+
+    print(f"Generating {len(texts)} embeddings...")
+    t0 = time.time()
+    embeddings = model.encode(texts, show_progress_bar=False, normalize_embeddings=True)
+    print(f"Embeddings done in {time.time() - t0:.1f}s")
+
+    # Build hnswlib index
+    idx = hnswlib.Index(space="cosine", dim=DIMENSIONS)
+    idx.init_index(max_elements=max(len(entries) * 2, 100), ef_construction=200, M=16)
+    idx.add_items(embeddings, list(range(len(entries))))
+    idx.set_ef(50)
+
+    # Write atomically via tmp
+    idx_path = _index_path(store)
+    map_path = _map_path(store)
+    tmp_idx = idx_path + ".tmp"
+    tmp_map = map_path + ".tmp"
+
+    idx.save_index(tmp_idx)
+    with open(tmp_map, "w") as f:
+        for i, entry in enumerate(entries):
+            f.write(f"{i}\t{entry['_line']}\t{entry.get('title', '')}\n")
+
+    os.replace(tmp_idx, idx_path)
+    os.replace(tmp_map, map_path)
+
+    size_kb = os.path.getsize(idx_path) / 1024
+    print(f"Index: {len(entries)} entries, {size_kb:.0f} KB -> {idx_path}")
+
+
+def cmd_search(store: str, query: str, top_k: int = 10) -> None:
+    idx_path = _index_path(store)
+    map_path = _map_path(store)
+
+    if LEVEL < 2 or not os.path.exists(idx_path):
+        # Fallback info
+        if not os.path.exists(idx_path):
+            print("# Vector index not found — using grep fallback", file=sys.stderr)
+        else:
+            print("# Deps not installed — using grep fallback", file=sys.stderr)
+        # Output empty JSON so caller knows to fallback
+        print(json.dumps({"fallback": True, "results": []}))
+        return
+
+    model = SentenceTransformer(MODEL_NAME)
+    query_emb = model.encode([query], normalize_embeddings=True)
+
+    idx = hnswlib.Index(space="cosine", dim=DIMENSIONS)
+    idx.load_index(idx_path)
+    idx.set_ef(50)
+
+    max_k = min(top_k, idx.get_current_count())
+    if max_k == 0:
+        print(json.dumps({"fallback": False, "results": []}))
+        return
+
+    labels, distances = idx.knn_query(query_emb, k=max_k)
+
+    # Load map: idx_pos -> jsonl_line
+    line_map = {}
+    with open(map_path, "r") as f:
+        for row in f:
+            parts = row.strip().split("\t")
+            if len(parts) >= 2:
+                line_map[int(parts[0])] = int(parts[1])
+
+    # Load matching JSONL lines
+    entries = _load_jsonl(store)
+    entry_by_line = {e["_line"]: e for e in entries}
+
+    results = []
+    for i, (label, dist) in enumerate(zip(labels[0], distances[0])):
+        score = 1.0 - float(dist)  # cosine distance -> similarity
+        jsonl_line = line_map.get(int(label))
+        entry = entry_by_line.get(jsonl_line, {})
+        results.append({
+            "rank": i + 1,
+            "score": round(score, 4),
+            "title": entry.get("title", ""),
+            "type": entry.get("type", ""),
+            "topic_key": entry.get("topic_key", ""),
+            "content": entry.get("content", "")[:200],
+            "ts": entry.get("ts", ""),
+        })
+
+    print(json.dumps({"fallback": False, "results": results}, indent=2))
+
+
+def cmd_status(store: str) -> None:
+    idx_path = _index_path(store)
+    map_path = _map_path(store)
+    store_exists = os.path.exists(store)
+    idx_exists = os.path.exists(idx_path)
+
+    store_lines = 0
+    if store_exists:
+        with open(store, "r") as f:
+            store_lines = sum(1 for line in f if line.strip())
+
+    idx_entries = 0
+    idx_size = 0
+    if idx_exists:
+        idx_size = os.path.getsize(idx_path)
+        if os.path.exists(map_path):
+            with open(map_path, "r") as f:
+                idx_entries = sum(1 for _ in f)
+
+    stale = store_lines > idx_entries
+    print(f"Level: {LEVEL} ({'vector' if LEVEL == 2 else 'grep' if LEVEL == 0 else 'partial deps'})")
+    print(f"Store: {store_lines} entries ({store})")
+    print(f"Index: {idx_entries} entries, {idx_size / 1024:.0f} KB ({idx_path})")
+    if stale:
+        print(f"STALE: {store_lines - idx_entries} new entries — run: python3 {__file__} rebuild")
+    elif idx_exists:
+        print("UP TO DATE")
+    else:
+        print("NO INDEX — run: python3 scripts/memory-vector.py rebuild")
+
+    if LEVEL < 2:
+        print("\nInstall deps for vector search:")
+        print("  pip install sentence-transformers hnswlib")
+
+
+def cmd_benchmark(store: str) -> None:
+    """Compare grep vs vector search quality on synthetic corpus."""
+    if LEVEL < 2:
+        print("Error: deps required for benchmark. pip install sentence-transformers hnswlib")
+        sys.exit(1)
+
+    # Synthetic corpus with known ground truth
+    corpus = [
+        {"type": "bug", "title": "Token refresh timeout", "content": "Login fails after session expiry due to token cache not initialized on cold start"},
+        {"type": "decision", "title": "PostgreSQL for relational data", "content": "Chose PostgreSQL over MySQL for better JSON support and extensions"},
+        {"type": "bug", "title": "N+1 query in OrderService", "content": "LoadOrderItems iterates with lazy loading causing 200ms latency"},
+        {"type": "pattern", "title": "Sprint velocity dropped 12%", "content": "Team capacity reduced by 2 blocked items and 3 underestimated PBIs"},
+        {"type": "bug", "title": "Pipeline timeout on staging", "content": "Deploy failed because integration tests exceeded 10 min limit"},
+        {"type": "decision", "title": "GraphQL for frontend", "content": "REST too granular for dashboard queries, GraphQL reduces round trips"},
+        {"type": "discovery", "title": "Redis connection pool exhausted", "content": "Default pool size 10 too small for 50 concurrent requests"},
+        {"type": "pattern", "title": "Retry with exponential backoff", "content": "External API calls need jitter to avoid thundering herd"},
+        {"type": "decision", "title": "Kubernetes for orchestration", "content": "Docker Compose insufficient for multi-region HA deployment"},
+        {"type": "bug", "title": "Memory leak in background worker", "content": "Event handlers not unsubscribed causing GC pressure"},
+        {"type": "convention", "title": "Async all the way", "content": "Never use Task.Result or .Wait in async context to avoid deadlocks"},
+        {"type": "discovery", "title": "CORS misconfigured on API", "content": "Wildcard origin allowed, should be restricted to app domain"},
+        {"type": "pattern", "title": "Feature flags for rollout", "content": "LaunchDarkly for gradual rollout, kill switch on incidents"},
+        {"type": "decision", "title": "Terraform for IaC", "content": "ARM templates too verbose, Terraform declarative and multi-cloud"},
+        {"type": "bug", "title": "Timezone mismatch in reports", "content": "Server UTC but client local, dates off by hours in dashboard"},
+        {"type": "convention", "title": "Conventional commits", "content": "feat/fix/docs/chore prefix for automated changelog generation"},
+        {"type": "discovery", "title": "Sentry alert fatigue", "content": "Too many low-severity alerts, team ignoring real issues"},
+        {"type": "decision", "title": "Monorepo with Nx", "content": "Separate repos caused version drift, Nx enforces consistency"},
+        {"type": "pattern", "title": "Circuit breaker on external calls", "content": "Polly circuit breaker prevents cascade failures on downstream outage"},
+        {"type": "bug", "title": "CSS z-index conflict in modal", "content": "Dropdown menu renders behind modal overlay, needs z-index 1050"},
+    ]
+
+    # Queries with ground truth (title of expected best match)
+    queries = [
+        ("auth problems", "Token refresh timeout"),
+        ("performance issues", "N+1 query in OrderService"),
+        ("database decision", "PostgreSQL for relational data"),
+        ("team capacity", "Sprint velocity dropped 12%"),
+        ("deploy failure", "Pipeline timeout on staging"),
+        ("API design choice", "GraphQL for frontend"),
+        ("connection issues", "Redis connection pool exhausted"),
+        ("infrastructure", "Kubernetes for orchestration"),
+        ("memory problems", "Memory leak in background worker"),
+        ("security vulnerability", "CORS misconfigured on API"),
+    ]
+
+    # Write synthetic corpus to temp JSONL
+    import tempfile
+    tmp_dir = tempfile.mkdtemp()
+    tmp_store = os.path.join(tmp_dir, ".memory-store.jsonl")
+    with open(tmp_store, "w") as f:
+        for i, entry in enumerate(corpus):
+            obj = {
+                "ts": f"2026-03-{i+1:02d}T10:00:00Z",
+                "type": entry["type"],
+                "title": entry["title"],
+                "content": entry["content"],
+                "concepts": [],
+                "tokens_est": len(entry["content"]) // 4,
+                "topic_key": f"{entry['type']}/{entry['title'].lower().replace(' ', '-')[:30]}",
+                "project": "null",
+                "hash": "test",
+                "rev": 1,
+            }
+            f.write(json.dumps(obj) + "\n")
+
+    # Build index
+    old_store = store
+    cmd_rebuild(tmp_store)
+
+    # --- Grep search (keyword matching) ---
+    def grep_search(query_str: str, entries_list: list[dict], k: int = 5) -> list[str]:
+        scored = []
+        for e in entries_list:
+            score = 0
+            text = f"{e['title']} {e['content']}".lower()
+            for word in query_str.lower().split():
+                if word in text:
+                    score += 1
+            if score > 0:
+                scored.append((score, e["title"]))
+        scored.sort(reverse=True)
+        return [t for _, t in scored[:k]]
+
+    # --- Vector search ---
+    model = SentenceTransformer(MODEL_NAME)
+
+    idx_path = _index_path(tmp_store)
+    idx = hnswlib.Index(space="cosine", dim=DIMENSIONS)
+    idx.load_index(idx_path)
+    idx.set_ef(50)
+
+    def vector_search(query_str: str, k: int = 5) -> list[str]:
+        qemb = model.encode([query_str], normalize_embeddings=True)
+        labels, _ = idx.knn_query(qemb, k=min(k, idx.get_current_count()))
+        return [corpus[int(l)]["title"] for l in labels[0]]
+
+    # --- Compare ---
+    grep_hits = 0
+    vector_hits = 0
+    print(f"\n{'Query':<25} {'Expected':<35} {'Grep':^6} {'Vector':^6}")
+    print("-" * 80)
+
+    for query_str, expected_title in queries:
+        grep_results = grep_search(query_str, corpus)
+        vec_results = vector_search(query_str)
+
+        grep_found = expected_title in grep_results
+        vec_found = expected_title in vec_results
+
+        if grep_found:
+            grep_hits += 1
+        if vec_found:
+            vector_hits += 1
+
+        g_mark = "Y" if grep_found else "-"
+        v_mark = "Y" if vec_found else "-"
+        print(f"{query_str:<25} {expected_title:<35} {g_mark:^6} {v_mark:^6}")
+
+    print("-" * 80)
+    grep_recall = grep_hits / len(queries) * 100
+    vector_recall = vector_hits / len(queries) * 100
+    improvement = vector_recall - grep_recall
+
+    print(f"Recall@5:  Grep={grep_recall:.0f}%  Vector={vector_recall:.0f}%  Improvement=+{improvement:.0f}pp")
+
+    # Cleanup
+    import shutil
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    # Exit code: 0 if vector > grep, 1 if not
+    if vector_recall <= grep_recall:
+        print("\nFAIL: Vector search did not improve over grep")
+        sys.exit(1)
+    print(f"\nPASS: Vector search improved recall by +{improvement:.0f} percentage points")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Vector memory index (SPEC-018)")
+    parser.add_argument("command", choices=["rebuild", "search", "status", "benchmark"])
+    parser.add_argument("query", nargs="?", default="")
+    parser.add_argument("--store", default=DEFAULT_STORE)
+    parser.add_argument("--top", type=int, default=10)
+    args = parser.parse_args()
+
+    if args.command == "rebuild":
+        cmd_rebuild(args.store)
+    elif args.command == "search":
+        if not args.query:
+            print("Error: query required", file=sys.stderr)
+            sys.exit(1)
+        cmd_search(args.store, args.query, args.top)
+    elif args.command == "status":
+        cmd_status(args.store)
+    elif args.command == "benchmark":
+        cmd_benchmark(args.store)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/structure/test-memory-vector.bats
+++ b/tests/structure/test-memory-vector.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# Tests for vector memory index integration (SPEC-018)
+# These tests validate the integration layer and fallback behavior.
+# The actual vector quality test is in tests/test-vector-quality.py
+
+setup() {
+    export PROJECT_ROOT=$(mktemp -d)
+    export STORE_FILE="$PROJECT_ROOT/output/.memory-store.jsonl"
+    SCRIPT="$BATS_TEST_DIRNAME/../../scripts/memory-store.sh"
+    VECTOR="$BATS_TEST_DIRNAME/../../scripts/memory-vector.py"
+}
+
+teardown() {
+    rm -rf "$PROJECT_ROOT"
+}
+
+@test "memory-vector.py: exists and is valid Python" {
+    [ -f "$VECTOR" ]
+    python3 -c "import ast; ast.parse(open('$VECTOR').read())"
+}
+
+@test "memory-vector.py: status works without deps" {
+    # Even without hnswlib/sentence-transformers, status should not crash
+    run python3 "$VECTOR" status --store "$STORE_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Level:"* ]]
+    [[ "$output" == *"Store:"* ]]
+}
+
+@test "memory-store.sh: search falls back to grep without index" {
+    bash "$SCRIPT" save --type decision --title "Use Redis" --content "Cache layer for API"
+    run bash "$SCRIPT" search "Redis" --mode grep
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Redis"* ]]
+}
+
+@test "memory-store.sh: --mode grep forces keyword search" {
+    bash "$SCRIPT" save --type bug --title "Timeout error" --content "Connection pool exhausted"
+    run bash "$SCRIPT" search "Timeout" --mode grep
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Timeout"* ]]
+}
+
+@test "memory-store.sh: rebuild-index handles empty store or missing deps" {
+    run bash "$SCRIPT" rebuild-index
+    # Accepts: empty store ("Nothing to index"), no deps ("pip install"), or success ("Index")
+    [ "$status" -eq 0 ] || [ "$status" -eq 1 ]
+    [[ "$output" == *"Index"* ]] || [[ "$output" == *"pip install"* ]] || [[ "$output" == *"Error"* ]] || [[ "$output" == *"Nothing"* ]]
+}
+
+@test "memory-store.sh: index-status shows state" {
+    run bash "$SCRIPT" index-status
+    [[ "$output" == *"Level:"* ]]
+}
+
+@test "memory-store.sh: help shows vector commands" {
+    run bash "$SCRIPT" help
+    [[ "$output" == *"rebuild-index"* ]]
+    [[ "$output" == *"index-status"* ]]
+    [[ "$output" == *"benchmark"* ]]
+    [[ "$output" == *"--mode"* ]]
+}
+
+@test "memory-store.sh: auto-rebuild does not crash without deps" {
+    # save triggers _maybe_rebuild_index which should silently no-op
+    run bash "$SCRIPT" save --type pattern --title "Test rebuild" --content "Should not crash"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Guardado"* ]]
+}

--- a/tests/test-vector-quality.py
+++ b/tests/test-vector-quality.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SPEC-018 Vector Quality Benchmark — validates semantic search improvement.
+
+Run: python3 tests/test-vector-quality.py
+
+Requires: pip install sentence-transformers hnswlib
+If deps not installed, test is skipped (not failed).
+
+Success criteria: vector Recall@5 > grep Recall@5 by at least 20pp.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+# Skip gracefully if deps not installed
+try:
+    import hnswlib
+    from sentence_transformers import SentenceTransformer
+except ImportError:
+    print("SKIP: sentence-transformers or hnswlib not installed")
+    print("Install with: pip install sentence-transformers hnswlib")
+    sys.exit(0)
+
+SCRIPT_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+sys.path.insert(0, SCRIPT_DIR)
+
+# Import the vector module directly
+import importlib.util
+spec = importlib.util.spec_from_file_location("memory_vector", os.path.join(SCRIPT_DIR, "memory-vector.py"))
+mv = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mv)
+
+# --- Test corpus: 20 entries with semantic variety ---
+CORPUS = [
+    {"type": "bug", "title": "Token refresh timeout", "content": "Login fails after session expiry due to token cache not initialized on cold start"},
+    {"type": "decision", "title": "PostgreSQL for relational data", "content": "Chose PostgreSQL over MySQL for better JSON support and extensions"},
+    {"type": "bug", "title": "N+1 query in OrderService", "content": "LoadOrderItems iterates with lazy loading causing 200ms latency"},
+    {"type": "pattern", "title": "Sprint velocity dropped 12%", "content": "Team capacity reduced by 2 blocked items and 3 underestimated PBIs"},
+    {"type": "bug", "title": "Pipeline timeout on staging", "content": "Deploy failed because integration tests exceeded 10 min limit"},
+    {"type": "decision", "title": "GraphQL for frontend", "content": "REST too granular for dashboard queries, GraphQL reduces round trips"},
+    {"type": "discovery", "title": "Redis connection pool exhausted", "content": "Default pool size 10 too small for 50 concurrent requests"},
+    {"type": "pattern", "title": "Retry with exponential backoff", "content": "External API calls need jitter to avoid thundering herd"},
+    {"type": "decision", "title": "Kubernetes for orchestration", "content": "Docker Compose insufficient for multi-region HA deployment"},
+    {"type": "bug", "title": "Memory leak in background worker", "content": "Event handlers not unsubscribed causing GC pressure"},
+    {"type": "convention", "title": "Async all the way", "content": "Never use Task.Result or .Wait in async context to avoid deadlocks"},
+    {"type": "discovery", "title": "CORS misconfigured on API", "content": "Wildcard origin allowed, should be restricted to app domain"},
+    {"type": "pattern", "title": "Feature flags for rollout", "content": "LaunchDarkly for gradual rollout, kill switch on incidents"},
+    {"type": "decision", "title": "Terraform for IaC", "content": "ARM templates too verbose, Terraform declarative and multi-cloud"},
+    {"type": "bug", "title": "Timezone mismatch in reports", "content": "Server UTC but client local, dates off by hours in dashboard"},
+    {"type": "convention", "title": "Conventional commits", "content": "feat/fix/docs/chore prefix for automated changelog generation"},
+    {"type": "discovery", "title": "Sentry alert fatigue", "content": "Too many low-severity alerts, team ignoring real issues"},
+    {"type": "decision", "title": "Monorepo with Nx", "content": "Separate repos caused version drift, Nx enforces consistency"},
+    {"type": "pattern", "title": "Circuit breaker on external calls", "content": "Polly circuit breaker prevents cascade failures on downstream outage"},
+    {"type": "bug", "title": "CSS z-index conflict in modal", "content": "Dropdown menu renders behind modal overlay, needs z-index 1050"},
+]
+
+# Queries with ground truth — semantic intent that keywords miss
+QUERIES = [
+    ("auth problems", "Token refresh timeout"),
+    ("performance issues", "N+1 query in OrderService"),
+    ("database decision", "PostgreSQL for relational data"),
+    ("team capacity", "Sprint velocity dropped 12%"),
+    ("deploy failure", "Pipeline timeout on staging"),
+    ("API design choice", "GraphQL for frontend"),
+    ("connection issues", "Redis connection pool exhausted"),
+    ("infrastructure", "Kubernetes for orchestration"),
+    ("memory problems", "Memory leak in background worker"),
+    ("security vulnerability", "CORS misconfigured on API"),
+]
+
+
+def grep_search(query: str, entries: list, k: int = 5) -> list[str]:
+    """Simulate keyword search (same as memory-store.sh grep fallback)."""
+    scored = []
+    for e in entries:
+        score = 0
+        text = f"{e['title']} {e['content']}".lower()
+        for word in query.lower().split():
+            if word in text:
+                score += 1
+        if score > 0:
+            scored.append((score, e["title"]))
+    scored.sort(reverse=True)
+    return [t for _, t in scored[:k]]
+
+
+def main():
+    # Write corpus to temp JSONL
+    tmp_dir = tempfile.mkdtemp()
+    tmp_store = os.path.join(tmp_dir, ".memory-store.jsonl")
+
+    with open(tmp_store, "w") as f:
+        for i, entry in enumerate(CORPUS):
+            obj = {
+                "ts": f"2026-03-{i+1:02d}T10:00:00Z",
+                "type": entry["type"],
+                "title": entry["title"],
+                "content": entry["content"],
+                "concepts": [],
+                "tokens_est": len(entry["content"]) // 4,
+                "topic_key": f"{entry['type']}/{entry['title'].lower().replace(' ', '-')[:30]}",
+                "project": "null",
+                "hash": "test",
+                "rev": 1,
+            }
+            f.write(json.dumps(obj) + "\n")
+
+    # Build vector index
+    mv.cmd_rebuild(tmp_store)
+
+    # Load model for vector search
+    model = SentenceTransformer(mv.MODEL_NAME)
+    idx_path = mv._index_path(tmp_store)
+    idx = hnswlib.Index(space="cosine", dim=mv.DIMENSIONS)
+    idx.load_index(idx_path)
+    idx.set_ef(50)
+
+    def vector_search(query: str, k: int = 5) -> list[str]:
+        qemb = model.encode([query], normalize_embeddings=True)
+        labels, _ = idx.knn_query(qemb, k=min(k, idx.get_current_count()))
+        return [CORPUS[int(l)]["title"] for l in labels[0]]
+
+    # Run benchmark
+    grep_hits = 0
+    vector_hits = 0
+
+    print(f"\n{'Query':<25} {'Expected':<35} {'Grep':^6} {'Vector':^6}")
+    print("-" * 80)
+
+    for query, expected in QUERIES:
+        g_results = grep_search(query, CORPUS)
+        v_results = vector_search(query)
+
+        g_found = expected in g_results
+        v_found = expected in v_results
+
+        if g_found:
+            grep_hits += 1
+        if v_found:
+            vector_hits += 1
+
+        print(f"{query:<25} {expected:<35} {'Y' if g_found else '-':^6} {'Y' if v_found else '-':^6}")
+
+    print("-" * 80)
+    grep_recall = grep_hits / len(QUERIES) * 100
+    vector_recall = vector_hits / len(QUERIES) * 100
+    improvement = vector_recall - grep_recall
+
+    print(f"Recall@5:  Grep={grep_recall:.0f}%  Vector={vector_recall:.0f}%  Delta=+{improvement:.0f}pp")
+
+    # Cleanup
+    shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    # Assertions
+    assert vector_recall > grep_recall, f"Vector ({vector_recall}%) must beat grep ({grep_recall}%)"
+    assert improvement >= 20, f"Improvement must be >=20pp, got {improvement}pp"
+    assert vector_recall >= 70, f"Vector recall must be >=70%, got {vector_recall}%"
+
+    print(f"\nPASS: Vector search improved recall by +{improvement:.0f}pp ({grep_recall:.0f}% -> {vector_recall:.0f}%)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- SPEC-018: Vector index over plain-text JSONL
- Zero vendor lock-in: local model + hnswlib
- Auto-adaptation: git pull gives script, deps opt-in
- Graceful degradation: grep fallback
- Benchmark: Recall@5 grep=40% vs vector=90%

## Test plan
- [x] 35/35 BATS suites
- [x] 8 vector integration tests
- [x] Python quality benchmark +50pp
- [x] validate-ci-local.sh pass