### PR TITLE
fix: CI test threshold + Spanish language directive (Era 165)

### DIFF
--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -73,12 +73,16 @@ if [ -f "$ACTIVE_USER_FILE" ]; then
   if [ -n "$ACTIVE_SLUG" ] && [ -d "$USERS_DIR/$ACTIVE_SLUG" ]; then
     PROFILE_NAME=$(grep -oP 'name:\s*"\K[^"]+' "$USERS_DIR/$ACTIVE_SLUG/identity.md" 2>/dev/null || echo "$ACTIVE_SLUG")
     PROFILE_ROLE=$(grep -oP 'role:\s*"\K[^"]+' "$USERS_DIR/$ACTIVE_SLUG/identity.md" 2>/dev/null || echo "")
+    # ── Leer idioma del perfil (preferences.md) ────────────────────────────
+    PROFILE_LANG=$(grep -oP 'language:\s*"\K[^"]+' "$USERS_DIR/$ACTIVE_SLUG/preferences.md" 2>/dev/null || echo "")
+
     if [ "$PROFILE_ROLE" = "Agent" ]; then
       AGENT_MODE="true"
       ITEMS+=("Perfil: $PROFILE_NAME (Agent)")
     else
       ITEMS+=("Perfil: $PROFILE_NAME")
     fi
+    [ -n "$PROFILE_LANG" ] && ITEMS+=("Idioma: $PROFILE_LANG")
   else
     ITEMS+=("Sin perfil — /profile-setup")
   fi

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=43aff274f16c9e4671ed13b70cc18800f36d8b7af89a5bac3b5d2b1710bf61f5
-timestamp=2026-04-01T05:15:07Z
+diff_hash=8d205d9e0dae35c4fb14cddff4e91c51ae08aed40aec8112016b4572833e8bab
+timestamp=2026-04-01T05:34:24Z
 branch=feat/era165-claudemd-diet-hooks
-head_commit=065a2ad
-signature=98e9f0fa6f6db45b0f5795f05a5537d6d51824617048aa57c67e93824f1589ea
+head_commit=1f2ffbc
+signature=ab6facb72bd11bb70fb1b3e069bc02dd337349aaedc2477e9691a419fa60f385

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8d205d9e0dae35c4fb14cddff4e91c51ae08aed40aec8112016b4572833e8bab
-timestamp=2026-04-01T05:34:24Z
+diff_hash=267a906081308d9e37a177aefd3964c5ec8c806ebcc8f8eb49056be8e6a714af
+timestamp=2026-04-01T06:11:14Z
 branch=feat/era165-claudemd-diet-hooks
-head_commit=1f2ffbc
-signature=ab6facb72bd11bb70fb1b3e069bc02dd337349aaedc2477e9691a419fa60f385
+head_commit=b861189
+signature=b986dbf00db94418465cce299893eba4fd09b0bb73064dd9d0bc0708342879ea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 
 **Savia** es la voz de pm-workspace — buhita directa, inteligente, radically honest (Rule #24). Siempre femenino. Personalidad: `@.claude/profiles/savia.md` · Honestidad: `@.claude/rules/domain/radical-honesty.md`
 Inicio de sesion: `active-user.md` → voz Savia → si perfil: saludar; si no: `/profile-setup` (`@.claude/rules/domain/profile-onboarding.md`). MCP servers bajo demanda, NO al arranque.
-**Idioma**: Savia responde SIEMPRE en el idioma del perfil activo (preferences.md). Por defecto: espanol. NUNCA cambiar a ingles salvo peticion explicita. Las reglas internas estan en ingles pero las respuestas son en espanol.
+**Idioma**: Savia responde SIEMPRE en el idioma del campo `language` de `preferences.md` del perfil activo. NUNCA cambiar de idioma salvo peticion explicita del usuario. Las reglas internas pueden estar en otro idioma pero las respuestas respetan el perfil.
 
 ## Reglas Criticas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@
 
 **Savia** es la voz de pm-workspace — buhita directa, inteligente, radically honest (Rule #24). Siempre femenino. Personalidad: `@.claude/profiles/savia.md` · Honestidad: `@.claude/rules/domain/radical-honesty.md`
 Inicio de sesion: `active-user.md` → voz Savia → si perfil: saludar; si no: `/profile-setup` (`@.claude/rules/domain/profile-onboarding.md`). MCP servers bajo demanda, NO al arranque.
+**Idioma**: Savia responde SIEMPRE en el idioma del perfil activo (preferences.md). Por defecto: espanol. NUNCA cambiar a ingles salvo peticion explicita. Las reglas internas estan en ingles pero las respuestas son en espanol.
 
 ## Reglas Criticas
 


### PR DESCRIPTION
Follow-up fixes for Era 165. CI tier1 threshold adjusted from 10 to 8 after CLAUDE.md diet. Spanish language directive added to prevent English bleed from rule files.