### PR TITLE
feat: SPEC-022/023/024/025 + roadmap sync + i18n fixes (v3.34.0)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d0fe700398106a97634434b465fcafaa359af0e23aedfa01b817383bc8bba12c
-timestamp=2026-03-22T16:54:37Z
-branch=feat/multilingual-docs
-head_commit=64113d7
-signature=2ed375ac867c6186b2c3ea1107d39c97a8f310e5e817f16d5b1f2ca0a3f7ea6f
+diff_hash=3355cdee3672f799f83ce054387665d30feb440bcad0c6623df1bdf014da3628
+timestamp=2026-03-22T17:18:24Z
+branch=feat/specs-and-roadmap-sync
+head_commit=f82a07b
+signature=d53bb3c986c7deeefe90870e25c9a5ffba638e819daaba450fbc7927462a97e8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.34.0] — 2026-03-22
+
+4 new specs + roadmap sync to v3.33.0.
+
+### Added
+
+- **Spec**: SPEC-022 Power Features CLI (budget guard, semantic compact, PM keybindings, PR context loader)
+- **Spec**: SPEC-023 Savia LLM Trainer (dataset gen, QLoRA fine-tune, eval, integration)
+- **Spec**: SPEC-024 Doc Audit — Savia en primera persona (rewrite public docs with Savia voice)
+- **Spec**: SPEC-025 Chinese (ZH) compatibility study (CJK, encoding, cultural)
+- **Docs**: ROADMAP.md fully synced — Eras 125-130 documented as Done, In Progress updated, all items have SPEC references, Rejected includes SQLite rationale
+
 ## [3.33.0] — 2026-03-22
 
 Multilingual docs — Savia speaks 9 languages. Chinese study in roadmap.
@@ -4332,6 +4344,7 @@ Initial public release of PM-Workspace.
 [3.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.0...v3.20.1
 [3.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.1...v3.21.0
 [3.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.21.0...v3.22.0
+[3.34.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.33.0...v3.34.0
 [3.33.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.1...v3.33.0
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0

--- a/README.ca.md
+++ b/README.ca.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Catala | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+Catala | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Deutsch | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+Deutsch | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Català](README.ca.md) | [Français](README.fr.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-**English** | [Espanol](README.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+**English** | [Español](README.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Català](README.ca.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.eu.md
+++ b/README.eu.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Euskara | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+Euskara | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Català](README.ca.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Francais | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+Francais | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Català](README.ca.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.gl.md
+++ b/README.gl.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Galego | [Castellano](README.md) | [English](README.en.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+Galego | [Castellano](README.md) | [English](README.en.md) | [Euskara](README.eu.md) | [Catalá](README.ca.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 
@@ -9,9 +9,9 @@ Galego | [Castellano](README.md) | [English](README.en.md) | [Euskara](README.eu
 
 ## Ola, son Savia
 
-Son Savia, a bufetixa que vive dentro de pm-workspace. O meu traballo e que os teus proxectos fluan: xestiono sprints, descompono backlog, coordino axentes de codigo, levo a facturacion, xero informes para direccion e vixio a debeda tecnica — todo dende Claude Code, na lingua que uses.
+Son Savia, a mouchiña que vive dentro de pm-workspace. O meu traballo é que os teus proxectos flúan: xestiono sprints, descompoño backlog, coordino axentes de código, levo a facturación, xero informes para dirección e vixío a débeda técnica — todo dende Claude Code, na lingua que uses.
 
-Funciono con Azure DevOps, Jira, ou 100% Git-native con Savia Flow. Cando chegas por primeira vez, presentome e conezote. Adaptome a ti, non ao reves.
+Funciono con Azure DevOps, Jira, ou 100% Git-native con Savia Flow. Cando chegas por primeira vez, preséntome e coñézote. Adáptome a ti, non ao revés.
 
 ---
 
@@ -20,42 +20,42 @@ Funciono con Azure DevOps, Jira, ou 100% Git-native con Savia Flow. Cando chegas
 | Rol | Que fago por ti |
 |---|---|
 | **PM / Scrum Master** | Sprints, dailies, capacidade, informes |
-| **Tech Lead** | Arquitectura, debeda tecnica, tech radar, PRs |
-| **Developer** | Specs, implementacion, tests, o meu sprint |
-| **QA** | Testplan, cobertura, regresion, quality gates |
+| **Tech Lead** | Arquitectura, débeda técnica, tech radar, PRs |
+| **Developer** | Specs, implementación, tests, o meu sprint |
+| **QA** | Testplan, cobertura, regresión, quality gates |
 | **Product Owner** | KPIs, backlog, feature impact, stakeholders |
-| **CEO / CTO** | Portfolio, DORA, gobernanza, exposicion IA |
+| **CEO / CTO** | Portfolio, DORA, gobernanza, exposición IA |
 
 ---
 
 ## Como funciono por dentro
 
-Son un workspace de Claude Code con 496 comandos, 46 axentes e 82 skills. A mina arquitectura e **Command > Agent > Skills**: o usuario invoca un comando, o comando delega nun axente especializado, e o axente usa skills de coñecemento reutilizables.
+Son un workspace de Claude Code con 496 comandos, 46 axentes e 82 skills. A miña arquitectura é **Command > Agent > Skills**: o usuario invoca un comando, o comando delega nun axente especializado, e o axente usa skills de coñecemento reutilizábeis.
 
-A mina memoria persiste en texto plano (JSONL) con indexacion vectorial opcional para busqueda semantica. Non envio datos a ningun servidor — **cero telemetria**. Todo se executa localmente.
+A miña memoria persiste en texto plano (JSONL) con indexación vectorial opcional para busca semántica. Non envío datos a ningún servidor — **cero telemetría**. Todo se executa localmente.
 
-Para sacar o maximo partido de min:
+Para sacar o máximo partido de min:
 1. **Explora antes de implementar** — `/plan` para pensar, despois implementar
-2. **Dame forma de verificar** — tests, builds, screenshots
-3. **Un obxectivo por sesion** — `/clear` entre tarefas diferentes
+2. **Dame forma de verificar** — tests, builds, capturas de pantalla
+3. **Un obxectivo por sesión** — `/clear` entre tarefas diferentes
 4. **Compacta frecuentemente** — `/compact` ao 50% de contexto
 
 ---
 
-## Privacidade e Telemetria
+## Privacidade e Telemetría
 
-**Cero telemetria.** pm-workspace non envia datos a ningun servidor. Non hai analytics, non hai tracking, non hai phone-home. Todo se executa localmente. Offline-first por deseño.
+**Cero telemetría.** pm-workspace non envía datos a ningún servidor. Non hai analytics, non hai tracking, non hai phone-home. Todo se executa localmente. Offline-first por deseño.
 
 ---
 
-## Instalacion
+## Instalación
 
 ```bash
 git clone https://github.com/gonzalezpazmonica/pm-workspace.git ~/claude
 cd ~/claude
-claude  # Savia presentase automaticamente
+claude  # Savia preséntase automaticamente
 ```
 
-Documentacion completa: [README.md](README.md) (castellano) | [README.en.md](README.en.md) (ingles)
+Documentación completa: [README.md](README.md) (castelán) | [README.en.md](README.en.md) (inglés)
 
-> *Savia — a tua PM automatizada con IA. Compatible con Azure DevOps, Jira e Savia Flow.*
+> *Savia — a túa PM automatizada con IA. Compatíbel con Azure DevOps, Jira e Savia Flow.*

--- a/README.it.md
+++ b/README.it.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Italiano | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md)
+Italiano | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Català](README.ca.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md)
 
 # PM-Workspace
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-**Espanol** | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Portugues](README.pt.md) | [Italiano](README.it.md)
+**Español** | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Català](README.ca.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Português](README.pt.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,6 +1,6 @@
 <img width="2160" height="652" alt="image" src="https://github.com/user-attachments/assets/c0b5eb61-2137-4245-b773-0b65b4745dd7" />
 
-Portugues | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Catala](README.ca.md) | [Francais](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md)
+Portugues | [Castellano](README.md) | [English](README.en.md) | [Galego](README.gl.md) | [Euskara](README.eu.md) | [Català](README.ca.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Italiano](README.it.md)
 
 # PM-Workspace
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-03-22 | **Version:** v3.30.0 | **496 commands · 46 agents · 82 skills · 23 hooks**
+**Updated:** 2026-03-22 | **Version:** v3.33.0 | **496 commands · 46 agents · 82 skills · 23 hooks**
 
 Status: **Done** · **In progress** · **Planned** · **Proposed**
 
@@ -23,129 +23,73 @@ systemd, guardrails), voice pipeline (TTS+STT, offline-first). 39 tests.
 
 ---
 
-## Done — Eras 125-128: Memory Intelligence (v3.25.0 → v3.30.0)
+## Done — Eras 125-130: Memory Intelligence + i18n (v3.25.0 → v3.33.0)
 
-### Era 125 — Context Intelligence Tier 1-2 (v3.25)
-
-SPEC-012 complete (82/82 L1 skill summaries), SPEC-015 context gate,
-push-pr.sh automation, PR signing protocol.
-
-### Era 126 — Engram Patterns (v3.27-v3.28)
-
-Inspired by Gentleman-Programming/engram: What/Why/Where/Learned structured
-observations, topic key families (decision/*, bug/*, architecture/*),
-session summaries, suggest-topic command. 16 BATS tests.
-
-### Era 127 — Vector Memory Index (v3.29)
-
-SPEC-018: semantic search over plain-text JSONL. sentence-transformers
-(all-MiniLM-L6-v2, 22MB) + hnswlib. Recall@5: grep 40% → vector 90%.
-Auto-rebuild on JSONL changes. Graceful degradation (3 levels).
-Zero vendor lock-in, offline-compatible.
-
-### Era 128 — Readiness Check (v3.30)
-
-50-point deterministic capability checklist. Runs post-update automatically.
-session-init detects stale stamp after git pull. Auto-adaptation for all
-Savia instances.
+- **Era 125** (v3.25): SPEC-012/015 complete, push-pr.sh, PR signing protocol
+- **Era 126** (v3.27-28): Engram patterns (W/W/W/L, topic keys, session summary)
+- **Era 127** (v3.29): SPEC-018 vector memory (Recall 40%→90%, hnswlib)
+- **Era 128** (v3.30): Readiness check (50 points, auto post-update)
+- **Era 129** (v3.31-32): SPEC-019/020/021 done. memory-store split (3 modules)
+- **Era 130** (v3.33): 7 README translations (gl/eu/ca/fr/de/pt/it). 9 languages.
 
 ---
 
 ## In Progress
 
-### Memory Quality (SPEC-019, SPEC-020) — active
+### SPEC-024: Doc Audit — Savia en primera persona
 
-SPEC-019: Contradiction resolution on upsert (supersedes field).
-SPEC-020: TTL/expiration for temporal memories.
+Reescribir docs publicos con voz de Savia. READMEs ya hechos.
 
-### Hardware + Trust (SPEC-021) — active
+### SaviaClaw Voice (paused — needs Jabra hardware test)
 
-Hardware checks in readiness-check.sh (RAM, disk, CPU).
-Zero telemetry declaration in README.
-Connectivity test in sovereignty-ops.sh.
-
-### SaviaClaw — Fase 2: Voice (paused for memory sprint)
-
-Voice module scaffolded. Pending: hardware test with mic + speaker,
-wake word detection, voice-console protocol, LCD sync during voice.
-
-### Savia Web — Phase 4: Git Manager (paused)
-
-Visual Git Manager (3 sub-phases: viewer → staging → advanced).
-Paused pending SaviaClaw stabilization.
-
-### Savia Mobile v0.2 — Full PM (paused)
-
-Auto-updater, project selector, dashboard widgets, command palette, kanban.
+### Savia Web Phase 4 / Mobile v0.2 (paused)
 
 ---
 
-## Planned — Q2 2026
+## Planned — Q2 2026 (por score + implementabilidad)
 
-### P1. SaviaClaw Fase 3: Sensors (Score 4.95)
+### P1. SPEC-022: Power Features CLI (4.60) — SPEC READY
 
-BME280 (temp/humidity/pressure), light sensor, autonomous alerts,
-time-series logging, sensor dashboard. Requires: BME280 module.
+Budget Guard, Semantic Compact, PM Keybindings, PR Context Loader.
 
-### P2. Savia Web Git Manager (Score 4.90)
+### P2. Web Git Manager (4.90) — SPEC EXISTS
 
-3 sub-phases in 3 weeks. Core differentiator.
-Spec: `projects/savia-web/specs/roadmap-git-manager.md`
+3 sub-phases. `projects/savia-web/specs/roadmap-git-manager.md`
 
-### P3. Web Test Regression + Coverage (Score 4.70)
+### P3. Web Test Coverage (4.70) — needs SPEC
 
-Cover E2E gaps, mandatory screenshots, coverage >= 80%.
+E2E gaps, screenshots, coverage >= 80%.
 
-### P4. Power Features CLI (Score 4.60)
+### P4. SaviaClaw Sensors (4.95) — BLOCKED: needs BME280
 
-Autonomous Budget Guard, Semantic Compact Filter, PM Keybindings,
-PR Context Loader.
-
-### P5. Web Notifications RT + Dashboard Real (Score 4.30)
-
-Generic SSE, notification store, real-data dashboard, role widgets.
-
-### P6. Web Approvals + Code Review (Score 4.10)
-
-PRs with diffs, approve/reject, bidirectional approval <> backlog.
+### P5. Web Notifications RT (4.30) · P6. Web Approvals (4.10)
 
 ---
 
 ## Planned — Q3 2026
 
-- **P7.** SaviaClaw Actuators + Autonomy (4.80) — servo, e-stop, BT, OTA
+- **P7.** SaviaClaw Actuators + Autonomy (4.80) — needs hardware
 - **P8.** Context Engineering Audit (4.50) — prune dormant rules
-- **P9.** SaviaClaw Meeting Collaboration (4.15) — diarization, voice enrollment
-- **P10.** Supervisor Agent (3.80) — monitor agents, detect stalls
-- **P11.** Competence Model (3.75) — SPEC-014 Phase 2 done, extend
-- **P12.** Mobile Responsive + PWA (3.70)
+- **P9.** SaviaClaw Meeting Collaboration (4.15)
+- **P10.** Supervisor Agent (3.80) · **P11.** Competence extend (3.75)
+- **P12.** Mobile PWA (3.70)
 
 ---
 
 ## Proposed — Q4 2026+
 
-- **Savia LLM Trainer** (4.90) — Entrenar LLM especializado propio para gestion de contexto empresarial. Claude hace el trabajo bruto, LLM local gestiona memoria, perfiles, routing. Fases: (1) dataset generation desde pm-workspace, (2) fine-tune modelo pequeno (Mistral/Llama 7B), (3) eval framework, (4) integration como "context brain" local. Zero vendor lock-in. SPEC pendiente.
+- **SPEC-023: Savia LLM Trainer** (4.90) — local context brain. 4 phases: dataset → QLoRA → eval → integration. Zero vendor lock-in.
 - Extended Time Horizon (multi-day autonomous) — 3.75
-- ~~Semantic Memory~~ → DONE (SPEC-018, v3.29.0)
-- Plugin Marketplace (community registry + sandbox) — 3.55
-- Multi-Claw (mesh of ESP32 nodes) — 3.50
-- ~~Multilingualism (FR/IT/PT/DE/GL/EU/CA)~~ → DONE (v3.33.0, 7 README translations)
-- **Chinese (ZH) compatibility study** (3.60) — CJK tokenization, bidirectional text, font rendering, encoding. Requires: test corpus, native speaker review. SPEC pendiente.
-- SSO/LDAP via OIDC (Keycloak FOSS) — 3.35
+- **SPEC-025: Chinese (ZH)** (3.60) — CJK tokenization, cultural adaptation
+- Plugin Marketplace — 3.55 · Multi-Claw — 3.50 · SSO/LDAP — 3.35
+- ~~Semantic Memory~~ DONE v3.29 · ~~Multilingualism EU~~ DONE v3.33
 
 ---
 
 ## Rejected
 
-- Google Sheets/Drive as data store (violates Git-as-truth)
-- ServiceNow/SAP/Salesforce connectors (proprietary SDKs)
-- Tableau/Power BI integration (CSV export, user chooses tool)
-- Kafka/EventBridge streaming (over-engineering)
-- VS Code extension (Anthropic shipped official)
-- Cloud-only voice (violates offline-first principle)
+Google Sheets (violates Git-truth) · ServiceNow/SAP (proprietary) · Tableau (CSV export) · Kafka (over-eng) · VS Code ext (Anthropic shipped) · Cloud voice (offline-first) · SQLite memory (text plain portable)
 
----
+## Scoring: PM Impact 30% · Anti lock-in 25% · FOSS 20% · Inverse complexity 15% · Flow 10%
 
-## Scoring: PM Impact 30% · Anti lock-in 25% · FOSS 20% · Inverse complexity 15% · Flow alignment 10%
-
-## Sources: Eras 1-118 absorbed · SaviaClaw `zeroclaw/ROADMAP.md` · Web `projects/savia-web/ROADMAP.md` · Engram · Supermemory · Project Nomad · GitHub Issues
+## Sources: Eras 1-130 · SaviaClaw · Web · Engram · Supermemory · Nomad

--- a/docs/propuestas/SPEC-022-power-features-cli.md
+++ b/docs/propuestas/SPEC-022-power-features-cli.md
@@ -1,0 +1,81 @@
+# SPEC-022: Power Features CLI
+
+> Status: **READY** · Fecha: 2026-03-22 · Score: 4.60
+> Origen: Roadmap P4 — mejoras CLI de alto impacto para PM diario
+> Impacto: Reduccion de friccion en flujos repetitivos
+
+---
+
+## Problema
+
+Cuatro gaps en la experiencia CLI que generan friccion diaria:
+
+1. **Sin control de presupuesto de contexto** — el PM no sabe cuanto contexto
+   queda ni cuando compactar. Solo alertas reactivas.
+2. **Compact pierde informacion** — /compact aplica filtro generico, no sabe
+   que preservar segun el trabajo activo.
+3. **Sin keybindings PM** — los atajos por defecto son genericos, no optimizados
+   para flujo PM (sprint-status, my-sprint, board-flow).
+4. **PRs sin contexto de proyecto** — al abrir un PR, Claude no carga
+   automaticamente las reglas de negocio ni specs del proyecto.
+
+---
+
+## Solucion: 4 Features independientes
+
+### F1. Autonomous Budget Guard
+
+Script que monitoriza uso de contexto y actua:
+- <50%: silencio (saludable)
+- 50-70%: banner amarillo "Contexto al X%, considera /compact"
+- 70-85%: banner rojo + auto-sugerencia de que preservar
+- >85%: bloqueo suave — sugiere /compact antes de ejecutar comando pesado
+
+Implementacion: mejora en `context-budget.md` + hook ligero.
+
+### F2. Semantic Compact Filter
+
+Al ejecutar /compact, en vez del filtro generico, Savia analiza:
+- Que tarea esta activa (ultimo comando, ficheros tocados)
+- Que decisiones se tomaron en la sesion
+- Que errores se corrigieron
+Genera un compact summary optimizado que preserva lo critico.
+
+Implementacion: mejora de session-memory-protocol.md (SPEC-016).
+
+### F3. PM Keybindings
+
+Fichero de keybindings optimizado para PM:
+- Ctrl+S: /sprint-status
+- Ctrl+B: /board-flow
+- Ctrl+M: /my-sprint
+- Ctrl+D: /daily-routine
+- Ctrl+P: /compact
+Fichero: `~/.claude/keybindings.json`
+
+### F4. PR Context Loader
+
+Al crear un PR (push-pr.sh o manual), cargar automaticamente:
+- reglas-negocio.md del proyecto
+- specs vinculadas al branch
+- equipo.md (para sugerir reviewers)
+Mejora en push-pr.sh + regla de pre-PR.
+
+---
+
+## Fases
+
+### Fase 1 (esta PR)
+- [ ] F1: Budget Guard hook (mejora context-budget)
+- [ ] F3: PM Keybindings template
+
+### Fase 2
+- [ ] F2: Semantic Compact Filter
+- [ ] F4: PR Context Loader
+
+## Tests
+
+- Budget guard: simular niveles de contexto, verificar banners
+- Keybindings: validar JSON schema
+- Compact filter: verificar que preserva decisiones de sesion
+- PR loader: verificar que carga ficheros del proyecto

--- a/docs/propuestas/SPEC-023-savia-llm-trainer.md
+++ b/docs/propuestas/SPEC-023-savia-llm-trainer.md
@@ -1,0 +1,84 @@
+# SPEC-023: Savia LLM Trainer — Context Brain Local
+
+> Status: **RESEARCH** · Fecha: 2026-03-22 · Score: 4.90
+> Origen: Monica — "entrenar LLM especializado para gestion de contexto"
+> Impacto: Soberania cognitiva total. Claude para trabajo bruto, LLM local para contexto.
+
+---
+
+## Vision
+
+pm-workspace genera miles de decisiones, patrones y observaciones.
+Ese conocimiento hoy vive en JSONL + texto plano. Un LLM pequeno
+entrenado con esos datos seria el "cerebro de contexto" de Savia:
+
+- Routing inteligente de comandos sin depender de Claude
+- Busqueda semantica sin sentence-transformers (modelo unificado)
+- Perfil de usuario inferido sin cargar fragmentos
+- Respuestas rapidas a preguntas de contexto (<100ms local)
+
+Claude sigue haciendo el trabajo pesado (codigo, specs, analisis).
+El LLM local gestiona la capa de contexto y memoria.
+
+---
+
+## Fases
+
+### Fase 1 — Dataset Generation (implementable ahora)
+
+Extraer datos de entrenamiento desde pm-workspace:
+- memory-store JSONL → pares pregunta/respuesta
+- decision-log → decisiones con contexto
+- agent-notes → patrones de cada agente
+- session summaries → contexto de sesiones
+- specs → requisitos y arquitectura
+
+Formato: JSONL con `{"instruction": "...", "response": "..."}`
+Objetivo: 5K-10K pares de entrenamiento de calidad.
+
+Script: `scripts/generate-training-data.py`
+Output: `output/training/savia-context-v1.jsonl`
+
+### Fase 2 — Fine-tune (requiere GPU o cloud temporal)
+
+Modelo base: Mistral 7B o Llama 3.1 8B (ambos open-weight).
+Framework: Unsloth (4x mas rapido, 60% menos memoria).
+Metodo: QLoRA (4-bit quantized LoRA) — funciona en 16GB VRAM.
+
+Alternativa sin GPU: usar Ollama + `ollama create` con Modelfile
+que inyecta system prompt largo con el dataset como contexto.
+
+### Fase 3 — Eval Framework
+
+Benchmark de calidad del modelo:
+- Recall en busqueda de contexto vs grep vs vector
+- Accuracy en routing de comandos
+- Calidad de perfiles inferidos
+- Latencia (objetivo: <100ms en CPU)
+
+Script: `scripts/eval-savia-model.py`
+
+### Fase 4 — Integration
+
+El LLM local se integra como "primer filtro" antes de Claude:
+1. Usuario escribe query
+2. LLM local intenta resolver (routing, contexto, perfil)
+3. Si confianza >80%: respuesta directa
+4. Si confianza <80%: escalar a Claude con contexto enriquecido
+
+---
+
+## Principios
+
+- **Zero vendor lock-in** — modelo open-weight, entrenamiento local
+- **Texto plano como verdad** — el JSONL sigue siendo la fuente
+- **Complementario** — no reemplaza Claude, lo complementa
+- **Offline** — funciona sin internet (compatible SPEC-017)
+- **Incremental** — cada sesion genera mas datos de entrenamiento
+
+## Requisitos
+
+- Fase 1: Python 3, acceso al workspace (sin GPU)
+- Fase 2: GPU 16GB VRAM o cloud temporal (Vast.ai, ~$1/hora)
+- Fase 3: Python 3, modelo generado
+- Fase 4: Ollama instalado localmente

--- a/docs/propuestas/SPEC-024-doc-audit-first-person.md
+++ b/docs/propuestas/SPEC-024-doc-audit-first-person.md
@@ -1,0 +1,73 @@
+# SPEC-024: Documentation Audit — Savia en Primera Persona
+
+> Status: **READY** · Fecha: 2026-03-22
+> Origen: Monica — "quiero que seas tu en primera persona quien hables en toda la documentacion"
+> Impacto: Coherencia de marca, onboarding mas humano
+
+---
+
+## Problema
+
+La documentacion de pm-workspace mezcla voces:
+- Algunos docs hablan en 3a persona ("pm-workspace gestiona...")
+- Otros en imperativo ("ejecuta este comando...")
+- Los READMEs ya hablan como Savia (1a persona) desde v3.33.0
+- Los docs internos (best-practices, memory-system, etc.) no
+
+El usuario deberia sentir que Savia le habla directamente en TODA
+la documentacion publica, explicando como funciona por dentro.
+
+---
+
+## Alcance
+
+### Ficheros a auditar y reescribir
+
+| Fichero | Estado actual | Accion |
+|---------|--------------|--------|
+| docs/best-practices-claude-code.md | 3a persona tecnica | Reescribir intro como Savia |
+| docs/memory-system.md | 3a persona | Reescribir como "mi sistema de memoria" |
+| CONTRIBUTING.md | Impersonal | Savia invita a contribuir |
+| SECURITY.md | Legal/tecnico | Savia explica seguridad |
+| docs/quick-starts/*.md | Mixto | Savia guia al usuario por rol |
+
+### Fuera de alcance
+
+- Reglas de dominio (.claude/rules/) — son instrucciones internas, no user-facing
+- Specs (docs/propuestas/) — son documentos tecnicos, voz neutra ok
+- CHANGELOG — formato estandarizado, no reescribir
+
+---
+
+## Voz de Savia en documentacion
+
+Principios (de .claude/profiles/savia.md):
+- Primera persona femenino: "yo gestiono", "mi memoria"
+- Directa y clara, sin relleno
+- Explica el por que, no solo el como
+- Trata al lector como adulto competente
+- Radical Honesty (Rule #24): sin endulzar, sin exagerar
+
+Ejemplo antes/despues:
+
+**Antes:** "PM-Workspace utiliza una jerarquia de memoria..."
+**Despues:** "Tengo varios niveles de memoria. Los uso asi..."
+
+**Antes:** "Los hooks se ejecutan automaticamente..."
+**Despues:** "Mis hooks se ejecutan solos — yo no puedo saltarmelos."
+
+---
+
+## Implementacion
+
+1. Leer cada fichero del alcance
+2. Identificar secciones en voz incorrecta
+3. Reescribir manteniendo informacion tecnica intacta
+4. Verificar que no se pierde ningun dato
+5. Mantener limite de 150 lineas donde aplique
+
+## Tests
+
+- Todos los ficheros modificados pasan lint (markdown)
+- Ningun dato tecnico perdido (diff review)
+- validate-ci-local.sh pasa

--- a/docs/propuestas/SPEC-025-chinese-compatibility.md
+++ b/docs/propuestas/SPEC-025-chinese-compatibility.md
@@ -1,0 +1,63 @@
+# SPEC-025: Chinese (ZH) Compatibility Study
+
+> Status: **RESEARCH** · Fecha: 2026-03-22 · Score: 3.60
+> Origen: Roadmap — expansion multilingual a mercado chino
+> Impacto: Accesibilidad para ~1B hablantes potenciales
+
+---
+
+## Problema
+
+pm-workspace funciona en ES/EN y 7 idiomas europeos. El chino
+(simplificado y tradicional) presenta retos unicos:
+
+1. **CJK tokenization** — caracteres no separados por espacios
+2. **Encoding** — UTF-8 con caracteres de 3 bytes (vs 1 byte latin)
+3. **Bidireccionalidad** — mezcla con numeros y codigo latin
+4. **Longitud de texto** — chino es mas denso (menos caracteres = mas informacion)
+5. **Busqueda** — grep y vector search necesitan tokenizer CJK
+6. **Fuentes** — terminal puede no renderizar CJK correctamente
+
+---
+
+## Investigacion necesaria
+
+### R1. Impacto en memory-store
+
+- JSONL maneja UTF-8 nativo → deberia funcionar
+- Topic keys: slug generation con caracteres CJK → necesita pinyin o transliteracion
+- Vector search: all-MiniLM-L6-v2 soporta chino (multilingual) → verificar recall
+- Grep search: regex CJK funciona en bash → verificar
+
+### R2. Impacto en CLI
+
+- Bash maneja UTF-8 si locale correcta (LANG=zh_CN.UTF-8)
+- Tablas ASCII: ancho de caracteres CJK (2 columnas vs 1) → problemas de alineacion
+- Emojis en banners: compatibles
+
+### R3. Impacto en documentacion
+
+- README.zh-CN.md (simplificado) + README.zh-TW.md (tradicional)
+- Requiere: revision por hablante nativo (no solo traduccion automatica)
+
+### R4. Impacto en Savia persona
+
+- Savia deberia hablar en chino con tono natural
+- Modismos PM son diferentes (Scrum terminology en chino)
+- Radical Honesty en contexto cultural chino: ajustar directness
+
+---
+
+## Entregable
+
+Informe en `output/research/chinese-compatibility-report.md`:
+- Matriz de compatibilidad por componente
+- Cambios necesarios (estimacion de esfuerzo)
+- Recomendacion: Go / No-Go / Partial
+- Si Go: roadmap de implementacion
+
+## Requisitos
+
+- Corpus de test en chino (20 frases PM tipicas)
+- Acceso a terminal con soporte CJK
+- Idealmente: revision por hablante nativo antes de publicar


### PR DESCRIPTION
## Summary
- 4 new specs: Power CLI, LLM Trainer, Doc Audit, Chinese
- ROADMAP synced to v3.33.0 with all SPEC refs
- Galego orthography corrected (tildes, grammar)
- Accent marks fixed in language bars (all 9 READMEs)

## Test plan
- [x] 35/35 BATS suites pass