### PR TITLE
docs: rewrite memory-architecture.md for humans (v3.42.0)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=9c6092682358e897d2ad6e94fb081f195a03984203a43cfb799b13f20250b500
-timestamp=2026-03-22T20:24:15Z
-branch=feat/memory-architecture-doc
-head_commit=01e5208
-signature=fbf4088d76330b198107f213d7f49fabf3bfc42b522328c41d5f942511394443
+diff_hash=52f2bb26e0fa457c485e615af041df86cb1bee697e73b7ec350af2a381675da9
+timestamp=2026-03-22T21:06:56Z
+branch=feat/memory-doc-rewrite
+head_commit=5684ebc
+signature=2f3b93801b7dda16c38b82b2b0a3f3617b348d6b2a0577e17c1431292379a298

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.42.0] — 2026-03-22
+
+Rewrite memory-architecture.md — human-friendly, complete, 379 lines.
+
+### Changed
+
+- **Docs**: `memory-architecture.md` — completely rewritten for non-technical readers. Explains with analogies (index of a book, not the book itself). Covers: project knowledge (meetings, team, rules, stakeholders, decision log), 7 digesters and their dual output (project markdown + central memory), contradiction tracking, TTL, search levels, privacy. New section "El panorama completo" connects everything.
+
 ## [3.41.0] — 2026-03-22
 
 Memory Architecture doc — Savia explains her memory system in first person.
@@ -4413,6 +4421,7 @@ Initial public release of PM-Workspace.
 [3.20.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.0...v3.20.1
 [3.21.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.20.1...v3.21.0
 [3.22.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.21.0...v3.22.0
+[3.42.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.41.0...v3.42.0
 [3.41.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.39.0...v3.41.0
 [3.39.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.38.0...v3.39.0
 [3.38.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.37.0...v3.38.0

--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -1,146 +1,379 @@
-# Mi Sistema de Memoria — Como Recuerdo, Busco y Aprendo
+# Mi Sistema de Memoria
 
-> Soy Savia. Este documento explica como funciona mi memoria por dentro.
-> Si quieres entender como persisto conocimiento entre sesiones, como busco
-> informacion semanticamente, y como los digestores alimentan mi cerebro
-> — esto es lo que necesitas leer.
+Soy Savia. Cada vez que cierras la conversacion, yo pierdo todo lo que hablamos. Asi funciona Claude: cada sesion empieza de cero. Eso es un problema enorme si gestionas proyectos, porque las decisiones de ayer importan hoy.
 
----
-
-## Principio fundamental
-
-**La persistencia final son ficheros de texto legibles por personas.** Mi
-memoria vive en JSONL (una linea JSON por observacion) y markdown. Cualquier
-humano puede abrir estos ficheros con un editor de texto y leer, buscar o
-editar mi memoria directamente. No uso bases de datos, no uso servicios cloud.
-
-Los indices (vector, graph) son **aceleradores derivados** — existen solo para
-hacer busquedas mas rapidas. Si los borro, los reconstruyo desde el texto plano.
-Si todo falla, grep sobre el JSONL sigue funcionando. El texto plano sobrevive
-a cualquier herramienta.
+Este documento explica como resolvi ese problema. Como recuerdo cosas entre sesiones, como las busco despues, y como me aseguro de que nunca dependas de una herramienta que no puedas leer tu misma con tus propios ojos.
 
 ---
 
-## Las 4 capas de mi memoria
+## Lo mas importante: todo se guarda en ficheros de texto
+
+Si solo lees una frase de este documento, que sea esta:
+
+**Mi memoria son ficheros de texto plano que cualquier persona puede abrir, leer y editar con un editor de texto normal.**
+
+No hay una base de datos oculta. No hay un servicio en la nube que guarde tus datos. No hay una caja negra. Si mañana desaparezco, tus ficheros siguen ahi, legibles, buscables con `grep`, editables con cualquier editor.
+
+Esto es una decision de diseño deliberada:
+- **Portabilidad**: mueves los ficheros a otro ordenador y funcionan.
+- **Transparencia**: abres el fichero y ves exactamente lo que recuerdo.
+- **Durabilidad**: el texto plano es el formato mas longevo de la informatica. Un fichero de texto de 1970 se lee hoy sin problemas. Una base de datos de 2020 puede necesitar software especifico para abrirse.
+- **Control**: si algo que recuerdo es incorrecto, lo editas directamente.
+- **Independencia**: no necesitas ni Savia ni Claude ni ningun software para acceder a tu propia memoria.
+
+---
+
+## Que recuerdo y como lo organizo
+
+Cada cosa que vale la pena recordar la guardo como una "observacion". Una observacion es una linea en un fichero de texto con esta informacion:
+
+- **Que paso** (What) — el hecho concreto
+- **Por que importa** (Why) — la razon
+- **Donde** (Where) — en que parte del proyecto o codigo
+- **Que aprendi** (Learned) — la leccion para la proxima vez
+
+Por ejemplo, si en una reunion el equipo decide usar PostgreSQL en vez de MySQL, yo guardo:
 
 ```
-Capa 4: Graph (entidades + relaciones)     ← "quien decidio que"
-Capa 3: Vector Index (embeddings)           ← "busca por significado"
-Capa 2: JSONL (observaciones estructuradas) ← "la verdad"
-Capa 1: Auto-Memory de Claude Code          ← "preferencias del usuario"
+Que: Elegimos PostgreSQL para la base de datos del proyecto
+Por que: Mejor soporte para JSON y extensiones mas maduras
+Donde: Proyecto Alpha, capa de persistencia
+Aprendi: Siempre evaluar las extensiones disponibles antes de elegir BD
 ```
 
-### Capa 1 — Auto-Memory (Claude Code nativo)
+Cada observacion tiene ademas:
+- Un **tipo**: decision, bug, patron, descubrimiento, convencion, arquitectura
+- Una **etiqueta tematica** (topic key): `decision/postgresql`, `bug/token-timeout`
+- Un **proyecto** asociado
+- Una **fecha** de cuando se registro
+- Opcionalmente, una **fecha de caducidad** — porque no todo es relevante para siempre. "El sprint actual termina el viernes" caduca; "Usamos PostgreSQL" no caduca.
 
-Ficheros `.md` en `~/.claude/projects/*/memory/`. Claude Code los carga
-automaticamente al inicio de cada sesion. Aqui guardo:
-- Feedback del usuario (correcciones sobre como trabajo)
-- Estado de proyecto del workspace (features, bugs conocidos)
-- Referencias externas
+Cuando actualizo una decision (por ejemplo, "finalmente cambiamos de PostgreSQL a MongoDB"), guardo la nueva decision Y registro que reemplaza a la anterior. Asi nunca pierdo el historico de por que cambiamos de opinion.
 
-**Limite:** 200 lineas en MEMORY.md. Topic files bajo demanda.
+---
 
-### Capa 2 — JSONL (mi memoria estructurada)
+## Donde viven fisicamente estos ficheros
 
-Fichero: `output/.memory-store.jsonl`
+Todo esta dentro de tu carpeta de trabajo. Nada sale de tu ordenador.
 
-Cada observacion tiene esta estructura:
+### El fichero principal: la memoria
+
+```
+output/.memory-store.jsonl
+```
+
+Es un fichero de texto donde cada linea es una observacion en formato JSON. Puedes abrirlo con cualquier editor. Cada linea es independiente — si borras una, las demas siguen funcionando.
+
+Ejemplo real de una linea (formateada para que se lea mejor):
+
 ```json
 {
   "ts": "2026-03-22T10:00:00Z",
   "type": "decision",
-  "title": "Use PostgreSQL",
-  "content": "What: Chose PostgreSQL | Why: Better JSON support | Where: Backend | Learned: Always evaluate extensions",
-  "topic_key": "decision/use-postgresql",
+  "title": "Usar PostgreSQL",
+  "content": "What: Elegimos PostgreSQL | Why: Mejor JSON | Where: Backend | Learned: Evaluar extensiones",
+  "topic_key": "decision/usar-postgresql",
   "concepts": ["database", "backend"],
   "project": "alpha",
-  "rev": 2,
-  "supersedes": "Use MySQL",
-  "expires_at": null,
-  "hash": "abc123",
-  "tokens_est": 45
+  "rev": 1
 }
 ```
 
-**Campos clave:**
-- `topic_key`: familia/slug (decision/*, bug/*, architecture/*). Upsert automatico.
-- `supersedes`: cuando actualizo una decision, guardo que reemplaza (SPEC-019).
-- `expires_at`: memorias temporales se ocultan tras expirar (SPEC-020).
-- W/W/W/L: campos `--what`, `--why`, `--where`, `--learned` estructuran el contenido.
+Si el equipo cambia de opinion y elige MongoDB, la siguiente linea tendra `"rev": 2` y un campo `"supersedes": "Elegimos PostgreSQL"` para que se vea que hubo un cambio y cual era la decision anterior.
 
-**Script:** `scripts/memory-store.sh` (dispatcher) + `memory-save.sh` + `memory-search.sh`
+### Las notas personales
 
-### Capa 3 — Vector Index (busqueda semantica)
+```
+~/.claude/projects/*/memory/
+```
 
-Ficheros: `output/.memory-store-index.idx` + `.map` (derivados, gitignored)
+Aqui guardo lo que aprendo sobre ti: que prefieres informes cortos, que trabajas con Azure DevOps, que tu equipo usa sprints de 2 semanas. Claude Code carga estos ficheros automaticamente cuando empezamos a hablar. Son markdown normal — los puedes leer y editar.
 
-Cuando buscas "auth problems", grep no encuentra "token refresh timeout".
-Mi indice vectorial si — porque entiende significado, no solo palabras.
+### El conocimiento de cada proyecto (la parte mas rica)
 
-**Motor:** sentence-transformers (all-MiniLM-L6-v2, 22MB, Apache 2.0) + hnswlib.
-**Recall:** 90% vs 40% del grep (benchmark con 20 queries).
-**Reranker:** cross-encoder/ms-marco-MiniLM-L-6-v2 mejora precision post-busqueda.
-**Auto-rebuild:** el indice se reconstruye en background cuando el JSONL cambia.
+Esta es probablemente la parte mas importante de mi memoria, y la que mas usas sin darte cuenta. Cada proyecto tiene su propia carpeta con ficheros markdown que cualquiera puede leer:
 
-**Script:** `scripts/memory-vector.py` (rebuild, search, status, benchmark)
+```
+projects/{nombre-proyecto}/
+  CLAUDE.md               — como funciona este proyecto, sus reglas, sus entornos
+  reglas-negocio.md       — las reglas de negocio: que se puede, que no, por que
+  equipo.md               — quien trabaja aqui, que rol tiene, que sabe hacer
+  stakeholders.md         — con quien hablamos, que les importa, como tratarles
+  decision-log.md         — todas las decisiones tomadas, con fecha y contexto
+  meetings/               — digestiones de cada reunion
+    2026-03-15-sprint-review.md
+    2026-03-18-daily.md
+    2026-03-20-one2one-carlos.md
+  agent-memory/           — lo que mis agentes aprenden del proyecto
+    meeting-digest/MEMORY.md
+    pdf-digest/MEMORY.md
+    meeting-risk-analyst/MEMORY.md
+```
 
-### Capa 4 — Graph (entidades y relaciones)
+**Cada uno de estos ficheros es markdown puro.** Los puedes abrir, leer, editar, compartir con el equipo, imprimir. No hay nada oculto.
 
-Fichero: `output/.memory-store-graph.json` (derivado, gitignored)
+Cuando me pides el estado del sprint, yo leo `equipo.md` para saber quien esta en el equipo. Cuando proceso una reunion, leo `reglas-negocio.md` para entender si lo que se discutio tiene sentido. Cuando asigno una tarea, leo `equipo.md` para saber las competencias de cada persona.
 
-Extraigo entidades (tecnologias, conceptos, proyectos) y relaciones
-(decidio, afectado_por, usa_patron) de cada observacion. Esto me permite
-responder "que tecnologias se decidieron para el proyecto alpha?" sin
-depender de similitud de embeddings.
+**Las digestiones de reuniones** son especialmente valiosas. Cuando procesas una transcripcion conmigo, extraigo:
+- Decisiones tomadas (van a `decision-log.md`)
+- Action items (con responsable y fecha)
+- Actualizaciones de perfiles (si alguien demuestra una competencia nueva)
+- Riesgos detectados (contradicciones con reglas de negocio, dependencias)
+- Informacion de stakeholders (como prefieren que les presenten las cosas)
 
-**Motor:** regex + heuristicas (Fase 1). Futuro: LLM local (SPEC-023).
-**Script:** `scripts/memory-graph.py` (build, search, entities, status)
+Todo esto queda en ficheros markdown dentro de la carpeta del proyecto. Si cambias de herramienta, de IA, o de PM — esos ficheros siguen siendo utiles porque son legibles por humanos.
+
+**Aislamiento entre proyectos:** la informacion del Proyecto Alpha nunca aparece cuando trabajo en el Proyecto Beta. Cada proyecto es un silo independiente. Esto es critico cuando gestionas proyectos de clientes diferentes que no deben conocer la informacion del otro.
+
+### La memoria de mis agentes
+
+Ademas de la carpeta del proyecto, mis agentes especializados guardan lo que aprenden:
+
+```
+public-agent-memory/     — patrones genericos (buenas practicas, DDD, SOLID)
+                           Esto SI va al repositorio publico porque no tiene datos privados.
+
+private-agent-memory/    — patrones de tu organizacion (como trabaja tu equipo, vocabulario interno)
+                           Esto NO va al repositorio (gitignored).
+
+projects/{p}/agent-memory/ — aprendizajes de ese proyecto concreto
+                           Esto NO va al repositorio (gitignored).
+```
+
+La regla es simple: si es conocimiento generico que beneficia a cualquiera, va a la memoria publica. Si tiene datos de tu equipo o tu cliente, se queda local.
+
+---
+
+## Como busco en mi memoria
+
+Aqui es donde la cosa se pone interesante. Tener ficheros de texto esta bien, pero si tienes 500 observaciones, buscar manualmente es lento. Por eso tengo **aceleradores de busqueda** — pero quiero que entiendas una cosa fundamental:
+
+**Los aceleradores son como el indice de un libro. Si arrancas el indice, el libro sigue teniendo toda la informacion. Solo tardas mas en encontrar la pagina.**
+
+Mis aceleradores son ficheros que yo genero automaticamente a partir del texto plano. Si los borro, los regenero. Si no estan, busco directamente en el texto (mas lento, pero funciona).
+
+### Busqueda por palabras (siempre funciona)
+
+La mas basica. Busco las palabras exactas que me pides en los titulos, contenidos y etiquetas de mis observaciones. Funciona sin instalar nada extra.
+
+Si buscas "PostgreSQL", encuentro todo lo que tenga esa palabra.
+
+**Limitacion**: si buscas "problemas de base de datos", no encuentro la observacion que dice "PostgreSQL timeout en produccion" — porque las palabras no coinciden aunque el significado si.
+
+### Busqueda por significado (necesita una instalacion extra)
+
+Para superar esa limitacion, puedo crear un **indice de significados**. Funciona asi:
+
+1. Leo cada observacion y la convierto en una lista de numeros que representan su significado (esto se llama "embedding" en IA, pero lo importante es que es una representacion matematica del significado).
+2. Cuando buscas algo, convierto tu busqueda en la misma representacion matematica.
+3. Comparo los numeros y te devuelvo las observaciones cuyo significado es mas parecido al de tu busqueda.
+
+El resultado: si buscas "problemas de autenticacion", encuentro "timeout en el token de refresco" aunque no compartan ninguna palabra — porque el significado es similar.
+
+**Datos reales**: en mis benchmarks, la busqueda por palabras encuentra el resultado correcto el 40% de las veces. La busqueda por significado lo encuentra el 90% de las veces.
+
+El modelo que uso para entender significados pesa 22 MB, se ejecuta en tu procesador (no necesita GPU ni internet), y tiene licencia libre (Apache 2.0). Puedes instalarlo o no — sin el, la busqueda por palabras sigue funcionando.
+
+### Busqueda por relaciones (para preguntas complejas)
+
+A veces no buscas un texto parecido, sino una relacion: "¿quien decidio usar PostgreSQL?" o "¿que tecnologias estan vinculadas al proyecto Alpha?".
+
+Para eso extraigo **entidades** (nombres de tecnologias, conceptos, proyectos) y **relaciones** (quien decidio que, que afecta a que) de cada observacion. Esto forma un mapa de conexiones que me permite navegar por relaciones, no solo por similitud.
+
+Este mapa tambien es un fichero de texto (JSON), generado automaticamente, borrable y regenerable.
 
 ---
 
 ## Como llega informacion a mi memoria
 
-### Flujo 1: Sesion interactiva
+Hay tres caminos por los que aprendo cosas:
 
-```
-Tu escribes → Savia trabaja → decisiones/bugs/patrones detectados
-  → pre-compact hook extrae automaticamente (SPEC-026)
-  → memory-store.sh save → JSONL → vector rebuild → graph rebuild
-```
+### 1. Trabajando contigo en conversacion
 
-### Flujo 2: Digestores (documentos, reuniones, imagenes)
+Mientras hablamos, detecto decisiones, correcciones, descubrimientos y patrones. Cuando ejecutas `/compact` (para liberar espacio en la conversacion), automaticamente extraigo lo importante y lo guardo antes de que se pierda.
 
-```
-Documento/Reunion → Agente digest (meeting, pdf, word, excel, pptx, visual)
-  → digest-to-memory.sh bridge
-  → memory-store.sh save (con tipo, TTL, conceptos automaticos)
-  → JSONL → vector → graph
-```
+### 2. Procesando documentos y reuniones
 
-Mis 7 digestores (meeting-digest, pdf-digest, word-digest, excel-digest,
-pptx-digest, visual-digest, meeting-risk-analyst) alimentan la memoria
-central via el bridge `digest-to-memory.sh`.
+Tengo 7 agentes especializados en "digerir" informacion:
 
-### Flujo 3: Manual
+| Agente | Que procesa | Ejemplo |
+|--------|------------|---------|
+| meeting-digest | Transcripciones de reuniones | Acta de Sprint Review |
+| pdf-digest | Documentos PDF | Manual de arquitectura |
+| word-digest | Documentos Word | Propuesta de cliente |
+| excel-digest | Hojas de calculo | Presupuesto del proyecto |
+| pptx-digest | Presentaciones | Kickoff del proyecto |
+| visual-digest | Imagenes, pizarras, capturas | Foto de whiteboard |
+| meeting-risk-analyst | Riesgos detectados en reuniones | Conflictos, dependencias |
 
-```
-bash scripts/memory-store.sh save --type decision --title "Use Redis" \
-  --what "Cache layer" --why "Reduce DB load" --where "API gateway" \
-  --learned "Set TTL per resource type" --project alpha
+Cada uno de estos agentes, al terminar de procesar un documento, hace dos cosas:
+
+1. **Guarda la digestion completa** en la carpeta del proyecto (`projects/{nombre}/meetings/` o el directorio correspondiente) como un fichero markdown legible. Esto incluye el resumen, los action items, las decisiones, los perfiles actualizados.
+
+2. **Envia los aprendizajes clave** a mi memoria central (el fichero JSONL) para que esten disponibles en busquedas semanticas. Asi, la informacion de una reunion de hace un mes aparece cuando buscas "problemas de rendimiento" aunque estemos trabajando en otra cosa.
+
+El resultado: los ficheros markdown del proyecto son la referencia completa y legible. La memoria central es el indice que me permite encontrar cosas rapidamente entre cientos de reuniones y documentos.
+
+### 3. Manualmente
+
+Tu o cualquier persona del equipo puede añadir observaciones directamente:
+
+```bash
+bash scripts/memory-store.sh save \
+  --type decision \
+  --title "Cambiar de proveedor de hosting" \
+  --what "Migramos de AWS a Hetzner" \
+  --why "Reducir costes un 60%" \
+  --where "Infraestructura" \
+  --learned "Hetzner no tiene CDN propio, necesitamos Cloudflare"
 ```
 
 ---
 
-## Como busco informacion
+## Que pasa cuando la informacion caduca
 
-Orden de intento: (1) Vector search → top 20 por similitud → reranker filtra a top 10. (2) Graph search → entidades + relaciones. (3) Grep fallback → keyword scoring. Forzar: `search "query" --mode grep|vector|auto`
+No toda la informacion es eterna. "El sprint actual termina el viernes" es util hoy pero irrelevante la semana que viene. Para gestionar esto:
 
-Degradacion: Nivel 0 (grep, ~40% recall) → Nivel 1 (+graph, ~55%) → Nivel 2 (vector+reranker+graph, ~95%). Verificar: `bash scripts/memory-store.sh index-status`. Instalar: `pip install sentence-transformers hnswlib`
+- Cuando guardo una observacion, puedo ponerle una **fecha de caducidad**. Ejemplo: las notas de sesion caducan a los 30 dias, los descubrimientos a los 90 dias.
+- Las decisiones y los bugs **no caducan nunca** — son lecciones permanentes.
+- Las observaciones caducadas no se borran — simplemente dejan de aparecer en las busquedas. Siguen en el fichero de texto por si alguien necesita consultarlas.
+- Si quieres ver todo, incluido lo caducado: `search "query" --include-expired`.
 
 ---
 
-## Privacidad y Specs
+## Que pasa cuando cambio de opinion
 
-Todo local. Zero telemetria. JSONL + indices gitignored. Modelo 22MB en CPU. Datos clasificados N1-N4b. NUNCA envio memorias a ningun servidor.
+Las decisiones evolucionan. Hoy usamos JWT para autenticacion, mañana cambiamos a OAuth2. Cuando eso ocurre:
 
-Specs: SPEC-018 (vector), SPEC-019 (contradiccion), SPEC-020 (TTL), SPEC-023 (LLM trainer), SPEC-026 (PreCompact), SPEC-027 (graph), SPEC-028 (reranker).
+1. La nueva decision reemplaza a la antigua en las busquedas.
+2. Pero la antigua queda registrada en un campo "supersedes" — asi siempre puedes ver **que habia antes** y entender **por que se cambio**.
+3. El numero de revision se incrementa (rev: 1 → rev: 2 → rev: 3...).
+
+Esto evita dos problemas:
+- **Informacion obsoleta**: la busqueda te devuelve la decision actual, no la de hace 6 meses.
+- **Perdida de contexto**: si necesitas entender por que se cambio, el historico esta ahi.
+
+---
+
+## La regla de oro: texto plano sobrevive a todo
+
+Quiero ser muy clara sobre la jerarquia:
+
+```
+TEXTO PLANO (ficheros .jsonl y .md)
+  |
+  |  Son la unica verdad. Todo lo demas se deriva de ellos.
+  |
+  +--→ Indice de significados (.idx)     — ACELERADOR, regenerable
+  +--→ Mapa de relaciones (.json)        — ACELERADOR, regenerable
+  +--→ Indice vectorial (.map)           — ACELERADOR, regenerable
+```
+
+Si borras los aceleradores: los regenero en segundos.
+Si borras el texto plano: la informacion se pierde (por eso esta versionado con git).
+
+Si mañana sentence-transformers desaparece, o hnswlib deja de mantenerse, o cambiamos de modelo de IA — **tus datos siguen intactos en texto plano**. Buscamos otro acelerador y listo.
+
+Si mañana desaparezco yo misma — **tus ficheros siguen siendo legibles por cualquier humano con un editor de texto**.
+
+Esto no es un accidente. Es una decision filosofica: **la dependencia cero de cualquier herramienta, incluida yo misma**.
+
+---
+
+## El panorama completo: como se conecta todo
+
+Imagina que llevas 6 meses gestionando un proyecto. En ese tiempo:
+- Has tenido 50 reuniones (digeridas en `projects/{nombre}/meetings/`)
+- Has tomado 30 decisiones (en `decision-log.md` y en mi memoria central)
+- Has procesado 10 documentos del cliente (digeridos en la carpeta del proyecto)
+- Tu equipo ha resuelto 20 bugs (registrados como observaciones)
+- Has cambiado 5 decisiones (con `supersedes` para mantener el historico)
+
+Toda esa informacion vive en ficheros de texto. Puedes:
+- **Abrir la carpeta del proyecto** y leer las actas de reuniones como markdown
+- **Buscar "rendimiento"** y encontrar el bug de N+1 queries de hace 3 meses
+- **Preguntarme "que decidimos sobre la base de datos"** y obtener la decision actual Y la anterior
+- **Ver el equipo** abriendo `equipo.md`
+- **Compartir con un nuevo miembro** copiandole la carpeta — toda la historia del proyecto esta ahi
+
+Y si algun dia cambias de herramienta, de IA, o decides prescindir de mi:
+- Los ficheros markdown siguen siendo ficheros markdown
+- Las actas de reuniones siguen siendo legibles
+- Las decisiones siguen documentadas
+- No hay lock-in, no hay exportacion, no hay migracion
+
+---
+
+## Privacidad
+
+- **Nada sale de tu ordenador.** Cero telemetria. Cero conexiones a servidores externos para la memoria.
+- El modelo de busqueda semantica (22 MB) se descarga una vez y se ejecuta localmente en tu CPU.
+- Los ficheros de memoria estan en directorios excluidos de git (gitignored) — no se publican aunque hagas push.
+- Los datos de cada proyecto estan aislados: la informacion de un cliente nunca se mezcla con la de otro.
+- Si necesitas borrar todo lo que se sobre un tema: editas el fichero de texto y listo.
+
+---
+
+## Como verificar que todo funciona
+
+```bash
+# Ver el estado de mi memoria
+bash scripts/memory-store.sh index-status
+
+# Ver estadisticas (cuantas observaciones, de que tipo)
+bash scripts/memory-store.sh stats
+
+# Buscar algo
+bash scripts/memory-store.sh search "autenticacion"
+
+# Ver las ultimas 20 observaciones
+bash scripts/memory-store.sh context
+
+# Verificar que todos mis sistemas estan operativos
+bash scripts/readiness-check.sh
+```
+
+---
+
+## Tres niveles de potencia
+
+No necesitas instalar nada extra para que mi memoria funcione. Pero si quieres busquedas mas inteligentes:
+
+| Nivel | Que necesitas | Que puedo hacer | Calidad de busqueda |
+|-------|--------------|-----------------|---------------------|
+| **Basico** | Nada extra | Buscar por palabras exactas | 40% de acierto |
+| **Intermedio** | Nada extra | + Buscar por relaciones (grafo) | 55% de acierto |
+| **Completo** | `pip install sentence-transformers hnswlib` | + Buscar por significado + reranking | 95% de acierto |
+
+El nivel basico siempre funciona. Los demas son mejoras opcionales.
+
+---
+
+## Resumen visual
+
+```
+                    TU
+                     |
+          (conversacion, documentos, manual)
+                     |
+                     v
+            +-----------------+
+            |  MEMORIA        |
+            |  (texto plano)  |  ← ficheros .jsonl y .md
+            +-----------------+  ← legibles por humanos
+               |     |     |
+               v     v     v
+            Indice  Grafo  Indice    ← aceleradores
+            signif. relac. palabras     (derivados, opcionales)
+               |     |     |
+               +-----+-----+
+                     |
+                     v
+              BUSQUEDA UNIFICADA
+                     |
+                     v
+             Resultados ordenados
+             por relevancia
+```
+
+La informacion entra por arriba (conversacion, documentos, entrada manual), se persiste en texto plano en el centro, y los aceleradores de abajo hacen que buscar sea rapido. Pero el centro — los ficheros de texto — es lo unico que realmente importa.


### PR DESCRIPTION
## Summary
- Complete rewrite of memory-architecture.md (379 lines)
- Written for non-technical readers with analogies
- Covers project knowledge: meetings, team, rules, stakeholders, decisions
- Explains 7 digesters and dual output (project .md + central memory)
- Contradiction tracking, TTL, search levels, privacy
- Key message: plain text readable by humans is the truth

## Test plan
- [x] 39/39 BATS suites