### PR TITLE
fix(pr-plan): g4 CHANGELOG reconstruction replaces marker-stripping

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=1c9f053a4546ee6100b6004d0cebd15e560e7193fcb57bc286ab988e34e06a54
 timestamp=2026-04-12T07:26:54Z
 branch=fix/pr-plan-changelog-reconstruct
-head_commit=03d7093
+head_commit=dcc54ff
 signature=f15c2aaeecfe7d0e654c58b8d5c0e19c1697908e2d2a164ff76cf74767f8bbdf

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=6241e0923fe0f13facae1aa82838533a83d20dcc03ea4909934ce41a8a85ffa7
-timestamp=2026-04-11T23:34:59Z
-branch=feat/savia-enterprise-project-definition-v2
-head_commit=760342c
-signature=c3205028f252e27df49693bcd8589a3be1bffdc96e42d8e4cb49608d0e8184fb
+diff_hash=a282c358616a6cede21e453b3fc2a13c01d04af8176ec44ee550b39e34391099
+timestamp=2026-04-12T07:15:13Z
+branch=fix/pr-plan-changelog-reconstruct
+head_commit=731e22b
+signature=58fe648d5f269f142d05809c116b5c2d97847d3e5c960287201e2847408cc763

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,0 +1,6 @@
+# Confidentiality audit signature — DO NOT EDIT
+diff_hash=1c9f053a4546ee6100b6004d0cebd15e560e7193fcb57bc286ab988e34e06a54
+timestamp=2026-04-12T07:26:54Z
+branch=fix/pr-plan-changelog-reconstruct
+head_commit=03d7093
+signature=f15c2aaeecfe7d0e654c58b8d5c0e19c1697908e2d2a164ff76cf74767f8bbdf

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=a282c358616a6cede21e453b3fc2a13c01d04af8176ec44ee550b39e34391099
 timestamp=2026-04-12T07:15:13Z
 branch=fix/pr-plan-changelog-reconstruct
-head_commit=731e22b
+head_commit=978028b
 signature=58fe648d5f269f142d05809c116b5c2d97847d3e5c960287201e2847408cc763

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.56.0] — 2026-04-12
+
+pr-plan G4 CHANGELOG reconstruction (replaces marker-stripping). Era 219.
+When a branch is behind origin/main and CHANGELOG.md conflicts, G4 now
+reconstructs the file from scratch: takes `origin/main:CHANGELOG.md` as
+base, extracts this branch's new entry, and inserts it at the correct
+position — above main's top version. This is deterministic and correct
+regardless of how many PRs have merged since the branch was created.
+The previous approach (sed-stripping conflict markers) could produce
+malformed output when conflict structure was complex. The reconstruction
+approach treats main's CHANGELOG as the authoritative base and simply
+prepends the branch's contribution.
+
+### Changed
+- **`scripts/pr-plan-gates.sh`** (g4): full rewrite. On CHANGELOG
+  conflict, extracts branch's new entry between header and main's top
+  version, takes main's CHANGELOG as base, inserts entry at line 8,
+  adds compare link at the correct position. Fallback to marker-strip
+  if extraction fails. `.confidentiality-signature` auto-removed.
+  Non-CHANGELOG conflicts still fail for human resolution.
+- **`scripts/changelog-assemble.sh`** (new): fragment-based assembly
+  script for future use. Reads `CHANGELOG.d/*.md` fragments and
+  concatenates into CHANGELOG.md. Currently optional; will become the
+  primary path when fragment workflow is adopted.
+- **`CHANGELOG.d/.gitkeep`** (new): directory for future per-version
+  fragments.
+
 ## [4.49.0] — 2026-04-12
 
 Savia Enterprise Project Definition — SOW-as-Code (SE-017). Era 212.
@@ -6367,6 +6394,7 @@ Initial public release of PM-Workspace.
 [3.32.1]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.32.0...v3.32.1
 [3.32.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v3.30.0...v3.31.0
+[4.56.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.55.0...v4.56.0
 [4.49.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.48.0...v4.49.0
 [4.48.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.47.0...v4.48.0
 [4.47.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.46.0...v4.47.0

--- a/scripts/changelog-assemble.sh
+++ b/scripts/changelog-assemble.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# changelog-assemble.sh — Assemble CHANGELOG.md from CHANGELOG.d/ fragments
+#
+# Each fragment: CHANGELOG.d/{version}.md (e.g., CHANGELOG.d/4.50.0.md)
+# Contains a single version entry starting with ## [{version}] — {date}
+#
+# Usage:
+#   bash scripts/changelog-assemble.sh              # dry-run (stdout)
+#   bash scripts/changelog-assemble.sh --apply       # write to CHANGELOG.md
+#   bash scripts/changelog-assemble.sh --check       # verify fragments parseable
+
+CHANGELOG="CHANGELOG.md"
+FRAGMENTS_DIR="CHANGELOG.d"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# Parse the existing CHANGELOG.md to extract:
+# 1. Header (lines before first ## [)
+# 2. Existing entries (everything from first ## [ onwards until link block)
+# 3. Link block (lines matching ^\[X.Y.Z\]:)
+
+header=""
+entries=""
+links=""
+in_links=0
+
+if [[ -f "$CHANGELOG" ]]; then
+  while IFS= read -r line; do
+    if [[ "$in_links" -eq 1 ]]; then
+      links+="$line"$'\n'
+    elif [[ "$line" =~ ^\[[0-9]+\.[0-9]+\.[0-9]+\]:\ https:// ]]; then
+      in_links=1
+      links+="$line"$'\n'
+    elif [[ -z "$entries" && ! "$line" =~ ^##\ \[ ]]; then
+      header+="$line"$'\n'
+    else
+      entries+="$line"$'\n'
+    fi
+  done < "$CHANGELOG"
+fi
+
+# Collect fragments and sort by version descending
+fragment_entries=""
+fragment_links=""
+if [[ -d "$FRAGMENTS_DIR" ]]; then
+  for f in "$FRAGMENTS_DIR"/*.md; do
+    [[ -f "$f" ]] || continue
+    local_ver=$(basename "$f" .md)
+    [[ "$local_ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+    content=$(cat "$f")
+    fragment_entries+="$content"$'\n\n'
+    # Generate compare link — find prev version
+    prev_minor=$(echo "$local_ver" | awk -F. '{ printf "%d.%d.0", $1, $2-1 }')
+    repo_url="https://github.com/gonzalezpazmonica/pm-workspace"
+    fragment_links+="[$local_ver]: $repo_url/compare/v$prev_minor...v$local_ver"$'\n'
+  done
+fi
+
+case "${1:-}" in
+  --check)
+    count=$(find "$FRAGMENTS_DIR" -name "*.md" ! -name ".gitkeep" 2>/dev/null | wc -l)
+    echo "Fragments: $count"
+    find "$FRAGMENTS_DIR" -name "*.md" ! -name ".gitkeep" -exec basename {} .md \; 2>/dev/null | sort -V
+    ;;
+  --apply)
+    if [[ -z "$fragment_entries" ]]; then
+      echo "No fragments to assemble."
+      exit 0
+    fi
+    # Build new CHANGELOG: header + fragments (newest first) + existing entries + combined links
+    {
+      printf '%s' "$header"
+      printf '%s\n' "$fragment_entries"
+      printf '%s' "$entries"
+      printf '%s' "$fragment_links"
+      printf '%s' "$links"
+    } > "$CHANGELOG"
+    # Clean up assembled fragments
+    find "$FRAGMENTS_DIR" -name "*.md" ! -name ".gitkeep" -delete
+    echo "Assembled $(echo "$fragment_links" | grep -c '^\[') fragments into $CHANGELOG"
+    ;;
+  *)
+    # Dry run — show what would be assembled
+    if [[ -z "$fragment_entries" ]]; then
+      echo "No fragments to assemble."
+      exit 0
+    fi
+    echo "=== Would prepend to $CHANGELOG ==="
+    echo "$fragment_entries"
+    echo "=== New links ==="
+    echo "$fragment_links"
+    ;;
+esac

--- a/scripts/pr-plan-gates.sh
+++ b/scripts/pr-plan-gates.sh
@@ -49,12 +49,77 @@ g3() {
 }
 g4() {
   git fetch origin main --quiet 2>/dev/null || true
-  git merge-base --is-ancestor origin/main HEAD 2>/dev/null || { echo "FAIL: Rebase onto main first"; return; }
-  echo "0 behind"
+  if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+    echo "0 behind"; return
+  fi
+  # Auto-merge origin/main (Era 216+219). Resolves CHANGELOG conflicts via
+  # fragment-based reconstruction: take main's CHANGELOG.md as base, prepend
+  # this branch's entry on top. .confidentiality-signature auto-removed.
+  git merge origin/main --no-ff --no-edit 2>&1 >/dev/null || true
+  # Non-CHANGELOG, non-signature conflicts → FAIL (human needed)
+  local hard_conflicts
+  hard_conflicts=$(git diff --name-only --diff-filter=U 2>/dev/null \
+    | grep -vE '^CHANGELOG\.md$|\.confidentiality-signature$' | head -5) || true
+  if [[ -n "$hard_conflicts" ]]; then
+    git merge --abort 2>/dev/null || true
+    echo "FAIL: Merge conflicts in: $hard_conflicts"; return
+  fi
+  # CHANGELOG: reconstruct from main base + this branch's new entry.
+  # This avoids the line-8 insertion conflict entirely.
+  if grep -q '^<<<<<<<' CHANGELOG.md 2>/dev/null; then
+    # Extract HEAD's new entry (between first ## [ and the next ## [ that matches main's top)
+    local mv; mv=$(git show origin/main:CHANGELOG.md 2>/dev/null | grep -oP '## \[\K[0-9.]+' | head -1) || true
+    if [[ -n "$mv" ]]; then
+      # Take main's CHANGELOG as base
+      git show origin/main:CHANGELOG.md > /tmp/_cl_base.md 2>/dev/null || true
+      # Extract my new entries (everything HEAD added above main's top version)
+      local my_entry=""
+      my_entry=$(sed -n "1,/^## \[$mv\]/{ /^## \[$mv\]/d; p; }" CHANGELOG.md \
+        | sed '/^<<<<<<</d; /^=======/d; /^>>>>>>>/d' \
+        | sed '/^# Changelog/d; /^$/d; /^All notable/d; /^The format/d; /adheres to/d' || true)
+      if [[ -n "$my_entry" ]]; then
+        # Insert my entry after the header (line 7) of base
+        head -7 /tmp/_cl_base.md > /tmp/_cl_new.md
+        echo "" >> /tmp/_cl_new.md
+        echo "$my_entry" >> /tmp/_cl_new.md
+        tail -n +8 /tmp/_cl_base.md >> /tmp/_cl_new.md
+        # Handle compare links: extract my link and prepend
+        local lv; lv=$(echo "$my_entry" | grep -oP '## \[\K[0-9.]+' | head -1) || true
+        if [[ -n "$lv" ]]; then
+          local prev; prev=$(echo "$lv" | awk -F. '{ printf "%d.%d.0", $1, $2-1 }')
+          local repo_url="https://github.com/gonzalezpazmonica/pm-workspace"
+          local link="[$lv]: $repo_url/compare/v$prev...v$lv"
+          # Find link block and prepend
+          local link_line; link_line=$(grep -n "^\[$mv\]:" /tmp/_cl_new.md | head -1 | cut -d: -f1) || true
+          if [[ -n "$link_line" ]]; then
+            sed -i "${link_line}i\\$link" /tmp/_cl_new.md
+          fi
+        fi
+        cp /tmp/_cl_new.md CHANGELOG.md
+        rm -f /tmp/_cl_base.md /tmp/_cl_new.md
+      else
+        # Fallback: strip markers (legacy)
+        sed -i '/^<<<<<<< HEAD$/d; /^=======$/d; /^>>>>>>> origin\/main$/d' CHANGELOG.md
+      fi
+    else
+      sed -i '/^<<<<<<< HEAD$/d; /^=======$/d; /^>>>>>>> origin\/main$/d' CHANGELOG.md
+    fi
+    git add CHANGELOG.md
+  fi
+  # .confidentiality-signature: remove, regenerated on sign
+  if git diff --name-only --diff-filter=U 2>/dev/null | grep -q '\.confidentiality-signature'; then
+    rm -f .confidentiality-signature; git rm .confidentiality-signature 2>/dev/null || true
+  fi
+  local remaining; remaining=$(git diff --name-only --diff-filter=U 2>/dev/null) || true
+  if [[ -n "$remaining" ]]; then
+    git merge --abort 2>/dev/null || true
+    echo "FAIL: Unresolved conflicts: $remaining"; return
+  fi
+  git commit --no-edit 2>/dev/null || true
+  echo "auto-merged"
 }
 g5() {
   local all; all=$(git diff origin/main..HEAD --name-only 2>/dev/null) || true
-  # Docs-only PRs (all .md files) are exempt, matching PR Guardian Gate 8
   local non_md; non_md=$(echo "$all" | grep -vE '\.md$' | grep -v '^$' || true)
   [[ -z "$non_md" ]] && echo "skipped (docs-only)" && return
   local hi; hi=$(echo "$all" | grep -E '^(\.claude/(rules|hooks|agents|skills|settings)|scripts/|CLAUDE\.md)' || true)
@@ -62,23 +127,13 @@ g5() {
   local lv; lv=$(grep -oP '## \[\K[0-9.]+' CHANGELOG.md 2>/dev/null | head -1)
   local mv; mv=$(git show origin/main:CHANGELOG.md 2>/dev/null | grep -oP '## \[\K[0-9.]+' | head -1) || true
   [[ "$lv" == "$mv" ]] && { FAILED_FILE="CHANGELOG.md"; echo "FAIL: CHANGELOG not updated (both $lv)"; return; }
-  # Verify Era reference in latest entry (required by BATS test-changelog-integrity)
   local era; era=$(sed -n "/## \[$lv\]/,/## \[/p" CHANGELOG.md | grep -ci 'era ' || true)
   [[ "$era" -eq 0 ]] && { FAILED_FILE="CHANGELOG.md"; echo "FAIL: CHANGELOG v$lv missing Era reference (add 'Era NNN' to description)"; return; }
-  # G5.5 — PR queue check: enforce lv > max_claimed_across_main_and_open_PRs.
-  # SPEC-SE-012 Module 4 + recurrent-conflict hardening (Era 210).
-  # The old check only failed on exact version equality. That prevented number
-  # collisions but NOT the real pain: two branches both insert at line 8 of
-  # CHANGELOG.md with different anchors, producing a merge conflict whenever
-  # one of them lands first. Fix: require the new entry to be strictly above
-  # every version already claimed by main OR any open PR. This guarantees the
-  # rebase after a peer lands is always a clean "my entry on top of theirs".
-  # Degrades to warning if gh is unavailable or offline.
+  # G5.5 — PR queue: enforce lv > max_claimed (Era 210+219).
   if command -v gh >/dev/null 2>&1 && [[ "${PR_PLAN_SKIP_QUEUE_CHECK:-0}" != "1" ]]; then
     local repo; repo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || repo=""
     if [[ -n "$repo" ]]; then
       local prs; prs=$(gh pr list --state open --json number,headRefName --jq '.[] | [.number, .headRefName] | @tsv' 2>/dev/null) || prs=""
-      # claimed_list holds "version:#PR" tuples so we can show who owns each version
       local claimed_list="" max_claimed="$mv"
       while IFS=$'\t' read -r pr_num pr_branch; do
         [[ -z "$pr_branch" || "$pr_branch" == "$BRANCH" ]] && continue
@@ -87,18 +142,15 @@ g5() {
           | base64 -d 2>/dev/null | grep -oP '^## \[\K[0-9.]+' | head -1) || other_v=""
         [[ -z "$other_v" ]] && continue
         claimed_list="$claimed_list $other_v(#$pr_num)"
-        # Track the highest version in flight
         if [[ -z "$max_claimed" ]] || \
            [[ "$(printf '%s\n%s\n' "$max_claimed" "$other_v" | sort -V | tail -1)" == "$other_v" ]]; then
           max_claimed="$other_v"
         fi
       done <<< "$prs"
-      # Enforce strictly-greater: lv must be above max_claimed (main + all open PRs)
       if [[ -n "$max_claimed" ]] && [[ "$lv" == "$max_claimed" || \
          "$(printf '%s\n%s\n' "$lv" "$max_claimed" | sort -V | tail -1)" != "$lv" ]]; then
         FAILED_FILE="CHANGELOG.md"
-        local suggested
-        suggested=$(echo "$max_claimed" | awk -F. '{ printf "%d.%d.0\n", $1, $2+1 }')
+        local suggested; suggested=$(echo "$max_claimed" | awk -F. '{ printf "%d.%d.0\n", $1, $2+1 }')
         echo "FAIL: version $lv <= max in queue $max_claimed${claimed_list:+ (claimed:$claimed_list)} — bump to $suggested"
         return
       fi


### PR DESCRIPTION
## Summary
fix(pr-plan): g4 CHANGELOG reconstruction replaces marker-stripping
### Changes
- 731e22b fix(pr-plan): g4 CHANGELOG reconstruction replaces marker-stripping
### Stats
5 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
