### PR TITLE
fix: pr-plan G5 docs-only exemption (v3.70.1)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5fab3e613d09d308068612f27a3c47f0162a2fd3821164497da6b4ac7665b70a
-timestamp=2026-03-27T17:28:08Z
-branch=feature/pr-plan
-head_commit=18c6b46
-signature=767e35a5957b90298e7917bd4f715779dad085cfe3ebe0a557f8319b69320508
+diff_hash=e9cf4c878a615b0ea1766a775329603bca368479df4f1dc36e8a7414f280b050
+timestamp=2026-03-27T18:13:20Z
+branch=fix/pr-plan-docs-exempt
+head_commit=861b2b0
+signature=b1c99c882b1c0e2ee05c3e8b131b0d6eb5cedd0ebb9bb26c286c3c06d59a198c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.70.1] — 2026-03-27
+
+pr-plan G5 fix: docs-only PRs exempt from CHANGELOG requirement.
+
+### Fixed
+
+- **`pr-plan.sh` G5**: docs-only PRs (.md files) no longer require CHANGELOG, aligned with PR Guardian Gate 8
+- **G5 high-impact patterns**: removed `docs/` from list (docs changes are not code changes)
+
 ## [3.70.0] — 2026-03-27
 
 PR pre-flight protocol: 10-gate checklist before push/PR.
@@ -4755,6 +4764,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.70.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.70.0...v3.70.1
 [3.70.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.69.0...v3.70.0
 [3.69.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.68.0...v3.69.0
 [3.68.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.67.0...v3.68.0

--- a/scripts/pr-plan.sh
+++ b/scripts/pr-plan.sh
@@ -49,7 +49,11 @@ g4() {
   echo "0 behind"
 }
 g5() {
-  local hi; hi=$(git diff origin/main..HEAD --name-only 2>/dev/null | grep -E '^(\.claude/(rules|hooks|agents|skills|settings)|scripts/|docs/|CLAUDE\.md)' || true)
+  local all; all=$(git diff origin/main..HEAD --name-only 2>/dev/null) || true
+  # Docs-only PRs (all .md files) are exempt, matching PR Guardian Gate 8
+  local non_md; non_md=$(echo "$all" | grep -vE '\.md$' | grep -v '^$' || true)
+  [[ -z "$non_md" ]] && echo "skipped (docs-only)" && return
+  local hi; hi=$(echo "$all" | grep -E '^(\.claude/(rules|hooks|agents|skills|settings)|scripts/|CLAUDE\.md)' || true)
   [[ -z "$hi" ]] && echo "skipped" && return
   local lv; lv=$(grep -oP '## \[\K[0-9.]+' CHANGELOG.md 2>/dev/null | head -1)
   local mv; mv=$(git show origin/main:CHANGELOG.md 2>/dev/null | grep -oP '## \[\K[0-9.]+' | head -1) || true


### PR DESCRIPTION
## Summary

- G5 now exempts docs-only PRs (all .md files) from CHANGELOG requirement, aligned with PR Guardian Gate 8
- Removed `docs/` from high-impact file patterns (docs changes are not code changes)

## Test plan

- [ ] BATS tests pass on CI
- [ ] PR Guardian passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)