### PR TITLE
feat: SPEC-036 agent evaluation framework (v3.47.0)

### DIFF
--- a/.claude/commands/eval-agent.md
+++ b/.claude/commands/eval-agent.md
@@ -1,0 +1,83 @@
+---
+name: eval-agent
+description: "Evaluate an agent against its golden set — precision, recall, hallucinations, bias (SPEC-036)"
+argument-hint: "{agent} [--compare {date}]"
+allowed-tools: [Read, Write, Bash, Glob, Grep, Task]
+model: opus
+context_cost: high
+---
+
+# /eval-agent — Agent Evaluation (SPEC-036)
+
+Evaluate an agent's quality using golden sets (known input/expected output pairs).
+
+## Parameters
+
+- `$ARGUMENTS` — Agent name (e.g., `security-attacker`, `code-reviewer`, `business-analyst`)
+- `--compare {date}` — Compare with previous evaluation
+
+## Reasoning
+
+Think step by step:
+1. First: identify the agent and load its golden set from `tests/evals/{agent}/`
+2. Then: for each input-N/expected-N pair, invoke the agent and compare output vs expected
+3. Calculate: precision, recall, F1, false positives, hallucinations, bias score
+4. Finally: save results and detect regressions vs previous evaluations
+
+## Flow
+
+1. **List mode**: if `$ARGUMENTS` is empty or `--list`, run `bash scripts/eval-agent.sh --list`
+2. **Validate**: confirm `tests/evals/{agent}/` exists with input/expected pairs
+3. **Generate template**: `bash scripts/eval-agent.sh {agent}` creates output file
+4. **Evaluate each pair**:
+   - Read `input-N.*` and `expected-N.yaml`
+   - Invoke the agent as a subagent (Task) with the input
+   - Compare agent output against expected findings
+   - Score: did it find what it should? Did it NOT find what it shouldn't?
+5. **Calculate metrics**:
+   - `precision` = correct findings / total findings reported
+   - `recall` = findings detected / findings in golden set (must_detect: true)
+   - `f1` = 2 * (precision * recall) / (precision + recall)
+   - `false_positives` = findings reported that aren't in expected
+   - `hallucinations` = claims with no support in the input
+   - `bias_score` = 0.0 if Equality Shield passes counterfactual test
+6. **Save results**: update the YAML file in `output/evals/{agent}/`
+7. **Regression check**: if precision or recall drops >10% vs previous → alert
+
+## Regression Detection
+
+```
+REGRESSION DETECTED in {agent}
+  Precision: 85% -> 72% (-13%)
+  Probable cause: prompt change in Era {N}
+  Action: review commit that modified the agent
+```
+
+## Output Template
+
+```yaml
+agent: {agent}
+date: "{date}"
+golden_set: "tests/evals/{agent}/"
+pairs_evaluated: N
+metrics:
+  precision: 0.XX
+  recall: 0.XX
+  f1: 0.XX
+  false_positives: N
+  hallucinations: N
+  bias_score: 0.0
+status: "completed"
+comparison:
+  vs_previous: "+X% precision, -Y% recall"
+```
+
+## Banner
+
+```
+/eval-agent {agent} — Agent Evaluation (SPEC-036)
+Golden set: tests/evals/{agent}/ (N pairs)
+```
+
+> Rules: @.claude/rules/domain/eval-criteria.md
+> Source: @docs/propuestas/SPEC-036-agent-evaluation.md

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=61251d6c40e43e01a7aac4ddf7f3e99f1674fb1b0d3556ecfd0ef3233cfed63d
-timestamp=2026-03-23T23:31:21Z
-branch=feat/hybrid-search-spec035
-head_commit=10efd55
-signature=f3b4e8ab6ac967678c4324b251a1411641f6fbc2dcfff3d79caa2f0aec6c5fdb
+diff_hash=bc826deaa794336646177ef68d89cc5ba2e1d5f84778d2fb8b55eee8d29e282d
+timestamp=2026-03-24T06:03:16Z
+branch=feat/agent-eval-spec036
+head_commit=cde2cb7
+signature=4a4b8bb1dd2fd42a3f88fdd63d22e23ad3538cc01db1684ee6c9a84aa2cc4cce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.47.0] — 2026-03-24
+
+Era 139. SPEC-036: Agent Evaluation Framework — golden sets, metrics, regression detection.
+
+### Added
+
+- **Tests**: `tests/evals/` directory structure with golden sets for 3 critical agents (security-attacker, code-reviewer, business-analyst)
+- **Scripts**: `eval-agent.sh` — runner that generates eval templates, lists agents, detects regressions (>10% drop)
+- **Commands**: `/eval-agent` — evaluate agent quality against golden sets (precision, recall, F1, hallucinations, bias)
+- **SPEC-036**: Agent evaluation framework with 4 dimensions (precision, coherence, bias, hallucination)
+
+### Changed
+
+- **SPEC-036**: status DRAFT -> APPROVED
+
 ## [3.46.0] — 2026-03-24
 
 Era 138. SPEC-035: Hybrid search (vector + graph + grep) with fallback chain.
@@ -4456,6 +4471,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.47.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.46.0...v3.47.0
 [3.7.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.6.1...v3.7.0
 [3.6.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.6.0...v3.6.1
 [3.6.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.5.3...v3.6.0

--- a/docs/propuestas/SPEC-036-agent-evaluation.md
+++ b/docs/propuestas/SPEC-036-agent-evaluation.md
@@ -1,6 +1,6 @@
 # SPEC-036: Agent Evaluation Framework — Medir para Mejorar
 
-> Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.65
+> Status: **APPROVED** · Fecha: 2026-03-24 · Score: 4.65
 > Origen: DeepEval (14K) + Giskard (5K) — testing de agentes LLM
 > Impacto: De "confio en que funciona" a "mido que funciona"
 

--- a/scripts/eval-agent.sh
+++ b/scripts/eval-agent.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# eval-agent.sh — Agent Evaluation Runner (SPEC-036)
+# Usage: bash scripts/eval-agent.sh {agent} [--compare {date}] [--list]
+
+EVALS_DIR="tests/evals"
+OUTPUT_DIR="output/evals"
+DATE=$(date +%Y%m%d-%H%M%S)
+REGRESSION_THRESHOLD=10
+
+show_help() {
+  echo "eval-agent.sh — Agent Evaluation Runner (SPEC-036)"
+  echo "Usage: bash scripts/eval-agent.sh <agent> [--compare <date>] [--list] [--help]"
+  echo "  <agent>            Run eval for agent"
+  echo "  --compare <date>   Compare with previous evaluation"
+  echo "  --list             List agents with golden sets"
+}
+
+list_agents() {
+  echo "Agents with golden sets:"
+  for dir in "$EVALS_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    local agent; agent=$(basename "$dir")
+    local ic; ic=$(find "$dir" -name 'input-*' 2>/dev/null | wc -l)
+    local ec; ec=$(find "$dir" -name 'expected-*' 2>/dev/null | wc -l)
+    echo "  $agent — $ic inputs, $ec expected"
+  done
+}
+
+validate_agent() {
+  local agent_dir="$EVALS_DIR/$1"
+  if [ ! -d "$agent_dir" ]; then
+    echo "ERROR: No golden set for '$1'"; list_agents; return 1
+  fi
+  local ic; ic=$(find "$agent_dir" -name 'input-*' 2>/dev/null | wc -l)
+  [ "$ic" -gt 0 ] || { echo "ERROR: No inputs in $agent_dir"; return 1; }
+}
+
+count_pairs() { find "$EVALS_DIR/$1" -name 'input-*' 2>/dev/null | wc -l; }
+
+get_previous_eval() {
+  local d="$OUTPUT_DIR/$1"
+  [ -d "$d" ] && ls -1 "$d"/*.yaml 2>/dev/null | sort -r | head -1
+}
+
+detect_regression() {
+  local current="$1" previous="$2"
+  [ -f "$previous" ] || { echo "NO_PREVIOUS"; return 0; }
+  local cp; cp=$(grep 'precision:' "$current" 2>/dev/null | head -1 | awk '{print $2}')
+  local pp; pp=$(grep 'precision:' "$previous" 2>/dev/null | head -1 | awk '{print $2}')
+  [ -n "$cp" ] && [ -n "$pp" ] || { echo "INCOMPLETE_DATA"; return 0; }
+  local ci; ci=$(echo "$cp" | awk '{printf "%d",$1*100}')
+  local pi; pi=$(echo "$pp" | awk '{printf "%d",$1*100}')
+  local drop=$((pi - ci))
+  if [ "$drop" -gt "$REGRESSION_THRESHOLD" ]; then
+    echo "REGRESSION:${pp}:${cp}:${drop}"; return 1
+  fi
+  echo "OK:${pp}:${cp}"
+}
+
+generate_template() {
+  local agent="$1" pairs; pairs=$(count_pairs "$agent")
+  local out="$OUTPUT_DIR/$agent/$DATE.yaml"
+  mkdir -p "$OUTPUT_DIR/$agent"
+  cat > "$out" <<YAML
+# Agent Evaluation Result — SPEC-036
+# Generated: $(date -Iseconds)
+agent: $agent
+date: "$DATE"
+golden_set: "$EVALS_DIR/$agent/"
+pairs_evaluated: $pairs
+metrics:
+  precision: 0.0
+  recall: 0.0
+  f1: 0.0
+  false_positives: 0
+  hallucinations: 0
+  bias_score: 0.0
+status: "template_generated"
+evaluator: "pending"
+comparison:
+  vs_previous: "N/A"
+YAML
+  echo "$out"
+}
+
+main() {
+  [ $# -eq 0 ] || [ "$1" = "--help" ] && { show_help; return 0; }
+  [ "$1" = "--list" ] && { list_agents; return 0; }
+
+  local agent="$1"; shift
+  local compare_date=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --compare) compare_date="$2"; shift 2 ;;
+      *) echo "Unknown: $1"; return 1 ;;
+    esac
+  done
+
+  validate_agent "$agent" || return 1
+  local out; out=$(generate_template "$agent")
+  echo "Eval template: $out"
+  echo "Golden set: $EVALS_DIR/$agent/ ($(count_pairs "$agent") pairs)"
+
+  if [ -n "$compare_date" ]; then
+    local pf="$OUTPUT_DIR/$agent/${compare_date}.yaml"
+    [ -f "$pf" ] && { echo "Comparing: $pf"; detect_regression "$out" "$pf"; } \
+                  || echo "WARNING: No eval at $pf"
+  else
+    local pf; pf=$(get_previous_eval "$agent")
+    [ -n "$pf" ] && [ -f "$pf" ] && echo "Previous: $pf (use --compare)"
+  fi
+  echo "Next: Claude evaluates agent against golden sets and fills $out"
+}
+
+main "$@"

--- a/tests/evals/business-analyst/expected-01.yaml
+++ b/tests/evals/business-analyst/expected-01.yaml
@@ -1,0 +1,30 @@
+# Expected findings for input-01.md (ambiguous PBI)
+findings:
+  - id: BA-01
+    type: "ambiguity"
+    description: "PBI lacks specific actions (CRUD? roles? permissions?)"
+    must_detect: true
+
+  - id: BA-02
+    type: "vague_criteria"
+    description: "Acceptance criteria are not measurable or testable"
+    must_detect: true
+
+  - id: BA-03
+    type: "missing_context"
+    description: "No definition of 'user' entity or scope boundaries"
+    must_detect: true
+
+expected_behavior: |
+  The business-analyst should identify that this PBI is too vague
+  to decompose into tasks. It should ask clarifying questions about:
+  - What operations (create, read, update, delete, disable)?
+  - What user attributes (name, email, role, permissions)?
+  - Who can manage users (admin only? self-service?)?
+  - What are the business rules (uniqueness, validation)?
+
+verdict: "INCOMPLETO"
+
+metrics:
+  min_questions: 3
+  min_ambiguities_detected: 2

--- a/tests/evals/business-analyst/input-01.md
+++ b/tests/evals/business-analyst/input-01.md
@@ -1,0 +1,7 @@
+# PBI: User Management
+
+As a user I want to manage users.
+
+## Acceptance Criteria
+- Users can be managed
+- The system works correctly

--- a/tests/evals/code-reviewer/expected-01.yaml
+++ b/tests/evals/code-reviewer/expected-01.yaml
@@ -1,0 +1,26 @@
+# Expected findings for input-01.diff
+findings:
+  - id: CR-01
+    rule: "REJECT"
+    type: "hardcoded_secret"
+    description: "DB_PASSWORD hardcoded in source code"
+    must_detect: true
+
+  - id: CR-02
+    rule: "REJECT"
+    type: "hardcoded_secret"
+    description: "API_KEY hardcoded in source code"
+    must_detect: true
+
+  - id: CR-03
+    rule: "REQUIRE"
+    type: "security_practice"
+    description: "Authentication should not compare passwords in plaintext"
+    must_detect: true
+
+verdict: "RECHAZADO"
+
+metrics:
+  min_precision: 0.90
+  min_recall: 1.00
+  max_false_positives: 1

--- a/tests/evals/code-reviewer/input-01.diff
+++ b/tests/evals/code-reviewer/input-01.diff
@@ -1,0 +1,16 @@
+diff --git a/src/auth/login.py b/src/auth/login.py
+index abc1234..def5678 100644
+--- a/src/auth/login.py
++++ b/src/auth/login.py
+@@ -1,5 +1,12 @@
++import os
++
++# Database credentials
++DB_PASSWORD = "SuperSecret123!"
++API_KEY = "sk-proj-abc123def456ghi789"
++
+ def authenticate(username, password):
+-    pass
++    if username == "admin" and password == DB_PASSWORD:
++        return {"token": API_KEY, "role": "admin"}
++    return None

--- a/tests/evals/security-attacker/expected-01.yaml
+++ b/tests/evals/security-attacker/expected-01.yaml
@@ -1,0 +1,20 @@
+# Expected findings for input-01.py
+findings:
+  - id: SEC-01
+    cwe: "CWE-89"
+    type: "SQL Injection"
+    severity: "critical"
+    location: "get_user function, line 8"
+    description: "String concatenation in SQL query allows injection"
+    must_detect: true
+
+  - id: SEC-02
+    function: "get_user_safe"
+    expected: "no_finding"
+    description: "Parameterized query is safe — must NOT flag as vulnerable"
+    must_detect: false
+
+metrics:
+  min_precision: 0.80
+  min_recall: 0.90
+  max_false_positives: 1

--- a/tests/evals/security-attacker/expected-02.yaml
+++ b/tests/evals/security-attacker/expected-02.yaml
@@ -1,0 +1,13 @@
+# Expected findings for input-02.py (clean code)
+findings: []
+
+notes: |
+  This code is intentionally clean. The agent should report
+  zero findings. Any finding is a false positive.
+  Note: SHA-256 for passwords is not ideal (bcrypt preferred),
+  but it is NOT a vulnerability per se — it's a recommendation.
+  The agent should not flag it as a security finding.
+
+metrics:
+  expected_findings: 0
+  max_false_positives: 0

--- a/tests/evals/security-attacker/input-01.py
+++ b/tests/evals/security-attacker/input-01.py
@@ -1,0 +1,19 @@
+# Golden set: SQL injection vulnerability (CWE-89)
+# Agent MUST detect the unsanitized user input in the query
+
+import sqlite3
+
+def get_user(username):
+    conn = sqlite3.connect("users.db")
+    cursor = conn.cursor()
+    # VULNERABLE: string concatenation in SQL query
+    query = "SELECT * FROM users WHERE name = '" + username + "'"
+    cursor.execute(query)
+    return cursor.fetchall()
+
+def get_user_safe(username):
+    conn = sqlite3.connect("users.db")
+    cursor = conn.cursor()
+    # SAFE: parameterized query
+    cursor.execute("SELECT * FROM users WHERE name = ?", (username,))
+    return cursor.fetchall()

--- a/tests/evals/security-attacker/input-02.py
+++ b/tests/evals/security-attacker/input-02.py
@@ -1,0 +1,16 @@
+# Golden set: Clean code — no vulnerabilities
+# Agent must NOT find any security issues here
+
+import hashlib
+import secrets
+
+def hash_password(password: str) -> tuple[str, str]:
+    """Hash password with random salt using SHA-256."""
+    salt = secrets.token_hex(16)
+    hashed = hashlib.sha256((salt + password).encode()).hexdigest()
+    return salt, hashed
+
+def verify_password(password: str, salt: str, expected_hash: str) -> bool:
+    """Verify password against stored hash."""
+    hashed = hashlib.sha256((salt + password).encode()).hexdigest()
+    return secrets.compare_digest(hashed, expected_hash)

--- a/tests/evals/test-eval-framework.bats
+++ b/tests/evals/test-eval-framework.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# Tests for SPEC-036 Agent Evaluation Framework
+
+@test "eval directory structure exists" {
+  [ -d "tests/evals" ]
+}
+
+@test "security-attacker golden set exists with pairs" {
+  [ -d "tests/evals/security-attacker" ]
+  [ -f "tests/evals/security-attacker/input-01.py" ]
+  [ -f "tests/evals/security-attacker/expected-01.yaml" ]
+  [ -f "tests/evals/security-attacker/input-02.py" ]
+  [ -f "tests/evals/security-attacker/expected-02.yaml" ]
+}
+
+@test "code-reviewer golden set exists with pairs" {
+  [ -d "tests/evals/code-reviewer" ]
+  [ -f "tests/evals/code-reviewer/input-01.diff" ]
+  [ -f "tests/evals/code-reviewer/expected-01.yaml" ]
+}
+
+@test "business-analyst golden set exists with pairs" {
+  [ -d "tests/evals/business-analyst" ]
+  [ -f "tests/evals/business-analyst/input-01.md" ]
+  [ -f "tests/evals/business-analyst/expected-01.yaml" ]
+}
+
+@test "eval-agent.sh exists and is valid bash" {
+  [ -f "scripts/eval-agent.sh" ]
+  bash -n scripts/eval-agent.sh
+}
+
+@test "eval-agent.sh --list shows agents" {
+  run bash scripts/eval-agent.sh --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"security-attacker"* ]]
+  [[ "$output" == *"code-reviewer"* ]]
+  [[ "$output" == *"business-analyst"* ]]
+}
+
+@test "eval-agent.sh --help shows usage" {
+  run bash scripts/eval-agent.sh --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "eval-agent.sh generates template for valid agent" {
+  run bash scripts/eval-agent.sh security-attacker
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Eval template"* ]]
+  [[ "$output" == *"2 pairs"* ]]
+}
+
+@test "eval-agent.sh fails for unknown agent" {
+  run bash scripts/eval-agent.sh nonexistent-agent
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ERROR"* ]]
+}
+
+@test "expected YAML files contain must_detect field" {
+  for f in tests/evals/*/expected-*.yaml; do
+    # At least one expected file should have must_detect or expected_findings
+    if grep -q 'must_detect\|expected_findings\|expected_behavior' "$f"; then
+      return 0
+    fi
+  done
+  # If we get here, no expected file had the required fields
+  return 1
+}
+
+@test "eval-agent command exists" {
+  [ -f ".claude/commands/eval-agent.md" ]
+}
+
+@test "SPEC-036 document exists" {
+  [ -f "docs/propuestas/SPEC-036-agent-evaluation.md" ]
+}


### PR DESCRIPTION
## Summary

- SPEC-036: Agent Evaluation Framework — golden sets, metrics, regression detection
- 3 golden sets: security-attacker (2 pairs), code-reviewer (1 pair), business-analyst (1 pair)
- `eval-agent.sh` runner with regression detection (>10% precision drop alerts)
- `/eval-agent` command for evaluating agent quality (precision, recall, F1, hallucinations, bias)
- 12 BATS tests pass
- Closes Tier 1 of the evolution roadmap (SPEC-034 + 035 + 036 + 037)

## Test plan

- [x] `bats tests/evals/test-eval-framework.bats` — 12/12 pass
- [x] `bats tests/structure/test-changelog-integrity.bats` — 7/7 pass
- [x] Script syntax validation (`bash -n`)
- [x] All files ≤150 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)