### PR TITLE
feat: wire 37 agents to Context Index (.ctx) — full adoption (Era 164)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -29,6 +29,10 @@ Eres un Senior Software Architect especializado en .NET con dominio profundo de:
 - Entity Framework Core: modelado de dominio, relaciones, queries eficientes, migrations
 - Microservicios vs monolito modular: cuándo y cómo transicionar
 
+## Context Index
+
+When loading project context, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find architecture docs, business rules, and team data efficiently.
+
 ## Tu proceso al analizar una tarea
 
 1. **Leer el contexto del proyecto**: `CLAUDE.md` del proyecto, `RULES.md (o reglas-negocio.md)`, `equipo.md`

--- a/.claude/agents/business-analyst.md
+++ b/.claude/agents/business-analyst.md
@@ -28,6 +28,10 @@ Eres un Business Analyst / Product Owner técnico con experiencia en proyectos .
 metodología Scrum. Tu especialidad es traducir requisitos de negocio en criterios precisos
 que permitan implementaciones sin ambigüedad.
 
+## Context Index
+
+When loading project context, consult `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to locate business rules, stakeholders, and meeting digests efficiently.
+
 ## Fuentes de verdad que siempre consultas
 
 1. `projects/[proyecto]/CLAUDE.md` — configuración del proyecto

--- a/.claude/agents/cobol-developer.md
+++ b/.claude/agents/cobol-developer.md
@@ -28,6 +28,10 @@ hooks:
 token_budget: 13000
 ---
 
+## Context Index
+
+When working on a project, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and COBOL program inventories.
+
 Eres un COBOL Assistant especializado en sistemas legacy (mainframe z/OS, CICS, DB2).
 Tu rol NO es implementar cambios directos en COBOL de producción, sino ASISTIR:
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -24,6 +24,10 @@ Eres un Senior Code Reviewer con foco en calidad, seguridad y mantenibilidad en 
 Tu rol es el quality gate antes de que el código llegue a main. Eres exigente pero
 constructivo: cada comentario incluye el problema, el impacto y la solución propuesta.
 
+## Context Index
+
+When reviewing project code, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find the relevant spec, architecture docs, and business rules for verification.
+
 ## Knowledge base de reglas
 
 Antes de iniciar cualquier revisión, **leer siempre** `.claude/rules/languages/csharp-rules.md`.

--- a/.claude/agents/coherence-validator.md
+++ b/.claude/agents/coherence-validator.md
@@ -24,6 +24,10 @@ You are an output coherence specialist — the quality gate that verifies alignm
 between intent and output. Your job is to ensure generated specs, reports, and code
 actually address what was asked, without gaps or contradictions.
 
+## Context Index
+
+When validating project outputs, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs and business rules for cross-referencing.
+
 ## Your Process
 
 1. **Receive**: the original objective/request + the output to validate + output type

--- a/.claude/agents/confidentiality-auditor.md
+++ b/.claude/agents/confidentiality-auditor.md
@@ -43,6 +43,10 @@ sensibles?" sino "hay datos que pertenecen a un nivel SUPERIOR al de este repo?"
 | N4-VASS | Evaluaciones individuales, one-to-ones, feedback personal, relaciones, credenciales |
 | N4b-PM | Solo credenciales/secrets tecnicos |
 
+## Context Index
+
+When auditing a project repo, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to understand the expected project structure and sensitive data paths.
+
 ## Fase 1 — Detectar nivel y construir contexto
 
 ### 1a. Detectar nivel del repo
@@ -127,19 +131,8 @@ Revisar CADA linea anadida (`+`) buscando:
 
 ## Fase 3 — Veredicto
 
-### Si hay CRITICALs:
-```
-VEREDICTO: BLOCKED
-Hallazgos: [lista de violaciones con fichero y linea]
-Accion: corregir antes de crear PR
-```
-
-### Si no hay CRITICALs:
-```
-VEREDICTO: CLEAN
-Warnings: [lista si hay]
-Firma: ejecutar `bash scripts/confidentiality-sign.sh sign`
-```
+CRITICALs → `VEREDICTO: BLOCKED` + hallazgos con fichero/linea + corregir antes de PR.
+Sin CRITICALs → `VEREDICTO: CLEAN` + warnings si hay + firmar con `confidentiality-sign.sh sign`.
 
 ## Reglas inmutables
 

--- a/.claude/agents/dev-orchestrator.md
+++ b/.claude/agents/dev-orchestrator.md
@@ -17,6 +17,10 @@ token_budget: 8500
 
 Eres un planificador de implementación. Recibes un spec y produces un plan de slices optimizado para ejecución dentro de contexto limitado (~80K tokens libres).
 
+## Context Index
+
+When planning slices, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for dependency analysis.
+
 ## Input
 
 1. **Spec completo** (`.spec.md`) con requisitos, ficheros, criterios de aceptación

--- a/.claude/agents/diagram-architect.md
+++ b/.claude/agents/diagram-architect.md
@@ -36,6 +36,10 @@ Agente especializado en análisis de diagramas de arquitectura. Valida consisten
 
 `claude-sonnet-4-6` — Balance entre capacidad de análisis y velocidad
 
+## Context Index
+
+When analyzing project architecture, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find architecture docs, entities, and business rules.
+
 ## Contexto que recibe
 
 1. Diagrama en formato Mermaid (siempre disponible como copia local)

--- a/.claude/agents/dotnet-developer.md
+++ b/.claude/agents/dotnet-developer.md
@@ -34,6 +34,10 @@ token_budget: 8500
 Eres un Senior .NET Developer con dominio de C# moderno y el ecosistema .NET. Implementas
 código limpio, testeable y mantenible siguiendo las specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/drift-auditor.md
+++ b/.claude/agents/drift-auditor.md
@@ -17,6 +17,10 @@ Verifica que CLAUDE.md reglas se cumplen en la realidad y detecta divergencias.
 
 ---
 
+## Context Index
+
+When auditing a project, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries as the expected map of project docs; compare reality against it to detect drift.
+
 ## Tareas Principales
 
 ### 1. Auditar Enforcement de Reglas

--- a/.claude/agents/excel-digest.md
+++ b/.claude/agents/excel-digest.md
@@ -80,6 +80,12 @@ Guardar como `{nombre}.digest.md` en misma carpeta. Si >150 lineas: dividir.
 ## Actualizaciones aplicadas
 ```
 
+## Context Index Integration
+
+Before writing output, check if `projects/{proyecto}/.context-index/PROJECT.ctx` exists.
+Use `[digest-target]` entries to determine WHERE to store each type of extracted info.
+If no .ctx exists, use default paths (current behavior as fallback).
+
 ## Reglas
 
 - NUNCA extraer datos transaccionales completos — solo estructura y muestra

--- a/.claude/agents/feasibility-probe.md
+++ b/.claude/agents/feasibility-probe.md
@@ -18,6 +18,10 @@ You are a feasibility analyst. Given a spec, you attempt a minimal prototype wit
 - **Core mission**: Produce honest viability scores backed by real implementation attempts
 - **Bias**: Pessimistic — score what you actually achieved, not what you think is possible
 
+## Context Index
+
+When probing a spec, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find architecture and dependency information for feasibility analysis.
+
 ## Protocol
 
 ### Phase 1 — Parse Spec (budget: 2 min)

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -34,6 +34,10 @@ Eres un Senior Frontend Developer con dominio tanto de Angular como de React mod
 Implementas código limpio, testeable y mantenible para interfaces de usuario complejas,
 siguiendo las specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/go-developer.md
+++ b/.claude/agents/go-developer.md
@@ -34,6 +34,10 @@ Eres un Senior Go Developer con dominio de Go moderno (1.21+), estándares de la
 y frameworks como Chi, Gin, Axum. Implementas código limpio, testeable y mantenible
 siguiendo las specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/java-developer.md
+++ b/.claude/agents/java-developer.md
@@ -34,6 +34,10 @@ Eres un Senior Java Developer con dominio de Java 21+, Spring Boot moderno, y el
 JVM. Implementas código limpio, testeable y mantenible siguiendo las specs SDD como contratos
 de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/meeting-confidentiality-judge.md
+++ b/.claude/agents/meeting-confidentiality-judge.md
@@ -109,6 +109,12 @@ Si necesita recordar patrones de confidencialidad de un proyecto:
 
 NUNCA escribir datos de proyecto en rutas globales.
 
+## Context Index Integration
+
+Before emitting verdicts, check if `projects/{proyecto}/.context-index/PROJECT.ctx` exists.
+Use `[digest-target]` entries to validate that proposed write destinations are correct.
+If no .ctx exists, use default paths (current behavior as fallback).
+
 ## Reglas
 
 1. **En caso de duda, BLOQUEAR** — es mejor no registrar que filtrar

--- a/.claude/agents/meeting-digest.md
+++ b/.claude/agents/meeting-digest.md
@@ -120,6 +120,10 @@ orientacion sexual, religion, ideologia, conflictos personales extra-laborales.
 4. AMBIGUO → marcar `[DATO AMBIGUO — confirmar con PM]`
 5. CONFIDENCIAL → solo informar a PM en conversacion, NUNCA en ficheros .md
 
+## Context Index — Consultar antes de escribir
+
+Si existe `projects/{proyecto}/.context-index/PROJECT.ctx`, usar sus entradas `[digest-target]` para decidir DONDE almacenar cada tipo de informacion extraida. Si no existe, usar rutas por defecto.
+
 ## Memoria — POR PROYECTO
 
 Ruta: `projects/{proyecto}/agent-memory/meeting-digest/MEMORY.md`

--- a/.claude/agents/meeting-risk-analyst.md
+++ b/.claude/agents/meeting-risk-analyst.md
@@ -134,9 +134,11 @@ Accion sugerida: {que debe hacer la PM}
 **REGLA CRITICA**: Este agente NO tiene memoria propia en `.claude/agent-memory/`.
 Toda informacion que aprenda de un proyecto se almacena en:
 `projects/{proyecto}/agent-memory/meeting-risk-analyst/MEMORY.md`
+Leer al iniciar si existe. Actualizar al terminar con patrones nuevos. NUNCA escribir datos de proyecto en rutas globales.
 
-Leer al iniciar si existe. Actualizar al terminar con patrones nuevos.
-NUNCA escribir datos de proyecto en rutas globales.
+## Context Index — Consultar antes de escribir
+
+Si existe `projects/{proyecto}/.context-index/PROJECT.ctx`, usar `[digest-target]` para decidir DONDE almacenar hallazgos. Si no existe, usar rutas por defecto.
 
 ## Reglas
 

--- a/.claude/agents/mobile-developer.md
+++ b/.claude/agents/mobile-developer.md
@@ -24,6 +24,10 @@ Eres un Senior Mobile Developer con dominio de Swift/iOS, Kotlin/Android, y Flut
 Implementas código limpio, testeable y mantenible en cualquier plataforma, siguiendo
 las specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 **Antes de escribir código, verificar plataforma y estado:**

--- a/.claude/agents/pdf-digest.md
+++ b/.claude/agents/pdf-digest.md
@@ -78,6 +78,12 @@ Si >150 lineas: dividir en resumen + detalle.
 ## Imagenes relevantes
 ```
 
+## Context Index Integration
+
+Before writing output, check if `projects/{proyecto}/.context-index/PROJECT.ctx` exists.
+Use `[digest-target]` entries to determine WHERE to store each type of extracted info.
+If no .ctx exists, use default paths (current behavior as fallback).
+
 ## Reglas
 
 - SIEMPRE las 4 fases en orden

--- a/.claude/agents/php-developer.md
+++ b/.claude/agents/php-developer.md
@@ -34,6 +34,10 @@ Eres un Senior PHP Developer con dominio de Laravel moderno (11+), Domain-Driven
 y servicios web escalables. Implementas código limpio, testeable y mantenible siguiendo
 las specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/pptx-digest.md
+++ b/.claude/agents/pptx-digest.md
@@ -77,6 +77,12 @@ Guardar como `{nombre}.digest.md` en misma carpeta. Si >150 lineas: dividir.
 ## Informacion nueva / Contradicciones / Actualizaciones
 ```
 
+## Context Index Integration
+
+Before writing output, check if `projects/{proyecto}/.context-index/PROJECT.ctx` exists.
+Use `[digest-target]` entries to determine WHERE to store each type of extracted info.
+If no .ctx exists, use default paths (current behavior as fallback).
+
 ## Reglas
 
 - SIEMPRE las 4 fases en orden

--- a/.claude/agents/python-developer.md
+++ b/.claude/agents/python-developer.md
@@ -34,6 +34,10 @@ Eres un Senior Python Developer con dominio de FastAPI, Django, SQLAlchemy y el 
 moderno de Python. Implementas código limpio, testeable y mantenible siguiendo las specs
 SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/reflection-validator.md
+++ b/.claude/agents/reflection-validator.md
@@ -27,6 +27,10 @@ what fast thinking misses. Your job is to verify that a response, spec,
 plan, or decision actually achieves the real objective, not just the
 literal one.
 
+## Context Index
+
+When validating project decisions, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, decisions, and architecture docs.
+
 ## Your Process
 
 1. **Receive**: the original question/context + the response to validate

--- a/.claude/agents/ruby-developer.md
+++ b/.claude/agents/ruby-developer.md
@@ -34,6 +34,10 @@ Eres un Senior Ruby Developer con dominio de Ruby on Rails moderno (7+), Domain-
 Design, y patterns como Service Objects. Implementas código limpio, testeable y mantenible
 siguiendo las specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/rust-developer.md
+++ b/.claude/agents/rust-developer.md
@@ -34,6 +34,10 @@ Eres un Senior Rust Developer con dominio de Rust moderno (1.75+), async/await c
 y frameworks como Axum. Implementas código limpio, testeable y mantenible siguiendo las
 specs SDD como contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/sdd-spec-writer.md
+++ b/.claude/agents/sdd-spec-writer.md
@@ -33,6 +33,10 @@ Claude debe poder implementar la tarea **sin hacer ninguna pregunta adicional**.
 
 "Si el agente falla, la Spec no era suficientemente buena" — tu trabajo es que esto nunca ocurra.
 
+## Context Index
+
+Before writing a spec, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find requirements, architecture, and business rules. Use `[digest-target]` entries to place the generated spec in the correct location.
+
 ## Fuentes que siempre consultas antes de escribir
 
 ```bash

--- a/.claude/agents/security-attacker.md
+++ b/.claude/agents/security-attacker.md
@@ -22,6 +22,10 @@ token_budget: 8500
 Eres un especialista en seguridad ofensiva (Red Team). Tu misión es encontrar vulnerabilidades
 en el código y configuración del proyecto, simulando la perspectiva de un atacante.
 
+## Context Index
+
+When analyzing a project, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find architecture, configs, and API surface quickly.
+
 ## Metodología
 
 1. **Reconocimiento**: Analizar la estructura del proyecto, tecnologías, dependencias

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -23,6 +23,10 @@ Eres un auditor de seguridad independiente. Tu misión es evaluar objetivamente
 el trabajo del Red Team (attacker) y Blue Team (defender), y producir el informe
 final de seguridad.
 
+## Context Index
+
+When auditing a project, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find architecture and config files for coverage analysis.
+
 ## Metodología
 
 1. **Revisión de hallazgos**: Verificar que cada VULN es real y correctamente clasificada

--- a/.claude/agents/security-defender.md
+++ b/.claude/agents/security-defender.md
@@ -23,6 +23,10 @@ token_budget: 8500
 Eres un especialista en seguridad defensiva (Blue Team). Tu misión es corregir
 las vulnerabilidades identificadas por el Red Team y fortalecer la seguridad del proyecto.
 
+## Context Index
+
+When fixing vulnerabilities in a project, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find configs, architecture, and dependency files.
+
 ## Metodología
 
 1. **Triaje**: Priorizar hallazgos por severidad e impacto

--- a/.claude/agents/security-guardian.md
+++ b/.claude/agents/security-guardian.md
@@ -50,6 +50,10 @@ Repositorio **público** en GitHub (`gonzalezpazmonica/pm-workspace`).
 - Nombres ficticios con dominio de ejemplo
 - Nombre del titular: `gonzalezpazmonica`, `Mónica González Paz` en CONTRIBUTORS.md
 
+## Context Index
+
+If auditing a project, check `projects/{project}/.context-index/PROJECT.ctx` for `[location]` entries pointing to architecture, configs, and sensitive data paths.
+
 ## PROTOCOLO DE AUDITORÍA
 
 Ejecuta SIEMPRE los 9 checks en orden (ver referencia detallada en `@.claude/rules/domain/security-check-patterns.md`):

--- a/.claude/agents/tech-writer.md
+++ b/.claude/agents/tech-writer.md
@@ -32,6 +32,10 @@ en 5 minutos leyendo el README.
 - **Ejemplos concretos**: siempre mejor que descripciones abstractas
 - **Actualidad**: la documentación desactualizada es peor que ninguna
 
+## Context Index
+
+Before writing project docs, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find existing docs, and `[digest-target]` entries to place new documentation correctly.
+
 ## Cuándo actualizar cada documento
 
 ### README.md — actualizar cuando:

--- a/.claude/agents/terraform-developer.md
+++ b/.claude/agents/terraform-developer.md
@@ -41,6 +41,10 @@ humana explícita**.
 **Si la spec requiere apply:** Generar plan detallado → Documentar cambios → 
 Esperar confirmación humana explícita → Humano ejecuta apply
 
+## Context Index
+
+When starting IaC work, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, environment configs, and infrastructure documentation.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir Terraform:

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -65,6 +65,10 @@ public async Task CalculateCapacity_CuandoEquipoConVacaciones_ReduceHorasDisponi
 [Trait("Category", "E2E")]          # Tests completos de extremo a extremo
 ```
 
+## Context Index
+
+When designing tests for a project, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs and business rules for test case derivation.
+
 ## Protocolo de trabajo
 
 1. **Leer el código a testear** — entender los contratos públicos, no los detalles internos

--- a/.claude/agents/typescript-developer.md
+++ b/.claude/agents/typescript-developer.md
@@ -34,6 +34,10 @@ Eres un Senior TypeScript Developer con dominio de Node.js moderno y frameworks 
 Fastify y Prisma ORM. Implementas código limpio, testeable y mantenible siguiendo las specs SDD como
 contratos de trabajo.
 
+## Context Index
+
+When starting implementation, check `projects/{project}/.context-index/PROJECT.ctx` if it exists. Use `[location]` entries to find specs, architecture, and business rules for the current task.
+
 ## Protocolo de inicio obligatorio
 
 Antes de escribir una sola línea de código:

--- a/.claude/agents/visual-digest.md
+++ b/.claude/agents/visual-digest.md
@@ -125,6 +125,12 @@ Si no hay suficiente contexto para desambiguar → listar candidatos con probabi
 - SIEMPRE aplicar protocolo de homónimos cuando hay nombres ambiguos
 - Max 150 líneas por fichero de output
 
+## Context Index Integration
+
+Before writing output, check if `projects/{proyecto}/.context-index/PROJECT.ctx` exists.
+Use `[digest-target]` entries to determine WHERE to store each type of extracted info.
+If no .ctx exists, use default paths (current behavior as fallback).
+
 ## Memoria
 
 Ruta: projects/{proyecto}/agent-memory/visual-digest/MEMORY.md

--- a/.claude/agents/word-digest.md
+++ b/.claude/agents/word-digest.md
@@ -132,6 +132,12 @@ OBLIGATORIA. Protocolo identico a pdf-digest Fase 4:
 - Ruta: misma carpeta del DOCX, con `.digest.md`
 - Si >150 lineas: dividir en resumen + detalle
 
+## Context Index Integration
+
+Before writing output, check if `projects/{proyecto}/.context-index/PROJECT.ctx` exists.
+Use `[digest-target]` entries to determine WHERE to store each type of extracted info.
+If no .ctx exists, use default paths (current behavior as fallback).
+
 ## Reglas
 
 - SIEMPRE las 4 fases en orden

--- a/.claude/rules/domain/context-health.md
+++ b/.claude/rules/domain/context-health.md
@@ -125,6 +125,9 @@ Si el PM cambia de objetivo, sugerir `/clear` + nuevo `/context-load`.
 
 ## 5. Memoria persistente entre sesiones
 
+### Context Index como mapa de navegacion
+Al cargar contexto de proyecto, consultar `projects/{p}/.context-index/PROJECT.ctx` primero (si existe). Mapea donde vive cada tipo de informacion, evitando busquedas por prueba y error.
+
 ### Ficheros de estado del proyecto
 Cada proyecto mantiene estado en disco (no en contexto):
 - `projects/{p}/debt-register.md` — deuda técnica

--- a/.claude/rules/domain/context-health.md
+++ b/.claude/rules/domain/context-health.md
@@ -145,9 +145,4 @@ un resumen conciso. No carga todo — solo lo justo para orientar al PM.
 
 ## 6. Límites de carga bajo demanda
 
-Cuando un comando referencia un fichero con `@`, Claude lo carga en contexto.
-Para evitar cargas excesivas:
-
-- Máximo 3 ficheros `@` por comando (los imprescindibles)
-- Skills: cargar solo SKILL.md, no references (cargar solo si el paso lo requiere)
-- Si necesita datos de otro comando anterior, leer del fichero de output
+Máximo 3 ficheros `@` por comando. Skills: solo SKILL.md (references bajo demanda). Datos de comandos anteriores: leer de output, no recargar.

--- a/.claude/rules/domain/digest-traceability.md
+++ b/.claude/rules/domain/digest-traceability.md
@@ -102,6 +102,8 @@ Creación automática por `/project-new` o al primera digestión si no existe.
 
 Los agentes de digestión DEBEN: (1) recibir la ruta al log, (2) consultar si ya procesado ANTES de leer, (3) actualizar el log al terminar o devolver `digest_entry:` YAML para que el orquestador actualice.
 
+Ademas, antes de escribir output deben consultar `projects/{proyecto}/.context-index/PROJECT.ctx` (si existe) y usar sus entradas `[digest-target]` para decidir DONDE almacenar cada tipo de informacion extraida.
+
 ---
 
 ## Límites y privacidad

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=8d1b5ba68529520879c144ee4bc3ed3acc21e137d9a94309dc4f02acd4b29719
 timestamp=2026-03-30T06:54:37Z
 branch=feat/era-164-specs-batch
-head_commit=923f4f2
+head_commit=5703944
 signature=64cbffc73be26f348b868a77899132d1ed293a60323c97fe9d7872dda140b3aa

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=1abc5ae62a783341407c636d422bbc9158743544b3ae1afdc2a29dcef5e4ed4c
-timestamp=2026-03-30T06:20:38Z
+diff_hash=19c20e06a677be83a720ad3787c0b7e837be7900e002118413faecfc788366dc
+timestamp=2026-03-30T06:40:43Z
 branch=feat/era-164-specs-batch
-head_commit=3fdd3bd
-signature=07f1f489b2c3af086b245ece6ff879f5f2c21929d84446b6d779bfc27a6da75a
+head_commit=a1196dd
+signature=81f175648147f2d1324025527522f2f2bec58de2805f5767ecfeb5a61a9b90ce

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=19c20e06a677be83a720ad3787c0b7e837be7900e002118413faecfc788366dc
-timestamp=2026-03-30T06:40:43Z
+diff_hash=8d1b5ba68529520879c144ee4bc3ed3acc21e137d9a94309dc4f02acd4b29719
+timestamp=2026-03-30T06:54:37Z
 branch=feat/era-164-specs-batch
-head_commit=a1196dd
-signature=81f175648147f2d1324025527522f2f2bec58de2805f5767ecfeb5a61a9b90ce
+head_commit=923f4f2
+signature=64cbffc73be26f348b868a77899132d1ed293a60323c97fe9d7872dda140b3aa

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=eae6914866e67e981ac9abd13a400b64c931edf2ffe717963b6188a7c1157653
 timestamp=2026-03-30T11:15:29Z
 branch=feat/era-164-specs-batch
-head_commit=8f6db4f
+head_commit=0433421
 signature=b4812f8c7cdc44238dc282e8cf26025708eded88e6ddaada051b0553c170b0bd

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8d1b5ba68529520879c144ee4bc3ed3acc21e137d9a94309dc4f02acd4b29719
-timestamp=2026-03-30T06:54:37Z
+diff_hash=eae6914866e67e981ac9abd13a400b64c931edf2ffe717963b6188a7c1157653
+timestamp=2026-03-30T11:15:29Z
 branch=feat/era-164-specs-batch
-head_commit=5703944
-signature=64cbffc73be26f348b868a77899132d1ed293a60323c97fe9d7872dda140b3aa
+head_commit=8f6db4f
+signature=b4812f8c7cdc44238dc282e8cf26025708eded88e6ddaada051b0553c170b0bd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.87.0] — 2026-03-30
+
+feat: wire 37 agents to Context Index — full .ctx adoption across workspace. Era 164.
+
+### Changed
+
+- **37 agents updated**: all writers (8 digesters), readers (17 analysts/validators), and developers (12 language agents) now consult `PROJECT.ctx` before reading/writing project data. Writers use `[digest-target]`, readers use `[location]`, developers use `[location]` for specs.
+- **context-health.md**: added Context Index as navigation map for project context loading
+- **digest-traceability.md**: digesters must consult .ctx before writing
+- **SPEC-054**: expanded to cover all agent groups, not just digesters
+
+### Added
+
+- **tests/evals/test-context-index-adoption.bats** — 7 tests verifying all 37 agents reference .ctx
+
 ## [3.86.0] — 2026-03-30
 
 feat: SPEC-054 Context Index System (.ctx) — knowledge map for digesters. Era 164.
@@ -5090,6 +5105,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[3.87.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.86.0...v3.87.0
 [3.86.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.85.0...v3.86.0
 [3.85.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.84.0...v3.85.0
 [3.84.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.83.0...v3.84.0

--- a/docs/propuestas/SPEC-054-context-index-system.md
+++ b/docs/propuestas/SPEC-054-context-index-system.md
@@ -57,7 +57,9 @@ directories that do not exist. Missing optional paths are listed as `[optional]`
 
 | Consumer | Uses |
 |----------|------|
-| meeting-digest, pdf-digest, word-digest | `[digest-target]` entries |
+| **Group A (writers)**: meeting-digest, pdf-digest, word-digest, excel-digest, pptx-digest, visual-digest, sdd-spec-writer, tech-writer | `[digest-target]` entries to place extracted/generated content |
+| **Group B (readers)**: architect, business-analyst, code-reviewer, security-*, coherence-validator, reflection-validator, dev-orchestrator, diagram-architect, drift-auditor, feasibility-probe, test-engineer, confidentiality-auditor | `[location]` and `[intent]` entries to find project context |
+| **Group C (developers)**: all 12 language-specific developers | `[location]` entries to find specs and architecture |
 | Savia question answering | `[intent]` entries |
 | `/context-load` | WORKSPACE.idx for session priming |
 | `/project-new` | PROJECT-TEMPLATE.idx for scaffold |

--- a/tests/evals/test-context-index-adoption.bats
+++ b/tests/evals/test-context-index-adoption.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# Tests for SPEC-054 Context Index adoption across all agent groups
+# Verifies that agents in Groups A/B/C reference the .ctx system.
+
+@test "all 8 Group A (writer) agents reference context-index or .ctx" {
+  local writers=(
+    ".claude/agents/meeting-digest.md"
+    ".claude/agents/pdf-digest.md"
+    ".claude/agents/word-digest.md"
+    ".claude/agents/excel-digest.md"
+    ".claude/agents/pptx-digest.md"
+    ".claude/agents/visual-digest.md"
+    ".claude/agents/meeting-risk-analyst.md"
+    ".claude/agents/meeting-confidentiality-judge.md"
+  )
+  for agent in "${writers[@]}"; do
+    grep -qiE '(context-index|\.ctx)' "$agent" || {
+      echo "FAIL: $agent missing context-index reference"; return 1
+    }
+  done
+}
+
+@test "Group B reader agents (batch 1 of 2) reference context-index or .ctx" {
+  local readers=(
+    ".claude/agents/architect.md"
+    ".claude/agents/business-analyst.md"
+    ".claude/agents/sdd-spec-writer.md"
+    ".claude/agents/code-reviewer.md"
+    ".claude/agents/security-guardian.md"
+    ".claude/agents/security-attacker.md"
+    ".claude/agents/security-defender.md"
+    ".claude/agents/security-auditor.md"
+  )
+  for agent in "${readers[@]}"; do
+    grep -qiE '(context-index|\.ctx)' "$agent" || {
+      echo "FAIL: $agent missing context-index reference"; return 1
+    }
+  done
+}
+
+@test "Group B reader agents (batch 2 of 2) reference context-index or .ctx" {
+  local readers=(
+    ".claude/agents/coherence-validator.md"
+    ".claude/agents/reflection-validator.md"
+    ".claude/agents/dev-orchestrator.md"
+    ".claude/agents/diagram-architect.md"
+    ".claude/agents/drift-auditor.md"
+    ".claude/agents/feasibility-probe.md"
+    ".claude/agents/test-engineer.md"
+    ".claude/agents/confidentiality-auditor.md"
+    ".claude/agents/tech-writer.md"
+  )
+  for agent in "${readers[@]}"; do
+    grep -qiE '(context-index|\.ctx)' "$agent" || {
+      echo "FAIL: $agent missing context-index reference"; return 1
+    }
+  done
+}
+
+@test "all 12 Group C (developer) agents reference context-index or .ctx" {
+  local devs=(
+    ".claude/agents/dotnet-developer.md"
+    ".claude/agents/typescript-developer.md"
+    ".claude/agents/frontend-developer.md"
+    ".claude/agents/java-developer.md"
+    ".claude/agents/python-developer.md"
+    ".claude/agents/go-developer.md"
+    ".claude/agents/rust-developer.md"
+    ".claude/agents/php-developer.md"
+    ".claude/agents/ruby-developer.md"
+    ".claude/agents/mobile-developer.md"
+    ".claude/agents/cobol-developer.md"
+    ".claude/agents/terraform-developer.md"
+  )
+  for agent in "${devs[@]}"; do
+    grep -qiE '(context-index|\.ctx)' "$agent" || {
+      echo "FAIL: $agent missing context-index reference"; return 1
+    }
+  done
+}
+
+@test "context-health.md references context-index or .ctx" {
+  grep -qiE '(context-index|\.ctx)' \
+    ".claude/rules/domain/context-health.md" || {
+    echo "FAIL: context-health.md missing context-index reference"
+    return 1
+  }
+}
+
+@test "SPEC-054 mentions all agent groups not just digesters" {
+  local spec="docs/propuestas/SPEC-054-context-index-system.md"
+  grep -q 'Group A' "$spec"
+  grep -q 'Group B' "$spec"
+  grep -q 'Group C' "$spec"
+}
+
+@test "no modified agent exceeds 150 lines" {
+  local agents=(
+    ".claude/agents/architect.md"
+    ".claude/agents/business-analyst.md"
+    ".claude/agents/sdd-spec-writer.md"
+    ".claude/agents/code-reviewer.md"
+    ".claude/agents/security-guardian.md"
+    ".claude/agents/dotnet-developer.md"
+    ".claude/agents/confidentiality-auditor.md"
+    ".claude/agents/meeting-digest.md"
+    ".claude/agents/terraform-developer.md"
+    ".claude/agents/cobol-developer.md"
+    ".claude/agents/mobile-developer.md"
+  )
+  for agent in "${agents[@]}"; do
+    lines=$(wc -l < "$agent")
+    [ "$lines" -le 150 ] || {
+      echo "FAIL: $agent has $lines lines (max 150)"; return 1
+    }
+  done
+}

--- a/tests/evals/test-context-index.bats
+++ b/tests/evals/test-context-index.bats
@@ -131,3 +131,22 @@ teardown() { rm -rf "$TMPDIR_IDX"; }
   [ -f ".context-index/WORKSPACE.ctx" ]
   grep -q '{project-name}' ".context-index/PROJECT-TEMPLATE.ctx"
 }
+
+@test "all 8 digester agents reference context-index or .ctx" {
+  local digesters=(
+    ".claude/agents/meeting-digest.md"
+    ".claude/agents/pdf-digest.md"
+    ".claude/agents/word-digest.md"
+    ".claude/agents/excel-digest.md"
+    ".claude/agents/pptx-digest.md"
+    ".claude/agents/visual-digest.md"
+    ".claude/agents/meeting-risk-analyst.md"
+    ".claude/agents/meeting-confidentiality-judge.md"
+  )
+  for agent in "${digesters[@]}"; do
+    grep -qiE '(context-index|\.ctx)' "$agent" || {
+      echo "FAIL: $agent does not reference context-index or .ctx"
+      return 1
+    }
+  done
+}


### PR DESCRIPTION
## Summary
feat: wire 37 agents to Context Index (.ctx) — full adoption (Era 164)
### Changes
- 923f4f2 docs: add CHANGELOG v3.87.0 for context index adoption
- 2ece24b Merge remote-tracking branch 'origin/main' into feat/era-164-specs-batch
- 636fdc2 chore: re-sign after agent context-index adoption
- a1196dd feat: wire 37 agents to Context Index (.ctx) — full adoption (Era 164)
### Stats
44 files changed across 4 commits.
## Test plan
- [x] validate-ci-local.sh passed
- [x] Confidentiality signed

Generated with [Claude Code](https://claude.com/claude-code)
