### PR TITLE
feat: Era 174 — Emergency Watchdog (auto LLM fallback on internet loss)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=66f06208f346af57826c98fae6ec6b1790365aa7bfda33c561553072ea626616
-timestamp=2026-04-03T19:21:53Z
+diff_hash=61bb274bb8acaa1e49312379daef07d8ae1604de236f7c4ee85d4cc677b78606
+timestamp=2026-04-03T19:35:42Z
 branch=feat/era174-emergency-watchdog
-head_commit=745e0ae
-signature=c39c81fd27f0acff9f09b07a83a7db9ca6dd2981a30e02dea76ce21644559d79
+head_commit=0014233
+signature=c13c3c25ba90b84cd493a289113bf6dc79c81471254927f2bce020a27335ab2e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0a75b535e59ab383e7597606905fbaa7992f45cf323bf9aed8f8caebdc16ccdc
-timestamp=2026-04-03T15:35:01Z
-branch=feat/era174-hygiene-debt-audit
-head_commit=2d52fa5
-signature=cd21e603ffa2fef17f0c0a22ffd97b1dc5ac6128b509a80061893d00508271c0
+diff_hash=66f06208f346af57826c98fae6ec6b1790365aa7bfda33c561553072ea626616
+timestamp=2026-04-03T19:21:53Z
+branch=feat/era174-emergency-watchdog
+head_commit=745e0ae
+signature=c39c81fd27f0acff9f09b07a83a7db9ca6dd2981a30e02dea76ce21644559d79

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.0] — 2026-04-03
+
+feat: Emergency Watchdog — automatic local LLM fallback on internet loss. Era 174.
+
+### Added
+
+- **savia-watchdog.sh**: Systemd service that monitors connectivity to api.anthropic.com every 5 min. After 3 consecutive failures, activates Ollama with local model and notifies via `wall`. When internet returns, unloads model to free RAM
+- **savia-watchdog.service**: Systemd unit file (runs as user monica, auto-restart)
+- **install-watchdog.sh**: One-time installer (`sudo bash scripts/install-watchdog.sh`)
+
+### Changed
+
+- **emergency-plan.sh**: Default model selection updated to Gemma 4 (e2b for 16GB, e4b for 32GB+, qwen2.5:3b for 8GB)
+- **ollama-classify.sh**: Shield default model changed from qwen2.5:7b to qwen2.5:3b (fits in available RAM alongside Claude Code)
+
 ## [4.4.0] — 2026-04-03
 
 feat: Hygiene + Debt Audit — SPEC dedup, PII gate bugfix, 5 new test suites. Era 174.
@@ -5518,6 +5533,7 @@ Initial public release of PM-Workspace.
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.30.0...v3.31.0
+[4.5.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.1.1...v4.2.0

--- a/scripts/emergency-plan.sh
+++ b/scripts/emergency-plan.sh
@@ -43,7 +43,7 @@ else RAM_GB=$(( $(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || 
 echo -e "  OS: ${GREEN}$OS${NC} · Arch: ${GREEN}$ARCH${NC} · RAM: ${GREEN}${RAM_GB}GB${NC}"
 
 if [[ -z "$MODEL" ]]; then
-  [[ $RAM_GB -ge 32 ]] && MODEL="qwen2.5:14b" || { [[ $RAM_GB -ge 16 ]] && MODEL="qwen2.5:7b" || MODEL="qwen2.5:3b"; }
+  [[ $RAM_GB -ge 32 ]] && MODEL="gemma4:e4b" || { [[ $RAM_GB -ge 16 ]] && MODEL="gemma4:e2b" || MODEL="qwen2.5:3b"; }
   echo -e "  Modelo: ${CYAN}$MODEL${NC} (auto)"
 fi; mkdir -p "$CACHE_DIR"
 

--- a/scripts/install-watchdog.sh
+++ b/scripts/install-watchdog.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# install-watchdog.sh — Installs savia-watchdog as systemd service
+# Usage: sudo bash scripts/install-watchdog.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_FILE="$SCRIPT_DIR/savia-watchdog.service"
+DEST="/etc/systemd/system/savia-watchdog.service"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Error: run with sudo"
+  echo "  sudo bash $0"
+  exit 1
+fi
+
+cp "$SERVICE_FILE" "$DEST"
+systemctl daemon-reload
+systemctl enable savia-watchdog
+systemctl start savia-watchdog
+
+echo "savia-watchdog installed and running"
+echo "  Status:  systemctl status savia-watchdog"
+echo "  Logs:    cat /tmp/savia-watchdog/watchdog.log"
+echo "  Stop:    sudo systemctl stop savia-watchdog"
+echo "  Config:  edit $DEST [Environment lines]"

--- a/scripts/ollama-classify.sh
+++ b/scripts/ollama-classify.sh
@@ -7,7 +7,7 @@
 set -uo pipefail
 
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_CLASSIFY_MODEL:-qwen2.5:7b}"
+OLLAMA_MODEL="${OLLAMA_CLASSIFY_MODEL:-qwen2.5:3b}"
 OLLAMA_TIMEOUT="${OLLAMA_TIMEOUT:-15}"
 
 # Leer texto de stdin o argumento
@@ -36,7 +36,7 @@ export OLLAMA_MODEL_FOR_PY="$OLLAMA_MODEL"
 PAYLOAD=$(printf '%s' "$TEXT" | python3 -c "
 import sys, json, os
 text = sys.stdin.read()[:2000]
-model = os.environ.get('OLLAMA_MODEL_FOR_PY', 'qwen2.5:7b')
+model = os.environ.get('OLLAMA_MODEL_FOR_PY', 'qwen2.5:3b')
 prompt = '''You are a data classification system. You MUST classify the text between [BEGIN DATA] and [END DATA] markers.
 
 CRITICAL RULES:

--- a/scripts/savia-watchdog.service
+++ b/scripts/savia-watchdog.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Savia Watchdog — Emergency LLM fallback on internet loss
+After=network.target ollama.service
+Wants=ollama.service
+
+[Service]
+Type=simple
+User=monica
+Environment=SAVIA_WATCHDOG_INTERVAL=300
+Environment=SAVIA_WATCHDOG_THRESHOLD=3
+Environment=SAVIA_EMERGENCY_MODEL=qwen2.5:3b
+ExecStart=/home/monica/claude/scripts/savia-watchdog.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/savia-watchdog.sh
+++ b/scripts/savia-watchdog.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# savia-watchdog.sh — Emergency fallback: detect internet loss, activate local LLM
+# Runs as systemd service. Checks connectivity every CHECK_INTERVAL seconds.
+# If API unreachable for FAIL_THRESHOLD consecutive checks: activate emergency mode.
+# If API returns: deactivate emergency mode and free RAM.
+
+CHECK_INTERVAL="${SAVIA_WATCHDOG_INTERVAL:-300}"
+FAIL_THRESHOLD="${SAVIA_WATCHDOG_THRESHOLD:-3}"
+API_URL="https://api.anthropic.com"
+BACKUP_URL="https://google.com"
+STATE_DIR="/tmp/savia-watchdog"
+STATE_FILE="$STATE_DIR/state"
+LOG_FILE="$STATE_DIR/watchdog.log"
+OLLAMA_MODEL="${SAVIA_EMERGENCY_MODEL:-qwen2.5:3b}"
+NOTIFY_FILE="$STATE_DIR/last-notify"
+
+mkdir -p "$STATE_DIR"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"; }
+
+rotate_log() {
+  [[ -f "$LOG_FILE" ]] && [[ $(wc -l < "$LOG_FILE") -gt 500 ]] && tail -250 "$LOG_FILE" > "${LOG_FILE}.tmp" && mv "${LOG_FILE}.tmp" "$LOG_FILE"
+}
+
+check_internet() {
+  curl -sf --max-time 5 "$API_URL" >/dev/null 2>&1 && return 0
+  curl -sf --max-time 5 "$BACKUP_URL" >/dev/null 2>&1 && return 0
+  return 1
+}
+
+get_state() { cat "$STATE_FILE" 2>/dev/null || echo "online"; }
+set_state() { echo "$1" > "$STATE_FILE"; }
+
+notify_user() {
+  local msg="$1"
+  # Write to terminal if available
+  wall "$msg" 2>/dev/null || true
+  # Write notification file for Savia session-init to pick up
+  echo "$msg" > "$NOTIFY_FILE"
+  log "NOTIFY: $msg"
+}
+
+activate_emergency() {
+  log "EMERGENCY ACTIVATED — starting Ollama with $OLLAMA_MODEL"
+  set_state "emergency"
+
+  # Ensure Ollama is running
+  if ! curl -sf --max-time 3 http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+    systemctl start ollama 2>/dev/null || ollama serve &>/dev/null &
+    sleep 3
+  fi
+
+  # Warm up model (load into RAM)
+  echo "ping" | ollama run "$OLLAMA_MODEL" --nowordwrap >/dev/null 2>&1 || true
+
+  notify_user "SAVIA EMERGENCY: Internet caido. Modelo local $OLLAMA_MODEL activo en localhost:11434. Usa: ollama run $OLLAMA_MODEL"
+}
+
+deactivate_emergency() {
+  log "INTERNET RESTORED — deactivating emergency mode"
+  set_state "online"
+
+  # Unload model to free RAM (stop Ollama if it was started by us)
+  ollama stop "$OLLAMA_MODEL" 2>/dev/null || true
+
+  notify_user "SAVIA: Internet restaurado. Modelo local descargado de RAM."
+}
+
+# ── Main loop ──
+
+fail_count=0
+log "Watchdog started. Interval: ${CHECK_INTERVAL}s, Threshold: $FAIL_THRESHOLD, Model: $OLLAMA_MODEL"
+
+while true; do
+  rotate_log
+
+  if check_internet; then
+    if [[ $(get_state) == "emergency" ]]; then
+      deactivate_emergency
+    fi
+    fail_count=0
+  else
+    ((fail_count++)) || true
+    log "Check failed ($fail_count/$FAIL_THRESHOLD)"
+
+    if [[ $fail_count -ge $FAIL_THRESHOLD ]] && [[ $(get_state) != "emergency" ]]; then
+      activate_emergency
+    fi
+  fi
+
+  sleep "$CHECK_INTERVAL"
+done

--- a/tests/scripts/test-emergency-plan.bats
+++ b/tests/scripts/test-emergency-plan.bats
@@ -69,8 +69,8 @@ teardown() {
 
 @test "emergency: model selection for 3 RAM tiers" {
   grep -q 'qwen2.5:3b' "$SCRIPT"
-  grep -q 'qwen2.5:7b' "$SCRIPT"
-  grep -q 'qwen2.5:14b' "$SCRIPT"
+  grep -q 'gemma4:e2b' "$SCRIPT"
+  grep -q 'gemma4:e4b' "$SCRIPT"
 }
 
 @test "emergency: RAM thresholds at 16GB and 32GB" {


### PR DESCRIPTION
## Summary

- **savia-watchdog.sh**: Systemd service that checks api.anthropic.com every 5 min. After 3 failures, auto-starts Ollama with local model and notifies via `wall`. When internet returns, unloads model to free RAM
- **Gemma 4 + Qwen evaluated**: 4 models installed on Lima (gemma4:e2b, gemma4:e4b, qwen2.5:7b, qwen2.5:3b). Shield default changed to 3b (fits alongside Claude Code)
- **Install**: `sudo bash scripts/install-watchdog.sh` (one-time)

## Test plan

- [x] CI local: 7/7 passed
- [x] Scripts validate: `bash -n` clean
- [x] qwen2.5:3b benchmark: Shield classification correct (CONFIDENTIAL), 3.5s
- [x] Watchdog logic: check_internet, activate/deactivate, state management
- [ ] Manual: kill internet, verify watchdog activates within 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)