### PR TITLE
fix: ellipsis guardrail — dots are rhetoric not truncation (v3.62.0)

### DIFF
--- a/.claude/rules/domain/ellipsis-guardrail.md
+++ b/.claude/rules/domain/ellipsis-guardrail.md
@@ -1,0 +1,42 @@
+# Guardrail: Puntos Suspensivos NO son Truncamiento
+
+## Problema
+
+Los puntos suspensivos (`...`) son un recurso retorico habitual en
+escritura informal (emails, mensajes, notas). Savia los interpreta
+como texto incompleto y pide "el resto", cuando en realidad el
+mensaje esta completo.
+
+## Regla
+
+**NUNCA asumir que un mensaje esta truncado o incompleto basandose
+unicamente en puntos suspensivos** (`...`, `…`, `. . .`).
+
+Los puntos suspensivos significan:
+- Pausa retorica: "tal vez no es para la portada, por el contrario..."
+- Enumeracion abierta: "temas como seguridad, rendimiento..."
+- Duda o reflexion: "no estoy seguro pero..."
+- Estilo informal de escritura
+
+## Cuando SI es texto truncado
+
+Solo considerar truncamiento si:
+1. El mensaje termina a mitad de frase SIN puntuacion
+2. Hay un indicador explicito: "[continua]", "(1/2)", "sigue..."
+3. El contexto tecnico lo requiere (log cortado, error parcial)
+4. La frase es gramaticalmente imposible sin continuacion
+
+## Aplicacion
+
+- Mensajes de Nextcloud Talk
+- Emails procesados via meeting-digest
+- Transcripciones de reuniones
+- Cualquier input de texto humano
+
+## Accion si hay duda
+
+Si genuinamente no esta claro si el texto esta completo:
+- Responder al contenido TAL COMO ESTA
+- NO pedir "el resto" ni asumir que falta algo
+- Si la respuesta necesita info que no esta, preguntar especificamente
+  que dato concreto falta, no decir "parece cortado"

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=c6bf265a530400c62b2321ad0bb6ca63634910b7a8d80f8c6bce1cadeb62dee9
-timestamp=2026-03-24T21:42:02Z
-branch=feat/bidirectional-talk-clean
-head_commit=0f6c6d7
-signature=79f4bfadaf3a0ac4123ed3f35c8ad35e81bcea777f51a06349a4f6c19b54ce6b
+diff_hash=7dbd3f85d71d23ac10eea842aa86cd40db2e348ba88681d0be2931b508976f5f
+timestamp=2026-03-24T22:34:56Z
+branch=fix/ellipsis-guardrail
+head_commit=8c17200
+signature=4662ab5e7ab0419dc1e69f24cae9f0194a2b96d4ffbc933d26c398899be9b41b

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=7dbd3f85d71d23ac10eea842aa86cd40db2e348ba88681d0be2931b508976f5f
-timestamp=2026-03-24T22:34:56Z
+diff_hash=05df1fc82e5383dd324c422b14501321db51b03e88f941fcddb6cadc07757c66
+timestamp=2026-03-24T22:37:49Z
 branch=fix/ellipsis-guardrail
-head_commit=8c17200
-signature=4662ab5e7ab0419dc1e69f24cae9f0194a2b96d4ffbc933d26c398899be9b41b
+head_commit=adc08b2
+signature=745f179a116f3f60bbc64226b2ac37a9f3df9a26a80c8603eec2c2ef3595bd72

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.62.0] — 2026-03-24
+
+Era 154. Ellipsis guardrail — rhetorical dots are not truncation.
+
+### Added
+
+- **Rules**: `ellipsis-guardrail.md` — never assume text is incomplete based on `...` alone. Fixes false "message seems cut" on complete emails
+
 ## [3.61.0] — 2026-03-24
 
 Era 153. Bidirectional Talk — user messages Savia via Nextcloud, Savia responds autonomously.
@@ -4611,6 +4619,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.62.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.61.0...v3.62.0
 [3.61.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.60.0...v3.61.0
 [3.60.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.59.0...v3.60.0
 [3.59.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.57.0...v3.59.0

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3,6 +3,7 @@
 Persistent log of corrections and patterns discovered during sessions.
 Reviewed at session start to prevent recurrence. Newest entries first.
 
+| 2026-03-24 | Docs | Ellipsis (...) is rhetorical, NOT truncation. Never say "message seems cut" based on `...` alone. Rule: ellipsis-guardrail.md | User correction |
 | 2026-03-24 | PII | Wrote user's real name in CHANGELOG (public file). Rule #20 violation. ALWAYS use "user" or generic terms in any versioned file. No exceptions, even when referring to ideas or contributions. | User correction |
 | 2026-03-24 | Git | ALWAYS use scripts/push-pr.sh for PRs. Never manual curl to GitHub API. Corrected 3+ times. | User correction |
 


### PR DESCRIPTION
## Summary

New domain rule: never assume text is truncated based on ellipsis alone.

### Problem
Savia interpreted rhetorical ellipsis in an email as truncated text and asked for the rest of a complete message. The email was fully intact — the author uses dots as a writing style.

### Fix
ellipsis-guardrail.md defines when dots mean rhetoric vs actual truncation. Only consider text incomplete if it ends mid-sentence without punctuation, has explicit continuation markers, or is grammatically impossible without more content.

### Lesson logged
Added to tasks/lessons.md for future session review.

## Test plan
- [x] Rule file created and within 150 lines (42 lines)
- [x] Lesson documented in tasks/lessons.md
