### PR TITLE
docs: add projects README, template, link Savia Models from main READMEs

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=555e7a641e5fa54b49e7bc654e54a0518762733bd5dd3287af7dfd9a87f006d6
-timestamp=2026-04-02T23:09:41Z
-branch=feat/savia-models
-head_commit=bec71a8
-signature=680f1348e83f2f95d7614e1b90eeb95ddb3cd5c73e267968bef5e01943bc13a6
+diff_hash=03d782afc465eba884b34322d6ad7aeba4b9bd670fd815baba67274d83782837
+timestamp=2026-04-02T23:16:51Z
+branch=feat/era173-sprint1-credibility
+head_commit=aaf1769
+signature=af58f56b431586574efd4da4eea0a06646a3f1ef1044db4944315ff7bf0403ef

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=c463c82d440b16afbbe5c43e931a20171851bc37092859d2f0b3a69e7fb7af7c
 timestamp=2026-04-02T23:27:57Z
 branch=feat/era173-sprint1-credibility
-head_commit=13b73e2
+head_commit=8ea2110
 signature=9f7db49492408e8601ada6faffbb55db78085788d9dfdee080ecb89e1b73f183

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=14e0ace2176fb48ef2fe09711956fe35785ea9a85d59897f8d5ec75632d00539
-timestamp=2026-04-02T23:19:20Z
+diff_hash=c463c82d440b16afbbe5c43e931a20171851bc37092859d2f0b3a69e7fb7af7c
+timestamp=2026-04-02T23:22:46Z
 branch=feat/era173-sprint1-credibility
-head_commit=57d66a7
-signature=7a5f722f7755b2811131a77e601d67c1ad3d2ef18d822d3c857829e4a815e4a8
+head_commit=3813ab1
+signature=9f7db49492408e8601ada6faffbb55db78085788d9dfdee080ecb89e1b73f183

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=03d782afc465eba884b34322d6ad7aeba4b9bd670fd815baba67274d83782837
-timestamp=2026-04-02T23:16:51Z
+diff_hash=14e0ace2176fb48ef2fe09711956fe35785ea9a85d59897f8d5ec75632d00539
+timestamp=2026-04-02T23:19:20Z
 branch=feat/era173-sprint1-credibility
-head_commit=aaf1769
-signature=af58f56b431586574efd4da4eea0a06646a3f1ef1044db4944315ff7bf0403ef
+head_commit=57d66a7
+signature=7a5f722f7755b2811131a77e601d67c1ad3d2ef18d822d3c857829e4a815e4a8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=c463c82d440b16afbbe5c43e931a20171851bc37092859d2f0b3a69e7fb7af7c
-timestamp=2026-04-02T23:22:46Z
+timestamp=2026-04-02T23:27:57Z
 branch=feat/era173-sprint1-credibility
-head_commit=3813ab1
+head_commit=13b73e2
 signature=9f7db49492408e8601ada6faffbb55db78085788d9dfdee080ecb89e1b73f183

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 # Cualquier proyecto nuevo queda automáticamente excluido sin necesidad de
 # nombrarlo aquí. Solo se declaran explícitamente los proyectos de ejemplo.
 projects/*
+!projects/README.md
+!projects/PROJECT_TEMPLATE.md
 !projects/proyecto-alpha/
 !projects/proyecto-beta/
 !projects/sala-reservas/

--- a/README.en.md
+++ b/README.en.md
@@ -62,6 +62,7 @@ pm-workspace/
 │   └── rules/          ← context, language, and domain rules
 ├── docs/
 │   ├── quick-starts/   ← role-based guides (PM, Dev, QA, PO, TL, CEO)
+│   ├── savia-models/   ← development models per language (7 stacks)
 │   ├── readme/         ← detailed documentation (13 sections)
 │   ├── guides/         ← 15 guides (Azure, Jira, startup, healthcare, memory...)
 │   └── savia-flow/     ← Git-native system docs

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ pm-workspace/
 │   └── rules/          ← reglas de contexto, lenguaje, dominio
 ├── docs/
 │   ├── quick-starts/   ← guías por rol (PM, Dev, QA, PO, TL, CEO)
+│   ├── savia-models/   ← modelos de desarrollo por lenguaje (7 stacks)
 │   ├── readme/         ← documentación detallada (13 secciones)
 │   ├── guides/         ← 15 guías por escenario (Azure, Jira, startup, memoria...)
 │   └── savia-flow/     ← docs del sistema Git-native

--- a/docs/savia-models/ROADMAP-IMPROVEMENTS.md
+++ b/docs/savia-models/ROADMAP-IMPROVEMENTS.md
@@ -236,6 +236,10 @@
 | A4 | Context evaluator | 12h | P2 |
 | A5 | Agent trust scoring | 16h | P3 |
 | A6 | Push notifications (async) | 8h | P3 |
+| A10 | Hybrid search (BM25 + vector) for memory/docs | 12h | P2 |
+| A11 | Semantic chunking in digest pipeline | 8h | P2 |
+| A12 | Query decomposition (complex → sub-queries) | 8h | P2 |
+| A13 | Two-phase retrieval (search candidates → read full) | 4h | P2 |
 
 ---
 

--- a/projects/PROJECT_TEMPLATE.md
+++ b/projects/PROJECT_TEMPLATE.md
@@ -1,0 +1,68 @@
+# {Project Name}
+
+> One-line description of what this project does and why it exists.
+
+## Stack
+
+| Aspect | Choice |
+|--------|--------|
+| Language | {language} |
+| Framework | {framework} |
+| Architecture | {pattern} — see [Savia Model]({link}) |
+| Database | {database} |
+| CI/CD | {platform} |
+
+## Quick Start
+
+```bash
+# Clone and setup
+git clone {url}
+cd {project}
+{install_command}
+
+# Run locally
+{run_command}
+
+# Run tests
+{test_command}
+```
+
+## Architecture
+
+> Brief description of the architecture. Link to ARCHITECTURE.md
+> for C4 diagrams and detailed layer descriptions.
+
+## Project Structure
+
+```
+src/
+├── {layer1}/     ← {description}
+├── {layer2}/     ← {description}
+└── {layer3}/     ← {description}
+tests/
+├── unit/         ← {test_framework}
+└── integration/  ← {test_framework}
+```
+
+## Savia Model Compliance
+
+| Section | Score | Notes |
+|---------|-------|-------|
+| Philosophy | /3 | |
+| Architecture | /3 | |
+| Structure | /3 | |
+| Code Patterns | /3 | |
+| Testing | /3 | |
+| Security | /3 | |
+| DevOps | /3 | |
+| Anti-Patterns | /3 | |
+| Agentic | /3 | |
+| **Total** | **/27** | |
+
+## SDD Configuration
+
+```
+DEVELOPER_TYPE    = "{lang}-developer"
+TEST_RUNNER       = "test-runner"
+SPEC_DIR          = "specs/"
+```

--- a/projects/README.md
+++ b/projects/README.md
@@ -23,7 +23,6 @@
 
 | Project | Purpose |
 |---------|---------|
-| **claude-code-analysis** | Architecture analysis of Claude Code internals |
 | **pm-workspace** | Self-referential — pm-workspace manages itself |
 
 ## Starting a New Project

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,36 @@
+# Projects
+
+> Each directory contains a software project managed by pm-workspace.
+> Projects follow [Savia Models](../docs/savia-models/README.md) for
+> quality standards and are scored via gap analysis.
+
+## Active Projects
+
+| Project | Stack | Model | Status |
+|---------|-------|-------|--------|
+| **savia-web** | Vue 3 + TypeScript + Vite | [Vue SPA](../docs/savia-models/01-vue-spa.md) | Active — web dashboard for pm-workspace |
+| **savia-mobile-android** | Kotlin + Jetpack Compose | [Kotlin Android](../docs/savia-models/03-kotlin-android.md) | Active — mobile companion app |
+| **sala-reservas** | C# / .NET 8 + Clean Architecture | [.NET Clean](../docs/savia-models/02-dotnet-clean.md) | Spec-only — room booking API example |
+
+## Example Projects
+
+| Project | Purpose |
+|---------|---------|
+| **proyecto-alpha** | Backlog management example — PBI templates, sprint planning |
+| **proyecto-beta** | Minimal project scaffold — starting point for new projects |
+
+## Analysis Projects
+
+| Project | Purpose |
+|---------|---------|
+| **claude-code-analysis** | Architecture analysis of Claude Code internals |
+| **pm-workspace** | Self-referential — pm-workspace manages itself |
+
+## Starting a New Project
+
+1. Copy `PROJECT_TEMPLATE.md` as starting point
+2. Create `CLAUDE.md` with stack, architecture, and SDD configuration
+3. Run gap analysis against the matching Savia Model
+4. Follow the [Savia Model Standard](../docs/savia-models/SAVIA-MODEL-STANDARD.md)
+
+Each project has its own `CLAUDE.md` — read it before working on that project.


### PR DESCRIPTION
## Summary
docs: add projects README, template, link Savia Models from main READMEs
### Changes
- 3813ab1 fix: remove non-generic project name from projects/README (confidentiality)
- 57d66a7 docs: add Onyx learnings to roadmap (A10-A13)
- aaf1769 docs: add projects README, template, link Savia Models from main READMEs
### Stats
7 files changed across 3 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
