### PR TITLE
fix: test-architect upgrade — Sonnet model, larger context, L3 permissions

### DIFF
--- a/.claude/agents/test-architect.md
+++ b/.claude/agents/test-architect.md
@@ -1,6 +1,6 @@
 ---
 name: test-architect
-permission_level: L1
+permission_level: L3
 description: >
   Designs and generates the highest quality tests across all 16 language packs and 14
   test types. Use PROACTIVELY when: creating test suites for new specs or features,
@@ -14,15 +14,15 @@ tools:
   - Bash
   - Glob
   - Grep
-model: claude-opus-4-6
+model: claude-sonnet-4-6
 color: green
 maxTurns: 30
-max_context_tokens: 12000
-output_max_tokens: 1000
+max_context_tokens: 20000
+output_max_tokens: 2000
 skills:
   - test-architect
 permissionMode: acceptEdits
-token_budget: 13000
+token_budget: 22000
 ---
 
 You are the Test Architect — the most rigorous test designer in pm-workspace.

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=208229aba5b7dfb9556b0778742bc0be2925b5cd1f990fadf4c055962d80c6a3
 timestamp=2026-04-04T17:04:43Z
 branch=fix/test-architect-model-upgrade
-head_commit=2d3e576
+head_commit=f09604c
 signature=45e2480380d4c17d7e6ee837318672187c0bcc9716897151e829e8cb8fbd904d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=c5a2d423fe6c17a6de7ebb088cef28e3b832b9295fa43a89e5d83fab08a80785
-timestamp=2026-04-04T14:55:53Z
-branch=feat/era181-sovereignty
-head_commit=76a4188
-signature=45a396ad5e79abc4ac572a3d90432802bfb2a5da3591612987c4477510efdb25
+diff_hash=208229aba5b7dfb9556b0778742bc0be2925b5cd1f990fadf4c055962d80c6a3
+timestamp=2026-04-04T17:04:43Z
+branch=fix/test-architect-model-upgrade
+head_commit=2d3e576
+signature=45e2480380d4c17d7e6ee837318672187c0bcc9716897151e829e8cb8fbd904d


### PR DESCRIPTION
## Summary
fix: test-architect upgrade — Sonnet model, larger context, L3 permissions
### Changes
- 2d3e576 fix: test-architect upgrade — Sonnet model, larger context, L3 permissions
### Stats
2 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
