### PR TITLE
feat(savia-dual): fully automatic installer with auto-launch

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=51feceeea9286f6426bca90b8d602e9ce31f3d4eb5dd0626adff6378cab3acaa
-timestamp=2026-04-11T17:37:13Z
-branch=feat/savia-enterprise-multi-tenant
-head_commit=e7aae99
-signature=2cac032d2b5df497c026d7bdf5a6ed9362e548e2f7a6864436f68dce72e2c325
+diff_hash=736a2d68d25dbbf800be0e57a12bff7307bcc5a0d6dfc9e2c512bdc567db7c9f
+timestamp=2026-04-11T18:17:01Z
+branch=fix/savia-dual-idempotent
+head_commit=0f31b2c
+signature=9982a1fa049a30ee482e8f322132d3b7663305b2594c467c12765e2e10824330

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=736a2d68d25dbbf800be0e57a12bff7307bcc5a0d6dfc9e2c512bdc567db7c9f
 timestamp=2026-04-11T18:17:01Z
 branch=fix/savia-dual-idempotent
-head_commit=0f31b2c
+head_commit=960ca4c
 signature=9982a1fa049a30ee482e8f322132d3b7663305b2594c467c12765e2e10824330

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.42.0] — 2026-04-11
+
+Savia Dual installer is now fully automatic. A single command provisions
+the proxy service, shell integration, and launches Claude Code with the
+routing environment already applied. The user runs one script and lands
+inside Claude Code with the proxy active — no manual sourcing, no new
+terminal, no thinking about environment propagation. Era 205.
+
+### Added
+- **systemd unit (Linux)** `savia-dual-proxy.service` installed at
+  `/etc/systemd/system/`, enabled at boot, runs as the invoking user
+  with logs at `/var/log/savia-dual-proxy.log`.
+- **launchd agent (macOS)** `com.savia.dual.proxy.plist` installed at
+  `~/Library/LaunchAgents/` with `KeepAlive`.
+- **Shell integration** — idempotent block appended to `~/.bashrc` and
+  `~/.zshrc` that sources `~/.savia/dual/env` on every new shell, so
+  `ANTHROPIC_BASE_URL` is set automatically without manual intervention.
+- **Health check** — `GET http://127.0.0.1:8787/health` verified right
+  after the service starts.
+- **Auto-launch** — the installer sources the env file in its own
+  process and `exec`s `claude`, so Claude Code inherits
+  `ANTHROPIC_BASE_URL` without requiring the parent shell to reload.
+  A child process cannot modify its parent's environment, so
+  `bash setup.sh && claude` is impossible on Unix. Exec from the same
+  process sidesteps the limitation cleanly.
+- **`--no-launch` flag** — install without exec'ing claude, for CI and
+  headless server provisioning.
+- **`--` passthrough** — arguments after `--` are forwarded to claude on
+  auto-launch (e.g. `./setup-savia-dual.sh -- --resume`).
+
+### Changed
+- **Installer UX** — the final summary no longer asks the user to open
+  a new terminal; the installer itself ends inside Claude Code.
+
 ## [4.41.0] — 2026-04-11
 
 Savia Enterprise multi-tenant isolation & RBAC (SE-002). Era 206. Third P0 of the Savia → Savia Enterprise migration plan. Depends on SE-001. Core stays untouched: all new behaviour is gated by `manifest.json → multi-tenant.enabled`.
@@ -6193,6 +6227,7 @@ Initial public release of PM-Workspace.
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.30.0...v3.31.0
+[4.42.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.41.0...v4.42.0
 [4.41.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.40.1...v4.41.0
 [4.40.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.40.0...v4.40.1
 [4.40.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.39.0...v4.40.0

--- a/scripts/setup-savia-dual.sh
+++ b/scripts/setup-savia-dual.sh
@@ -7,20 +7,26 @@
 # only the config without touching Ollama/models.
 #
 # Usage:
-#   ./scripts/setup-savia-dual.sh              # install + configure (idempotent)
+#   ./scripts/setup-savia-dual.sh              # install + configure + launch claude
+#   ./scripts/setup-savia-dual.sh --no-launch  # install only, do not exec claude
 #   ./scripts/setup-savia-dual.sh --dry-run    # show what would happen
 #   ./scripts/setup-savia-dual.sh --reconfigure # regenerate config only
 #   ./scripts/setup-savia-dual.sh --force      # rewrite config even if present
+#   ./scripts/setup-savia-dual.sh -- --resume  # pass args after -- to claude
 set -uo pipefail
 
 DRY_RUN=0
 RECONFIG_ONLY=0
 FORCE=0
+NO_LAUNCH=0
+CLAUDE_ARGS=()
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=1 ;;
     --reconfigure) RECONFIG_ONLY=1; FORCE=1 ;;
     --force) FORCE=1 ;;
+    --no-launch) NO_LAUNCH=1 ;;
+    --) shift; CLAUDE_ARGS=("$@"); break ;;
     -h|--help)
       grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -25
       exit 0
@@ -32,6 +38,11 @@ say() { printf '\033[0;36m[savia-dual]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[savia-dual]\033[0m %s\n' "$*" >&2; }
 err() { printf '\033[0;31m[savia-dual]\033[0m %s\n' "$*" >&2; }
 run() { if [[ $DRY_RUN -eq 1 ]]; then echo "  + $*"; else eval "$*"; fi }
+
+# Resolve repo dir from this script's location (absolute, symlink-safe).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROXY_PATH="$SCRIPT_DIR/savia-dual-proxy.py"
+PYTHON_BIN="$(command -v python3 || true)"
 
 # ── Detect OS ───────────────────────────────────────────────────────────────
 OS="$(uname -s)"
@@ -240,22 +251,192 @@ ENV
   say "Env file:       $ENV_PATH"
 fi
 
-# ── Final instructions ──────────────────────────────────────────────────────
+# ── Install system-wide systemd service (Linux) ─────────────────────────────
+install_systemd_system_service() {
+  [[ "$PLATFORM" != "linux" ]] && return 0
+  if ! command -v systemctl >/dev/null 2>&1; then
+    warn "systemctl not available — cannot install system service."
+    return 1
+  fi
+  if [[ -z "$PYTHON_BIN" ]]; then
+    err "python3 not found in PATH — cannot create service."
+    return 1
+  fi
+  if [[ ! -f "$PROXY_PATH" ]]; then
+    err "Proxy script not found: $PROXY_PATH"
+    return 1
+  fi
+
+  local unit_path="/etc/systemd/system/savia-dual-proxy.service"
+  local svc_user="${SUDO_USER:-$USER}"
+  local svc_home; svc_home="$(getent passwd "$svc_user" | cut -d: -f6)"
+  [[ -z "$svc_home" ]] && svc_home="$HOME"
+
+  # Ensure Ollama starts on boot too (installer usually does this already).
+  if systemctl list-unit-files 2>/dev/null | grep -q '^ollama\.service'; then
+    run "sudo systemctl enable --now ollama.service >/dev/null 2>&1 || true"
+  fi
+
+  local tmp_unit; tmp_unit="$(mktemp)"
+  cat > "$tmp_unit" <<UNIT
+[Unit]
+Description=Savia Dual Proxy (inference sovereignty failover)
+Documentation=file://$SCRIPT_DIR/../.claude/rules/domain/savia-dual.md
+After=network-online.target ollama.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$svc_user
+Environment=HOME=$svc_home
+Environment=SAVIA_DUAL_CONFIG=$svc_home/.savia/dual/config.json
+ExecStart=$PYTHON_BIN $PROXY_PATH
+Restart=on-failure
+RestartSec=3
+StandardOutput=append:/var/log/savia-dual-proxy.log
+StandardError=append:/var/log/savia-dual-proxy.log
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    say "[dry-run] Would install systemd unit at $unit_path"
+    cat "$tmp_unit"
+    rm -f "$tmp_unit"
+    return 0
+  fi
+
+  say "Installing systemd unit (requires sudo): $unit_path"
+  if ! sudo install -m 0644 "$tmp_unit" "$unit_path"; then
+    err "Failed to install unit file (sudo denied?)"
+    rm -f "$tmp_unit"
+    return 1
+  fi
+  rm -f "$tmp_unit"
+
+  sudo touch /var/log/savia-dual-proxy.log
+  sudo chown "$svc_user":"$svc_user" /var/log/savia-dual-proxy.log 2>/dev/null || true
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable savia-dual-proxy.service >/dev/null
+  sudo systemctl restart savia-dual-proxy.service
+  sleep 1
+
+  if systemctl is-active --quiet savia-dual-proxy.service; then
+    say "Service active: savia-dual-proxy.service (enabled at boot)"
+  else
+    err "Service failed to start. Check: sudo journalctl -u savia-dual-proxy -n 50"
+    return 1
+  fi
+}
+
+# ── Install launchd agent (macOS) ───────────────────────────────────────────
+install_launchd_agent() {
+  [[ "$PLATFORM" != "macos" ]] && return 0
+  local plist_path="$HOME/Library/LaunchAgents/com.savia.dual.proxy.plist"
+  run "mkdir -p '$HOME/Library/LaunchAgents'"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    say "[dry-run] Would install launchd agent at $plist_path"
+    return 0
+  fi
+  cat > "$plist_path" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.savia.dual.proxy</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$PYTHON_BIN</string>
+    <string>$PROXY_PATH</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$HOME/.savia/dual/proxy.log</string>
+  <key>StandardErrorPath</key><string>$HOME/.savia/dual/proxy.log</string>
+</dict></plist>
+PLIST
+  launchctl unload "$plist_path" 2>/dev/null || true
+  launchctl load "$plist_path"
+  say "launchd agent loaded: com.savia.dual.proxy"
+}
+
+# ── Shell integration (auto-source env on every new shell) ──────────────────
+install_shell_integration() {
+  local marker="# >>> savia-dual >>>"
+  local endmark="# <<< savia-dual <<<"
+  local block="$marker
+# Auto-added by setup-savia-dual.sh — do not edit between markers.
+if [ -f \"$ENV_PATH\" ]; then . \"$ENV_PATH\"; fi
+$endmark"
+
+  for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+    [[ -f "$rc" ]] || continue
+    if grep -qF "$marker" "$rc"; then
+      say "Shell integration already in $rc"
+      continue
+    fi
+    if [[ $DRY_RUN -eq 1 ]]; then
+      say "[dry-run] Would append savia-dual block to $rc"
+      continue
+    fi
+    printf '\n%s\n' "$block" >> "$rc"
+    say "Shell integration added to $rc"
+  done
+}
+
+install_systemd_system_service || warn "System service install failed — you can run the proxy manually."
+install_launchd_agent || true
+install_shell_integration
+
+# ── Health check ────────────────────────────────────────────────────────────
+if [[ $DRY_RUN -eq 0 ]]; then
+  sleep 1
+  if curl -fsS --max-time 3 http://127.0.0.1:8787/health >/dev/null 2>&1; then
+    say "Proxy health check: OK (http://127.0.0.1:8787/health)"
+  else
+    warn "Proxy health check failed — review: sudo journalctl -u savia-dual-proxy -n 50"
+  fi
+fi
+
+# ── Final summary ───────────────────────────────────────────────────────────
 cat <<EOF
 
-Savia Dual is ready.
+Savia Dual is installed and running.
 
-Next steps:
-  1. Start the proxy in a terminal:
-       python3 $(pwd)/scripts/savia-dual-proxy.py
+  Service:  savia-dual-proxy.service  (enabled at boot)
+  Proxy:    http://127.0.0.1:8787
+  Events:   $HOME/.savia/dual/events.jsonl
+  Model:    $MODEL
 
-  2. In another terminal, source the env file and start Claude Code:
-       source $ENV_PATH
-       claude
+Manage the service:
+  sudo systemctl status savia-dual-proxy
+  sudo systemctl restart savia-dual-proxy
+  sudo journalctl -u savia-dual-proxy -f
 
-  3. Verify routing:
-       curl -s http://127.0.0.1:8787/health
-       tail -f $HOME/.savia/dual/events.jsonl
-
-To reconfigure later: ./scripts/setup-savia-dual.sh --reconfigure
+Reconfigure:  ./scripts/setup-savia-dual.sh --reconfigure
 EOF
+
+# ── Auto-launch Claude Code with env applied ────────────────────────────────
+# A child process CANNOT modify its parent shell's environment, so running
+# `bash setup.sh && claude` would leave ANTHROPIC_BASE_URL unset in the parent.
+# Solution: source the env in THIS script's process and exec claude here.
+# The exec'd claude inherits ANTHROPIC_BASE_URL and routes through the proxy.
+if [[ $DRY_RUN -eq 0 && $NO_LAUNCH -eq 0 ]]; then
+  if [[ -t 1 ]] && command -v claude >/dev/null 2>&1; then
+    # shellcheck disable=SC1090
+    . "$ENV_PATH"
+    say "Launching Claude Code with Savia Dual active (ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL)"
+    echo
+    exec claude "${CLAUDE_ARGS[@]}"
+  else
+    cat <<EOF
+
+To start Claude Code with Savia Dual active in the current shell:
+  source $ENV_PATH && claude
+
+Or open a NEW terminal (shell integration will load it automatically):
+  claude
+EOF
+  fi
+fi


### PR DESCRIPTION
## Summary

Savia Dual installer is now fully automatic. A single command provisions
the proxy service, shell integration, and launches Claude Code with the
routing environment already applied.

- `bash scripts/setup-savia-dual.sh` → installer runs, sources
  `~/.savia/dual/env` in its own process, and `exec`s `claude`. The
  user lands inside Claude Code with `ANTHROPIC_BASE_URL` active —
  no manual sourcing, no new terminal needed.
- A child process cannot modify its parent shell's environment on Unix,
  so `bash setup.sh && claude` is impossible. Exec from the same process
  sidesteps the limitation cleanly.
- New flags: `--no-launch` (CI/headless), `-- <args>` passthrough to
  Claude Code on auto-launch.
- Also includes what was already on this branch unmerged: systemd unit
  (Linux), launchd agent (macOS), idempotent shell integration block
  appended to `~/.bashrc`/`~/.zshrc`, and post-start health check.

Era 205. Bumps to v4.42.0 (4.41.0 already reserved by PR #521).

## Test plan

- [x] `bash -n scripts/setup-savia-dual.sh` — syntax OK
- [x] `--help` output reflects new flags
- [x] PR Pre-Flight 11/11 gates PASS (including BATS and CI validation)
- [ ] Manual smoke test: run `bash scripts/setup-savia-dual.sh` from a
      fresh terminal, verify Claude Code opens with `ANTHROPIC_BASE_URL`
      set and first request shows up in `~/.savia/dual/events.jsonl`
- [ ] Verify `--no-launch` returns to shell without exec'ing claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)