### PR TITLE
feat(scheduling): Claude Code native integrations — Auto Mode + Routines (v4.84.0)

### DIFF
--- a/.claude/commands/scheduled-create.md
+++ b/.claude/commands/scheduled-create.md
@@ -15,16 +15,29 @@ context_cost: medium
 ## Argumentos
 
 ```
-$ARGUMENTS = descripción --notify {platform} --cron "schedule"
+$ARGUMENTS = descripción --notify {platform} --trigger {cron|api|event} [--cron "schedule"|--event {evento}]
 ```
 
 - `descripción` — descripción de la tarea (ej: "Daily standup summary")
 - `--notify {platform}` — plataforma: telegram|slack|teams|whatsapp|nextcloud
-- `--cron "schedule"` — cronograma en formato cron (ej: "0 9 * * *" = cada día 09:00)
+- `--trigger {tipo}` — tipo de disparador (default: `cron`)
+  - `cron` — ejecución programada por horario
+  - `api` — ejecución bajo demanda via remote-trigger API (Claude Code Routines, 2026-04-14)
+  - `event` — ejecución por evento (webhook entrante, GitHub push, etc.)
+- `--cron "schedule"` — cronograma POSIX (requerido si trigger=cron). Mín. 1h cloud, 1m desktop
+- `--event {evento}` — nombre del evento (requerido si trigger=event)
+- `--mode {cloud|desktop|session}` — dónde corre (default: `desktop`)
 
-Ejemplo:
+Ejemplos:
 ```
-/scheduled-create "Daily standup summary" --notify slack --cron "0 9 * * *"
+# Cron clásico
+/scheduled-create "Daily standup" --notify slack --trigger cron --cron "0 9 * * *"
+
+# API trigger — se invoca desde código o webhook externo
+/scheduled-create "On-demand risk report" --notify teams --trigger api --mode cloud
+
+# Event trigger — se dispara por GitHub push a main
+/scheduled-create "Deploy notification" --notify slack --trigger event --event "github.push.main"
 ```
 
 ---
@@ -32,10 +45,17 @@ Ejemplo:
 ## Flujo
 
 1. Validar que `scripts/notify-{platform}.sh` existe
-2. Crear entrada de tarea programada en Claude Code Scheduled Tasks
-3. Configurar step de notificación que capture output + invoque script
-4. Guardar configuración en `output/scheduled-tasks/{task-id}.json`
-5. Mostrar confirmación con próxima ejecución
+2. Validar argumentos según trigger:
+   - `cron` → exigir `--cron`
+   - `event` → exigir `--event`
+   - `api` → devolver endpoint invocable
+3. Crear entrada según trigger:
+   - `cron` → Scheduled Tasks (cloud si mode=cloud, Desktop si mode=desktop, /loop si mode=session)
+   - `api` → registrar en remote-trigger API, devolver URL invocable
+   - `event` → suscribir a event bus (webhook handler)
+4. Configurar step de notificación que capture output + invoque script
+5. Guardar configuración en `output/scheduled-tasks/{task-id}.json`
+6. Mostrar confirmación con la forma de invocación resultante
 
 ---
 
@@ -60,8 +80,16 @@ Gestión:
 
 ---
 
-## Restricciones
+## Restricciones por trigger
 
-- Mínimo cronograma: cada 5 minutos
+| Trigger | Mín. intervalo | Requisitos | Notas |
+|---------|----------------|------------|-------|
+| cron + cloud | 1h | Pro/Max/Team/Enterprise | Sin acceso a MCPs locales |
+| cron + desktop | 1m | Desktop app abierta | Acceso completo local (N3/N4) |
+| cron + session | variable | Sesión activa | Vida corta; usa `/loop` |
+| api | — | Token API Claude Code | Invocable por HTTPS |
+| event | — | Webhook endpoint configurado | Configurar en `/scheduled-setup` paso 2 |
+
+Límites generales:
 - Máximo 10 tareas programadas activas simultáneamente
 - Si cronograma se ejecutaría <5 min respecto a otra tarea → advertencia (puede sobrecargar)

--- a/.claude/commands/scheduled-setup.md
+++ b/.claude/commands/scheduled-setup.md
@@ -77,7 +77,24 @@ Plantillas:
 4. **Deploy notifications** — manual (post-deploy)
 5. **Security scan** — cada 24h (medianoche)
 
-Usuario elige → crear entrada en `Claude Code Scheduled Tasks`
+Luego preguntar: **¿Dónde debe correr la rutina?** (Claude Code Routines, 2026-04-14)
+
+```
+1. ☁️  Cloud (mínimo 1h) — corre en servidores Anthropic. Requiere Pro/Max/Team/Enterprise.
+       Sin acceso a ficheros locales ni MCPs locales. Ideal para resúmenes basados en APIs.
+       Se crea con /schedule o Web/Desktop.
+2. 💻 Desktop Local (mínimo 1m) — corre en tu máquina via Desktop app. Acceso a ficheros
+       locales y MCPs locales. Ideal para digests de proyectos privados (datos N3/N4).
+3. 🔁 Session /loop — vive mientras la sesión esté abierta. Polling rápido, one-shot.
+       Ideal para "check deploy cada 5 min durante esta sesión".
+
+¿Cuál eliges? (1-3):
+```
+
+Usuario elige → crear entrada en el backend correspondiente:
+- Cloud → `/schedule` (remote trigger API)
+- Desktop Local → Desktop Scheduled Tasks
+- Session → `/loop` skill
 
 ### Paso 5 — Test
 

--- a/.claude/rules/domain/autonomous-safety.md
+++ b/.claude/rules/domain/autonomous-safety.md
@@ -119,21 +119,13 @@ Contenido mínimo:
 
 ## Auto Mode — Capa complementaria (Claude Code 2026-03-24)
 
-`claude --enable-auto-mode` activa un classifier pre-tool-call de Anthropic que
-bloquea acciones potencialmente destructivas (rm masivo, exfiltración de datos,
-ejecución maliciosa) sin requerir `--dangerously-skip-permissions`. Si Claude
-insiste en una acción bloqueada repetidamente, se dispara prompt de permiso.
-
-**Relación con esta regla:** Auto Mode NO reemplaza los gates de pm-workspace
-(AUTONOMOUS_REVIEWER, ramas agent/*, PR Draft, AGENT_MAX_CONSECUTIVE_FAILURES).
-Añade una capa de defensa en profundidad. Recomendado en toda sesión que invoque
-`overnight-sprint`, `code-improvement-loop` o `tech-research-agent`.
-
-Activación:
-- CLI: `claude --enable-auto-mode` al lanzar la sesión
-- Desktop/VS Code: Settings → Claude Code → Auto Mode → seleccionar en dropdown; Shift+Tab cicla modos
-
-Referencia: https://www.anthropic.com/engineering/claude-code-auto-mode
+`claude --enable-auto-mode` activa un classifier pre-tool-call que bloquea
+acciones destructivas sin requerir `--dangerously-skip-permissions`. NO
+reemplaza los gates de esta regla (AUTONOMOUS_REVIEWER, ramas agent/*, PR
+Draft, AGENT_MAX_CONSECUTIVE_FAILURES) — añade defensa en profundidad.
+Recomendado en toda sesión que invoque `overnight-sprint`,
+`code-improvement-loop` o `tech-research-agent`. Desktop/VS Code: Settings
+→ Claude Code → Auto Mode. Ref: anthropic.com/engineering/claude-code-auto-mode
 
 ---
 

--- a/.claude/rules/domain/autonomous-safety.md
+++ b/.claude/rules/domain/autonomous-safety.md
@@ -117,6 +117,26 @@ Contenido mínimo:
 
 ---
 
+## Auto Mode — Capa complementaria (Claude Code 2026-03-24)
+
+`claude --enable-auto-mode` activa un classifier pre-tool-call de Anthropic que
+bloquea acciones potencialmente destructivas (rm masivo, exfiltración de datos,
+ejecución maliciosa) sin requerir `--dangerously-skip-permissions`. Si Claude
+insiste en una acción bloqueada repetidamente, se dispara prompt de permiso.
+
+**Relación con esta regla:** Auto Mode NO reemplaza los gates de pm-workspace
+(AUTONOMOUS_REVIEWER, ramas agent/*, PR Draft, AGENT_MAX_CONSECUTIVE_FAILURES).
+Añade una capa de defensa en profundidad. Recomendado en toda sesión que invoque
+`overnight-sprint`, `code-improvement-loop` o `tech-research-agent`.
+
+Activación:
+- CLI: `claude --enable-auto-mode` al lanzar la sesión
+- Desktop/VS Code: Settings → Claude Code → Auto Mode → seleccionar en dropdown; Shift+Tab cicla modos
+
+Referencia: https://www.anthropic.com/engineering/claude-code-auto-mode
+
+---
+
 ## Escalamiento de modelo
 
 Si un agente falla consecutivamente en una tarea:

--- a/.claude/skills/code-improvement-loop/SKILL.md
+++ b/.claude/skills/code-improvement-loop/SKILL.md
@@ -34,10 +34,18 @@ priority: "medium"
 ## Prerequisitos
 
 ```
-1. AUTONOMOUS_REVIEWER configurado     → si no: ❌ ABORT
-2. Tests pasan (baseline sano)         → si no: ❌ ABORT
-3. Métricas baseline capturadas        → si no: capturar antes de empezar
+1. AUTONOMOUS_REVIEWER configurado            → si no: ❌ ABORT
+2. Tests pasan (baseline sano)                → si no: ❌ ABORT
+3. Métricas baseline capturadas               → si no: capturar antes de empezar
+4. Auto Mode activado (claude --enable-auto-mode) → si no: ⚠️ warning, continuar
 ```
+
+## Auto Mode — Red de seguridad complementaria
+
+`--enable-auto-mode` (Claude Code 2026-03-24) añade un classifier pre-tool-call
+que bloquea acciones destructivas sin detener el bucle. Complementa los gates
+de `autonomous-safety.md`, no los reemplaza. Recomendado para toda sesión que
+invoque esta skill. Ver `docs/scheduling-guide.md` para detalles.
 
 ## Flujo completo (patrón autoresearch adaptado)
 

--- a/.claude/skills/code-improvement-loop/SKILL.md
+++ b/.claude/skills/code-improvement-loop/SKILL.md
@@ -40,12 +40,8 @@ priority: "medium"
 4. Auto Mode activado (claude --enable-auto-mode) → si no: ⚠️ warning, continuar
 ```
 
-## Auto Mode — Red de seguridad complementaria
-
-`--enable-auto-mode` (Claude Code 2026-03-24) añade un classifier pre-tool-call
-que bloquea acciones destructivas sin detener el bucle. Complementa los gates
-de `autonomous-safety.md`, no los reemplaza. Recomendado para toda sesión que
-invoque esta skill. Ver `docs/scheduling-guide.md` para detalles.
+**Auto Mode**: activar `claude --enable-auto-mode` en la sesión que invoque esta
+skill — añade classifier pre-tool-call complementario a `autonomous-safety.md`.
 
 ## Flujo completo (patrón autoresearch adaptado)
 

--- a/.claude/skills/overnight-sprint/SKILL.md
+++ b/.claude/skills/overnight-sprint/SKILL.md
@@ -37,7 +37,20 @@ priority: "medium"
 2. OVERNIGHT_SPRINT_ENABLED = true                           → si no: ❌ ABORT
 3. Hay tareas etiquetadas como overnight-safe en el backlog  → si no: ⚠️ nada que hacer
 4. Tests del proyecto pasan en estado actual (baseline)      → si no: ❌ ABORT
+5. Auto Mode activado (claude --enable-auto-mode)            → si no: ⚠️ warning, continuar
 ```
+
+## Auto Mode — Red de seguridad complementaria
+
+Desde Claude Code 2026-03-24, el flag `--enable-auto-mode` activa un classifier
+pre-tool-call que bloquea acciones potencialmente destructivas (rm masivo,
+exfiltración de datos sensibles, ejecución de código malicioso) sin detener
+el bucle autónomo. Es complementario a los gates de `autonomous-safety.md`
+— no reemplaza `AUTONOMOUS_REVIEWER` ni `AGENT_MAX_CONSECUTIVE_FAILURES`,
+añade una capa extra de defensa en profundidad.
+
+Activar: `claude --enable-auto-mode` al lanzar la sesión que invoca esta skill,
+o desde Desktop/VS Code Settings → Claude Code → Auto Mode.
 
 ## Flujo completo
 

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=14a666ff40a6aeca7633724a94974ca7311007ecdcdc816c030d02e7b9f83fa0
 timestamp=2026-04-14T21:49:13Z
 branch=feat/claude-code-native-integrations
-head_commit=0524960
+head_commit=6e8b9b9
 signature=04bd0faced59ccc4ee140f3e0c138246f75a0992547304e5a5bedeaff64987ff

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=336095f8c6e0cb498f4712b2d4401e1b331e045a449c9d1cf65076456899da58
-timestamp=2026-04-14T16:49:33Z
-branch=feat/postponement-judge
-head_commit=a0211ed
-signature=4be424fe2cfe899ec71513e2875b7de7933f27e24a865bcdba3104e3d48631a5
+diff_hash=6b44e91205cb5c29de84702bda126458b9a200ab1aee0716d92f8e604939941a
+timestamp=2026-04-14T21:43:04Z
+branch=feat/claude-code-native-integrations
+head_commit=e3c20be
+signature=a9f9df46abffa2ce25d06ab3b5ebd0f0cbe99270c614032c880e14ed636b650e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=0179194b6b3fe72eb141a992530ed72c6929bede54daeaceebfcb4a43c4bb031
 timestamp=2026-04-14T22:11:37Z
 branch=feat/claude-code-native-integrations
-head_commit=4ea2444
+head_commit=7a20996
 signature=19f7e63123caefd74b74568a757eca0c9d3a0f5e8fde72f852554b5d7b23c936

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=14a666ff40a6aeca7633724a94974ca7311007ecdcdc816c030d02e7b9f83fa0
-timestamp=2026-04-14T21:49:13Z
+diff_hash=0179194b6b3fe72eb141a992530ed72c6929bede54daeaceebfcb4a43c4bb031
+timestamp=2026-04-14T22:11:37Z
 branch=feat/claude-code-native-integrations
-head_commit=6e8b9b9
-signature=04bd0faced59ccc4ee140f3e0c138246f75a0992547304e5a5bedeaff64987ff
+head_commit=4ea2444
+signature=19f7e63123caefd74b74568a757eca0c9d3a0f5e8fde72f852554b5d7b23c936

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=6b44e91205cb5c29de84702bda126458b9a200ab1aee0716d92f8e604939941a
-timestamp=2026-04-14T21:43:04Z
+diff_hash=14a666ff40a6aeca7633724a94974ca7311007ecdcdc816c030d02e7b9f83fa0
+timestamp=2026-04-14T21:49:13Z
 branch=feat/claude-code-native-integrations
-head_commit=e3c20be
-signature=a9f9df46abffa2ce25d06ab3b5ebd0f0cbe99270c614032c880e14ed636b650e
+head_commit=0524960
+signature=04bd0faced59ccc4ee140f3e0c138246f75a0992547304e5a5bedeaff64987ff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Claude Code native integrations — document Auto Mode as complementary
 defense layer for autonomous modes, extend scheduling commands to cover
 Routines' three execution modes (cloud/desktop/session) and three
 trigger types (cron/api/event), add scheduling guide disambiguating
-`/loop`, `/schedule`, Routines and OS cron.
+`/loop`, `/schedule`, Routines and OS cron. Era 238.
 
 ### Added
 - **`docs/scheduling-guide.md`**: decision tree + table comparing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.84.0] — 2026-04-14
+
+Claude Code native integrations — document Auto Mode as complementary
+defense layer for autonomous modes, extend scheduling commands to cover
+Routines' three execution modes (cloud/desktop/session) and three
+trigger types (cron/api/event), add scheduling guide disambiguating
+`/loop`, `/schedule`, Routines and OS cron.
+
+### Added
+- **`docs/scheduling-guide.md`**: decision tree + table comparing the
+  four scheduling mechanisms available in pm-workspace. Covers when to
+  use each, their persistence model, minimum intervals, and supported
+  triggers. Includes Auto Mode integration guidance.
+- **Auto Mode section in `autonomous-safety.md`**: documents
+  `claude --enable-auto-mode` as a complementary pre-tool-call
+  classifier that blocks destructive actions. Explicit statement that
+  Auto Mode does NOT replace AUTONOMOUS_REVIEWER, agent/* branches,
+  PR Draft or AGENT_MAX_CONSECUTIVE_FAILURES — it adds defense in
+  depth.
+
+### Changed
+- **`.claude/skills/overnight-sprint/SKILL.md`**: new prerequisite
+  row recommending `--enable-auto-mode`; new section describing Auto
+  Mode as complementary safety net.
+- **`.claude/skills/code-improvement-loop/SKILL.md`**: same Auto Mode
+  additions.
+- **`.claude/commands/scheduled-setup.md`**: Paso 4 now asks where the
+  routine should run (Cloud / Desktop Local / Session /loop) with
+  interval limits and capability notes for each backend.
+- **`.claude/commands/scheduled-create.md`**: new `--trigger
+  {cron|api|event}` and `--mode {cloud|desktop|session}` options.
+  Restrictions table expanded per-trigger.
+
+### Why
+Claude Code 2026-03-24 introduced Auto Mode and 2026-04-14 introduced
+Routines. pm-workspace already used Claude Code Scheduled Tasks
+natively, but docs treated cron as the only trigger. Users had no
+reference to disambiguate `/loop` vs `/schedule` vs Routines (third
+parties already publish comparisons). This release closes the doc gap
+and recommends Auto Mode as complementary safety layer — without
+rewriting the pm-workspace autonomous-safety gates which remain
+stricter than the Anthropic classifier.
+
 ## [4.83.0] — 2026-04-14
 
 Postponement Judge — Stop hook that refuses unjustified deferrals in
@@ -6834,6 +6877,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[4.84.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.83.0...v4.84.0
 [4.83.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.82.0...v4.83.0
 [4.82.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.81.0...v4.82.0
 [4.81.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.80.0...v4.81.0

--- a/docs/scheduling-guide.md
+++ b/docs/scheduling-guide.md
@@ -1,0 +1,111 @@
+# Scheduling Guide — /loop vs /schedule vs Routines vs cron
+
+> Guía para elegir el mecanismo correcto de ejecución programada/recurrente
+> en pm-workspace, tras la introducción de Claude Code Routines (2026-04-14).
+
+---
+
+## Los 4 mecanismos
+
+| Mecanismo | Dónde vive | Vida | Mín. intervalo | Triggers |
+|-----------|-----------|------|----------------|----------|
+| **`/loop` skill** | Sesión Claude Code actual | Mientras la sesión esté abierta | N/A (pacing libre o manual) | Solo cron simple |
+| **`/schedule` skill (cloud)** | Servidores Anthropic (remote-trigger) | Persistente cross-sesión | 1 hora | cron, API, eventos |
+| **Desktop Scheduled Tasks** | Tu máquina (Desktop app) | Persistente mientras Desktop corra | 1 minuto | cron local |
+| **cron del SO** | Sistema operativo | Siempre | 1 minuto | cron |
+
+---
+
+## Cuándo usar cada uno
+
+### `/loop` — Polling dentro de una sesión activa
+
+Usar cuando la tarea solo tiene sentido mientras estás trabajando:
+- "Comprueba el build cada 5 min hasta que acabe"
+- "Recuérdame en 30 min revisar el PR"
+- Polling de estado externo durante una sesión de trabajo
+
+No usar para tareas que deben sobrevivir a cerrar la sesión.
+
+### `/schedule` (cloud) — Rutinas persistentes sin acceso local
+
+Usar cuando:
+- La tarea NO necesita ficheros locales ni MCPs locales
+- Quieres que corra aunque tu ordenador esté apagado
+- Intervalo ≥ 1 hora es aceptable
+- Requieres trigger por API o evento (webhook)
+
+Requisito: plan Pro / Max / Team / Enterprise.
+
+Ejemplo típico: informe ejecutivo diario generado desde APIs externas
+(Azure DevOps, GitHub) y enviado por Slack.
+
+### Desktop Scheduled Tasks — Rutinas con acceso local
+
+Usar cuando:
+- La tarea NECESITA acceder a ficheros locales (datos N3/N4)
+- Necesitas MCPs locales (Ollama, bases de datos internas)
+- Intervalo < 1 hora
+- El ordenador estará encendido durante la ventana de ejecución
+
+Requisito: Desktop app de Claude Code abierta.
+
+Ejemplo típico: digest diario de reuniones en carpetas locales de proyecto.
+
+### cron del SO — Fallback determinista
+
+Usar solo si:
+- No puedes depender de Claude Code estando activo
+- La tarea es un script puro sin necesidad de LLM
+- O la tarea debe correr incluso si la cuenta/sesión caduca
+
+pm-workspace prefiere `/schedule` o Desktop Scheduled Tasks sobre cron del SO
+porque mantienen el ciclo completo dentro del ecosistema Claude Code (auditoría,
+logs, compactación de contexto).
+
+---
+
+## Árbol de decisión rápido
+
+```
+¿La tarea debe sobrevivir a cerrar la sesión?
+├─ NO  → /loop
+└─ SÍ  → ¿Necesita ficheros o MCPs locales?
+         ├─ SÍ → Desktop Scheduled Tasks
+         └─ NO → ¿Intervalo <1h o trigger API/evento?
+                  ├─ <1h sin API → Desktop Scheduled Tasks
+                  └─ ≥1h o API/evento → /schedule (cloud)
+```
+
+---
+
+## Relación con comandos de pm-workspace
+
+- `/scheduled-setup` — wizard que configura notificaciones para los 3 modos
+- `/scheduled-create` — crea una rutina con `--mode cloud|desktop|session`
+  y `--trigger cron|api|event`
+- `/scheduled-list` — lista rutinas activas en los 3 backends
+- `/scheduled-test` — envía test message via la plataforma configurada
+
+---
+
+## Auto Mode y scheduling
+
+Para rutinas que invoquen modos autónomos (`overnight-sprint`,
+`code-improvement-loop`), activar Auto Mode en la sesión o rutina:
+
+- CLI: lanzar con `claude --enable-auto-mode`
+- Desktop/VS Code: Settings → Claude Code → Auto Mode
+
+Auto Mode añade un classifier pre-tool-call que bloquea acciones destructivas
+sin requerir `--dangerously-skip-permissions`. Es complementario a los gates
+de `autonomous-safety.md`, no los sustituye.
+
+---
+
+## Referencias externas
+
+- [Claude Code Scheduled Tasks — docs oficiales](https://code.claude.com/docs/en/scheduled-tasks)
+- [Anthropic: Routines announcement (2026-04-14)](https://9to5mac.com/2026/04/14/anthropic-adds-repeatable-routines-feature-to-claude-code-heres-how-it-works/)
+- [Anthropic Engineering: Auto Mode](https://www.anthropic.com/engineering/claude-code-auto-mode)
+- [Comparativa /schedule vs /loop vs cron — wmedia.es](https://wmedia.es/en/tips/claude-code-schedule-vs-loop-vs-cron)


### PR DESCRIPTION
## Summary
feat(scheduling): Claude Code native integrations — Auto Mode + Routines (v4.84.0)
### Changes
- 0524960 chore(changelog): add Era 238 reference to v4.84.0
- e3c20be fix(ci): trim code-improvement-loop SKILL.md to 150 lines
- 1a967cf feat(scheduling): native Claude Code integrations (Auto Mode + Routines)
### Stats
8 files changed across 3 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
