### PR TITLE
feat: Memory Resilience — deep extraction with quality gates (Era 166)

### DIFF
--- a/.claude/hooks/lib/memory-extract-lib.sh
+++ b/.claude/hooks/lib/memory-extract-lib.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# memory-extract-lib.sh — Shared functions for memory extraction hooks
+# Used by: stop-memory-extract.sh
+
+MIN_LENGTH=${MIN_LENGTH:-50}
+
+# Quality gate: reject short, duplicate, or PII-containing items
+passes_quality_gate() {
+  local text="$1"
+  local memory_dir="$2"
+  [[ ${#text} -lt $MIN_LENGTH ]] && return 1
+  echo "$text" | grep -qE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' && return 1
+  local check="${text:0:40}"
+  # Check only previously saved session_* files (not session-hot.md source)
+  grep -rqF "$check" "$memory_dir"/session_*.md 2>/dev/null && return 1
+  return 0
+}
+
+# Register a memory file in MEMORY.md index
+register_in_index() {
+  local memory_md="$1" filename="$2" title="$3" desc="$4"
+  [[ ! -f "$memory_md" ]] && touch "$memory_md"
+  local lines
+  lines=$(wc -l < "$memory_md")
+  [[ "$lines" -ge 195 ]] && return 0
+  grep -qF "$filename" "$memory_md" 2>/dev/null && return 0
+  echo "- [$title]($filename) — ${desc:0:80}" >> "$memory_md"
+}
+
+# Save a memory file with frontmatter and register in index
+# Sets ITEMS_SAVED++ (caller must declare ITEMS_SAVED)
+save_memory_file() {
+  local memory_dir="$1" memory_md="$2"
+  local filename="$3" name="$4" desc="$5" type="$6" content="$7"
+  cat > "$memory_dir/$filename" << MEMEOF
+---
+name: $name
+description: $desc
+type: $type
+---
+
+$content
+
+**Why:** Extracted automatically at session stop (SPEC-013v2).
+**How to apply:** Review and incorporate if still relevant.
+MEMEOF
+  register_in_index "$memory_md" "$filename" "$name" "$desc"
+  ITEMS_SAVED=$((ITEMS_SAVED + 1))
+}

--- a/.claude/hooks/stop-memory-extract.sh
+++ b/.claude/hooks/stop-memory-extract.sh
@@ -2,16 +2,16 @@
 set -uo pipefail
 # stop-memory-extract.sh — SPEC-013v2: Deep memory extraction at session stop
 # Hook: Stop | Timeout: 10 min (vs SessionEnd's 1.5s)
-# Strategy: scan session-hot.md + session-actions.jsonl, extract valuable
-# items, persist to auto-memory. This is the heavy extraction that
-# SessionEnd (1.5s) cannot do.
+# Extracts decisions, failures, discoveries, references from session context.
 
 # Tier: standard
 LIB_DIR="$(dirname "${BASH_SOURCE[0]}")/lib"
 if [[ -f "$LIB_DIR/profile-gate.sh" ]]; then
-  # shellcheck source=/dev/null
   source "$LIB_DIR/profile-gate.sh"
   profile_gate "standard"
+fi
+if [[ -f "$LIB_DIR/memory-extract-lib.sh" ]]; then
+  source "$LIB_DIR/memory-extract-lib.sh"
 fi
 
 INPUT=$(cat 2>/dev/null || true)
@@ -23,82 +23,87 @@ SESSION_HOT="$MEMORY_DIR/session-hot.md"
 ACTION_LOG="$HOME/.savia/session-actions.jsonl"
 MEMORY_MD="$MEMORY_DIR/MEMORY.md"
 
-# Skip if nothing to extract
 [[ ! -f "$SESSION_HOT" ]] && [[ ! -f "$ACTION_LOG" ]] && exit 0
+mkdir -p "$MEMORY_DIR"
 
-# ── PHASE 1: Scan session-hot.md for decisions/corrections ──
-DECISIONS=""
-CORRECTIONS=""
+TIMESTAMP=$(date +%Y-%m-%d)
+ITEMS_SAVED=0
+
+# ── PHASE 1: Scan session-hot for decisions/corrections ──
+DECISIONS="" CORRECTIONS="" HOT_TEXT=""
 if [[ -f "$SESSION_HOT" ]] && [[ -s "$SESSION_HOT" ]]; then
-  DECISIONS=$(grep -ioE '(Decisions?:)[^|]*' "$SESSION_HOT" | head -3 | sed 's/Decisions\?:\s*//' | tr '\n' '; ' || true)
-  CORRECTIONS=$(grep -ioE '(Corrections?:)[^|]*' "$SESSION_HOT" | head -3 | sed 's/Corrections\?:\s*//' | tr '\n' '; ' || true)
+  HOT_TEXT=$(cat "$SESSION_HOT")
+  DECISIONS=$(echo "$HOT_TEXT" | grep -ioE '(Decisions?:)[^|]*' | head -3 \
+    | sed 's/Decisions\?:\s*//' | tr '\n' '; ' || true)
+  CORRECTIONS=$(echo "$HOT_TEXT" | grep -ioE '(Corrections?:)[^|]*' | head -3 \
+    | sed 's/Corrections\?:\s*//' | tr '\n' '; ' || true)
 fi
 
-# ── PHASE 2: Scan action log for patterns ──
+# ── PHASE 2: Scan action log for repeated failures ──
 REPEATED_FAILURES=""
 if [[ -f "$ACTION_LOG" ]]; then
-  # Find actions that failed 3+ times (pattern worth remembering)
   REPEATED_FAILURES=$(grep '"attempt":[3-9]' "$ACTION_LOG" 2>/dev/null \
     | grep -o '"action":"[^"]*"' | cut -d'"' -f4 | sort | uniq -c | sort -rn \
     | head -3 | awk '{print $2}' | tr '\n' ', ' || true)
 fi
 
-# ── PHASE 3: Persist valuable items ──
-ITEMS_SAVED=0
+# ── PHASE 2b: Discovery extraction ──
+DISCOVERIES=""
+if [[ -n "$HOT_TEXT" ]]; then
+  DISCOVERIES=$(echo "$HOT_TEXT" | grep -ioE \
+    '(bug was|caused by|root cause|raiz|resulta que|turned out|issue was|problema era)[^|;]{10,80}' \
+    | head -3 | tr '\n' '; ' || true)
+fi
 
-# Persist decisions as project memory
-if [[ -n "$DECISIONS" ]] && [[ ${#DECISIONS} -gt 20 ]]; then
-  SAFE_DECISIONS=$(echo "$DECISIONS" | head -c 200 | tr '"' "'")
-  TIMESTAMP=$(date +%Y-%m-%d)
-  # Check for duplicates before saving
-  if ! grep -qF "${SAFE_DECISIONS:0:40}" "$MEMORY_DIR"/*.md 2>/dev/null; then
-    cat > "$MEMORY_DIR/session_decisions_${TIMESTAMP}.md" << MEMEOF
----
-name: Session decisions ${TIMESTAMP}
-description: Decisions extracted from session stop — ${SAFE_DECISIONS:0:60}
-type: project
----
+# ── PHASE 2c: Reference extraction (URLs) ──
+REFERENCES=""
+if [[ -n "$HOT_TEXT" ]]; then
+  REFERENCES=$(echo "$HOT_TEXT" | grep -oE 'https?://[^ ")<>]+' \
+    | sort -u | head -3 | tr '\n' '; ' || true)
+fi
 
-${SAFE_DECISIONS}
-
-**Why:** Extracted automatically at session stop (SPEC-013v2).
-**How to apply:** Review and incorporate into project decisions if still relevant.
-MEMEOF
-    ITEMS_SAVED=$((ITEMS_SAVED + 1))
+# ── PHASE 3: Persist with quality gates ──
+if [[ -n "$DECISIONS" ]]; then
+  SAFE=$(echo "$DECISIONS" | head -c 200 | tr '"' "'")
+  if passes_quality_gate "$SAFE" "$MEMORY_DIR"; then
+    save_memory_file "$MEMORY_DIR" "$MEMORY_MD" \
+      "session_decisions_${TIMESTAMP}.md" "Session decisions ${TIMESTAMP}" \
+      "Decisions extracted — ${SAFE:0:60}" "project" "$SAFE"
   fi
 fi
 
-# Persist repeated failures as feedback memory
 if [[ -n "$REPEATED_FAILURES" ]]; then
-  SAFE_FAILURES=$(echo "$REPEATED_FAILURES" | head -c 150 | tr '"' "'")
-  TIMESTAMP=$(date +%Y-%m-%d)
-  if ! grep -qF "${SAFE_FAILURES:0:30}" "$MEMORY_DIR"/*.md 2>/dev/null; then
-    cat > "$MEMORY_DIR/session_failures_${TIMESTAMP}.md" << MEMEOF
----
-name: Repeated failures ${TIMESTAMP}
-description: Actions that failed 3+ times this session — ${SAFE_FAILURES:0:60}
-type: feedback
----
-
-Repeated failures: ${SAFE_FAILURES}
-
-**Why:** Pattern of repeated failures indicates a systemic issue.
-**How to apply:** Investigate root cause before retrying same approach.
-MEMEOF
-    ITEMS_SAVED=$((ITEMS_SAVED + 1))
+  SAFE=$(echo "$REPEATED_FAILURES" | head -c 150 | tr '"' "'")
+  if passes_quality_gate "Repeated failures: $SAFE" "$MEMORY_DIR"; then
+    save_memory_file "$MEMORY_DIR" "$MEMORY_MD" \
+      "session_failures_${TIMESTAMP}.md" "Repeated failures ${TIMESTAMP}" \
+      "Actions that failed 3+ times — ${SAFE:0:60}" "feedback" \
+      "Repeated failures: ${SAFE}"
   fi
 fi
 
-# ── PHASE 4: Cleanup action log (consumed) ──
+if [[ -n "$DISCOVERIES" ]]; then
+  SAFE=$(echo "$DISCOVERIES" | head -c 200 | tr '"' "'")
+  if passes_quality_gate "$SAFE" "$MEMORY_DIR"; then
+    save_memory_file "$MEMORY_DIR" "$MEMORY_MD" \
+      "session_discoveries_${TIMESTAMP}.md" "Session discoveries ${TIMESTAMP}" \
+      "Root causes and insights — ${SAFE:0:60}" "project" "$SAFE"
+  fi
+fi
+
+if [[ -n "$REFERENCES" ]]; then
+  SAFE=$(echo "$REFERENCES" | head -c 200 | tr '"' "'")
+  if passes_quality_gate "$SAFE" "$MEMORY_DIR"; then
+    save_memory_file "$MEMORY_DIR" "$MEMORY_MD" \
+      "session_references_${TIMESTAMP}.md" "Session references ${TIMESTAMP}" \
+      "URLs and docs referenced — ${SAFE:0:60}" "reference" "$SAFE"
+  fi
+fi
+
+# ── PHASE 4: Archive action log ──
 if [[ -f "$ACTION_LOG" ]]; then
-  # Archive instead of delete
-  ARCHIVE="$HOME/.savia/session-actions-$(date +%Y%m%d-%H%M%S).jsonl"
-  mv "$ACTION_LOG" "$ARCHIVE" 2>/dev/null || true
+  mv "$ACTION_LOG" "$HOME/.savia/session-actions-$(date +%Y%m%d-%H%M%S).jsonl" 2>/dev/null || true
 fi
 
-# Output summary (visible to Claude on next session)
-if [[ $ITEMS_SAVED -gt 0 ]]; then
-  echo "Session stop: $ITEMS_SAVED items extracted to memory."
-fi
-
+[[ $ITEMS_SAVED -gt 0 ]] && echo "Session stop: $ITEMS_SAVED items extracted to memory."
 exit 0

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f791087bd9a6d8097edefd39b24e1a15a76b7c75ee35384daee702fead6ce948
-timestamp=2026-04-02T23:37:28Z
-branch=feat/era173-overnight-sprint
-head_commit=ef3ea47
-signature=dab9780495a604c3aacbe9508adde696b5e2a5ff608909b212a01c39e3c1712f
+diff_hash=1300f70a9b653f27435508fbc37b2907fc8fac20a8263cc36dee29b198e1563d
+timestamp=2026-04-03T00:15:47Z
+branch=feat/era166-memory-resilience
+head_commit=9aba6ef
+signature=0a69400f04032e7222c0ffa40ebb62d645fd64f9547f62d370aa4635feb4f82e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=1300f70a9b653f27435508fbc37b2907fc8fac20a8263cc36dee29b198e1563d
-timestamp=2026-04-03T00:15:47Z
+diff_hash=58f185dbdd1b5bb3387208a5d35cf4ffcd919b6decb8b339258759b72fc91fe4
+timestamp=2026-04-03T06:45:06Z
 branch=feat/era166-memory-resilience
-head_commit=9aba6ef
-signature=0a69400f04032e7222c0ffa40ebb62d645fd64f9547f62d370aa4635feb4f82e
+head_commit=aace634
+signature=fae0e29501d73d4473b0802041803432c650501e365751a987b0a92b0d4fecad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] — 2026-04-03
+
+feat: Memory Resilience — deep extraction with quality gates. Era 166.
+
+### Added
+
+- **memory-extract-lib.sh**: Shared library for memory extraction hooks (quality gates, MEMORY.md index registration, file persistence)
+- **Discovery extraction**: Detects root cause patterns (bug was, caused by, root cause, resulta que) in session context
+- **Reference extraction**: Captures URLs from session context as reference memory
+- **Quality gates**: Rejects items < 50 chars, PII (email patterns), and duplicates
+- **MEMORY.md index registration**: Extracted items automatically registered in memory index
+- **22 BATS tests**: stop-memory-extract (14) + session-end-memory (8) — first test coverage for memory hooks
+
+### Changed
+
+- **stop-memory-extract.sh**: Refactored with lib extraction, 4 extraction types (decisions, failures, discoveries, references)
+
 ## [4.2.0] — 2026-04-03
 
 feat: Savia Emotional Regulation System — functional stress monitoring and self-regulation. Era 173.
@@ -5471,6 +5488,7 @@ Initial public release of PM-Workspace.
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.30.0...v3.31.0
+[4.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.1.1...v4.2.0
 [3.30.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.29.0...v3.30.0
 [3.29.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.28.0...v3.29.0

--- a/tests/hooks/test-session-end-memory.bats
+++ b/tests/hooks/test-session-end-memory.bats
@@ -75,8 +75,38 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "never exits non-zero" {
-  # Even with completely broken environment
+@test "handles empty action-log gracefully" {
+  touch "$HOME/.savia/session-actions.jsonl"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+}
+
+@test "zero failures counted when no retries in log" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"build","attempt":1}' > "$log"
+  echo '{"action":"test","attempt":1}' >> "$log"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  grep -q "Failures: 0" "$MEMORY_DIR/session-hot.md"
+}
+
+@test "session-hot.md contains timestamp" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"build","attempt":1}' > "$log"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  grep -qE "[0-9]{4}-[0-9]{2}-[0-9]{2}" "$MEMORY_DIR/session-hot.md"
+}
+
+@test "session-end log written to .savia directory" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"test","attempt":1}' > "$log"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/.savia/session-end.log" ]
+}
+
+@test "never exits non-zero even with broken environment" {
   export CLAUDE_PROJECT_DIR="/nonexistent/path/$$"
   run bash "$HOOK" <<< ""
   [ "$status" -eq 0 ]

--- a/tests/hooks/test-session-end-memory.bats
+++ b/tests/hooks/test-session-end-memory.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# tests/hooks/test-session-end-memory.bats — SPEC-013: fast session-end extraction
+
+HOOK="$BATS_TEST_DIRNAME/../../.claude/hooks/session-end-memory.sh"
+
+setup() {
+  export TMPDIR_TEST="$BATS_TEST_TMPDIR/session-end-$$"
+  mkdir -p "$TMPDIR_TEST"
+  export HOME="$TMPDIR_TEST"
+  export CLAUDE_PROJECT_DIR="$TMPDIR_TEST/project"
+  mkdir -p "$CLAUDE_PROJECT_DIR" "$HOME/.savia"
+  PROJ_SLUG=$(echo "$CLAUDE_PROJECT_DIR" | sed 's|[/:\]|-|g; s|^-||')
+  export MEMORY_DIR="$HOME/.claude/projects/$PROJ_SLUG/memory"
+  mkdir -p "$MEMORY_DIR"
+  # Enable standard profile so hook logic runs
+  export SAVIA_HOOK_PROFILE="standard"
+  # Create a minimal git repo for git operations
+  git -C "$CLAUDE_PROJECT_DIR" init -q 2>/dev/null || true
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+@test "script is valid bash" {
+  bash -n "$HOOK"
+}
+
+@test "script uses set -uo pipefail" {
+  head -5 "$HOOK" | grep -q "set -uo pipefail"
+}
+
+@test "creates session-hot.md when action-log exists" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"build","attempt":1,"ts":"2026-04-03T10:00:00Z"}' > "$log"
+  echo '{"action":"test","attempt":2,"ts":"2026-04-03T10:01:00Z"}' >> "$log"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  [ -f "$MEMORY_DIR/session-hot.md" ]
+}
+
+@test "includes failure count from action log" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"deploy","attempt":2,"ts":"2026-04-03T10:00:00Z"}' > "$log"
+  echo '{"action":"build","attempt":3,"ts":"2026-04-03T10:01:00Z"}' >> "$log"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  grep -q "Failures: 2" "$MEMORY_DIR/session-hot.md"
+}
+
+@test "includes last actions from action log" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"compile-service","attempt":1}' > "$log"
+  echo '{"action":"run-tests","attempt":1}' >> "$log"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  grep -q "compile-service" "$MEMORY_DIR/session-hot.md"
+}
+
+@test "includes modified files from git" {
+  # Create a tracked file and modify it
+  echo "initial" > "$CLAUDE_PROJECT_DIR/test.txt"
+  git -C "$CLAUDE_PROJECT_DIR" -c user.name="Test" -c user.email="t@t.com" add test.txt 2>/dev/null
+  git -C "$CLAUDE_PROJECT_DIR" -c user.name="Test" -c user.email="t@t.com" commit -m "init" -q 2>/dev/null
+  echo "modified" > "$CLAUDE_PROJECT_DIR/test.txt"
+  echo '{"action":"edit","attempt":1}' > "$HOME/.savia/session-actions.jsonl"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  grep -q "Files modified:" "$MEMORY_DIR/session-hot.md"
+}
+
+@test "handles missing action-log gracefully" {
+  rm -f "$HOME/.savia/session-actions.jsonl"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+}
+
+@test "never exits non-zero" {
+  # Even with completely broken environment
+  export CLAUDE_PROJECT_DIR="/nonexistent/path/$$"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+}

--- a/tests/hooks/test-stop-memory-extract.bats
+++ b/tests/hooks/test-stop-memory-extract.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# tests/hooks/test-stop-memory-extract.bats — SPEC-013v2: deep memory extraction
+
+HOOK="$BATS_TEST_DIRNAME/../../.claude/hooks/stop-memory-extract.sh"
+LIB="$BATS_TEST_DIRNAME/../../.claude/hooks/lib/memory-extract-lib.sh"
+
+setup() {
+  export TMPDIR_TEST="$BATS_TEST_TMPDIR/stop-extract-$$"
+  mkdir -p "$TMPDIR_TEST/memory" "$TMPDIR_TEST/savia"
+  export HOME="$TMPDIR_TEST"
+  export CLAUDE_PROJECT_DIR="$TMPDIR_TEST/project"
+  mkdir -p "$CLAUDE_PROJECT_DIR"
+  PROJ_SLUG=$(echo "$CLAUDE_PROJECT_DIR" | sed 's|[/:\]|-|g; s|^-||')
+  export MEMORY_DIR="$HOME/.claude/projects/$PROJ_SLUG/memory"
+  mkdir -p "$MEMORY_DIR" "$HOME/.savia"
+  # Enable standard profile so hook logic runs
+  export SAVIA_HOOK_PROFILE="standard"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+@test "script is valid bash" {
+  bash -n "$HOOK"
+}
+
+@test "lib is valid bash" {
+  bash -n "$LIB"
+}
+
+@test "script uses set -uo pipefail" {
+  head -5 "$HOOK" | grep -q "set -uo pipefail"
+}
+
+@test "no extraction when no session-hot or action-log" {
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "decisions extracted from session-hot" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  echo "Decisions: We decided to use PostgreSQL instead of MySQL for the new service architecture" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  local found=$(find "$MEMORY_DIR" -name "session_decisions_*.md" | head -1)
+  [ -n "$found" ]
+  grep -q "PostgreSQL" "$found"
+}
+
+@test "repeated failures extracted from action log" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  # 3 different actions that each failed 3+ times = enough content to pass 50-char gate
+  for i in 1 2 3; do
+    echo '{"action":"deploy-staging-environment","attempt":3,"ts":"2026-04-03T10:0'$i':00Z"}' >> "$log"
+    echo '{"action":"run-integration-test-suite","attempt":4,"ts":"2026-04-03T10:0'$i':00Z"}' >> "$log"
+  done
+  touch "$MEMORY_DIR/session-hot.md"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  local found=$(find "$MEMORY_DIR" -name "session_failures_*.md" | head -1)
+  [ -n "$found" ]
+  grep -q "deploy-staging-environment" "$found"
+}
+
+@test "discovery extraction from session-hot" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  echo "The root cause was a race condition in the connection pool manager that caused timeouts" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  local found=$(find "$MEMORY_DIR" -name "session_discoveries_*.md" | head -1)
+  [ -n "$found" ]
+  grep -q "race condition" "$found"
+}
+
+@test "reference extraction (URL) from session-hot" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  # Put URL on its own line (not inside Decisions: line) to test reference extraction independently
+  echo "See https://docs.microsoft.com/aspnet/core/security/authentication/overview and https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow for details" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  local found=$(find "$MEMORY_DIR" -name "session_references_*.md" | head -1)
+  [ -n "$found" ]
+  grep -q "docs.microsoft.com" "$found"
+}
+
+@test "quality gate: items shorter than 50 chars rejected" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  echo "Decisions: use X" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  local count=$(find "$MEMORY_DIR" -name "session_decisions_*.md" | wc -l)
+  [ "$count" -eq 0 ]
+}
+
+@test "quality gate: duplicate detection prevents double save" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  local content="We decided to use PostgreSQL instead of MySQL for the new service architecture"
+  echo "Decisions: $content" > "$hot"
+  # First run saves
+  bash "$HOOK" <<< ""
+  local count1=$(find "$MEMORY_DIR" -name "session_decisions_*.md" | wc -l)
+  [ "$count1" -eq 1 ]
+  # Second run with same content should not duplicate
+  echo "Decisions: $content" > "$hot"
+  bash "$HOOK" <<< ""
+  local count2=$(find "$MEMORY_DIR" -name "session_decisions_*.md" | wc -l)
+  [ "$count2" -eq 1 ]
+}
+
+@test "quality gate: PII (email) rejected" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  echo "Decisions: Send the report to john.doe@company.com and wait for approval from the team" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  local count=$(find "$MEMORY_DIR" -name "session_decisions_*.md" | wc -l)
+  [ "$count" -eq 0 ]
+}
+
+@test "MEMORY.md index updated after extraction" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  echo "Decisions: We decided to migrate from REST to GraphQL for the public API because of query flexibility" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  [ -f "$MEMORY_DIR/MEMORY.md" ]
+  grep -q "session_decisions_" "$MEMORY_DIR/MEMORY.md"
+}
+
+@test "action log archived after extraction" {
+  local log="$HOME/.savia/session-actions.jsonl"
+  echo '{"action":"test","attempt":1}' > "$log"
+  touch "$MEMORY_DIR/session-hot.md"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  [ ! -f "$log" ]
+  local archived=$(find "$HOME/.savia" -name "session-actions-*.jsonl" | head -1)
+  [ -n "$archived" ]
+}
+
+@test "output reports items saved count" {
+  local hot="$MEMORY_DIR/session-hot.md"
+  echo "Decisions: We decided to implement caching at the application layer using Redis for session storage" > "$hot"
+  run bash "$HOOK" <<< ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"items extracted to memory"* ]]
+}


### PR DESCRIPTION
## Summary
- Enhanced `stop-memory-extract.sh` with 4 extraction types: decisions, failures, discoveries, references
- Quality gates: min 50 chars, PII rejection (email patterns), duplicate detection
- Automatic MEMORY.md index registration for extracted items
- Extracted shared lib `memory-extract-lib.sh` for reusable quality gate + persistence functions
- 22 new BATS tests (14 + 8) — first test coverage for memory hooks

## Era 166 — Memory Resilience (SPEC-013v2)
Completes Phase 2 of session memory extraction. Memory now survives compactions and session ends with higher fidelity.

## Test plan
- [x] `bats tests/hooks/test-stop-memory-extract.bats` — 14/14 pass
- [x] `bats tests/hooks/test-session-end-memory.bats` — 8/8 pass
- [x] `bash tests/run-all.sh` — 78/86 suites (8 pre-existing failures)
- [x] `bash scripts/validate-ci-local.sh` — 7/7 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)