### PR TITLE
feat: SaviaClaw Nextcloud Talk — autonomous messaging (v3.60.0)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=58910b5dc0e60e73deb5f0a85ba046b24ae13ae4c0f4ba058526736516e76cd9
-timestamp=2026-03-24T13:57:46Z
-branch=feat/hooks-consciousness-combined
-head_commit=5c05b4c
-signature=ab62474c17bf93a30543d538f64165a13a1ec0310725038ecaa3e873b291c602
+diff_hash=cc8e550bd087614f7535350ca3513f71a26291c560b3b13b04e22eca37f7be84
+timestamp=2026-03-24T19:58:02Z
+branch=feat/saviaclaw-nctalk
+head_commit=495169f
+signature=1f89994d9f5c4b1c623d5b1029c92592901e9bd22931e8d47539a7e4d0f0c36d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.60.0] — 2026-03-24
+
+Era 152. SaviaClaw talks — Nextcloud Talk integration for autonomous messaging.
+
+### Added
+
+- **ZeroClaw**: `nctalk.py` — send/read Nextcloud Talk messages. SaviaClaw can message Monica autonomously via http://localhost
+- **ZeroClaw**: consciousness notifies via Talk on task failure or important results
+- **Config**: `~/.savia/nextcloud-config` stores credentials locally (never in repo)
+
 ## [3.59.0] — 2026-03-24
 
 Era 151. Memory prime hook + SaviaClaw consciousness — persistent daemon with identity and scheduler.
@@ -4592,6 +4602,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.60.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.59.0...v3.60.0
 [3.59.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.57.0...v3.59.0
 [3.57.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.56.0...v3.57.0
 [3.56.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.55.0...v3.56.0

--- a/zeroclaw/host/consciousness.py
+++ b/zeroclaw/host/consciousness.py
@@ -30,17 +30,13 @@ log = logging.getLogger("consciousness")
 
 
 def load_identity():
-    """Load SaviaClaw identity — who am I, what do I do."""
     if os.path.isfile(IDENTITY_FILE):
-        with open(IDENTITY_FILE) as f:
-            return json.load(f)
+        with open(IDENTITY_FILE) as f: return json.load(f)
     return {"name": "SaviaClaw", "device_id": "unknown"}
 
 def load_schedule():
-    """Load schedule from file, or use defaults."""
     if os.path.isfile(SCHEDULE_FILE):
-        with open(SCHEDULE_FILE) as f:
-            return json.load(f)
+        with open(SCHEDULE_FILE) as f: return json.load(f)
     return DEFAULT_SCHEDULE
 
 
@@ -87,6 +83,14 @@ def run_claude_task(action):
         return str(e)
 
 
+def _notify(msg):
+    """Send notification via Nextcloud Talk (best effort)."""
+    try:
+        from .nctalk import send_message
+        send_message(msg)
+    except Exception:
+        pass
+
 def tick(ser, schedule, last_runs):
     """Check schedule, run due tasks. Called from daemon loop."""
     now = time.time()
@@ -117,6 +121,12 @@ def tick(ser, schedule, last_runs):
             status = f"{name}: OK" if result else f"{name}: FAIL"
             l1, l2 = truncate_lcd(status)
             send_cmd(ser, f"lcd {l1}" + (f" | {l2}" if l2 else ""), 1)
+
+            # Notify on failure or if task requests it
+            if not result:
+                _notify(f"SaviaClaw: tarea '{name}' fallo")
+            elif task.get("notify"):
+                _notify(f"SaviaClaw [{name}]: {str(result)[:200]}")
 
         except Exception as e:
             log.error("Task %s failed: %s", name, e)

--- a/zeroclaw/host/nctalk.py
+++ b/zeroclaw/host/nctalk.py
@@ -1,0 +1,89 @@
+"""Nextcloud Talk integration for SaviaClaw — send messages autonomously.
+Reads credentials from ~/.savia/nextcloud-config (never in repo).
+"""
+import os
+import urllib.request
+import urllib.parse
+import json
+import base64
+
+CONFIG_FILE = os.path.expanduser("~/.savia/nextcloud-config")
+
+
+def _load_config():
+    """Load NC config from local file."""
+    if not os.path.isfile(CONFIG_FILE):
+        return None
+    cfg = {}
+    with open(CONFIG_FILE) as f:
+        for line in f:
+            line = line.strip()
+            if "=" in line and not line.startswith("#"):
+                k, v = line.split("=", 1)
+                cfg[k.strip()] = v.strip()
+    return cfg
+
+
+def send_message(text, room_token=None):
+    """Send a message to Nextcloud Talk. Returns True on success."""
+    cfg = _load_config()
+    if not cfg:
+        return False
+    url = cfg.get("NC_URL", "http://localhost")
+    user = cfg.get("NC_USER", "savia")
+    passwd = cfg.get("NC_PASS", "")
+    token = room_token or cfg.get("NC_TALK_TOKEN_MONICA", "")
+    if not token or not passwd:
+        return False
+
+    endpoint = f"{url}/ocs/v2.php/apps/spreed/api/v1/chat/{token}?format=json"
+    data = urllib.parse.urlencode({"message": text[:1000]}).encode()
+    auth = base64.b64encode(f"{user}:{passwd}".encode()).decode()
+
+    req = urllib.request.Request(endpoint, data=data, method="POST",
+        headers={"OCS-APIRequest": "true", "Authorization": f"Basic {auth}"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read())
+            return body.get("ocs", {}).get("meta", {}).get("status") == "ok"
+    except Exception:
+        return False
+
+
+def read_messages(room_token=None, limit=5):
+    """Read recent messages from a Talk room."""
+    cfg = _load_config()
+    if not cfg:
+        return []
+    url = cfg.get("NC_URL", "http://localhost")
+    user = cfg.get("NC_USER", "savia")
+    passwd = cfg.get("NC_PASS", "")
+    token = room_token or cfg.get("NC_TALK_TOKEN_MONICA", "")
+    if not token or not passwd:
+        return []
+
+    endpoint = f"{url}/ocs/v2.php/apps/spreed/api/v1/chat/{token}?format=json&limit={limit}&lookIntoFuture=0"
+    auth = base64.b64encode(f"{user}:{passwd}".encode()).decode()
+
+    req = urllib.request.Request(endpoint, headers={
+        "OCS-APIRequest": "true", "Authorization": f"Basic {auth}"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read())
+            messages = body.get("ocs", {}).get("data", [])
+            return [{"actor": m.get("actorDisplayName", ""),
+                     "message": m.get("message", ""),
+                     "ts": m.get("timestamp", 0)} for m in messages]
+    except Exception:
+        return []
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        ok = send_message(" ".join(sys.argv[1:]))
+        print(f"Sent: {ok}")
+    else:
+        msgs = read_messages()
+        for m in msgs:
+            print(f"[{m['actor']}] {m['message']}")


### PR DESCRIPTION
## Summary

SaviaClaw can now message Monica autonomously via Nextcloud Talk on Lima (localhost).

### New: `nctalk.py`
- `send_message(text)` — sends to Monica's Talk room
- `read_messages(limit)` — reads recent messages
- Uses urllib (no external deps), Basic auth, OCS API v2
- Credentials in `~/.savia/nextcloud-config` (local, 600 perms, never in repo)

### Updated: `consciousness.py`
- `_notify()` function sends Talk messages on task failure
- Tasks with `notify: true` in schedule report results via Talk
- Best-effort: if Talk is down, task still runs

### Verified live
- 3 test messages sent and confirmed from this session
- Nextcloud 31.0.2 on localhost responding
- Room token: configured, one-to-one with Monica

## Test plan
- [x] `python3 zeroclaw/host/nctalk.py "test"` — Sent: True
- [x] Messages visible in Monica's Nextcloud Talk
- [x] `bats tests/structure/test-changelog-integrity.bats` — 7/7 pass
- [x] All files within 150 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)