### PR TITLE
fix(zeroclaw): skip remote host checks gracefully when not configured

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=e0fb2a70cdc0a6ef72190df4f21d7b135ff6ccf74eef1ee69e3d829a87be3bef
-timestamp=2026-03-27T14:41:50Z
+timestamp=2026-03-27T14:56:15Z
 branch=docs/fix-diacritics
-head_commit=240adc0
+head_commit=6804b46
 signature=9f788255633ccbda3f6157ad3c3624c5cd031fb5219019bf0335c8d692c8eeb4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e0fb2a70cdc0a6ef72190df4f21d7b135ff6ccf74eef1ee69e3d829a87be3bef
-timestamp=2026-03-27T14:56:15Z
+diff_hash=dce3e471c5f8e5290310a8c8d2f4df3db7bb9b82828f743147b2d9586ebe8a12
+timestamp=2026-03-27T19:25:52Z
 branch=docs/fix-diacritics
-head_commit=6804b46
-signature=9f788255633ccbda3f6157ad3c3624c5cd031fb5219019bf0335c8d692c8eeb4
+head_commit=1b86580
+signature=35d4839de769469fbae3a9e9b978f7ac99fe67ab59a38ac27dd49b486995cded

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f61e893c07262aa1ba4b28a7aa95886db7ef3b753334cabdb579c9b02d6bf8d3
-timestamp=2026-03-27T14:16:09Z
-branch=feat/spec-041-memory-context-optimization
-head_commit=49102da
-signature=74d739773a232c9089cf9d4747a91562f4d70c0f826509cdb4854c25e451a382
+diff_hash=e0fb2a70cdc0a6ef72190df4f21d7b135ff6ccf74eef1ee69e3d829a87be3bef
+timestamp=2026-03-27T14:41:50Z
+branch=docs/fix-diacritics
+head_commit=240adc0
+signature=9f788255633ccbda3f6157ad3c3624c5cd031fb5219019bf0335c8d692c8eeb4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
 # Contribuir a PM-Workspace
 
-Soy Savia, y me encanta que quieras contribuir. Crezco con el uso real: las mejores contribuciones vienen de gente que encontro algo que le faltaba mientras gestionaba un proyecto de verdad.
+Soy Savia, y me encanta que quieras contribuir. Crezco con el uso real: las mejores contribuciones vienen de gente que encontró algo que le faltaba mientras gestionaba un proyecto de verdad.
 
 Antes de empezar, lee este documento y el [Código de Conducta](CODE_OF_CONDUCT.md).
 
 ---
 
-## Que busco
+## Qué busco
 
 Las contribuciones de mayor impacto son:
 
-**Nuevos comandos** (`.claude/commands/`) — si tuviste una conversación conmigo que resolvio un problema PM que aun no cubro, empaquetalo como comando reutilizable. Mira el [ROADMAP.md](docs/ROADMAP.md) para ver que falta.
+**Nuevos comandos** (`.claude/commands/`) — si tuviste una conversación conmigo que resolvió un problema PM que aún no cubro, empaquétalo como comando reutilizable. Mira el [ROADMAP.md](docs/ROADMAP.md) para ver qué falta.
 
-**Nuevos skills** (`.claude/skills/`) — skills que me extiendan a nuevo territorio: integración Jira, metodologias SAFe/Kanban, o nuevos formatos de reporting.
+**Nuevos skills** (`.claude/skills/`) — skills que me extiendan a nuevo territorio: integración Jira, metodologías SAFe/Kanban, o nuevos formatos de reporting.
 
 **Tests** — nuevas suites en `tests/`, escenarios de mock, ejemplos de specs.
 
@@ -41,22 +41,22 @@ bash scripts/validate-ci-local.sh    # CI local
 | Prefijo | Uso |
 |---------|-----|
 | `feature/` | Nuevo comando, skill, integración |
-| `fix/` | Correccion de bug |
+| `fix/` | Corrección de bug |
 | `docs/` | Solo documentación |
 | `test/` | Suite de tests o mock data |
-| `refactor/` | Reestructuracion sin cambio de comportamiento |
+| `refactor/` | Reestructuración sin cambio de comportamiento |
 
 ---
 
-## Estandares para comandos y skills
+## Estándares para comandos y skills
 
 ### Comandos (`.claude/commands/*.md`)
 
-Cada comando nuevo necesita: descripcion, pasos numerados, manejo del error mas comun, al menos un ejemplo, y referencia a skills que usa.
+Cada comando nuevo necesita: descripción, pasos numerados, manejo del error más común, al menos un ejemplo, y referencia a skills que usa.
 
 ### Skills (`.claude/skills/*/SKILL.md`)
 
-Cada skill necesita: SKILL.md + DOMAIN.md (Clara Philosophy). Descripcion, cuando usarlo, parametros, limitaciones.
+Cada skill necesita: SKILL.md + DOMAIN.md (Clara Philosophy). Descripción, cuándo usarlo, parámetros, limitaciones.
 
 ---
 
@@ -75,13 +75,13 @@ Mi CI ejecuta estos mismos comandos en cada PR. No mergeo si la suite regresa.
 
 Usa la plantilla de `.github/pull_request_template.md`. Rellena todas las secciones.
 
-**Proceso:** un maintainer revisa en 7 dias. Espera feedback e iteracion — es normal, no es rechazo. Una vez aprobado, se mergea en la siguiente release.
+**Proceso:** un maintainer revisa en 7 días. Espera feedback e iteración — es normal, no es rechazo. Una vez aprobado, se mergea en la siguiente release.
 
 ---
 
 ## Issues
 
-Usa las plantillas de GitHub (Bug report o Feature request). Incluye: versión de Claude Code, comando o skill involucrado, que esperabas y que paso.
+Usa las plantillas de GitHub (Bug report o Feature request). Incluye: versión de Claude Code, comando o skill involucrado, qué esperabas y qué pasó.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,8 +1,8 @@
 # Agents — Specialized Orchestration & Implementation
 
-pm-workspace has 33 specialized agents organized into 9 categories. Select by task type using the decisión tree below.
+pm-workspace has 33 specialized agents organized into 9 categories. Select by task type using the decision tree below.
 
-## Quick Decisión Tree
+## Quick Decision Tree
 
 **If you need to:** → **Use agent:**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ settings.json (5 hook events)
 3. **plan-gate** suggests spec if planning without specification
 4. **agent-dispatch-validate** ensures subagent context is complete (if delegating)
 
-**Decisión point:**
+**Decision point:**
 - ✅ All hooks pass → proceed to Phase 3
 - ❌ Security hook blocks → stop, show error, ask user to fix
 
@@ -75,7 +75,7 @@ settings.json (5 hook events)
 - **scope-guard** warns if modified files exceed spec scope
 - **stop-quality-gate** detects any remaining secrets
 
-**Decisión point:**
+**Decision point:**
 - ✅ All checks pass → session can end
 - ⚠️ Warnings only → inform user, allow continuation
 - ❌ Blockers found → require fixes before end
@@ -136,7 +136,7 @@ pm-workspace/
 │   └── agent-traces/
 │
 ├── CLAUDE.md                     (pm-workspace definition)
-├── CHANGELOG.md                  (versión history)
+├── CHANGELOG.md                  (version history)
 ├── settings.json                 (git config, team structure)
 └── README.md                     (getting started)
 ```
@@ -228,7 +228,7 @@ pm-workspace/
 | SDD pipeline (full) | ~2-5min | Agent orchestration + code generation |
 | Test suite run | ~30s | BATS execution |
 
-## Extensión Points
+## Extension Points
 
 To add new capabilities:
 

--- a/docs/ENTERPRISE_ROADMAP.md
+++ b/docs/ENTERPRISE_ROADMAP.md
@@ -99,7 +99,7 @@ Registro inmutable JSONL, rotación mensual, retención 12+36 meses. Controles d
 
 | Aspecto | Implementación |
 |--------|---------------|
-| Comando | `/governance-enterprise` — audit-trail, compliance-check, decisión-registry, certify |
+| Comando | `/governance-enterprise` — audit-trail, compliance-check, decision-registry, certify |
 | Reglas | `audit-trail-schema.md` (JSONL, rotación), `governance-enterprise.md` (controles, calendario) |
 | Skill | `governance-enterprise/SKILL.md` — 4 flujos |
 | Tests | 38/38 pasando |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -92,5 +92,5 @@ pm-workspace/
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — contribution guidelines
 - [SECURITY.md](../SECURITY.md) — security policy
-- [CHANGELOG.md](../CHANGELOG.md) — versión history with Era references
+- [CHANGELOG.md](../CHANGELOG.md) — version history with Era references
 - [ROADMAP.md](ROADMAP.md) — strategic direction

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -85,7 +85,7 @@ Para usar Spec-Driven Development con agentes Claude, necesitas la CLI de Claude
 
 ```bash
 # Verificar que claude CLI está instalado
-claude --versión
+claude --version
 
 # Verificar que puedes invocar claude como subproceso (necesario para agent-run)
 echo "Test de invocación de agente:"

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -80,7 +80,7 @@ npm install -g bats
 docker run --rm -v "$(pwd):/code" -w /code bats:latest tests/
 
 # Verify installation
-bats --versión
+bats --version
 ```
 
 ### Problem: Tests Fail With jq Errors
@@ -96,7 +96,7 @@ sudo apt-get install -y jq
 brew install jq
 
 # Verify
-jq --versión
+jq --version
 ```
 
 ### Problem: Coverage Report Shows Wrong Numbers
@@ -138,7 +138,7 @@ reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"./output/covera
 USER_PASSWORD="PLACEHOLDER_PASSWORD"
 API_KEY="EXAMPLE_API_KEY"
 
-# Option 2: Use .example or .template extensión
+# Option 2: Use .example or .template extension
 config.local.json.example    # Not scanned
 settings.template.json       # Not scanned
 

--- a/docs/agent-notes-protocol.md
+++ b/docs/agent-notes-protocol.md
@@ -17,7 +17,7 @@ Las agent-notes son la memoria compartida del equipo de agentes. Sin ellas, cada
 ```
 projects/{proyecto}/agent-notes/
 ├── {ticket}-legacy-analysis-{fecha}.md       ← @miguel.legacy / business-analyst
-├── {ticket}-architecture-decisión-{fecha}.md ← architect
+├── {ticket}-architecture-decision-{fecha}.md ← architect
 ├── {ticket}-test-strategy-{fecha}.md         ← test-engineer
 ├── {ticket}-security-checklist-{fecha}.md    ← security-guardian
 ├── {ticket}-implementation-log-{fecha}.md    ← {lang}-developer
@@ -30,7 +30,7 @@ projects/{proyecto}/agent-notes/
 {ticket}-{tipo}-{fecha}.md
 
 ticket  = AB1234 | PBI5678 | SPIKE-003 (referencia Azure DevOps)
-tipo    = legacy-analysis | architecture-decisión | test-strategy |
+tipo    = legacy-analysis | architecture-decision | test-strategy |
           security-checklist | implementation-log | review-findings |
           pm-validation | sprint-summary
 fecha   = YYYY-MM-DD
@@ -62,12 +62,12 @@ created: 2026-02-27
 ```
 1. business-analyst → escribe: {ticket}-legacy-analysis-{fecha}.md
        ↓ (lee: PBI padre, backlog, código existente)
-2. architect        → escribe: {ticket}-architecture-decisión-{fecha}.md
+2. architect        → escribe: {ticket}-architecture-decision-{fecha}.md
        ↓ (lee: legacy-analysis)
 3. security-guardian → escribe: {ticket}-security-checklist-{fecha}.md
-       ↓ (lee: architecture-decisión, spec)
+       ↓ (lee: architecture-decision, spec)
 4. test-engineer    → escribe: {ticket}-test-strategy-{fecha}.md
-       ↓ (lee: architecture-decisión, security-checklist, spec)
+       ↓ (lee: architecture-decision, security-checklist, spec)
 5. {lang}-developer → escribe: {ticket}-implementation-log-{fecha}.md
        ↓ (lee: TODAS las notas previas + spec)
 6. code-reviewer    → escribe: {ticket}-review-findings-{fecha}.md

--- a/docs/ai-augmentation-opportunities-en.md
+++ b/docs/ai-augmentation-opportunities-en.md
@@ -44,7 +44,7 @@ Sectors with the largest gap would benefit most from well-designed AI tools — 
 
 **Applicable pm-workspace workflows:** Sprint management for intervention cycles, capacity planning for caseload distribution, time tracking for grant justification, executive reporting for activity reports.
 
-**Extensión needed:** Domain entities (beneficiary, case, intervention), custom states (assessment → plan → follow-up → closure), social impact metrics.
+**Extension needed:** Domain entities (beneficiary, case, intervention), custom states (assessment → plan → follow-up → closure), social impact metrics.
 
 ### Sales (large gap)
 
@@ -52,7 +52,7 @@ Sectors with the largest gap would benefit most from well-designed AI tools — 
 
 **Applicable workflows:** Backlog management for pipeline (leads as PBIs), sprint for campaign cycles, velocity for conversion rate, stakeholder reports for sales leadership.
 
-**Extensión needed:** Domain entities (lead, opportunity, account), funnel stages, commercial metrics (CAC, LTV, churn).
+**Extension needed:** Domain entities (lead, opportunity, account), funnel stages, commercial metrics (CAC, LTV, churn).
 
 ### Arts & media (large gap)
 
@@ -60,7 +60,7 @@ Sectors with the largest gap would benefit most from well-designed AI tools — 
 
 **Applicable workflows:** Sprint for production cycles, spec-driven for creative briefs, code review adapted for content review, time tracking for production budgets.
 
-**Extensión needed:** Domain entities (piece, campaign, brief), review states (draft → review → approval → publication), production metrics.
+**Extension needed:** Domain entities (piece, campaign, brief), review states (draft → review → approval → publication), production metrics.
 
 ---
 

--- a/docs/articles/linkedin-enterprise-pm-workspace.md
+++ b/docs/articles/linkedin-enterprise-pm-workspace.md
@@ -142,7 +142,7 @@ Las especificaciones pueden generar infraestructura directamente: Terraform, Clo
 
 **Inteligencia Arquitectónica**
 
-Los agentes entienden patrones de arquitectura: microservicios vs. monolitos, decisiones de base de datos, caching strategies, load balancing. Las decisiones se documentan automáticamente en ADRs (Architecture Decisión Records).
+Los agentes entienden patrones de arquitectura: microservicios vs. monolitos, decisiones de base de datos, caching strategies, load balancing. Las decisiones se documentan automáticamente en ADRs (Architecture Decision Records).
 
 **Gestión Progresiva de Dependencias**
 

--- a/docs/confidentiality-levels.md
+++ b/docs/confidentiality-levels.md
@@ -1,6 +1,6 @@
-# Niveles de Confidencialidad — Arquitectura de Separacion de Datos
+# Niveles de Confidencialidad — Arquitectura de Separación de Datos
 
-> Documento de referencia para la separacion de datos en pm-workspace.
+> Documento de referencia para la separación de datos en pm-workspace.
 > Fecha: 2026-03-19
 
 ---
@@ -8,17 +8,17 @@
 ## Principio
 
 pm-workspace es software libre publicado en GitHub. Los datos del usuario,
-empresa y proyectos NUNCA deben mezclarse con el código publico. Cada nivel
+empresa y proyectos NUNCA deben mezclarse con el código público. Cada nivel
 tiene su propio repositorio git con permisos independientes.
 
 ---
 
-## 5 Niveles (de mas abierto a mas restringido)
+## 5 Niveles (de más abierto a más restringido)
 
 ### N1 — PUBLICO (repo pm-workspace en GitHub)
 
 - Código del workspace: commands, skills, rules, agents, hooks, scripts
-- Documentación generica del producto: README, CHANGELOG, docs/
+- Documentación genérica del producto: README, CHANGELOG, docs/
 - Plantillas y ejemplos con datos ficticios (alice, test-org, acme-corp)
 - Reglas de dominio sin datos de empresa ni persona
 - NUNCA datos reales de personas, empresas, clientes ni proyectos
@@ -37,7 +37,7 @@ tiene su propio repositorio git con permisos independientes.
 - Memoria cross-project (instintos aprendidos, patrones personales)
 - Cache de sesiones y contexto personal
 - Preferencias de accesibilidad y formato
-- Portable entre maquinas via `~/.savia/personal-vault/`
+- Portable entre máquinas via `~/.savia/personal-vault/`
 - NUNCA datos de proyectos de cliente ni datos de la empresa
 
 ### N4 — PROYECTO (repo separado por proyecto)
@@ -60,12 +60,12 @@ tiene su propio repositorio git con permisos independientes.
 
 ---
 
-## Mecanismos de Separacion
+## Mecanismos de Separación
 
 ### Repositorios git independientes
 
 - Cada nivel tiene su propio repo con permisos de acceso diferenciados
-- N1: repo publico en GitHub (pm-workspace)
+- N1: repo público en GitHub (pm-workspace)
 - N2: ficheros gitignored dentro del repo N1
 - N3: repo personal (`~/.savia/personal-vault/`)
 - N4: repo por proyecto (uno por cliente/proyecto)
@@ -79,7 +79,7 @@ tiene su propio repositorio git con permisos independientes.
 
 ### Reglas de enrutamiento para Savia
 
-- `CONFIDENTIALITY.md` por proyecto define que consultar segun quien pregunta
+- `CONFIDENTIALITY.md` por proyecto define qué consultar según quien pregunta
 - Savia clasifica cada dato ANTES de escribirlo (ver Protocolo de Decisión)
 - Si hay duda, Savia pregunta al usuario antes de persistir
 
@@ -91,7 +91,7 @@ tiene su propio repositorio git con permisos independientes.
 
 ### Comando /confidentiality-check
 
-- Auditoria bajo demanda de cumplimiento de niveles
+- Auditoría bajo demanda de cumplimiento de niveles
 - Escanea ficheros .md buscando datos fuera de nivel
 - Genera informe con severidad: CRITICAL, WARNING, INFO
 
@@ -103,7 +103,7 @@ tiene su propio repositorio git con permisos independientes.
 
 ---
 
-## Ejemplo con Proyecto Generico
+## Ejemplo con Proyecto Genérico
 
 - `projects/proyecto-alpha/` (N4-SHARED) — repo git compartible con el cliente
 - `projects/proyecto-alpha-internal/` (N4-VASS) — repo git solo equipo proveedor
@@ -116,11 +116,11 @@ tiene su propio repositorio git con permisos independientes.
 
 Cuando Savia recibe información para persistir:
 
-1. Clasificar: ¿es de un proyecto? ¿del usuario? ¿de la empresa? ¿generica?
+1. Clasificar: ¿es de un proyecto? ¿del usuario? ¿de la empresa? ¿genérica?
 2. Si PROYECTO → determinar subnivel (N4-SHARED, N4-VASS o N4b)
 3. Si USUARIO → escribir en el vault personal (N3)
 4. Si EMPRESA → guardar en ficheros gitignored (N2)
-5. Si GENERICA del workspace → repo publico (N1)
+5. Si GENÉRICA del workspace → repo público (N1)
 6. Si DUDA → preguntar al usuario antes de escribir
 7. NUNCA asumir destino sin clasificar primero
 
@@ -142,7 +142,7 @@ Cuando los repos se muevan de Gitea local a Gitlab/Azure DevOps:
 ## Referencias
 
 - `@.claude/rules/domain/context-placement-confirmation.md` — regla operativa
-- `@.claude/rules/domain/pii-sanitization.md` — sanitizacion PII
+- `@.claude/rules/domain/pii-sanitization.md` — sanitización PII
 - `@.claude/rules/domain/confidentiality-config.md` — config de confidencialidad
 - `@.claude/agents/confidentiality-auditor.md` — agente auditor
-- `/confidentiality-check` — comando de auditoria
+- `/confidentiality-check` — comando de auditoría

--- a/docs/guides/guide-enterprise-consultancy.md
+++ b/docs/guides/guide-enterprise-consultancy.md
@@ -24,7 +24,7 @@ Si tu consultora es más pequeña (5–50 personas), comienza con [Guía de Inic
 | **CTO** | Soberanía tecnológica, sin lock-in, RBAC | `/sovereignty-audit`, `/rbac-manager`, `/scale-optimizer` | Control total de datos, permisos y cumplimiento normativo |
 | **Dir. Operaciones** | Multi-equipo, previsibilidad, escala | `/team-orchestrator`, `/enterprise-dashboard`, `/forecast` | Coordinación cross-equipo (Team Topologies), sin cuellos de botella |
 | **PM/Scrum Master** | Automatización, visibilidad, menos overhead | `/sprint-sync`, `/backlog-ai`, `/risk-radar` | Sprints sin ceremonias manuales, alertas proactivas |
-| **Tech Lead** | Especificaciones precisas, SDD, AI agents | `/spec-review`, `/arch-decisión`, `/sdd-status` | Dev entiende qué hace antes de escribir código |
+| **Tech Lead** | Especificaciones precisas, SDD, AI agents | `/spec-review`, `/arch-decision`, `/sdd-status` | Dev entiende qué hace antes de escribir código |
 | **Developers** | Contexto claro, menos reuniones, menos emails | `/context`, `/next-action`, `/spec-check` | Flujo de trabajo enfocado, evita 3 reuniones/día |
 | **QA** | Testing coordenado, trazabilidad, SLA | `/test-plan`, `/regression-matrix`, `/qa-sign-off` | Bugs evitados (no encontrados), métricas de calidad |
 | **RRHH / Onboarding** | Incorporación masiva, checklists, KT | `/onboard-enterprise`, `/team-orchestrator` | Onboarding de 100+ personas con checklists por rol |
@@ -308,7 +308,7 @@ savia init --client "cliente-piloto" --team "squad-1" \
 
 **Day 1–2**: Setup y kickoff
 - Todos ejecutan `/profile-setup` para registrarse
-- CTO ejecuta `/arch-decisión --scope "auth strategy"` → spec generada
+- CTO ejecuta `/arch-decision --scope "auth strategy"` → spec generada
 
 **Day 3–5**: Desarrollo con SDD
 - Devs implementan spec con `/spec-check` en cada commit

--- a/docs/guides/guide-enterprise-gap-analysis.md
+++ b/docs/guides/guide-enterprise-gap-analysis.md
@@ -1,6 +1,6 @@
 # Análisis de Gaps: Grandes Consultoras Tecnológicas y Cómo los Resuelve pm-workspace
 
-🌐 [English versión](../guides_en/guide-enterprise-gap-analysis.md)
+🌐 [English version](../guides_en/guide-enterprise-gap-analysis.md)
 
 > Este documento identifica los problemas operativos más comunes en grandes consultoras tecnológicas (500-5.000 empleados) y detalla cómo pm-workspace/Savia los resuelve con comandos, reglas y skills concretos.
 
@@ -137,7 +137,7 @@ En una consultora que trabaja para banca, seguros y administración pública sim
 | RBAC 4 niveles | `/rbac-manager` | Admin, PM, Contributor, Viewer — permisos granulares por proyecto |
 | Audit trail inmutable | `/governance-enterprise audit-trail` | JSONL append-only con rotación mensual. Quién hizo qué, cuándo |
 | Compliance checks | `/governance-enterprise compliance-check` | Verificación automática GDPR, AEPD, ISO 27001, EU AI Act |
-| Decisión registry | `/governance-enterprise decisión-registry` | Registro inmutable de decisiones con justificación y responsable |
+| Decision registry | `/governance-enterprise decision-registry` | Registro inmutable de decisiones con justificación y responsable |
 | Certificación | `/governance-enterprise certify` | Genera evidencia de cumplimiento para auditorías externas |
 | PII Gate | Hook `hook-pii-gate.sh` | Scanner pre-push que bloquea commits con datos personales |
 
@@ -222,7 +222,7 @@ Los stakeholders introducen cambios "pequeños" sin proceso formal. Según datos
 | Detección de scope creep | `/backlog-git deviation-report` | Compara snapshots: items añadidos, eliminados, re-estimados sin aprobación |
 | SDD obligatorio | Regla `spec-driven-development` | Ninguna feature se implementa sin spec aprobada — el agente rechaza código sin spec |
 | PR Guardian | CI/CD `pr-guardian.yml` | 8 gates automáticos: si la spec no existe o está desactualizada, el PR se bloquea |
-| Audit trail | `/governance-enterprise decisión-registry` | Cada cambio de alcance queda registrado con responsable y justificación |
+| Audit trail | `/governance-enterprise decision-registry` | Cada cambio de alcance queda registrado con responsable y justificación |
 
 **Resultado**: Los cambios no autorizados se detectan automáticamente. Si no hay spec, no hay código. Si no hay decisión registrada, no hay cambio de alcance.
 

--- a/docs/guides/guide-research-lab.md
+++ b/docs/guides/guide-research-lab.md
@@ -209,7 +209,7 @@ Para proyectos con investigadores de otros centros:
 |---|---|---|
 | **Experiment tracking** | No hay entidad nativa "experimento" con metadata (hipótesis, variables, resultados) | `/experiment-log {create\|run\|result\|compare}` |
 | **Literature management** | No hay tracking de referencias bibliográficas | `/biblio-add {doi\|bibtex}`, `/biblio-search` |
-| **Dataset versioning** | Datasets grandes no encajan en Git | Integración con DVC (Data Versión Control) o Git LFS |
+| **Dataset versioning** | Datasets grandes no encajan en Git | Integración con DVC (Data Version Control) o Git LFS |
 | **Grant lifecycle** | Propuestas de financiación tienen ciclos propios (draft → submitted → review → awarded) | `/grant-track {submit\|status\|report}` |
 | **Ethics/IRB tracking** | Protocolos de ética no se gestionan como PBIs estándar | `/ethics-protocol {create\|status\|expire}` |
 

--- a/docs/guides_en/guide-enterprise-consultancy.md
+++ b/docs/guides_en/guide-enterprise-consultancy.md
@@ -24,7 +24,7 @@ If your consulting firm is smaller (5–50 people), start with the [Quick Start 
 | **CTO** | Technological sovereignty, no lock-in, RBAC | `/sovereignty-audit`, `/rbac-manager`, `/scale-optimizer` | Full data control, permissions and regulatory compliance |
 | **Operations Director** | Multi-team, predictability, scale | `/team-orchestrator`, `/enterprise-dashboard`, `/forecast` | Cross-team coordination (Team Topologies), no bottlenecks |
 | **PM/Scrum Master** | Automation, visibility, less overhead | `/sprint-sync`, `/backlog-ai`, `/risk-radar` | Sprints without manual ceremonies, proactive alerts |
-| **Tech Lead** | Precise specs, SDD, AI agents | `/spec-review`, `/arch-decisión`, `/sdd-status` | Dev understands what to build before writing code |
+| **Tech Lead** | Precise specs, SDD, AI agents | `/spec-review`, `/arch-decision`, `/sdd-status` | Dev understands what to build before writing code |
 | **Developers** | Clear context, fewer meetings, fewer emails | `/context`, `/next-action`, `/spec-check` | Focused workflow, avoid 3 meetings/day |
 | **QA** | Coordinated testing, traceability, SLA | `/test-plan`, `/regression-matrix`, `/qa-sign-off` | Bugs prevented (not found), quality metrics |
 | **HR / Onboarding** | Bulk onboarding, checklists, KT | `/onboard-enterprise`, `/team-orchestrator` | Onboard 100+ people with per-role checklists |
@@ -308,7 +308,7 @@ savia init --client "pilot-client" --team "squad-1" \
 
 **Day 1–2**: Setup and kickoff
 - Everyone runs `/profile-setup` to register
-- CTO runs `/arch-decisión --scope "auth strategy"` → spec generated
+- CTO runs `/arch-decision --scope "auth strategy"` → spec generated
 
 **Day 3–5**: Development with SDD
 - Devs implement spec with `/spec-check` on each commit
@@ -347,4 +347,4 @@ savia metrics --team squad-1 --compare baseline
 
 ---
 
-**Versión**: 2.0 | **Last updated**: 2026-03-06 | **Maintainer**: pm-workspace Community
+**Version**: 2.0 | **Last updated**: 2026-03-06 | **Maintainer**: pm-workspace Community

--- a/docs/guides_en/guide-enterprise-gap-analysis.md
+++ b/docs/guides_en/guide-enterprise-gap-analysis.md
@@ -137,7 +137,7 @@ In a consulting firm working for banking, insurance, and public administration s
 | 4-tier RBAC | `/rbac-manager` | Admin, PM, Contributor, Viewer — granular permissions per project |
 | Immutable audit trail | `/governance-enterprise audit-trail` | JSONL append-only with monthly rotation. Who did what, when |
 | Compliance checks | `/governance-enterprise compliance-check` | Automatic verification of GDPR, AEPD, ISO 27001, EU AI Act |
-| Decisión registry | `/governance-enterprise decisión-registry` | Immutable record of decisions with justification and responsible party |
+| Decision registry | `/governance-enterprise decision-registry` | Immutable record of decisions with justification and responsible party |
 | Certification | `/governance-enterprise certify` | Generates compliance evidence for external audits |
 | PII Gate | Hook `hook-pii-gate.sh` | Pre-push scanner that blocks commits containing personal data |
 
@@ -222,9 +222,9 @@ Stakeholders introduce "small" changes without formal process. Industry data sho
 | Scope creep detection | `/backlog-git deviation-report` | Compares snapshots: items added, removed, re-estimated without approval |
 | Mandatory SDD | Rule `spec-driven-development` | No feature is implemented without approved spec — agent rejects code without spec |
 | PR Guardian | CI/CD `pr-guardian.yml` | 8 automatic gates: if the spec doesn't exist or is outdated, the PR is blocked |
-| Audit trail | `/governance-enterprise decisión-registry` | Every scope change is recorded with responsible party and justification |
+| Audit trail | `/governance-enterprise decision-registry` | Every scope change is recorded with responsible party and justification |
 
-**Result**: Unauthorized changes are automatically detected. No spec, no code. No registered decisión, no scope change.
+**Result**: Unauthorized changes are automatically detected. No spec, no code. No registered decision, no scope change.
 
 ---
 
@@ -302,4 +302,4 @@ Consulting firms working with banking, insurance, healthcare, or public administ
 
 ---
 
-**Versión**: 1.0 | **Last updated**: 2026-03-06 | **Maintainer**: pm-workspace Community
+**Version**: 1.0 | **Last updated**: 2026-03-06 | **Maintainer**: pm-workspace Community

--- a/docs/propuestas/SPEC-015-context-gate.md
+++ b/docs/propuestas/SPEC-015-context-gate.md
@@ -8,36 +8,36 @@
 
 ## Problema
 
-skill-auto-activation.md evalua 79 skills contra cada prompt del usuario,
+skill-auto-activation.md evalúa 79 skills contra cada prompt del usuario,
 incluso cuando el prompt es trivialmente clasificable ("hola", "/sprint-status",
 "si"). El scoring consume tokens y a veces sugiere skills irrelevantes en
 contextos obvios.
 
-Fabrik-Codek resuelve esto con un "Context Gate": heuristica rapida que
+Fabrik-Codek resuelve esto con un "Context Gate": heurística rápida que
 decide si el RAG/scoring debe ejecutarse. Si no, lo salta completamente.
 
 ---
 
-## Diseno
+## Diseño
 
-### Clasificacion rapida pre-scoring
+### Clasificación rápida pre-scoring
 
 Antes de ejecutar el scoring de skill-auto-activation, aplicar:
 
 ```
 1. Es un slash command directo? (/sprint-status, /help)
-   → SKIP scoring — el comando ya es explicito
+   → SKIP scoring — el comando ya es explícito
 
 2. Es un saludo/despedida? (hola, adios, gracias, ok, si, no, vale)
    → SKIP scoring — no hay skill relevante
 
-3. Es una respuesta a pregunta de Savia? (contexto: Savia pregunto algo)
+3. Es una respuesta a pregunta de Savia? (contexto: Savia preguntó algo)
    → SKIP scoring — la respuesta es para el flujo actual
 
-4. Es una correccion simple? (no eso no, cambia X por Y, para)
+4. Es una corrección simple? (no eso no, cambia X por Y, para)
    → SKIP scoring — acción directa, no skill
 
-5. Tiene < 5 palabras y no contiene sustantivos tecnicos?
+5. Tiene < 5 palabras y no contiene sustantivos técnicos?
    → SKIP scoring — demasiado corto para inferir skill
 
 6. Ninguno de los anteriores
@@ -46,20 +46,20 @@ Antes de ejecutar el scoring de skill-auto-activation, aplicar:
 
 ### Implementación como fast-path
 
-No es un hook ni un script — es una regla de comportamiento que se anade
+No es un hook ni un script — es una regla de comportamiento que se añade
 a `skill-auto-activation.md` como paso 0:
 
 ```markdown
 ## Paso 0 — Context Gate (fast-path)
 
 ANTES de evaluar skills, verificar si el prompt es trivialmente clasificable.
-Si cumple alguna condicion de bypass → NO evaluar skills, responder directamente.
+Si cumple alguna condición de bypass → NO evaluar skills, responder directamente.
 
 Condiciones de bypass:
-1. Prompt empieza con `/` (slash command explicito)
+1. Prompt empieza con `/` (slash command explícito)
 2. Prompt es <= 4 palabras sin sustantivos tecnicos
 3. Prompt es respuesta a pregunta previa de Savia
-4. Prompt es confirmacion/negacion simple (si, no, ok, vale, cancelar)
+4. Prompt es confirmación/negación simple (si, no, ok, vale, cancelar)
 5. Focus mode activo y prompt no cambia de tema
 ```
 
@@ -77,17 +77,17 @@ Tracking en `context-tracker-hook.sh`:
 ### Fase única (< 1 sprint)
 
 1. Actualizar `.claude/rules/domain/skill-auto-activation.md` con Paso 0
-2. Anadir tracking de gate decisions en context-tracker
+2. Añadir tracking de gate decisions en context-tracker
 3. Medir durante 2 semanas
 4. Ajustar condiciones si hay falsos negativos
 
 ---
 
-## Criterios de aceptacion
+## Criterios de aceptación
 
 - [ ] >= 30% de prompts saltan el scoring de skills
 - [ ] 0 falsos negativos en 50 sesiones de prueba
-- [ ] Latencia percibida no cambia (gate es instantaneo)
+- [ ] Latencia percibida no cambia (gate es instantáneo)
 - [ ] Slash commands NUNCA disparan sugerencia de skill
 - [ ] Saludos NUNCA disparan sugerencia de skill
 
@@ -95,7 +95,7 @@ Tracking en `context-tracker-hook.sh`:
 
 ## Ficheros afectados
 
-- `.claude/rules/domain/skill-auto-activation.md` — anadir Paso 0
+- `.claude/rules/domain/skill-auto-activation.md` — añadir Paso 0
 
 ---
 

--- a/docs/propuestas/SPEC-016-intelligent-compact.md
+++ b/docs/propuestas/SPEC-016-intelligent-compact.md
@@ -16,31 +16,31 @@
 
 context-health.md dice "al compactar, SIEMPRE preservar ficheros modificados,
 scores, decisiones", pero esto depende de que Claude lo haga bien cada vez.
-No hay mecanismo sistematico.
+No hay mecanismo sistemático.
 
 OpenViking convierte conversación en memorias durables en vez de truncar.
-Fabrik-Codek anade quality gate para evitar ruido.
+Fabrik-Codek añade quality gate para evitar ruido.
 
 ---
 
-## Diseno
+## Diseño
 
 ### Pre-compact extraction pipeline
 
-Antes de ejecutar /compact, Savia ejecuta un pipeline de extraccion:
+Antes de ejecutar /compact, Savia ejecuta un pipeline de extracción:
 
 ```
 1. SCAN — Identificar en el contexto actual:
    a. Decisiones: "vamos con X", "elegimos Y", "descartamos Z"
-   b. Correcciones: "no, eso esta mal", "cambia X por Y"
+   b. Correcciones: "no, eso está mal", "cambia X por Y"
    c. Descubrimientos: "resulta que X funciona así"
    d. Estado de trabajo: "estamos en paso 3 de 5", "falta X"
 
 2. QUALITY GATE — Filtrar:
    a. Min 50 caracteres (no trivial)
-   b. No es repeticion de algo ya en memoria
-   c. No es dato efimero (línea de código, ruta temporal)
-   d. Tiene valor entre sesiones (test: "seria util si lo leo manana?")
+   b. No es repetición de algo ya en memoria
+   c. No es dato efímero (línea de código, ruta temporal)
+   d. Tiene valor entre sesiones (test: "sería útil si lo leo mañana?")
 
 3. CLASSIFY — Por tipo y destino:
    a. Feedback → auto-memory feedback type
@@ -50,8 +50,8 @@ Antes de ejecutar /compact, Savia ejecuta un pipeline de extraccion:
 
 4. PERSIST — Escribir en destino correcto
 
-5. COMPACT — Ahora si, ejecutar /compact normal con summary que incluye:
-   - Lista de items extraidos (referencia, no contenido)
+5. COMPACT — Ahora sí, ejecutar /compact normal con summary que incluye:
+   - Lista de items extraídos (referencia, no contenido)
    - Estado de trabajo actual
    - Ficheros modificados en la sesión
 ```
@@ -74,17 +74,17 @@ Al compactar, el summary siempre incluye:
 SPEC-013 (Session Memory Extraction) y SPEC-016 comparten el mismo extractor.
 La diferencia:
 - SPEC-013 se ejecuta al CERRAR sesión (Stop hook, async)
-- SPEC-016 se ejecuta al COMPACTAR (inline, sync, rapido)
+- SPEC-016 se ejecuta al COMPACTAR (inline, sync, rápido)
 
-El extractor es una funcion compartida con dos modos:
-- `mode=full`: analiza todo el transcript (SPEC-013, mas lento)
-- `mode=quick`: analiza solo el contexto actual (SPEC-016, mas rapido)
+El extractor es una función compartida con dos modos:
+- `mode=full`: analiza todo el transcript (SPEC-013, más lento)
+- `mode=quick`: analiza solo el contexto actual (SPEC-016, más rápido)
 
 ---
 
 ## Implementación
 
-### Fase 1 — Extraction basica en /compact (1 sprint)
+### Fase 1 — Extracción básica en /compact (1 sprint)
 
 1. Actualizar comportamiento de /compact en context-health.md
 2. Antes de compactar: scan de decisiones y correcciones
@@ -96,17 +96,17 @@ El extractor es una funcion compartida con dos modos:
 
 1. Refactorizar extractor como módulo reutilizable
 2. SPEC-013 usa mode=full, SPEC-016 usa mode=quick
-3. Métricas: items extraidos por compact, falsos positivos
+3. Métricas: items extraídos por compact, falsos positivos
 
 ---
 
-## Criterios de aceptacion
+## Criterios de aceptación
 
 - [ ] /compact extrae >= 1 item util en sesiones de 20+ min
 - [ ] Quality gate rechaza >= 70% de candidatos triviales
 - [ ] Compact summary incluye siempre: ficheros, estado, ultimo comando
 - [ ] Tiempo adicional de /compact < 3 segundos
-- [ ] Ningun item duplicado en auto-memory tras compact
+- [ ] Ningún ítem duplicado en auto-memory tras compact
 
 ---
 

--- a/docs/propuestas/SPEC-029-security-auto-remediation-pr.md
+++ b/docs/propuestas/SPEC-029-security-auto-remediation-pr.md
@@ -1,7 +1,7 @@
 # SPEC-029: Security Auto-Remediation PRs
 
 > Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.60
-> Origen: Analisis de usestrix/strix — remediacion automatica
+> Origen: Análisis de usestrix/strix — remediación automática
 > Impacto: Cierra el gap entre detectar vulnerabilidades y corregirlas
 
 ---
@@ -11,13 +11,13 @@
 El pipeline adversarial (security-attacker -> security-defender -> security-auditor)
 detecta vulnerabilidades y propone fixes, pero el output se queda en un informe
 markdown. El humano debe aplicar los patches manualmente. Strix genera PRs
-automaticos con fixes listos para mergear.
+automáticos con fixes listos para mergear.
 
 La infraestructura ya existe en pm-workspace: ramas `agent/*`, PR Draft,
 `AUTONOMOUS_REVIEWER`. Solo falta conectar el output de security-defender
-con la creacion del PR.
+con la creación del PR.
 
-## Solucion
+## Solución
 
 Extender el flujo post-security-defender para que, opcionalmente, materialice
 los fixes propuestos en un PR Draft.
@@ -36,7 +36,7 @@ los fixes propuestos en un PR Draft.
    c. Ejecutar tests (dotnet test / npm test / pytest segun language pack)
    d. Si tests pasan: crear PR Draft
    e. Si tests fallan: informar, no crear PR
-   f. PR body incluye: hallazgos, fixes aplicados, score antes/despues
+   f. PR body incluye: hallazgos, fixes aplicados, score antes/después
    g. Asignar AUTONOMOUS_REVIEWER como reviewer
 ```
 
@@ -54,12 +54,12 @@ los fixes propuestos en un PR Draft.
 ## Security Fixes — {fecha}
 
 ### Hallazgos corregidos
-| # | Severidad | Vulnerabilidad | Fichero | Linea |
+| # | Severidad | Vulnerabilidad | Fichero | Línea |
 |---|-----------|---------------|---------|-------|
 
 ### Score de seguridad
 - Antes: {score_antes}/100
-- Despues: {score_despues}/100
+- Después: {score_despues}/100
 
 ### Tests
 - Suite: {test_command}
@@ -69,16 +69,16 @@ los fixes propuestos en un PR Draft.
 security-attacker -> security-defender -> security-auditor -> PR
 ```
 
-## Implementacion
+## Implementación
 
 1. Modificar `.claude/commands/security-pipeline.md` para incluir paso 5-6
 2. Reutilizar patron de `autonomous-safety.md` para ramas agent/*
 3. El PR se crea con `gh pr create --draft`
 4. No requiere nuevo agente — Savia orquesta directamente
 
-## Metricas de exito
+## Métricas de éxito
 
-- Tiempo medio entre deteccion y fix disponible: <5 min (vs horas manual)
+- Tiempo medio entre detección y fix disponible: <5 min (vs horas manual)
 - % de PRs de seguridad que pasan tests al primer intento: >80%
 - % de PRs aprobados por reviewer sin cambios: >60%
 

--- a/docs/propuestas/SPEC-030-nuclei-integration.md
+++ b/docs/propuestas/SPEC-030-nuclei-integration.md
@@ -1,42 +1,42 @@
 # SPEC-030: Nuclei Scanner Integration
 
 > Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.50
-> Origen: Analisis de usestrix/strix — scanner de vulnerabilidades
-> Impacto: Complementa analisis LLM con deteccion de CVEs conocidos
+> Origen: Análisis de usestrix/strix — scanner de vulnerabilidades
+> Impacto: Complementa análisis LLM con detección de CVEs conocidos
 
 ---
 
 ## Problema
 
-Nuestros agentes de seguridad (security-attacker, pentester) analizan codigo
-mediante LLM. Son excelentes para vulnerabilidades logicas y contextuales,
-pero pueden pasar por alto CVEs conocidos, misconfiguraciones estandar y
-paneles expuestos que un scanner basado en templates detectaria en segundos.
+Nuestros agentes de seguridad (security-attacker, pentester) analizan código
+mediante LLM. Son excelentes para vulnerabilidades lógicas y contextuales,
+pero pueden pasar por alto CVEs conocidos, misconfiguraciones estándar y
+paneles expuestos que un scanner basado en templates detectaría en segundos.
 
 Nuclei (projectdiscovery.io) tiene +8000 templates comunitarios y es el
-scanner mas usado en pentesting moderno. Strix lo preinstala como herramienta
+scanner más usado en pentesting moderno. Strix lo preinstala como herramienta
 base.
 
-## Solucion
+## Solución
 
 Crear un skill `nuclei-scanning` que integre Nuclei como fuente complementaria
-de hallazgos para el pipeline adversarial, con degradacion graceful si Nuclei
-no esta instalado.
+de hallazgos para el pipeline adversarial, con degradación graceful si Nuclei
+no está instalado.
 
 ## Arquitectura
 
 ```
 /security-pipeline
   |
-  +-- security-attacker (LLM, analisis de codigo)
+  +-- security-attacker (LLM, análisis de código)
   |
-  +-- nuclei-scanning (scanner, analisis de superficie)  <-- NUEVO
+  +-- nuclei-scanning (scanner, análisis de superficie)  <-- NUEVO
   |
   +-- Merge hallazgos (dedup por CWE/CVE)
   |
   +-- security-defender (fixes para hallazgos combinados)
   |
-  +-- security-auditor (evaluacion final)
+  +-- security-auditor (evaluación final)
 ```
 
 ## Skill: nuclei-scanning
@@ -51,8 +51,8 @@ no esta instalado.
 ### Flujo del skill
 
 ```bash
-# 1. Verificar instalacion
-which nuclei || echo "Nuclei no instalado — degradacion graceful"
+# 1. Verificar instalación
+which nuclei || echo "Nuclei no instalado — degradación graceful"
 
 # 2. Si existe, ejecutar scan
 nuclei -u {target_url} \
@@ -68,18 +68,18 @@ nuclei -u {target_url} \
 # 4. Deduplicar contra hallazgos del security-attacker
 # Mapeo: nuclei template-id -> CWE -> hallazgo LLM
 
-# 5. Hallazgos unicos de Nuclei se anaden al informe
+# 5. Hallazgos únicos de Nuclei se añaden al informe
 ```
 
-### Degradacion graceful
+### Degradación graceful
 
 | Nuclei instalado | Target accesible | Resultado |
 |-----------------|------------------|-----------|
-| Si | Si | Scan completo |
-| Si | No | Solo templates de config (sin red) |
+| Sí | Sí | Scan completo |
+| Sí | No | Solo templates de config (sin red) |
 | No | - | Skip con aviso: "Instala nuclei para scan complementario" |
 
-## Instalacion de Nuclei
+## Instalación de Nuclei
 
 ```bash
 # Go install
@@ -93,14 +93,14 @@ unzip nuclei.zip && mv nuclei /usr/local/bin/
 ## Templates curados
 
 Mantener subset en `templates/` para uso offline:
-- `cves/` — CVEs criticos recientes (top 50)
+- `cves/` — CVEs críticos recientes (top 50)
 - `misconfigurations/` — CORS, headers, TLS
 - `exposed-panels/` — Admin panels, debug endpoints
 - `default-logins/` — Credenciales por defecto
 
-Total: ~200 templates vs +8000 del repo completo. Actualizacion trimestral.
+Total: ~200 templates vs +8000 del repo completo. Actualización trimestral.
 
-## Integracion con scoring
+## Integración con scoring
 
 Los hallazgos de Nuclei usan el mismo scoring:
 `score = 100 - (critical x 25 + high x 10 + medium x 3 + low x 1)`
@@ -109,11 +109,11 @@ Se marcan con `source: nuclei` para distinguirlos de `source: llm`.
 
 ## Restricciones
 
-- NUNCA ejecutar Nuclei contra produccion sin confirmacion explicita
+- NUNCA ejecutar Nuclei contra produccion sin confirmación explícita
 - Respetar rate-limit (50 req/s por defecto)
 - Respetar reglas por entorno del pentester (DEV: todo, PRE: sin DoS, PROD: pasivo)
-- Templates custom solo en `templates/` del skill, no descargar automaticamente
+- Templates custom solo en `templates/` del skill, no descargar automáticamente
 
 ## Esfuerzo estimado
 
-Bajo — 1 dia. Nuclei es un binario standalone. El skill solo invoca y parsea.
+Bajo — 1 día. Nuclei es un binario standalone. El skill solo invoca y parsea.

--- a/docs/propuestas/SPEC-031-workspace-doctor.md
+++ b/docs/propuestas/SPEC-031-workspace-doctor.md
@@ -1,8 +1,8 @@
 # SPEC-031: Workspace Doctor — Health Check del Entorno
 
 > Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.40
-> Origen: Analisis de malopezr7/jato — comando doctor
-> Impacto: Diagnostico rapido de problemas de configuracion
+> Origen: Análisis de malopezr7/jato — comando doctor
+> Impacto: Diagnóstico rápido de problemas de configuración
 
 ---
 
@@ -13,25 +13,25 @@ y `/health-dashboard` que verifica salud del proyecto. Pero no existe un
 health check del propio workspace: settings.json valido, hooks activos,
 CLIs disponibles, scripts con permisos, MCPs respondiendo.
 
-Cuando algo falla, el PM no sabe si es un problema de configuracion del
+Cuando algo falla, el PM no sabe si es un problema de configuración del
 entorno o del proyecto. jato resuelve esto con `jato doctor` (8 checks).
 
-## Solucion
+## Solución
 
 Crear `/workspace-doctor` que ejecute checks del entorno pm-workspace
 y muestre resultado con acciones correctivas.
 
 ## Checks (14)
 
-### Criticos (bloquean operacion)
+### Críticos (bloquean operación)
 
 | # | Check | Verificacion | Fix sugerido |
 |---|-------|-------------|-------------|
 | 1 | Git repo | `git rev-parse --is-inside-work-tree` | `git init` |
 | 2 | Rama != main | `git branch --show-current` != main | `git checkout -b feat/...` |
-| 3 | settings.json valido | JSON parseable | Regenerar desde template |
+| 3 | settings.json válido | JSON parseable | Regenerar desde template |
 | 4 | CLAUDE.md existe | Fichero presente | `cp CLAUDE.md.template CLAUDE.md` |
-| 5 | CLAUDE.md <= 150 lineas | `wc -l CLAUDE.md` | Refactorizar con @imports |
+| 5 | CLAUDE.md <= 150 líneas | `wc -l CLAUDE.md` | Refactorizar con @imports |
 
 ### Importantes (degradan funcionalidad)
 
@@ -48,9 +48,9 @@ y muestre resultado con acciones correctivas.
 | # | Check | Verificacion | Fix sugerido |
 |---|-------|-------------|-------------|
 | 11 | Scripts ejecutables | `test -x scripts/*.sh` | `chmod +x scripts/*.sh` |
-| 12 | Tests BATS pasan | `bash tests/run-all.sh` (rapido) | Corregir tests |
-| 13 | CHANGELOG integro | Sin marcadores de conflicto | Resolver conflictos |
-| 14 | Backup reciente | Ultimo backup < 7 dias | `/backup now` |
+| 12 | Tests BATS pasan | `bash tests/run-all.sh` (rápido) | Corregir tests |
+| 13 | CHANGELOG íntegro | Sin marcadores de conflicto | Resolver conflictos |
+| 14 | Backup reciente | Último backup < 7 días | `/backup now` |
 
 ## Output
 
@@ -59,7 +59,7 @@ y muestre resultado con acciones correctivas.
   /workspace-doctor — Health Check
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  Criticos .............. 5/5 OK
+  Críticos .............. 5/5 OK
   Importantes ........... 4/5 (1 warning)
   Recomendados .......... 3/4 (1 info)
 
@@ -69,27 +69,27 @@ y muestre resultado con acciones correctivas.
       Impacto: /sprint-status y otros comandos degradados
 
   ── Info ──────────────────────────────
-  #14 Ultimo backup hace 12 dias
+  #14 Último backup hace 12 días
       Fix: /backup now
 
   RESULTADO: 12/14 checks OK
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## Implementacion
+## Implementación
 
 1. Crear `.claude/commands/workspace-doctor.md` con los 14 checks
 2. Crear `scripts/workspace-doctor.sh` para checks deterministas (bash)
 3. El comando orquesta: ejecuta script + interpreta + formatea
-4. Opcion `--fix` para aplicar fixes automaticos donde sea seguro
-5. Opcion `--quick` para solo checks criticos (5 checks, <2s)
+4. Opción `--fix` para aplicar fixes automáticos donde sea seguro
+5. Opción `--quick` para solo checks críticos (5 checks, <2s)
 
-## Integracion
+## Integración
 
-- `session-init.sh` puede sugerir `/workspace-doctor` si detecta anomalia
+- `session-init.sh` puede sugerir `/workspace-doctor` si detecta anomalía
 - `/help` menciona doctor como primer paso ante problemas
-- Ejecutar automaticamente tras `/update` (actualizacion de pm-workspace)
+- Ejecutar automáticamente tras `/update` (actualización de pm-workspace)
 
 ## Esfuerzo estimado
 
-Bajo — 1 dia. La mayoria de checks son comandos bash triviales.
+Bajo — 1 día. La mayoría de checks son comandos bash triviales.

--- a/docs/propuestas/SPEC-032-security-benchmarks.md
+++ b/docs/propuestas/SPEC-032-security-benchmarks.md
@@ -1,7 +1,7 @@
-# SPEC-032: Security Benchmarks — Evaluacion Objetiva de Agentes
+# SPEC-032: Security Benchmarks — Evaluación Objetiva de Agentes
 
 > Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.70
-> Origen: Analisis de usestrix/strix — benchmark XBEN (96% en 104 CTFs)
+> Origen: Análisis de usestrix/strix — benchmark XBEN (96% en 104 CTFs)
 > Impacto: Sin benchmarks no podemos medir ni mejorar nuestros agentes
 
 ---
@@ -11,29 +11,29 @@
 pm-workspace tiene 4 agentes de seguridad (attacker, defender, auditor,
 pentester) pero no hay forma objetiva de medir su efectividad. No sabemos:
 
-- Que % de vulnerabilidades detectan vs las que existen
-- Cuantos falsos positivos generan
-- Si un cambio de prompt mejora o empeora la deteccion
+- Qué % de vulnerabilidades detectan vs las que existen
+- Cuántos falsos positivos generan
+- Si un cambio de prompt mejora o empeora la detección
 - Como comparamos contra herramientas como Strix (96% en XBEN)
 
-Sin benchmarks, cualquier mejora es anecdotica.
+Sin benchmarks, cualquier mejora es anecdótica.
 
-## Solucion
+## Solución
 
 Framework de benchmarks con aplicaciones vulnerables de referencia,
-metricas estandarizadas y ejecucion periodica.
+métricas estandarizadas y ejecución periódica.
 
 ## Targets de referencia
 
 | App | Vulnerabilidades | Stack | Docker |
 |-----|-----------------|-------|--------|
 | OWASP Juice Shop | 100+ challenges | Node.js/Angular | `bkimminich/juice-shop` |
-| DVWA | 14 categorias | PHP/MySQL | `vulnerables/web-dvwa` |
+| DVWA | 14 categorías | PHP/MySQL | `vulnerables/web-dvwa` |
 | WebGoat | 30+ lecciones | Java/Spring | `webgoat/webgoat` |
 
 Empezar con Juice Shop (la mas completa y mantenida).
 
-## Metricas
+## Métricas
 
 ### Detection Rate (principal)
 ```
@@ -50,13 +50,13 @@ fpr = falsos_positivos / total_hallazgos * 100
 
 Un hallazgo es falso positivo si no se puede reproducir contra la app.
 
-### Tiempo de ejecucion
+### Tiempo de ejecución
 ```
 tiempo_total = tiempo_attacker + tiempo_defender + tiempo_auditor
 ```
 
 ### Calidad del reporte
-Evaluacion manual (por ahora): claridad, accionabilidad, precision.
+Evaluación manual (por ahora): claridad, accionabilidad, precisión.
 
 ## Estructura
 
@@ -97,7 +97,7 @@ tests/security-benchmarks/
   detectable_by: [attacker, pentester]
 ```
 
-## Flujo de ejecucion
+## Flujo de ejecución
 
 ```bash
 # 1. Levantar target
@@ -124,7 +124,7 @@ docker compose down
 `/security-benchmark [--target juice-shop|dvwa|webgoat] [--compare {fecha}]`
 
 - Sin `--compare`: ejecuta y muestra resultados
-- Con `--compare`: ejecuta y diff contra ejecucion anterior
+- Con `--compare`: ejecuta y diff contra ejecución anterior
 
 ## Informe de benchmark
 
@@ -148,7 +148,7 @@ docker compose down
     nuclei ................. 8 hallazgos (0m 32s)
     (overlap: 12 hallazgos detectados por 2+ agentes)
 
-  vs ultima ejecucion (2026-03-15):
+  vs última ejecución (2026-03-15):
     Detection rate: +5% (67% -> 72%)
     FPR: -2% (10% -> 8%)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -164,7 +164,7 @@ docker compose down
 ## Esfuerzo estimado
 
 Medio — 1 sprint. Requiere curar la lista de vulns conocidas,
-crear docker-compose, script de orquestacion y formato de reporte.
+crear docker-compose, script de orquestación y formato de reporte.
 
 ## Dependencias
 

--- a/docs/propuestas/SPEC-033-security-skills-modular.md
+++ b/docs/propuestas/SPEC-033-security-skills-modular.md
@@ -1,8 +1,8 @@
 # SPEC-033: Security Skills Modulares
 
 > Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.30
-> Origen: Analisis de usestrix/strix — 10 categorias de skills de seguridad
-> Impacto: Mejora precision de agentes cargando conocimiento relevante
+> Origen: Análisis de usestrix/strix — 10 categorías de skills de seguridad
+> Impacto: Mejora precisión de agentes cargando conocimiento relevante
 
 ---
 
@@ -10,22 +10,22 @@
 
 Nuestros agentes de seguridad (security-attacker, pentester) tienen su
 conocimiento embebido en el prompt del agente. Todo el conocimiento se
-carga siempre, independientemente del tipo de aplicacion o vulnerabilidad.
+carga siempre, independientemente del tipo de aplicación o vulnerabilidad.
 
-Strix tiene 10 categorias de skills que se cargan dinamicamente (max 5
-por sesion) segun el contexto del target. Esto reduce ruido y mejora
-precision.
+Strix tiene 10 categorías de skills que se cargan dinámicamente (max 5
+por sesión) según el contexto del target. Esto reduce ruido y mejora
+precisión.
 
-## Solucion
+## Solución
 
 Extraer el conocimiento de seguridad a skills modulares que se carguen
-segun el stack tecnologico y tipo de aplicacion del proyecto.
+según el stack tecnológico y tipo de aplicación del proyecto.
 
-## Catalogo de skills de seguridad
+## Catálogo de skills de seguridad
 
 ```
 .claude/skills/security-testing/
-  SKILL.md                    -- Indice y protocolo de carga
+  SKILL.md                    -- Índice y protocolo de carga
   DOMAIN.md                   -- Clara Philosophy
   categories/
     injection.md              -- SQLi, NoSQLi, LDAP, OS command
@@ -40,7 +40,7 @@ segun el stack tecnologico y tipo de aplicacion del proyecto.
     cloud-config.md           -- AWS/Azure/GCP misconfigurations
 ```
 
-## Formato por categoria
+## Formato por categoría
 
 ```markdown
 # Injection — Security Skill
@@ -51,21 +51,21 @@ segun el stack tecnologico y tipo de aplicacion del proyecto.
 - OS Command Injection (pipes, backticks, $())
 - LDAP Injection
 
-## Patrones de deteccion
+## Patrones de detección
 - Source: user input (query params, headers, body, cookies)
 - Sink: database query, system call, LDAP query
 - Sanitization check: parameterized queries, prepared statements
 
 ## Por lenguaje
-| Lenguaje | ORM seguro | Patron inseguro |
+| Lenguaje | ORM seguro | Patrón inseguro |
 |----------|-----------|----------------|
 | C#/EF | `.Where(x => x.Id == id)` | `$"SELECT * WHERE id = {id}"` |
 | Java/JPA | `@Query` con `?1` | String concatenation en JPQL |
 | Python/SQLAlchemy | `filter_by(id=id)` | f-string en `text()` |
 | Node/Prisma | `prisma.user.findUnique()` | Raw query con template literal |
 
-## Checklist de verificacion
-- [ ] Todas las queries usan parametros vinculados
+## Checklist de verificación
+- [ ] Todas las queries usan parámetros vinculados
 - [ ] Input validation en boundaries (controllers)
 - [ ] No hay eval/exec con input del usuario
 - [ ] Logging no incluye payloads del usuario sin sanitizar
@@ -76,7 +76,7 @@ segun el stack tecnologico y tipo de aplicacion del proyecto.
 Al iniciar un scan de seguridad:
 
 1. Detectar stack del proyecto (Language Pack)
-2. Detectar tipo de aplicacion (web API, SPA, mobile backend, CLI)
+2. Detectar tipo de aplicación (web API, SPA, mobile backend, CLI)
 3. Seleccionar categories relevantes:
 
 | Tipo de app | Categories a cargar |
@@ -87,34 +87,34 @@ Al iniciar un scan de seguridad:
 | Microservicios | injection, api-security, infrastructure, cloud-config |
 | CLI/scripts | injection, supply-chain |
 
-4. Max 5 categories por sesion (limite de contexto)
+4. Max 5 categories por sesión (límite de contexto)
 5. Categories se cargan como contexto adicional del agente
 
-## Integracion con agentes
+## Integración con agentes
 
 ```yaml
 # En el prompt del security-attacker:
 # Antes: conocimiento generico embebido (~3000 tokens)
-# Despues: skill index (~200 tokens) + categories relevantes (~1500 tokens)
-# Ahorro: ~1300 tokens + mayor precision por relevancia
+# Después: skill index (~200 tokens) + categories relevantes (~1500 tokens)
+# Ahorro: ~1300 tokens + mayor precisión por relevancia
 ```
 
 El agente recibe:
-- SKILL.md (indice, ~200 tokens)
+- SKILL.md (índice, ~200 tokens)
 - 3-5 categories seleccionadas (~300 tokens cada una)
 - Total: ~1700 tokens vs ~3000 tokens actuales
 
-## Metricas de exito
+## Métricas de éxito
 
 - Detection rate en benchmarks (SPEC-032): mejora >= 5%
-- False positive rate: reduccion >= 10%
-- Tokens por scan: reduccion >= 30%
+- False positive rate: reducción >= 10%
+- Tokens por scan: reducción >= 30%
 
-## Evolucion
+## Evolución
 
 Las categories se enriquecen con hallazgos reales:
-- Cada vuln encontrada en un proyecto real anade un patron al skill
-- Patron de public-agent-memory: conocimiento generico, en git
+- Cada vuln encontrada en un proyecto real añade un patrón al skill
+- Patrón de public-agent-memory: conocimiento genérico, en git
 - Review trimestral para podar patrones obsoletos
 
 ## Esfuerzo estimado
@@ -125,4 +125,4 @@ categories, adaptar prompts de agentes, verificar con benchmarks.
 ## Dependencias
 
 - SPEC-032 (Benchmarks) para medir impacto
-- agent-context-budget.md para respetar limites de tokens
+- agent-context-budget.md para respetar límites de tokens

--- a/docs/propuestas/SPEC-035-hybrid-search.md
+++ b/docs/propuestas/SPEC-035-hybrid-search.md
@@ -2,38 +2,38 @@
 
 > Status: **DRAFT** · Fecha: 2026-03-23 · Score: 4.55
 > Origen: LightRAG (30K stars) — dual graph+vector RAG
-> Impacto: Responder preguntas relacionales que la busqueda lineal no puede
+> Impacto: Responder preguntas relacionales que la búsqueda lineal no puede
 
 ---
 
 ## Problema
 
-SPEC-018 (vector memory) permite buscar por similitud semantica.
+SPEC-018 (vector memory) permite buscar por similitud semántica.
 SPEC-027 (graph memory) extrae entidades y relaciones. Pero no hay
-busqueda combinada: "que decisiones afectan al modulo de pagos y
-quien las tomo?" requiere recorrer el grafo Y buscar por similitud.
+búsqueda combinada: "qué decisiones afectan al módulo de pagos y
+quién las tomó?" requiere recorrer el grafo Y buscar por similitud.
 
-LightRAG demuestra que la combinacion graph+vector mejora el recall
+LightRAG demuestra que la combinación graph+vector mejora el recall
 significativamente en preguntas relacionales.
 
 ## Principio inmutable
 
-**Los .md son la fuente de verdad.** Los indices vectoriales y el grafo
-son caches derivadas que se reconstruyen con `memory-vector.py` y
+**Los .md son la fuente de verdad.** Los índices vectoriales y el grafo
+son cachés derivadas que se reconstruyen con `memory-vector.py` y
 `memory-graph.py`. Si se pierden, `--rebuild` los regenera.
 
-## Solucion
+## Solución
 
-Combinar los dos sistemas existentes en una busqueda unificada.
+Combinar los dos sistemas existentes en una búsqueda unificada.
 
-### Modos de busqueda
+### Modos de búsqueda
 
-| Modo | Metodo | Cuando usar |
+| Modo | Método | Cuándo usar |
 |------|--------|-------------|
-| `vector` | Solo similitud coseno | Busqueda por concepto suelto |
-| `graph` | Solo recorrido de relaciones | Busqueda por entidad concreta |
+| `vector` | Solo similitud coseno | Búsqueda por concepto suelto |
+| `graph` | Solo recorrido de relaciones | Búsqueda por entidad concreta |
 | `hybrid` | Vector + graph + reranker | Default — mejor recall |
-| `naive` | Grep en .md (fallback) | Sin indices disponibles |
+| `naive` | Grep en .md (fallback) | Sin índices disponibles |
 
 ### Flujo hybrid
 
@@ -43,7 +43,7 @@ Combinar los dos sistemas existentes en una busqueda unificada.
 3. Graph search: entidades mencionadas → vecinos 2-hop (SPEC-027)
 4. Merge: union de resultados (dedup por source file)
 5. Rerank: cross-encoder ordena por relevancia (SPEC-028)
-6. Return: top-5 con source file y linea
+6. Return: top-5 con source file y línea
 ```
 
 ### Fallback chain
@@ -55,21 +55,21 @@ vector disponible? → usar vector
   ↓ no
 graph disponible? → usar graph
   ↓ no
-grep en .md → siempre funciona (soberania)
+grep en .md → siempre funciona (soberanía)
 ```
 
-## Implementacion
+## Implementación
 
 1. Extender `scripts/memory-search.sh` con `--mode hybrid|vector|graph|naive`
 2. Crear `scripts/memory-hybrid.py` que combine vector + graph
 3. Reutilizar cross-encoder de SPEC-028 para reranking
-4. Default: hybrid si indices existen, naive si no
-5. `/memory-recall` usa hybrid automaticamente
+4. Default: hybrid si índices existen, naive si no
+5. `/memory-recall` usa hybrid automáticamente
 
-## Integracion con temporalidad (SPEC-034)
+## Integración con temporalidad (SPEC-034)
 
-La busqueda hybrid respeta `valid_to`:
-- Resultados con `valid_to < hoy` se marcan como `[historico]`
+La búsqueda hybrid respeta `valid_to`:
+- Resultados con `valid_to < hoy` se marcan como `[histórico]`
 - Por defecto solo resultados vigentes
 - Flag `--include-historical` para ver todo
 

--- a/docs/propuestas/SPEC-036-agent-evaluation.md
+++ b/docs/propuestas/SPEC-036-agent-evaluation.md
@@ -12,7 +12,7 @@ pm-workspace tiene 46 agentes pero no mide su calidad objetivamente.
 No sabemos si un agente alucina, si un cambio de prompt degrada el
 output, ni si el Equality Shield realmente elimina sesgos.
 
-DeepEval y Giskard resuelven esto con metricas G-Eval, deteccion de
+DeepEval y Giskard resuelven esto con métricas G-Eval, detección de
 alucinaciones y benchmarks de sesgos.
 
 ## Principio inmutable
@@ -21,39 +21,39 @@ alucinaciones y benchmarks de sesgos.
 en `output/evals/` y `tests/evals/`, no en bases de datos externas.
 Reproducibles con un solo comando.
 
-## Solucion
+## Solución
 
-Framework de evaluacion que mide 4 dimensiones por agente.
+Framework de evaluación que mide 4 dimensiones por agente.
 
 ### Dimensiones
 
-| Dimension | Metrica | Herramienta |
+| Dimensión | Métrica | Herramienta |
 |-----------|---------|-------------|
-| Precision | Hallazgos correctos vs falsos positivos | Golden set por agente |
+| Precisión | Hallazgos correctos vs falsos positivos | Golden set por agente |
 | Coherencia | Output alineado con spec/objetivo | coherence-validator |
 | Sesgo | Test contrafactual (Equality Shield) | bias-check mecanizado |
-| Alucinacion | Afirmaciones sin soporte en context | Verificacion contra fuentes |
+| Alucinación | Afirmaciones sin soporte en context | Verificación contra fuentes |
 
 ### Golden sets (test fixtures)
 
-Cada agente critico tiene un golden set en `tests/evals/{agente}/`:
+Cada agente crítico tiene un golden set en `tests/evals/{agente}/`:
 
 ```
 tests/evals/
   security-attacker/
-    input-01.md          -- Codigo con SQL injection conocida
-    expected-01.yaml     -- Hallazgo esperado (CWE-89, linea, severidad)
-    input-02.md          -- Codigo limpio (no debe encontrar nada)
+    input-01.md          -- Código con SQL injection conocida
+    expected-01.yaml     -- Hallazgo esperado (CWE-89, línea, severidad)
+    input-02.md          -- Código limpio (no debe encontrar nada)
     expected-02.yaml     -- Hallazgo esperado: ninguno
   code-reviewer/
     input-01.diff        -- Diff con secret hardcodeado
-    expected-01.yaml     -- REJECT con mencion de secret
+    expected-01.yaml     -- REJECT con mención de secret
   business-analyst/
     input-01.md          -- PBI ambiguo
-    expected-01.yaml     -- Preguntas de clarificacion esperadas
+    expected-01.yaml     -- Preguntas de clarificación esperadas
 ```
 
-### Metricas por evaluacion
+### Métricas por evaluación
 
 ```yaml
 eval_result:
@@ -68,7 +68,7 @@ eval_result:
     hallucinations: 0     # afirmaciones sin soporte
     bias_score: 0.0       # 0 = sin sesgo detectado
   comparison:
-    vs_previous: "+3% precision, -1% recall"
+    vs_previous: "+3% precisión, -1% recall"
 ```
 
 ### Comando
@@ -76,34 +76,34 @@ eval_result:
 `/eval-agent {agente} [--compare {fecha}]`
 
 - Ejecuta el golden set contra el agente
-- Calcula metricas
-- Compara con ejecucion anterior
+- Calcula métricas
+- Compara con ejecución anterior
 - Guarda resultado en `output/evals/{agente}/{fecha}.yaml`
 
-### Deteccion de regresion
+### Detección de regresión
 
-Si precision o recall bajan >10% vs evaluacion anterior:
+Si precisión o recall bajan >10% vs evaluación anterior:
 ```
-REGRESION DETECTADA en {agente}
-  Precision: 85% -> 72% (-13%)
+REGRESIÓN DETECTADA en {agente}
+  Precisión: 85% -> 72% (-13%)
   Causa probable: cambio de prompt en Era {N}
-  Accion: revisar commit {hash} que modifico el agente
+  Acción: revisar commit {hash} que modificó el agente
 ```
 
-## Integracion con SPEC-032 (Security Benchmarks)
+## Integración con SPEC-032 (Security Benchmarks)
 
-SPEC-032 es un caso especifico de este framework:
+SPEC-032 es un caso específico de este framework:
 - Golden set = vulnerabilidades conocidas de Juice Shop
 - Agentes evaluados = security-attacker + pentester + nuclei
-- Metricas = detection rate + false positive rate
+- Métricas = detection rate + false positive rate
 
 ## Esfuerzo
 
 Alto — 2 sprints. Requiere crear golden sets (curado manual),
-implementar framework de ejecucion, y calibrar metricas.
+implementar framework de ejecución, y calibrar métricas.
 
 ## Dependencias
 
 - SPEC-032 (Security Benchmarks) como primer caso de uso
-- eval-criteria.md (existente) para metricas G-Eval
-- consensus-protocol.md (existente) para validacion cruzada
+- eval-criteria.md (existente) para métricas G-Eval
+- consensus-protocol.md (existente) para validación cruzada

--- a/docs/propuestas/SPEC-038-knowledge-domain-routing.md
+++ b/docs/propuestas/SPEC-038-knowledge-domain-routing.md
@@ -1,30 +1,30 @@
 # SPEC-038: Knowledge Domain Routing — Equipos de Memoria
 
 > Status: **APPROVED** · Fecha: 2026-03-24 · Score: 4.8
-> Origen: Monica (insight de gestion de equipos humanos por dominio)
-> Impacto: Busquedas de memoria 3-5x mas rapidas, resultados mas relevantes
+> Origen: Monica (insight de gestión de equipos humanos por dominio)
+> Impacto: Búsquedas de memoria 3-5x más rápidas, resultados más relevantes
 
 ---
 
 ## Problema
 
 La memoria de Savia busca en TODO el store (grep lineal, vector full-scan,
-graph full-traversal). Con 100+ entradas es manejable, con 1000+ sera lento.
+graph full-traversal). Con 100+ entradas es manejable, con 1000+ será lento.
 Peor: resultados de dominios irrelevantes contaminan el ranking.
 
 Cuando un equipo humano necesita una respuesta sobre seguridad, pregunta al
-equipo de seguridad — no a toda la empresa. La memoria de Savia deberia
+equipo de seguridad — no a toda la empresa. La memoria de Savia debería
 funcionar igual.
 
 ## Principio inmutable
 
-**Los dominios se derivan del contenido .md/JSONL, no al reves.** El domain
-index es una capa de aceleracion que se reconstruye desde la fuente de verdad.
+**Los dominios se derivan del contenido .md/JSONL, no al revés.** El domain
+index es una capa de aceleración que se reconstruye desde la fuente de verdad.
 
-## Solucion
+## Solución
 
 Capa intermedia de **Knowledge Domains** que clasifica cada entrada de memoria
-y enruta las busquedas al subconjunto correcto.
+y enruta las búsquedas al subconjunto correcto.
 
 ### Taxonomia de dominios
 
@@ -39,10 +39,10 @@ y enruta las busquedas al subconjunto correcto.
 | memory | context, compact, search, vector, graph | memory commands | config/* |
 | product | PBI, story, epic, discovery, JTBD, PRD | BA, PO commands | product/* |
 
-### Flujo de busqueda con routing
+### Flujo de búsqueda con routing
 
 ```
-Query: "SQL injection en el modulo de auth"
+Query: "SQL injection en el módulo de auth"
   |
   v
 [Domain Classifier] → score: security=0.95, architecture=0.30
@@ -71,35 +71,35 @@ Fichero derivado: `output/.memory-domain-index.json`
 
 Se reconstruye con: `python3 scripts/memory-domains.py rebuild`
 
-### Clasificacion de queries
+### Clasificación de queries
 
-Keyword matching con pesos (rapido, sin LLM):
+Keyword matching con pesos (rápido, sin LLM):
 1. Extraer keywords del query
 2. Match contra tabla de dominios (regex)
 3. Score por dominio (0-1)
 4. Seleccionar top 1-2 dominios (>0.5)
-5. Si ninguno >0.5: busqueda full (sin filtro)
+5. Si ninguno >0.5: búsqueda full (sin filtro)
 
-### Clasificacion de entradas
+### Clasificación de entradas
 
-Al guardar (save), asignar dominio automaticamente:
+Al guardar (save), asignar dominio automáticamente:
 1. Por topic_key prefix: `security/*` → security
 2. Por concepts tag: `["testing"]` → quality
 3. Por keywords en title/content
 4. Default: buscar en tabla, si no match → "general"
 
-## Metricas de benchmark
+## Métricas de benchmark
 
-Medir antes y despues:
-- **Tiempo de busqueda**: ms por query
-- **Precision@5**: relevancia de los top 5 resultados
+Medir antes y después:
+- **Tiempo de búsqueda**: ms por query
+- **Precisión@5**: relevancia de los top 5 resultados
 - **Noise ratio**: resultados irrelevantes en top 10
 - **Domain accuracy**: % de queries correctamente clasificadas
 
 ## Esfuerzo
 
-Medio — 1 sprint. El clasificador es keyword-based (rapido de implementar).
-El indice es un JSON derivado. La integracion con hybrid search es un filtro.
+Medio — 1 sprint. El clasificador es keyword-based (rápido de implementar).
+El índice es un JSON derivado. La integración con hybrid search es un filtro.
 
 ## Dependencias
 

--- a/docs/propuestas/SPEC-040-memory-research-experiments.md
+++ b/docs/propuestas/SPEC-040-memory-research-experiments.md
@@ -1,60 +1,60 @@
 # SPEC-040: Memory Research Experiments — I+D en Memoria Agentica
 
 > Status: **IN PROGRESS** · Fecha: 2026-03-24
-> Tipo: Investigacion experimental con benchmarks
-> Objetivo: Frontier en gestion de contexto para entrar en etapa de innovacion
+> Tipo: Investigación experimental con benchmarks
+> Objetivo: Frontier en gestión de contexto para entrar en etapa de innovación
 
 ---
 
 ## Motivacion
 
 pm-workspace tiene 6 SPECs de memoria integrados (034-039). La base es
-solida. Ahora necesitamos metodos cientificos para empujar mas alla de
-lo que el ecosistema ofrece. Tres experimentos, cada uno con hipotesis,
-metodo y metricas verificables.
+sólida. Ahora necesitamos métodos científicos para empujar más allá de
+lo que el ecosistema ofrece. Tres experimentos, cada uno con hipótesis,
+método y métricas verificables.
 
 ---
 
 ## EXP-01: Curva de Olvido de Ebbinghaus para Memoria Agentica
 
-**Hipotesis:** Las memorias accedidas con espaciado temporal se
+**Hipótesis:** Las memorias accedidas con espaciado temporal se
 fortalecen; las no accedidas decaen exponencialmente. Aplicar esta
-curva al scoring mejora precision@5 en >15% vs scoring lineal.
+curva al scoring mejora precisión@5 en >15% vs scoring lineal.
 
-**Base cientifica:** Ebbinghaus (1885) demostro que la retencion
+**Base científica:** Ebbinghaus (1885) demostró que la retención
 decae como R = e^(-t/S) donde S es la fuerza de la memoria (crece
 con cada acceso espaciado). SM-2 (SuperMemo) usa este principio
-para optimizar intervalos de revision.
+para optimizar intervalos de revisión.
 
-**Metodo:**
+**Método:**
 1. Cada entrada tiene: `access_count`, `last_accessed`, `strength`
 2. Al acceder: strength += 0.4 * (1 - strength) [refuerzo decreciente]
 3. Al no acceder: strength *= e^(-days/half_life)
-4. half_life se adapta: mas accesos → half_life mas largo
+4. half_life se adapta: más accesos → half_life más largo
 5. prime_score usa strength como factor multiplicador
 
-**Formula:**
+**Fórmula:**
 ```
 strength_decay = e^(-days_since_access / half_life)
 half_life = base_half_life * (1 + ln(1 + access_count))
-base_half_life = 7 dias (configurable por sector cognitivo)
+base_half_life = 7 días (configurable por sector cognitivo)
 ```
 
-**Metrica:** precision@5 en test set de 20 queries vs scoring actual.
+**Métrica:** precisión@5 en test set de 20 queries vs scoring actual.
 
 ---
 
 ## EXP-02: Prediccion de Secuencias de Workflow (Prefetch Cache)
 
-**Hipotesis:** Los workflows PM son repetitivos. Si registramos
+**Hipótesis:** Los workflows PM son repetitivos. Si registramos
 secuencias comando→comando, podemos predecir el siguiente contexto
 necesario con >70% accuracy en top-3.
 
-**Base cientifica:** Modelos de Markov de orden 1-2 capturan patrones
-secuenciales. Como el prefetch de CPU que carga la siguiente linea
-de cache antes de que se pida.
+**Base científica:** Modelos de Markov de orden 1-2 capturan patrones
+secuenciales. Como el prefetch de CPU que carga la siguiente línea
+de caché antes de que se pida.
 
-**Metodo:**
+**Método:**
 1. Registrar pares (comando_actual, comando_siguiente) en log
 2. Construir tabla de transiciones con probabilidades
 3. Dado comando actual, predecir top-3 siguientes
@@ -64,29 +64,29 @@ de cache antes de que se pida.
 ya documentan secuencias reales (PM: sprint-status → team-workload →
 board-flow). Usarlos como ground truth.
 
-**Metrica:** top-3 accuracy en secuencias conocidas de role-workflows.md.
+**Métrica:** top-3 accuracy en secuencias conocidas de role-workflows.md.
 
 ---
 
-## EXP-03: Consolidacion Semantica (Compresion de Memoria)
+## EXP-03: Consolidación Semántica (Compresión de Memoria)
 
-**Hipotesis:** Memorias similares pueden fusionarse sin perder
-informacion recuperable. La consolidacion reduce el store en >30%
-manteniendo precision@5 en >90% del nivel original.
+**Hipótesis:** Memorias similares pueden fusionarse sin perder
+información recuperable. La consolidación reduce el store en >30%
+manteniendo precisión@5 en >90% del nivel original.
 
-**Base cientifica:** La consolidacion de memoria durante el sueno
-(Diekelmann & Born, 2010) transforma recuerdos episodicos en
-semanticos. Las memorias redundantes se fusionan en representaciones
-mas compactas.
+**Base científica:** La consolidación de memoria durante el sueño
+(Diekelmann & Born, 2010) transforma recuerdos episódicos en
+semánticos. Las memorias redundantes se fusionan en representaciones
+más compactas.
 
-**Metodo:**
+**Método:**
 1. Calcular similaridad entre pares de entradas (jaccard de keywords)
 2. Si similaridad > 0.6 y mismo dominio → candidatos a merge
-3. Merge: titulo del mas reciente, contenido combinado, rev sumados
+3. Merge: título del más reciente, contenido combinado, rev sumados
 4. Marcar originales con valid_to (SPEC-034)
-5. Comparar busqueda pre/post consolidacion
+5. Comparar búsqueda pre/post consolidación
 
-**Metrica:** store size reduction + precision@5 post-consolidation.
+**Métrica:** store size reduction + precisión@5 post-consolidation.
 
 ---
 

--- a/docs/savia-flow/01-whitepaper-savia-flow.md
+++ b/docs/savia-flow/01-whitepaper-savia-flow.md
@@ -15,7 +15,7 @@ Durante tres décadas, Scrum ha sido la metodología de facto para equipos de de
 Gartner proyecta que el 80% de las organizaciones transformarán sus equipos con IA para 2030, con un gasto global de $2.52 billones anuales en IA. El 40% de las aplicaciones empresariales tendrán agentes de IA integrados. Yet, 80% of organizations see no measurable business impact from their AI investments—una paradoja costosa.
 
 ### El Problema
-Scrum fue diseñado para equipos completamente humanos, con ceremoni replicadas frecuencia fija y métricasbasadas en estimaciones (story points) que suponen predictibilidad humana. Los equipos que colaboran con asistentes de IA enfrentan tres desajustes críticos:
+Scrum fue diseñado para equipos completamente humanos, con ceremonias replicadas frecuencia fija y métricas basadas en estimaciones (story points) que suponen predictibilidad humana. Los equipos que colaboran con asistentes de IA enfrentan tres desajustes críticos:
 
 1. **Tiempo Fijo vs. Velocidad Variable:** Sprints de dos semanas asumen consistencia; IA reduce el tiempo de algunas tareas de semanas a horas, introduciendo volatilidad.
 
@@ -61,17 +61,17 @@ Con IA generativa, la velocidad es impredecible:
 
 El resultado: planificar por sprints introduce una fricción artificial. Los equipos terminar tareas en 3 días pero "deben esperar" a la siguiente iteración para comprometerlas. O por el contrario, sobrestiman lo que IA puede hacer en tiempo fijo porque desconocen sus límites reales.
 
-**Datos:** Equipos DORA "Elite" ya desployan múltiples veces por día. Mantener sprints de dos semanas es retroceder.
+**Datos:** Equipos DORA "Elite" ya despliegan múltiples veces por día. Mantener sprints de dos semanas es retroceder.
 
 #### Desajuste 2: Ceremonias Humanas vs. Equipos Híbridos
 
-Las ceremoni de Scrum asumen que todos los participantes pueden estar presentes simultáneamente y que la comunicación síncrona es normal:
+Las ceremonias de Scrum asumen que todos los participantes pueden estar presentes simultáneamente y que la comunicación síncrona es normal:
 
 - **Daily Standup (15 min):** Asume 5-8 humanos reportando. Con IA, hay agentes especializados que trabajan asincronamente. Una daily es ineficiente o se convierte en "teatro agile" donde nadie entiende qué hace la IA.
 
 - **Sprint Planning (4 horas):** Asume que el esfuerzo estimado por punto es consistente. Con IA, "estimar" es especular sobre capacidades de lenguaje que varían diariamente.
 
-- **Retrospective (1.5 horas):** Diseñada para equipos que comparten un contexto humano común. Con IA, retrospeccivasdeberían enfocarse en gobernanza de agentes, calidad del output, y colaboración humano-máquina—temas distintos.
+- **Retrospective (1.5 horas):** Diseñada para equipos que comparten un contexto humano común. Con IA, retrospectivas deberían enfocarse en gobernanza de agentes, calidad del output, y colaboración humano-máquina—temas distintos.
 
 **Datos:** Encuestas de 2025 muestran que el 63% de equipos ágiles considera las reuniones como el mayor desperdicio de tiempo; la adopción de IA amplifica esto.
 
@@ -79,7 +79,7 @@ Las ceremoni de Scrum asumen que todos los participantes pueden estar presentes 
 
 La métrica "velocidad" (puntos completados por sprint) es la raíz de muchos problemas en IA:
 
-1. **Gameable:** Los equipos aprender rápidamente que pueden inflar puntos para parecer "más rápidos". Con IA, es aún más fácil—un agente puede generar 10k líneas de código "rápidamente", pero el 60% requiere reescritura humana.
+1. **Gameable:** Los equipos aprenden rápidamente que pueden inflar puntos para parecer "más rápidos". Con IA, es aún más fácil—un agente puede generar 10k líneas de código "rápidamente", pero el 60% requiere reescritura humana.
 
 2. **No correlaciona con valor:** Un proyecto puede "completar" 300 puntos de story pero entregar cero valor si el output de IA se enfoca en cosas equivocadas.
 
@@ -176,7 +176,7 @@ Savia Flow no es inventado de cero. Es una síntesis de cinco generaciones de pe
 ### 2.3 La Síntesis: Savia Flow
 
 Savia Flow toma lo mejor de cada generación:
-- **De Scrum:** Roles claros y ceremoni adaptadas (no eliminadas)
+- **De Scrum:** Roles claros y ceremonias adaptadas (no eliminadas)
 - **De Flujo:** Métricas continuas, WIP limits, ciclo de lead time
 - **De Shape Up:** Especificaciones como herramienta, ciclos realistas
 - **De DORA:** Las 4 métricas primarias como brújula de rendimiento
@@ -248,7 +248,7 @@ Un equipo de fintech enfrenta tasa de abandono alta en onboarding de cuentas de 
 
 **Métrica que Importa:**
 - Tasa de completion: +42% (vs objetivo 40%) ✓
-- Revenue impact: +$2.3M anuales (10% mas clientes completados)
+- Revenue impact: +$2.3M anuales (10% más clientes completados)
 
 #### Métrica Clave: Outcome Achievement Rate
 - % de outcomes completados vs. planificados (target: >85%)
@@ -265,7 +265,7 @@ El trabajo fluye continuamente del backlog a completitud, sin necesidad de cerem
 #### Rationale
 Scrum asume que un contenedor de tiempo fijo (sprint) reduce riesgo. Con IA, el riesgo proviene de especificaciones débiles o arquitectura defectuosa, no de "perder tiempo". Encapsular en sprints introduce fricción innecesaria.
 
-DORA data muestra que elite performers desployan múltiples veces por día. Mantener sprints de 2 semanas es retroceder 15 años.
+DORA data muestra que elite performers despliegan múltiples veces por día. Mantener sprints de 2 semanas es retroceder 15 años.
 
 #### Cómo Funciona en Práctica
 
@@ -309,7 +309,7 @@ Equipo de analytics que típicamente trabaja en 2-semana sprints.
 - Daily (15 min × 10 días) = 2.5 hrs
 - Viernes 2pm: Review (1.5 hrs)
 - Viernes 3:30pm: Retro (1.5 hrs)
-- **Total tiempo en ceremoni: 9 horas**
+- **Total tiempo en ceremonias: 9 horas**
 - **Tiempo construcción real: ~35 horas**
 
 **Semana típica Savia Flow:**
@@ -317,7 +317,7 @@ Equipo de analytics que típicamente trabaja en 2-semana sprints.
 - Async: Especificación escrita
 - Flujo: Builders construyen, ai QA valida continuamente
 - Cuando está ready: Demo a stakeholder
-- **Total tiempo en ceremoni: ~1 hora** (async stand-in via dashboard)
+- **Total tiempo en ceremonias: ~1 hora** (async stand-in via dashboard)
 - **Tiempo construcción real: ~39 horas**
 
 **Resultado:**
@@ -1011,7 +1011,7 @@ Adicionales para equipos con heavy IA usage:
 | AI Code Coverage | % de líneas de código generadas por IA | 40-60% |
 | AI QA Gate Pass Rate | % de code generado por IA que pasa gates sin cambios humanos | >70% |
 | Rework Rate | % de AI code que requiere reescritura humana significativa | <20% |
-| Specification Clarity Score | % de ambigüedades découvert en QA / specs | <5% |
+| Specification Clarity Score | % de ambigüedades descubiertas en QA / specs | <5% |
 
 ---
 
@@ -2021,7 +2021,7 @@ El futuro de la gestión de proyectos en era de IA evoluciona en tres direccione
 
 **Año 2027:**
 - Multi-agent orchestration es normal (15+ agentes en gates)
-- Outcome-driven orientation reemplaza velocity en la mayoría de equipos
+- Outcome-driven orientation reemplaza velocity en la mayoría de los equipos
 - Métricas DORA son baseline compliance, no innovación
 
 **Año 2028:**
@@ -2041,7 +2041,7 @@ En 2030, imaginamos equipos que:
 - PMs tienen intuición de data + human empathy
 - QA Architects supervisan agentes, no escriben tests
 
-**El éxito será medido no por ceremonias asistidas, sino por outcomes realizado.**
+**El éxito será medido no por ceremonias asistidas, sino por outcomes realizados.**
 
 ---
 

--- a/docs/savia-flow/04-roles-evolucionados.md
+++ b/docs/savia-flow/04-roles-evolucionados.md
@@ -675,7 +675,7 @@ Director of Quality (5+ years)
 
 | Competencia | Scrum Master | Flow Facilitator | Brecha | Desarrollo |
 |-----------|---|---|---|---|
-| Faciliación | Fuerte | Fuerte | Bajo | Mantener |
+| Facilitación | Fuerte | Fuerte | Bajo | Mantener |
 | Métricas DORA | Débil | Fuerte | Alto | Training + dashboard practice |
 | Coaching | Fuerte | Fuerte | Bajo | Refocarse en coaching |
 | Estadística | Débil | Fuerte | Alto | Data analysis training |

--- a/docs/savia-flow/06-spec-driven-development.md
+++ b/docs/savia-flow/06-spec-driven-development.md
@@ -540,7 +540,7 @@ Spec-Driven Development transforma cómo building sucede:
 - Rework disminuye dramáticamente
 - Quality mejora naturalmente
 
-**Para PMs:** SDD significa gastar más tiempo en pensamiento profundo (outco­mes, métricas) y menos tiempo en refinar historias vagas.
+**Para PMs:** SDD significa gastar más tiempo en pensamiento profundo (outcomes, métricas) y menos tiempo en refinar historias vagas.
 
 **Para builders:** SDD significa más claridad, menos adivinanzas, menos rework.
 

--- a/docs/savia-flow/07-quality-gates-autonomos.md
+++ b/docs/savia-flow/07-quality-gates-autonomos.md
@@ -429,7 +429,7 @@ Investigation:
 
 ### Gate Pass-Through Rate
 
-**Definición:** % de code que passa gates na primeira tentativa
+**Definición:** % de código que pasa los gates en el primer intento
 
 ```
 Target Savia Flow: >75%
@@ -439,7 +439,7 @@ Calculation:
 ├─ Pass-through: 15/20 = 75% ✓
 
 Meaning:
-├─ 75% passed na primeira tentativa (good)
+├─ 75% passed in first attempt (good)
 ├─ 25% required fixes/resubmission (acceptable)
 ├─ If <50%: Gates too strict or IA quality low
 ├─ If >90%: Possible gates too lenient
@@ -447,7 +447,7 @@ Meaning:
 
 ### Mean Time to Fix (MTTF)
 
-**Definição:** Tempo médio para um builder corrigir uma rejeição de gate
+**Definición:** Tiempo promedio para que un builder corrija un rechazo de gate
 
 ```
 Target Savia Flow: <30 minutos
@@ -583,7 +583,7 @@ Architects overwhelmed with reviews
 
 ## Conclusión
 
-Autonomous Quality Gates são o futuro do controle de qualidade com IA:
+Autonomous Quality Gates son el futuro del control de calidad con IA:
 
 1. **Level 1-4:** Automated validation (instant feedback)
 2. **Level 5:** Human judgment (lightweight, focused)
@@ -598,4 +598,4 @@ Autonomous Quality Gates são o futuro do controle de qualidade com IA:
 
 ---
 
-**Comienza com Levels 1-2 esta semana. Adiciona Levels 3-5 progressivamente.**
+**Comienza con Levels 1-2 esta semana. Agrega Levels 3-5 progresivamente.**

--- a/docs/savia-flow/08-casos-uso-por-vertical.md
+++ b/docs/savia-flow/08-casos-uso-por-vertical.md
@@ -19,7 +19,7 @@ Aunque Savia Flow es agnóstica del dominio, cada sector tiene desafíos únicos
 
 ```
 Regulatory:
-├─ HIPAA: Protected Health Information (PHI) strictamente regulado
+├─ HIPAA: Protected Health Information (PHI) estrictamente regulado
 ├─ FDA (si es medical device): Multi-year approval cycles
 ├─ GDPR: Si maneja datos europeos
 ├─ State regulations: CCPA, HIPAA state variants

--- a/docs/savia-shield.md
+++ b/docs/savia-shield.md
@@ -213,32 +213,32 @@ detectando patrones que se forman al juntar ambas escrituras.
 ### Contenido conversacional (prompts al asistente IA)
 
 La Capa 4 (masking reversible) permite enmascarar texto ANTES de pegarlo
-en el chat. El NER hook escanea ficheros que el asistente lee. Formacion:
+en el chat. El NER hook escanea ficheros que el asistente lee. Formación:
 los usuarios referencian ficheros por ruta en vez de copiar contenido.
-Limite residual: no hay interceptacion tecnica del texto que el usuario
-escribe directamente en el prompt — requiere integracion a nivel de
+Límite residual: no hay interceptación técnica del texto que el usuario
+escribe directamente en el prompt — requiere integración a nivel de
 protocolo (mejora futura).
 
 ### Prompt injection en el clasificador local
 
 Triple defensa: (1) delimitadores [BEGIN/END DATA], (2) sandwich defense
-con instruccion repetida post-datos, (3) validacion estricta de output
-(respuesta no valida = CONFIDENTIAL automatico). Temperature=0 y
+con instrucción repetida post-datos, (3) validación estricta de output
+(respuesta no válida = CONFIDENTIAL automático). Temperature=0 y
 num_predict=5 limitan la superficie de ataque.
 
-### Precision del NER en espanol
+### Precisión del NER en español
 
-Escaneo dual ES+EN: NER ejecuta el analisis en ambos idiomas y combina
-resultados. GLOSSARY-MASK.md carga entidades especificas del proyecto
-como deny-list (score 1.0, deteccion garantizada).
+Escaneo dual ES+EN: NER ejecuta el análisis en ambos idiomas y combina
+resultados. GLOSSARY-MASK.md carga entidades específicas del proyecto
+como deny-list (score 1.0, detección garantizada).
 
 ---
 
-## Documentacion tecnica (EN, para comite de seguridad)
+## Documentación técnica (EN, para comité de seguridad)
 
-- `docs/data-sovereignty-architecture.md` — Arquitectura tecnica
+- `docs/data-sovereignty-architecture.md` — Arquitectura técnica
 - `docs/data-sovereignty-operations.md` — Compliance y riesgo
-- `docs/data-sovereignty-auditability.md` — Guia de auditoria
+- `docs/data-sovereignty-auditability.md` — Guía de auditoría
 - `docs/data-sovereignty-finetune-plan.md` — Plan de modelo fine-tuned
 
 ---
@@ -250,5 +250,5 @@ como deny-list (score 1.0, deteccion garantizada).
 - jq instalado (para JSON parsing)
 - Python 3.12+ (para masking y NER)
 - Presidio (`pip install presidio-analyzer`) — para Capa 1.5 NER
-- spaCy modelo espanol (`python3 -m spacy download es_core_news_md`)
+- spaCy modelo español (`python3 -m spacy download es_core_news_md`)
 - 8 GB RAM mínimo (16+ recomendado)

--- a/projects/savia-web/backlog/_config.yaml
+++ b/projects/savia-web/backlog/_config.yaml
@@ -6,7 +6,7 @@ pbi:
   types: [User Story, Bug, Tech Debt, Spike]
   priorities: [1-Critical, 2-High, 3-Medium, 4-Low]
   id_prefix: "PBI"
-  id_counter: 41
+  id_counter: 47
 tasks:
   states: [New, Active, In Review, Done, Blocked]
   types: [Development, Testing, Documentation, Design, DevOps]

--- a/projects/savia-web/backlog/pbi/PBI-042-test-item.md
+++ b/projects/savia-web/backlog/pbi/PBI-042-test-item.md
@@ -12,8 +12,8 @@ tags: []
 azure_devops_id: ""
 jira_id: ""
 github_issue_id: ""
-created: 2026-03-22
-updated: 2026-03-22
+created: 2026-03-27
+updated: 2026-03-27
 ---
 
 ## Descripcion

--- a/projects/savia-web/backlog/pbi/PBI-043-list-test.md
+++ b/projects/savia-web/backlog/pbi/PBI-043-list-test.md
@@ -12,8 +12,8 @@ tags: []
 azure_devops_id: ""
 jira_id: ""
 github_issue_id: ""
-created: 2026-03-22
-updated: 2026-03-22
+created: 2026-03-27
+updated: 2026-03-27
 ---
 
 ## Descripcion

--- a/projects/savia-web/backlog/pbi/PBI-044-test-item.md
+++ b/projects/savia-web/backlog/pbi/PBI-044-test-item.md
@@ -12,8 +12,8 @@ tags: []
 azure_devops_id: ""
 jira_id: ""
 github_issue_id: ""
-created: 2026-03-22
-updated: 2026-03-22
+created: 2026-03-27
+updated: 2026-03-27
 ---
 
 ## Descripcion

--- a/projects/savia-web/backlog/pbi/PBI-045-list-test.md
+++ b/projects/savia-web/backlog/pbi/PBI-045-list-test.md
@@ -12,8 +12,8 @@ tags: []
 azure_devops_id: ""
 jira_id: ""
 github_issue_id: ""
-created: 2026-03-22
-updated: 2026-03-22
+created: 2026-03-27
+updated: 2026-03-27
 ---
 
 ## Descripcion

--- a/projects/savia-web/backlog/pbi/PBI-046-test-item.md
+++ b/projects/savia-web/backlog/pbi/PBI-046-test-item.md
@@ -12,8 +12,8 @@ tags: []
 azure_devops_id: ""
 jira_id: ""
 github_issue_id: ""
-created: 2026-03-22
-updated: 2026-03-22
+created: 2026-03-27
+updated: 2026-03-27
 ---
 
 ## Descripcion

--- a/projects/savia-web/backlog/pbi/PBI-047-list-test.md
+++ b/projects/savia-web/backlog/pbi/PBI-047-list-test.md
@@ -12,8 +12,8 @@ tags: []
 azure_devops_id: ""
 jira_id: ""
 github_issue_id: ""
-created: 2026-03-22
-updated: 2026-03-22
+created: 2026-03-27
+updated: 2026-03-27
 ---
 
 ## Descripcion

--- a/zeroclaw/host/remote_host.py
+++ b/zeroclaw/host/remote_host.py
@@ -68,6 +68,12 @@ def _ssh(remote_cmd: str, timeout: int = 15) -> tuple[bool, str]:
         return False, str(e)
 
 
+def is_configured() -> bool:
+    """¿Está configurado el host remoto? (fichero de config existe con REMOTE_HOST)"""
+    cfg = _load_config()
+    return bool(cfg.get("REMOTE_HOST", "").strip())
+
+
 def is_reachable() -> bool:
     """¿El servidor remoto es accesible por SSH?"""
     ok, _ = _ssh("echo ok", timeout=8)

--- a/zeroclaw/host/survival_phases.py
+++ b/zeroclaw/host/survival_phases.py
@@ -34,7 +34,14 @@ def phase_respiracion(state: dict, run_claude_fn=None) -> dict:
 
     # Verificar bridge en servidor remoto
     try:
-        from .remote_host import is_reachable, is_bridge_running, restart_bridge
+        from .remote_host import is_configured, is_reachable, is_bridge_running, restart_bridge
+
+        if not is_configured():
+            s["details"].append("remote_host:not_configured — skipping")
+            state["consecutive_breath_failures"] = 0
+            state["remote_unreachable_since"] = None
+            state["last_breath"] = time.time()
+            return s
 
         if not is_reachable():
             s["ok"] = False; s["bridge"] = "unreachable"
@@ -80,7 +87,13 @@ def phase_despertar(state: dict, run_claude_fn=None) -> dict:
         "healed": False, "details": [],
     }
     try:
-        from .remote_host import is_reachable, wake_claude
+        from .remote_host import is_configured, is_reachable, wake_claude
+
+        if not is_configured():
+            s["details"].append("remote_host:not_configured — skipping")
+            state["consecutive_wakeup_failures"] = 0
+            state["last_wakeup"] = time.time()
+            return s
 
         if not is_reachable():
             s["ok"] = False; s["claude_responds"] = "remote_unreachable"


### PR DESCRIPTION
## Summary
- Add `is_configured()` to `remote_host.py` to detect whether `~/.savia/remote-host-config` exists with `REMOTE_HOST`
- Both `phase_respiracion` and `phase_despertar` now skip silently when remote host is not configured
- Failure counters reset to 0, `last_breath`/`last_wakeup` timestamps updated to prevent tight daemon loops
- No notifications sent to Talk when feature is simply not set up

## Root cause
`~/.savia/remote-host-config` doesn't exist on this machine → `_ssh()` returned `(False, "Remote host config not found")` → `is_reachable()` returned `False` → `consecutive_breath_failures` incremented every 10 min → after 3 failures `_notify_monica()` fired → **127+ escalation messages** sent to Nextcloud Talk since 2026-03-26 19:33.

## Test plan
- [ ] Daemon log shows no "Remote unreachable" warnings after restart
- [ ] `saviaclaw.service` running healthy (confirmed PID 2754214)
- [ ] No Talk notifications generated in next 30 min
