### PR TITLE
fix(savia-dual): make setup scripts fully idempotent

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=7153ec682a36e4bfd7d5b0b07611d3042171ea31c548e11c0ac0d7e5c278a0b1
-timestamp=2026-04-11T16:52:00Z
-branch=feat/savia-dual
-head_commit=3fcf5b6
-signature=2ab5b64b89d03c541274c0c80ab99c665e428b4162a3cdcde7001f7f056150ff
+diff_hash=52033fbfb625954443b113a46fa64d3fc93f05eb6e1ad0fd91ebc0c6fc4ab748
+timestamp=2026-04-11T17:21:23Z
+branch=fix/savia-dual-idempotent
+head_commit=07ebdff
+signature=5d2fe74363362eedfb61f4931b74a012b0a1f41a51c76fc3552cc4ccf002c417

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=52033fbfb625954443b113a46fa64d3fc93f05eb6e1ad0fd91ebc0c6fc4ab748
 timestamp=2026-04-11T17:21:23Z
 branch=fix/savia-dual-idempotent
-head_commit=07ebdff
+head_commit=81de222
 signature=5d2fe74363362eedfb61f4931b74a012b0a1f41a51c76fc3552cc4ccf002c417

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Savia Dual installer scripts are now fully idempotent. Re-running them
 no longer re-downloads Ollama or models already present, and no longer
-overwrites an existing config.
+overwrites an existing config. Era 205.
 
 ### Fixed
 - **Installer reuse logic** `scripts/setup-savia-dual.sh` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.40.1] — 2026-04-11
+
+Savia Dual installer scripts are now fully idempotent. Re-running them
+no longer re-downloads Ollama or models already present, and no longer
+overwrites an existing config.
+
+### Fixed
+- **Installer reuse logic** `scripts/setup-savia-dual.sh` and
+  `scripts/setup-savia-dual.ps1` — if any `gemma4` variant is already
+  installed, reuse it instead of pulling the hardware-ideal pick. The
+  user's deliberate choice is honored (e.g. `gemma4:26b` kept even on
+  machines where the ideal pick would be smaller).
+- **Config preservation** — existing `~/.savia/dual/config.json` and
+  `env` files are no longer overwritten on re-run. New `--force` /
+  `-Force` flag to rewrite them explicitly; `--reconfigure` now
+  implies `--force`.
+- **Model detection** — stronger parsing of `ollama list` output
+  (skip header, filter by `gemma4:` prefix).
+
 ## [4.40.0] — 2026-04-11
 
 Savia Dual: inference sovereignty layer with transparent failover between
@@ -6158,6 +6177,7 @@ Initial public release of PM-Workspace.
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.30.0...v3.31.0
+[4.40.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.40.0...v4.40.1
 [4.40.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.39.0...v4.40.0
 [4.39.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.37.0...v4.39.0
 [4.37.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.36.0...v4.37.0

--- a/scripts/setup-savia-dual.ps1
+++ b/scripts/setup-savia-dual.ps1
@@ -1,20 +1,27 @@
 # setup-savia-dual.ps1 — Installer for Savia Dual (Windows)
 #
-# Installs/updates Ollama via winget, detects hardware, picks the best
-# gemma4 variant, downloads it, writes config, and prepares the environment
-# to run the savia-dual-proxy. Hardware details stay local and are never
-# written to tracked files.
+# Fully idempotent: re-running this script will NOT re-download Ollama,
+# re-pull models, or overwrite an existing config. Only missing pieces are
+# added. Use -Force to rewrite config, or -Reconfigure to regenerate only
+# the config without touching Ollama/models.
+#
+# If an acceptable gemma4 variant is already installed, it will be reused
+# instead of pulling a new one — even if it differs from the ideal pick
+# for this hardware.
 #
 # Usage:
-#   pwsh .\scripts\setup-savia-dual.ps1
+#   pwsh .\scripts\setup-savia-dual.ps1             # install + configure
 #   pwsh .\scripts\setup-savia-dual.ps1 -DryRun
-#   pwsh .\scripts\setup-savia-dual.ps1 -Reconfigure
+#   pwsh .\scripts\setup-savia-dual.ps1 -Reconfigure # config only
+#   pwsh .\scripts\setup-savia-dual.ps1 -Force       # rewrite config
 
 [CmdletBinding()]
 param(
     [switch]$DryRun,
-    [switch]$Reconfigure
+    [switch]$Reconfigure,
+    [switch]$Force
 )
+if ($Reconfigure) { $Force = $true }
 
 $ErrorActionPreference = "Stop"
 
@@ -117,14 +124,45 @@ function Select-GemmaVariant($ram, $vram) {
     return "gemma4:e2b"
 }
 
-$Model = Select-GemmaVariant $RamGB $VramGB
-Say "Selected local model: $Model"
+function Get-InstalledGemma4 {
+    $raw = & ollama list 2>$null
+    if (-not $raw) { return @() }
+    $lines = $raw -split "`n" | Select-Object -Skip 1
+    $names = @()
+    foreach ($line in $lines) {
+        $first = ($line -split '\s+')[0]
+        if ($first -match '^gemma4:') { $names += $first }
+    }
+    return $names
+}
 
-# ── Download model ─────────────────────────────────────────────────────────
+function Choose-FromInstalled($installed) {
+    # Any already-installed gemma4 variant is acceptable — user downloaded
+    # it deliberately. Prefer largest (26b > e4b > e2b).
+    if ($installed -contains 'gemma4:26b') { return 'gemma4:26b' }
+    if ($installed -contains 'gemma4:e4b') { return 'gemma4:e4b' }
+    if ($installed -contains 'gemma4:e2b') { return 'gemma4:e2b' }
+    return $null
+}
+
+$Ideal = Select-GemmaVariant $RamGB $VramGB
+$Installed = Get-InstalledGemma4
+
+if ($Installed -contains $Ideal) {
+    $Model = $Ideal
+    Say "Ideal variant already installed: $Model (skipping download)"
+} elseif ($Installed.Count -gt 0) {
+    $Model = Choose-FromInstalled $Installed
+    Say "Reusing already-installed variant: $Model (ideal would be $Ideal, skipping download)"
+} else {
+    $Model = $Ideal
+    Say "No gemma4 variant installed — will pull $Model"
+}
+
+# ── Download model (only if truly missing) ─────────────────────────────────
 if (-not $Reconfigure) {
-    $installed = (& ollama list 2>$null) -split "`n" | ForEach-Object { ($_ -split '\s+')[0] }
-    if ($installed -contains $Model) {
-        Say "Model $Model already present."
+    if ($Installed -contains $Model) {
+        Say "Model $Model already present — no download needed."
     } else {
         Say "Downloading $Model (this may take a while)..."
         Invoke-Step "ollama pull $Model" { & ollama pull $Model | Out-Host }
@@ -141,7 +179,18 @@ Invoke-Step "mkdir $ConfigDir" {
     New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
 }
 
-if (-not $DryRun) {
+$WriteConfig = $true
+$WriteEnv = $true
+if ((Test-Path $ConfigPath) -and -not $Force) {
+    Say "Config already exists: $ConfigPath (use -Force to rewrite)"
+    $WriteConfig = $false
+}
+if ((Test-Path $EnvPath) -and -not $Force) {
+    Say "Env file already exists: $EnvPath (use -Force to rewrite)"
+    $WriteEnv = $false
+}
+
+if (-not $DryRun -and $WriteConfig) {
     $config = [ordered]@{
         listen_host = "127.0.0.1"
         listen_port = 8787
@@ -161,15 +210,16 @@ if (-not $DryRun) {
         log_path = $LogPath
     }
     $config | ConvertTo-Json -Depth 5 | Set-Content -Path $ConfigPath -Encoding UTF8
+    Say "Config written: $ConfigPath"
+}
 
+if (-not $DryRun -and $WriteEnv) {
     @"
 # Dot-source this file to route Claude Code through Savia Dual.
 `$env:ANTHROPIC_BASE_URL = "http://127.0.0.1:8787"
 `$env:SAVIA_DUAL_ACTIVE = "1"
 `$env:OLLAMA_KEEP_ALIVE = "24h"
 "@ | Set-Content -Path $EnvPath -Encoding UTF8
-
-    Say "Config written: $ConfigPath"
     Say "Env file:       $EnvPath"
 }
 

--- a/scripts/setup-savia-dual.sh
+++ b/scripts/setup-savia-dual.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
 # setup-savia-dual.sh — Installer for Savia Dual (Linux/macOS)
 #
-# Installs/updates Ollama, detects hardware, picks the best gemma4 variant,
-# downloads it, writes config, and prepares the environment to run the
-# savia-dual-proxy. Does NOT log hardware specifics to any tracked file.
+# Fully idempotent: re-running this script will NOT re-download Ollama,
+# re-pull models, or overwrite an existing config. Only missing pieces are
+# added. Use --force to rewrite config, or --reconfigure to regenerate
+# only the config without touching Ollama/models.
 #
 # Usage:
-#   ./scripts/setup-savia-dual.sh              # install + configure
+#   ./scripts/setup-savia-dual.sh              # install + configure (idempotent)
 #   ./scripts/setup-savia-dual.sh --dry-run    # show what would happen
 #   ./scripts/setup-savia-dual.sh --reconfigure # regenerate config only
+#   ./scripts/setup-savia-dual.sh --force      # rewrite config even if present
 set -uo pipefail
 
 DRY_RUN=0
 RECONFIG_ONLY=0
+FORCE=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=1 ;;
-    --reconfigure) RECONFIG_ONLY=1 ;;
+    --reconfigure) RECONFIG_ONLY=1; FORCE=1 ;;
+    --force) FORCE=1 ;;
     -h|--help)
-      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -25
       exit 0
       ;;
   esac
@@ -108,8 +112,12 @@ RAM_GB=$(detect_ram_gb)
 VRAM_GB=$(detect_vram_gb)
 say "Hardware detection complete (values kept local, not logged)."
 
-# ── Pick gemma4 variant ─────────────────────────────────────────────────────
-# Rationale kept generic so no hardware specifics leak to docs.
+# ── List installed gemma4 variants (idempotency source of truth) ────────────
+list_installed_gemma4() {
+  ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -E '^gemma4:' || true
+}
+
+# ── Pick gemma4 variant by hardware (ideal pick) ────────────────────────────
 pick_variant() {
   local ram="$1" vram="$2"
   if [[ "$ram" -lt 12 ]]; then
@@ -127,13 +135,51 @@ pick_variant() {
   echo "gemma4:e2b"
 }
 
-MODEL=$(pick_variant "$RAM_GB" "$VRAM_GB")
-say "Selected local model: $MODEL"
+# ── Reuse already-downloaded variant when possible ──────────────────────────
+# Priority:
+#   1. If the ideal pick is already installed → use it.
+#   2. Else, if ANY gemma4 variant is already installed → reuse it (best fit
+#      by hardware, no new download).
+#   3. Else → pull the ideal pick.
+IDEAL=$(pick_variant "$RAM_GB" "$VRAM_GB")
+INSTALLED=$(list_installed_gemma4)
 
-# ── Download model ──────────────────────────────────────────────────────────
+choose_from_installed() {
+  # Any already-installed gemma4 variant is acceptable — the user downloaded
+  # it deliberately. Prefer the largest one (26b > e4b > e2b) since disk
+  # space was already spent.
+  local installed="$1"
+  local has_e2b=0 has_e4b=0 has_26b=0
+  while IFS= read -r m; do
+    [[ -z "$m" ]] && continue
+    case "$m" in
+      gemma4:e2b) has_e2b=1 ;;
+      gemma4:e4b) has_e4b=1 ;;
+      gemma4:26b) has_26b=1 ;;
+    esac
+  done <<< "$installed"
+  [[ $has_26b -eq 1 ]] && { echo "gemma4:26b"; return; }
+  [[ $has_e4b -eq 1 ]] && { echo "gemma4:e4b"; return; }
+  [[ $has_e2b -eq 1 ]] && { echo "gemma4:e2b"; return; }
+  echo ""
+}
+
+if echo "$INSTALLED" | grep -qx "$IDEAL"; then
+  MODEL="$IDEAL"
+  say "Ideal variant already installed: $MODEL (skipping download)"
+elif [[ -n "$INSTALLED" ]]; then
+  REUSE=$(choose_from_installed "$INSTALLED")
+  MODEL="$REUSE"
+  say "Reusing already-installed variant: $MODEL (ideal would be $IDEAL, skipping download)"
+else
+  MODEL="$IDEAL"
+  say "No gemma4 variant installed — will pull $MODEL"
+fi
+
+# ── Download model (only if truly missing) ──────────────────────────────────
 if [[ $RECONFIG_ONLY -eq 0 ]]; then
-  if ollama list 2>/dev/null | awk '{print $1}' | grep -qx "$MODEL"; then
-    say "Model $MODEL already present."
+  if echo "$INSTALLED" | grep -qx "$MODEL"; then
+    say "Model $MODEL already present — no download needed."
   else
     say "Downloading $MODEL (this may take a while)..."
     run "ollama pull $MODEL"
@@ -146,7 +192,21 @@ CONFIG_PATH="$CONFIG_DIR/config.json"
 ENV_PATH="$CONFIG_DIR/env"
 run "mkdir -p '$CONFIG_DIR'"
 
-if [[ $DRY_RUN -eq 0 ]]; then
+if [[ -f "$CONFIG_PATH" && $FORCE -eq 0 ]]; then
+  say "Config already exists: $CONFIG_PATH (use --force to rewrite)"
+  WRITE_CONFIG=0
+else
+  WRITE_CONFIG=1
+fi
+
+if [[ -f "$ENV_PATH" && $FORCE -eq 0 ]]; then
+  say "Env file already exists: $ENV_PATH (use --force to rewrite)"
+  WRITE_ENV=0
+else
+  WRITE_ENV=1
+fi
+
+if [[ $DRY_RUN -eq 0 && $WRITE_CONFIG -eq 1 ]]; then
   cat > "$CONFIG_PATH" <<JSON
 {
   "listen_host": "127.0.0.1",
@@ -167,13 +227,16 @@ if [[ $DRY_RUN -eq 0 ]]; then
   "log_path": "$HOME/.savia/dual/events.jsonl"
 }
 JSON
+  say "Config written: $CONFIG_PATH"
+fi
+
+if [[ $DRY_RUN -eq 0 && $WRITE_ENV -eq 1 ]]; then
   cat > "$ENV_PATH" <<ENV
 # Source this file to route Claude Code through Savia Dual.
 export ANTHROPIC_BASE_URL="http://127.0.0.1:8787"
 export SAVIA_DUAL_ACTIVE="1"
 export OLLAMA_KEEP_ALIVE="24h"
 ENV
-  say "Config written: $CONFIG_PATH"
   say "Env file:       $ENV_PATH"
 fi
 


### PR DESCRIPTION
## Summary
fix(savia-dual): make setup scripts fully idempotent
### Changes
- 07ebdff docs(changelog): add Era 205 reference to 4.40.1
- 612bc05 docs(changelog): 4.40.1 — savia-dual installer idempotency fix
- 3ed189a fix(savia-dual): make setup scripts fully idempotent
### Stats
4 files changed across 3 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
