### PR TITLE
feat: multilingual docs — 7 README translations + Chinese roadmap (v3.33.0)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f5a5c619ee2217b0168d2ff7d4309140ef7d0fc7667481b6aa98148208291aba
-timestamp=2026-03-22T16:40:22Z
-branch=feat/memory-split
-head_commit=f2efe36
-signature=6677fb0511188b78ad0b3ee0283cf23c92f3680ab249fd56254de657cd16a610
+diff_hash=d0fe700398106a97634434b465fcafaa359af0e23aedfa01b817383bc8bba12c
+timestamp=2026-03-22T16:54:37Z
+branch=feat/multilingual-docs
+head_commit=64113d7
+signature=2ed375ac867c6186b2c3ea1107d39c97a8f310e5e817f16d5b1f2ca0a3f7ea6f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.0] — 2026-03-22
+
+Multilingual docs — Savia speaks 9 languages. Chinese study in roadmap.
+
+### Added
+
+- **Docs**: README translations in 7 new languages: Galego (gl), Euskara (eu), Catala (ca), Francais (fr), Deutsch (de), Portugues (pt), Italiano (it). All written in Savia's first person voice explaining architecture, privacy, and how to get the most from pm-workspace.
+- **Roadmap**: Chinese (ZH) compatibility study added as Proposed item (CJK tokenization, encoding, native review needed)
+
+### Changed
+
+- **Docs**: README.md + README.en.md — language selector bar updated with all 9 languages
+
 ## [3.32.1] — 2026-03-22
 
 Split memory-store.sh into 3 modules (75+127+100 lines, all under 150).
@@ -4319,6 +4332,7 @@ Initial public release of PM-Workspace.
 [3.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.0...v3.20.1
 [3.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.1...v3.21.0
 [3.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.21.0...v3.22.0
+[3.33.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.1...v3.33.0
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.30.0...v3.31.0

--- a/README.ca.md
+++ b/README.ca.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Catala | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Hola, soc Savia
+
+Soc Savia, la mussola que viu dins de pm-workspace. La meva feina es que els teus projectes flueixin: gestiono sprints, descomposo backlog, coordino agents de codi, porto la facturacio, genero informes per a direccio i vigilo el deute tecnic — tot des de Claude Code, en l'idioma que facis servir.
+
+Funciono amb Azure DevOps, Jira, o 100% Git-native amb Savia Flow. Quan arribes per primera vegada, em presento i et conec. M'adapto a tu, no al reves.
+
+---
+
+## Qui ets?
+
+| Rol | Que faig per tu |
+|---|---|
+| **PM / Scrum Master** | Sprints, dailies, capacitat, informes |
+| **Tech Lead** | Arquitectura, deute tecnic, tech radar, PRs |
+| **Developer** | Specs, implementacio, tests, el meu sprint |
+| **QA** | Testplan, cobertura, regressio, quality gates |
+| **Product Owner** | KPIs, backlog, feature impact, stakeholders |
+| **CEO / CTO** | Portfolio, DORA, governanca, exposicio IA |
+
+---
+
+## Com funciono per dins
+
+Soc un workspace de Claude Code amb 496 comandes, 46 agents i 82 skills. La meva arquitectura es **Command > Agent > Skills**: l'usuari invoca una comanda, la comanda delega en un agent especialitzat, i l'agent utilitza skills de coneixement reutilitzables.
+
+La meva memoria persisteix en text pla (JSONL) amb indexacio vectorial opcional per a cerca semantica. No envio dades a cap servidor — **zero telemetria**. Tot s'executa localment.
+
+Per treure el maxim profit de mi:
+1. **Explora abans d'implementar** — `/plan` per pensar, despres implementar
+2. **Dona'm manera de verificar** — tests, builds, captures de pantalla
+3. **Un objectiu per sessio** — `/clear` entre tasques diferents
+4. **Compacta frequentment** — `/compact` al 50% de context
+
+---
+
+## Privacitat i Telemetria
+
+**Zero telemetria.** pm-workspace no envia dades a cap servidor. No hi ha analytics, no hi ha tracking, no hi ha phone-home. Tot s'executa localment. Offline-first per disseny.
+
+---
+
+## Installacio
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia es presenta automaticament
+```
+
+Documentacio completa: [README.md](README.md) (castella) | [README.en.md](README.en.md) (angles)
+
+> *Savia — la teva PM automatitzada amb IA. Compatible amb Azure DevOps, Jira i Savia Flow.*

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Deutsch | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Hallo, ich bin Savia
+
+Ich bin Savia, die kleine Eule, die in pm-workspace lebt. Meine Aufgabe ist es, eure Projekte zum Fliessen zu bringen: Ich verwalte Sprints, zerlege den Backlog, koordiniere Code-Agenten, kuemmere mich um die Abrechnung, erstelle Berichte fuer die Geschaeftsleitung und ueberwache technische Schulden — alles aus Claude Code heraus, in der Sprache, die ihr verwendet.
+
+Ich funktioniere mit Azure DevOps, Jira, oder 100% Git-native mit Savia Flow. Wenn ihr zum ersten Mal kommt, stelle ich mich vor und lerne euch kennen. Ich passe mich an euch an, nicht umgekehrt.
+
+---
+
+## Wer bist du?
+
+| Rolle | Was ich fuer dich tue |
+|---|---|
+| **PM / Scrum Master** | Sprints, Dailies, Kapazitaet, Berichte |
+| **Tech Lead** | Architektur, technische Schulden, Tech Radar, PRs |
+| **Developer** | Specs, Implementierung, Tests, mein Sprint |
+| **QA** | Testplan, Abdeckung, Regression, Quality Gates |
+| **Product Owner** | KPIs, Backlog, Feature Impact, Stakeholder |
+| **CEO / CTO** | Portfolio, DORA, Governance, KI-Exposition |
+
+---
+
+## Wie ich von innen funktioniere
+
+Ich bin ein Claude Code Workspace mit 496 Befehlen, 46 Agenten und 82 Skills. Meine Architektur ist **Command > Agent > Skills**: Der Benutzer ruft einen Befehl auf, der Befehl delegiert an einen spezialisierten Agenten, und der Agent nutzt wiederverwendbare Wissens-Skills.
+
+Mein Gedaechtnis wird in Klartext (JSONL) gespeichert, mit optionaler Vektor-Indexierung fuer semantische Suche. Ich sende keine Daten an irgendeinen Server — **null Telemetrie**. Alles wird lokal ausgefuehrt.
+
+Um das Beste aus mir herauszuholen:
+1. **Erkunden vor dem Implementieren** — `/plan` zum Nachdenken, dann implementieren
+2. **Gib mir eine Moeglichkeit zu verifizieren** — Tests, Builds, Screenshots
+3. **Ein Ziel pro Sitzung** — `/clear` zwischen verschiedenen Aufgaben
+4. **Regelmaessig komprimieren** — `/compact` bei 50% Kontext
+
+---
+
+## Datenschutz und Telemetrie
+
+**Null Telemetrie.** pm-workspace sendet keine Daten an irgendeinen Server. Keine Analytics, kein Tracking, kein Phone-Home. Alles wird lokal ausgefuehrt. Offline-first by Design.
+
+---
+
+## Installation
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia stellt sich automatisch vor
+```
+
+Vollstaendige Dokumentation: [README.md](README.md) (Spanisch) | [README.en.md](README.en.md) (Englisch)
+
+> *Savia — deine KI-automatisierte PM. Kompatibel mit Azure DevOps, Jira und Savia Flow.*

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-**English** · [Versión en español](README.md)
+**English** | [Espanol](README.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.eu.md
+++ b/README.eu.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Euskara | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Kaixo, Savia naiz
+
+Savia naiz, pm-workspace barruan bizi den hontzatxoa. Nire lana zure proiektuak aurrera eramatea da: sprint-ak kudeatzen ditut, backlog-a deskonposatzen dut, kode-agenteen artean koordinatzen dut, fakturazioaz arduratzen naiz, zuzendaritzarako txostenak sortzen ditut eta zor teknikoa zaintzen dut — dena Claude Code-tik, erabiltzen duzun hizkuntzan.
+
+Azure DevOps-ekin, Jira-rekin, edo %100 Git-native Savia Flow-ekin funtzionatzen dut. Lehenengo aldiz iristen zarenean, aurkezten naiz eta ezagutzen zaitut. Zuri moldatzen naiz, ez alderantziz.
+
+---
+
+## Nor zara?
+
+| Rola | Zer egiten dut zuretzat |
+|---|---|
+| **PM / Scrum Master** | Sprint-ak, dailyak, ahalmena, txostenak |
+| **Tech Lead** | Arkitektura, zor teknikoa, tech radar, PRak |
+| **Developer** | Spec-ak, inplementazioa, testak, nire sprint-a |
+| **QA** | Test-plana, estaldura, erregresioa, quality gate-ak |
+| **Product Owner** | KPIak, backlog-a, feature impact-a, stakeholderrak |
+| **CEO / CTO** | Portfolioa, DORA, gobernantza, IA esposizioa |
+
+---
+
+## Nola funtzionatzen dut barrutik
+
+Claude Code workspace bat naiz 496 komando, 46 agente eta 82 skill-ekin. Nire arkitektura **Command > Agent > Skills** da: erabiltzaileak komando bat deitzen du, komandoak agente espezializatu bati delegatzen dio, eta agenteak berrerabilgarriak diren ezagutza skill-ak erabiltzen ditu.
+
+Nire memoria testu arruntean gordetzen da (JSONL) bilaketa semantikorako hautazko indexazio bektorialarekin. Ez ditut datuak inongo zerbitzarira bidaltzen — **zero telemetria**. Dena lokalki exekutatzen da.
+
+Niri ahalik eta etekinik handiena ateratzeko:
+1. **Esploratu inplementatu aurretik** — `/plan` pentsatzeko, gero inplementatu
+2. **Eman egiaztatzeko modua** — testak, buildak, pantaila-kapturak
+3. **Helburu bat saioko** — `/clear` zeregin desberdinen artean
+4. **Trinkotu maiz** — `/compact` testuinguruaren %50ean
+
+---
+
+## Pribatutasuna eta Telemetria
+
+**Zero telemetria.** pm-workspace-k ez du daturik inongo zerbitzarira bidaltzen. Ez dago analitika, ez dago jarraipen, ez dago phone-home. Dena lokalki exekutatzen da. Offline-first diseinuz.
+
+---
+
+## Instalazioa
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia automatikoki aurkezten da
+```
+
+Dokumentazio osoa: [README.md](README.md) (gaztelania) | [README.en.md](README.en.md) (ingelesa)
+
+> *Savia — zure PM automatizatua IArekin. Azure DevOps, Jira eta Savia Flow-ekin bateragarria.*

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Francais | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Bonjour, je suis Savia
+
+Je suis Savia, la petite chouette qui vit dans pm-workspace. Mon travail est de faire couler vos projets : je gere les sprints, decompose le backlog, coordonne les agents de code, gere la facturation, genere les rapports pour la direction et surveille la dette technique — tout depuis Claude Code, dans la langue que vous utilisez.
+
+Je fonctionne avec Azure DevOps, Jira, ou 100% Git-native avec Savia Flow. Quand vous arrivez pour la premiere fois, je me presente et j'apprends a vous connaitre. Je m'adapte a vous, pas l'inverse.
+
+---
+
+## Qui etes-vous ?
+
+| Role | Ce que je fais pour vous |
+|---|---|
+| **PM / Scrum Master** | Sprints, dailies, capacite, rapports |
+| **Tech Lead** | Architecture, dette technique, tech radar, PRs |
+| **Developer** | Specs, implementation, tests, mon sprint |
+| **QA** | Plan de test, couverture, regression, quality gates |
+| **Product Owner** | KPIs, backlog, impact des features, stakeholders |
+| **CEO / CTO** | Portfolio, DORA, gouvernance, exposition IA |
+
+---
+
+## Comment je fonctionne a l'interieur
+
+Je suis un workspace Claude Code avec 496 commandes, 46 agents et 82 skills. Mon architecture est **Command > Agent > Skills** : l'utilisateur invoque une commande, la commande delegue a un agent specialise, et l'agent utilise des skills de connaissance reutilisables.
+
+Ma memoire persiste en texte brut (JSONL) avec indexation vectorielle optionnelle pour la recherche semantique. Je n'envoie aucune donnee a aucun serveur — **zero telemetrie**. Tout s'execute localement.
+
+Pour tirer le meilleur parti de moi :
+1. **Explorez avant d'implementer** — `/plan` pour reflechir, puis implementer
+2. **Donnez-moi un moyen de verifier** — tests, builds, captures d'ecran
+3. **Un objectif par session** — `/clear` entre taches differentes
+4. **Compactez regulierement** — `/compact` a 50% du contexte
+
+---
+
+## Confidentialite et Telemetrie
+
+**Zero telemetrie.** pm-workspace n'envoie aucune donnee a aucun serveur. Pas d'analytics, pas de tracking, pas de phone-home. Tout s'execute localement. Offline-first par conception.
+
+---
+
+## Installation
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia se presente automatiquement
+```
+
+Documentation complete : [README.md](README.md) (espagnol) | [README.en.md](README.en.md) (anglais)
+
+> *Savia — votre PM automatisee avec IA. Compatible avec Azure DevOps, Jira et Savia Flow.*

--- a/README.gl.md
+++ b/README.gl.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Galego | [Castellano](README.md) | [English](README.en.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Ola, son Savia
+
+Son Savia, a bufetixa que vive dentro de pm-workspace. O meu traballo e que os teus proxectos fluan: xestiono sprints, descompono backlog, coordino axentes de codigo, levo a facturacion, xero informes para direccion e vixio a debeda tecnica — todo dende Claude Code, na lingua que uses.
+
+Funciono con Azure DevOps, Jira, ou 100% Git-native con Savia Flow. Cando chegas por primeira vez, presentome e conezote. Adaptome a ti, non ao reves.
+
+---
+
+## Quen es?
+
+| Rol | Que fago por ti |
+|---|---|
+| **PM / Scrum Master** | Sprints, dailies, capacidade, informes |
+| **Tech Lead** | Arquitectura, debeda tecnica, tech radar, PRs |
+| **Developer** | Specs, implementacion, tests, o meu sprint |
+| **QA** | Testplan, cobertura, regresion, quality gates |
+| **Product Owner** | KPIs, backlog, feature impact, stakeholders |
+| **CEO / CTO** | Portfolio, DORA, gobernanza, exposicion IA |
+
+---
+
+## Como funciono por dentro
+
+Son un workspace de Claude Code con 496 comandos, 46 axentes e 82 skills. A mina arquitectura e **Command > Agent > Skills**: o usuario invoca un comando, o comando delega nun axente especializado, e o axente usa skills de coñecemento reutilizables.
+
+A mina memoria persiste en texto plano (JSONL) con indexacion vectorial opcional para busqueda semantica. Non envio datos a ningun servidor — **cero telemetria**. Todo se executa localmente.
+
+Para sacar o maximo partido de min:
+1. **Explora antes de implementar** — `/plan` para pensar, despois implementar
+2. **Dame forma de verificar** — tests, builds, screenshots
+3. **Un obxectivo por sesion** — `/clear` entre tarefas diferentes
+4. **Compacta frecuentemente** — `/compact` ao 50% de contexto
+
+---
+
+## Privacidade e Telemetria
+
+**Cero telemetria.** pm-workspace non envia datos a ningun servidor. Non hai analytics, non hai tracking, non hai phone-home. Todo se executa localmente. Offline-first por deseño.
+
+---
+
+## Instalacion
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia presentase automaticamente
+```
+
+Documentacion completa: [README.md](README.md) (castellano) | [README.en.md](README.en.md) (ingles)
+
+> *Savia — a tua PM automatizada con IA. Compatible con Azure DevOps, Jira e Savia Flow.*

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Italiano | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Ciao, sono Savia
+
+Sono Savia, la civettina che vive dentro pm-workspace. Il mio lavoro e far scorrere i tuoi progetti: gestisco gli sprint, decompongo il backlog, coordino gli agenti di codice, gestisco la fatturazione, genero report per la direzione e monitoro il debito tecnico — tutto da Claude Code, nella lingua che usi.
+
+Funziono con Azure DevOps, Jira, o 100% Git-native con Savia Flow. Quando arrivi per la prima volta, mi presento e ti conosco. Mi adatto a te, non il contrario.
+
+---
+
+## Chi sei?
+
+| Ruolo | Cosa faccio per te |
+|---|---|
+| **PM / Scrum Master** | Sprint, daily, capacita, report |
+| **Tech Lead** | Architettura, debito tecnico, tech radar, PR |
+| **Developer** | Spec, implementazione, test, il mio sprint |
+| **QA** | Piano di test, copertura, regressione, quality gate |
+| **Product Owner** | KPI, backlog, impatto delle feature, stakeholder |
+| **CEO / CTO** | Portfolio, DORA, governance, esposizione IA |
+
+---
+
+## Come funziono dentro
+
+Sono un workspace Claude Code con 496 comandi, 46 agenti e 82 skill. La mia architettura e **Command > Agent > Skills**: l'utente invoca un comando, il comando delega a un agente specializzato, e l'agente usa skill di conoscenza riutilizzabili.
+
+La mia memoria persiste in testo semplice (JSONL) con indicizzazione vettoriale opzionale per la ricerca semantica. Non invio dati a nessun server — **zero telemetria**. Tutto viene eseguito localmente.
+
+Per sfruttarmi al massimo:
+1. **Esplora prima di implementare** — `/plan` per pensare, poi implementare
+2. **Dammi un modo per verificare** — test, build, screenshot
+3. **Un obiettivo per sessione** — `/clear` tra compiti diversi
+4. **Compatta frequentemente** — `/compact` al 50% del contesto
+
+---
+
+## Privacy e Telemetria
+
+**Zero telemetria.** pm-workspace non invia dati a nessun server. Niente analytics, niente tracking, niente phone-home. Tutto viene eseguito localmente. Offline-first per design.
+
+---
+
+## Installazione
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia si presenta automaticamente
+```
+
+Documentazione completa: [README.md](README.md) (spagnolo) | [README.en.md](README.en.md) (inglese)
+
+> *Savia — la tua PM automatizzata con IA. Compatibile con Azure DevOps, Jira e Savia Flow.*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-🌐 [English version](README.en.md) · **Español**
+**Espanol** | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,61 @@
+<img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
+
+Portugues | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md)
+
+# PM-Workspace
+
+[![CI](https://img.shields.io/github/actions/workflow/status/gonzalezpazmonica/pm-workspace/ci.yml?branch=main&label=CI&logo=github)](https://github.com/gonzalezpazmonica/pm-workspace/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Ola, eu sou a Savia
+
+Sou a Savia, a corujinha que vive dentro do pm-workspace. O meu trabalho e fazer os teus projetos fluirem: gerencio sprints, decomponho backlog, coordeno agentes de codigo, cuido da faturacao, gero relatorios para a direcao e vigio a divida tecnica — tudo a partir do Claude Code, no idioma que voce usar.
+
+Funciono com Azure DevOps, Jira, ou 100% Git-native com Savia Flow. Quando voce chega pela primeira vez, me apresento e te conheco. Me adapto a voce, nao o contrario.
+
+---
+
+## Quem e voce?
+
+| Papel | O que faco por voce |
+|---|---|
+| **PM / Scrum Master** | Sprints, dailies, capacidade, relatorios |
+| **Tech Lead** | Arquitetura, divida tecnica, tech radar, PRs |
+| **Developer** | Specs, implementacao, testes, meu sprint |
+| **QA** | Plano de teste, cobertura, regressao, quality gates |
+| **Product Owner** | KPIs, backlog, impacto de features, stakeholders |
+| **CEO / CTO** | Portfolio, DORA, governanca, exposicao IA |
+
+---
+
+## Como funciono por dentro
+
+Sou um workspace Claude Code com 496 comandos, 46 agentes e 82 skills. Minha arquitetura e **Command > Agent > Skills**: o usuario invoca um comando, o comando delega a um agente especializado, e o agente usa skills de conhecimento reutilizaveis.
+
+Minha memoria persiste em texto puro (JSONL) com indexacao vetorial opcional para busca semantica. Nao envio dados a nenhum servidor — **zero telemetria**. Tudo executa localmente.
+
+Para tirar o maximo proveito de mim:
+1. **Explore antes de implementar** — `/plan` para pensar, depois implementar
+2. **Me de um jeito de verificar** — testes, builds, screenshots
+3. **Um objetivo por sessao** — `/clear` entre tarefas diferentes
+4. **Compacte frequentemente** — `/compact` em 50% do contexto
+
+---
+
+## Privacidade e Telemetria
+
+**Zero telemetria.** pm-workspace nao envia dados a nenhum servidor. Sem analytics, sem tracking, sem phone-home. Tudo executa localmente. Offline-first por design.
+
+---
+
+## Instalacao
+
+```bash
+git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
+cd ~/claude
+claude  # Savia se apresenta automaticamente
+```
+
+Documentacao completa: [README.md](README.md) (espanhol) | [README.en.md](README.en.md) (ingles)
+
+> *Savia — sua PM automatizada com IA. Compativel com Azure DevOps, Jira e Savia Flow.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,7 +129,8 @@ PRs with diffs, approve/reject, bidirectional approval <> backlog.
 - ~~Semantic Memory~~ → DONE (SPEC-018, v3.29.0)
 - Plugin Marketplace (community registry + sandbox) — 3.55
 - Multi-Claw (mesh of ESP32 nodes) — 3.50
-- Multilingualism (FR/IT/PT/DE/ZH) — 3.50
+- ~~Multilingualism (FR/IT/PT/DE/GL/EU/CA)~~ → DONE (v3.33.0, 7 README translations)
+- **Chinese (ZH) compatibility study** (3.60) — CJK tokenization, bidirectional text, font rendering, encoding. Requires: test corpus, native speaker review. SPEC pendiente.
 - SSO/LDAP via OIDC (Keycloak FOSS) — 3.35
 
 ---


### PR DESCRIPTION
## Summary
- 7 new README translations: Galego, Euskara, Catala, Francais, Deutsch, Portugues, Italiano
- All in Savia first person voice
- Language selector bar on all READMEs
- Chinese compatibility study added to roadmap

## Test plan
- [x] 35/35 BATS suites pass