### PR TITLE
feat(models): upgrade workspace to Claude Opus 4.7

### DIFF
--- a/.claude/AGENTS-INDEX.md
+++ b/.claude/AGENTS-INDEX.md
@@ -21,11 +21,11 @@
 | Mobile iOS | mobile-developer | claude-sonnet-4-6 | 8500 |
 | Mobile Android | mobile-developer | claude-sonnet-4-6 | 8500 |
 | Mobile Flutter | mobile-developer | claude-sonnet-4-6 | 8500 |
-| COBOL maintenance | cobol-developer | claude-opus-4-6 | 13000 |
+| COBOL maintenance | cobol-developer | claude-opus-4-7 | 13000 |
 | VB.NET migration | dotnet-developer | claude-sonnet-4-6 | 8500 |
-| Spec técnica | sdd-spec-writer | claude-opus-4-6 | 13000 |
-| Análisis de negocio | business-analyst | claude-opus-4-6 | 13000 |
-| Diseño arquitectura | architect | claude-opus-4-6 | 13000 |
+| Spec técnica | sdd-spec-writer | claude-opus-4-7 | 13000 |
+| Análisis de negocio | business-analyst | claude-opus-4-7 | 13000 |
+| Diseño arquitectura | architect | claude-opus-4-7 | 13000 |
 | DB migration (.NET) | dotnet-developer | claude-sonnet-4-6 | 8500 |
 | DB migration (Java) | java-developer | claude-sonnet-4-6 | 8500 |
 
@@ -44,12 +44,12 @@ Digest:   meeting-digest → confidentiality-judge → risk-analyst
 
 | # | Agent | Model | Permission | Specialty |
 |---|-------|-------|------------|-----------|
-| 1 | architect | claude-opus-4-6 | L1 | > |
+| 1 | architect | claude-opus-4-7 | L1 | > |
 | 2 | architecture-judge | sonnet | L1 | Code Review Court judge — boundaries, coupling, layer v... |
 | 3 | azure-devops-operator | claude-haiku-4-5-20251001 | L1 | > |
-| 4 | business-analyst | claude-opus-4-6 | L1 | > |
-| 5 | cobol-developer | claude-opus-4-6 | L3 | > |
-| 6 | code-reviewer | claude-opus-4-6 | L1 | > |
+| 4 | business-analyst | claude-opus-4-7 | L1 | > |
+| 5 | cobol-developer | claude-opus-4-7 | L3 | > |
+| 6 | code-reviewer | claude-opus-4-7 | L1 | > |
 | 7 | cognitive-judge | sonnet | L1 | Code Review Court judge — debuggability at 3AM, naming,... |
 | 8 | coherence-validator | claude-sonnet-4-6 | L0 | > |
 | 9 | commit-guardian | claude-sonnet-4-6 | L4 | > |
@@ -59,35 +59,35 @@ Digest:   meeting-digest → confidentiality-judge → risk-analyst
 | 13 | dev-orchestrator | claude-sonnet-4-6 | L4 | Analiza specs y crea planes de implementación con slices... |
 | 14 | diagram-architect | claude-sonnet-4-6 | L1 | > |
 | 15 | dotnet-developer | claude-sonnet-4-6 | L3 | > |
-| 16 | drift-auditor | claude-opus-4-6 | L1 | Auditoría de convergencia repo: detecta drift entre docs... |
+| 16 | drift-auditor | claude-opus-4-7 | L1 | Auditoría de convergencia repo: detecta drift entre docs... |
 | 17 | excel-digest | opus | L2 | > |
 | 18 | feasibility-probe | sonnet | L3 | Validates spec feasibility by attempting a time-boxed pro... |
 | 19 | fix-assigner | sonnet | L2 | Creates fix tasks from Court findings, assigns to dev age... |
 | 20 | frontend-developer | claude-sonnet-4-6 | L3 | > |
 | 21 | frontend-test-runner | claude-sonnet-4-6 | L4 | Post-commit frontend test execution — unit, component, ... |
 | 22 | go-developer | claude-sonnet-4-6 | L3 | > |
-| 23 | infrastructure-agent | claude-opus-4-6 | L4 | > |
+| 23 | infrastructure-agent | claude-opus-4-7 | L4 | > |
 | 24 | java-developer | claude-sonnet-4-6 | L3 | > |
-| 25 | legal-compliance | claude-opus-4-6 | L2 | > |
-| 26 | meeting-confidentiality-judge | claude-opus-4-6 | L1 | > |
+| 25 | legal-compliance | claude-opus-4-7 | L2 | > |
+| 26 | meeting-confidentiality-judge | claude-opus-4-7 | L1 | > |
 | 27 | meeting-digest | sonnet | L2 | > |
 | 28 | meeting-risk-analyst | opus | L1 | > |
 | 29 | memory-agent | haiku | L2 | Gestiona la memoria persistente de pm-workspace via lengu... |
 | 30 | mobile-developer | claude-sonnet-4-6 | L3 | > |
 | 31 | model-upgrade-auditor | opus | L1 | Audits agents, skills, and prompts for workarounds that n... |
 | 32 | pdf-digest | opus | L2 | > |
-| 33 | pentester | claude-opus-4-6 | L3 | > |
+| 33 | pentester | claude-opus-4-7 | L3 | > |
 | 34 | php-developer | claude-sonnet-4-6 | L3 | > |
 | 35 | pptx-digest | opus | L2 | > |
 | 36 | python-developer | claude-sonnet-4-6 | L3 | > |
-| 37 | reflection-validator | claude-opus-4-6 | L0 | > |
+| 37 | reflection-validator | claude-opus-4-7 | L0 | > |
 | 38 | ruby-developer | claude-sonnet-4-6 | L3 | > |
 | 39 | rust-developer | claude-sonnet-4-6 | L3 | > |
-| 40 | sdd-spec-writer | claude-opus-4-6 | L2 | > |
+| 40 | sdd-spec-writer | claude-opus-4-7 | L2 | > |
 | 41 | security-attacker | claude-sonnet-4-6 | L3 | > |
 | 42 | security-auditor | claude-sonnet-4-6 | L1 | > |
 | 43 | security-defender | claude-sonnet-4-6 | L3 | > |
-| 44 | security-guardian | claude-opus-4-6 | L4 | > |
+| 44 | security-guardian | claude-opus-4-7 | L4 | > |
 | 45 | security-judge | sonnet | L1 | Code Review Court judge — OWASP, PII, injection, auth, ... |
 | 46 | spec-judge | sonnet | L1 | Code Review Court judge — implementation vs approved sp... |
 | 47 | tech-writer | claude-haiku-4-5-20251001 | L2 | > |

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -12,7 +12,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: blue
 maxTurns: 30
 max_context_tokens: 12000

--- a/.claude/agents/business-analyst.md
+++ b/.claude/agents/business-analyst.md
@@ -13,7 +13,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: purple
 maxTurns: 25
 max_context_tokens: 8000

--- a/.claude/agents/cobol-developer.md
+++ b/.claude/agents/cobol-developer.md
@@ -13,7 +13,7 @@ tools:
   - Bash
   - Glob
   - Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: gray
 maxTurns: 20
 max_context_tokens: 8000

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -12,7 +12,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: red
 maxTurns: 25
 max_context_tokens: 12000

--- a/.claude/agents/drift-auditor.md
+++ b/.claude/agents/drift-auditor.md
@@ -3,7 +3,7 @@ name: drift-auditor
 permission_level: L1
 description: "Auditoría de convergencia repo: detecta drift entre docs, config y código. Usar PROACTIVELY tras cambios grandes o al inicio de sprint."
 tools: [Read, Glob, Grep, Bash]
-model: claude-opus-4-6
+model: claude-opus-4-7
 permissionMode: plan
 maxTurns: 20
 color: yellow

--- a/.claude/agents/infrastructure-agent.md
+++ b/.claude/agents/infrastructure-agent.md
@@ -13,7 +13,7 @@ tools:
   - Bash
   - Glob
   - Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: orange
 maxTurns: 35
 max_context_tokens: 2000

--- a/.claude/agents/legal-compliance.md
+++ b/.claude/agents/legal-compliance.md
@@ -12,7 +12,7 @@ tools:
   - Grep
   - Bash
   - Write
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: indigo
 maxTurns: 30
 max_context_tokens: 12000

--- a/.claude/agents/meeting-confidentiality-judge.md
+++ b/.claude/agents/meeting-confidentiality-judge.md
@@ -8,7 +8,7 @@ description: >
 tools:
   - Read
   - Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: amber
 maxTurns: 10
 max_context_tokens: 12000

--- a/.claude/agents/pentester.md
+++ b/.claude/agents/pentester.md
@@ -12,7 +12,7 @@ tools:
   - Write
   - Glob
   - Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: "#FF0000"
 maxTurns: 40
 max_context_tokens: 12000

--- a/.claude/agents/reflection-validator.md
+++ b/.claude/agents/reflection-validator.md
@@ -11,7 +11,7 @@ tools:
   - Read
   - Glob
   - Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: purple
 maxTurns: 15
 max_context_tokens: 8000

--- a/.claude/agents/sdd-spec-writer.md
+++ b/.claude/agents/sdd-spec-writer.md
@@ -14,7 +14,7 @@ tools:
   - Glob
   - Grep
   - Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: cyan
 maxTurns: 35
 max_context_tokens: 8000

--- a/.claude/agents/security-guardian.md
+++ b/.claude/agents/security-guardian.md
@@ -11,7 +11,7 @@ tools:
   - Read
   - Glob
   - Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 color: red
 maxTurns: 20
 max_context_tokens: 12000

--- a/.claude/commands/agent-run.md
+++ b/.claude/commands/agent-run.md
@@ -28,7 +28,7 @@ Lanza un agente Claude sobre una Spec SDD (o batch de specs pendientes).
 - `--all-pending`: Todas las specs `agent-single` pendientes del sprint
 - `--team`: Patrón `agent-team` (default `impl-test`)
 - `--pattern`: `single` | `impl-test` | `impl-test-review` | `full-stack` | `parallel-handlers`
-- `--model`: Sobreescribir modelo (default: `claude-opus-4-6`)
+- `--model`: Sobreescribir modelo (default: `claude-opus-4-7`)
 
 ## 3. Protocolo
 

--- a/.claude/rules/domain/agents-catalog.md
+++ b/.claude/rules/domain/agents-catalog.md
@@ -3,11 +3,11 @@
 | Agente | Modelo | Especialidad |
 |---|---|---|
 | `memory-agent` | Haiku 4.5 | Memoria conversacional: recall, save, stats, forget via lenguaje natural (SPEC-029) |
-| `architect` | Opus 4.6 | Diseño de capas, interfaces, patrones |
-| `business-analyst` | Opus 4.6 | Reglas de negocio, criterios de aceptación, evaluación de competencias |
-| `sdd-spec-writer` | Opus 4.6 | Specs ejecutables para agentes de código |
-| `code-reviewer` | Opus 4.6 | Calidad, seguridad, SOLID |
-| `security-guardian` | Opus 4.6 | Auditoría de seguridad y confidencialidad pre-commit |
+| `architect` | Opus 4.7 | Diseño de capas, interfaces, patrones |
+| `business-analyst` | Opus 4.7 | Reglas de negocio, criterios de aceptación, evaluación de competencias |
+| `sdd-spec-writer` | Opus 4.7 | Specs ejecutables para agentes de código |
+| `code-reviewer` | Opus 4.7 | Calidad, seguridad, SOLID |
+| `security-guardian` | Opus 4.7 | Auditoría de seguridad y confidencialidad pre-commit |
 | `dotnet-developer` | Sonnet 4.6 | Implementación C#/.NET |
 | `typescript-developer` | Sonnet 4.6 | Implementación TypeScript/Node.js (NestJS, Express, Prisma) |
 | `frontend-developer` | Sonnet 4.6 | Implementación Angular + React |
@@ -18,44 +18,44 @@
 | `php-developer` | Sonnet 4.6 | Implementación PHP/Laravel |
 | `mobile-developer` | Sonnet 4.6 | Implementación Swift/iOS, Kotlin/Android, Flutter |
 | `ruby-developer` | Sonnet 4.6 | Implementación Ruby on Rails |
-| `cobol-developer` | Opus 4.6 | Asistencia COBOL (documentación, copybooks, tests) |
+| `cobol-developer` | Opus 4.7 | Asistencia COBOL (documentación, copybooks, tests) |
 | `terraform-developer` | Sonnet 4.6 | Terraform/IaC (NUNCA ejecuta apply) |
-| `infrastructure-agent` | Opus 4.6 | Infra multi-cloud: detectar, crear (tier mínimo), escalar (aprobación humana) |
+| `infrastructure-agent` | Opus 4.7 | Infra multi-cloud: detectar, crear (tier mínimo), escalar (aprobación humana) |
 | `diagram-architect` | Sonnet 4.6 | Análisis de diagramas: consistencia, layering, decomposición Features/PBIs |
 | `test-engineer` | Sonnet 4.6 | Testing multi-lenguaje, TestContainers, cobertura |
 | `test-runner` | Sonnet 4.6 | Ejecución de tests, cobertura ≥ TEST_COVERAGE_MIN_PERCENT, orquestación de mejora |
 | `commit-guardian` | Sonnet 4.6 | Pre-commit checks: rama, secrets, build, tests, code review, README |
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, XML docs |
 | `azure-devops-operator` | Haiku 4.5 | WIQL, work items, sprint, capacity |
-| `drift-auditor` | Opus 4.6 | Auditoría de convergencia repo: detecta drift entre docs, config y código |
-| `reflection-validator` | Opus 4.6 | Validación meta-cognitiva (System 2): supuestos, cadena causal, brechas |
+| `drift-auditor` | Opus 4.7 | Auditoría de convergencia repo: detecta drift entre docs, config y código |
+| `reflection-validator` | Opus 4.7 | Validación meta-cognitiva (System 2): supuestos, cadena causal, brechas |
 | `coherence-validator` | Sonnet 4.6 | Coherencia output↔objetivo: cobertura, consistencia, completitud |
 | `frontend-test-runner` | Sonnet 4.6 | Tests frontend: E2E, componentes, accesibilidad |
 | `security-attacker` | Sonnet 4.6 | Red Team: OWASP Top 10, CWE Top 25, dependency audit |
 | `security-defender` | Sonnet 4.6 | Blue Team: patches, hardening, NIST/CIS |
 | `security-auditor` | Sonnet 4.6 | Auditor independiente: evaluación, score 0-100, gap analysis |
-| `pentester` | Opus 4.6 | Pentesting dinámico: pipeline 5 fases (recon → vuln-analysis 5∥ → exploitation proof-based → report). Política "no exploit, no report" |
+| `pentester` | Opus 4.7 | Pentesting dinámico: pipeline 5 fases (recon → vuln-analysis 5∥ → exploitation proof-based → report). Política "no exploit, no report" |
 | `visual-qa-agent` | Sonnet 4.6 | Visual QA: screenshot analysis, wireframe comparison, regression detection |
 | `dev-orchestrator` | Sonnet 4.6 | Planificación de slices: análisis de specs, dependencias, presupuestos de contexto |
 | `meeting-digest` | Sonnet 4.6 | Digestión de transcripciones: extracción de perfiles, contexto de negocio y action items |
-| `meeting-risk-analyst` | Opus 4.6 | Análisis de riesgos post-digestión: contradicciones, conflictos, duplicidades, dependencias |
-| `meeting-confidentiality-judge` | Opus 4.6 | Juez de confidencialidad: valida que datos sensibles no se filtren a ficheros del proyecto |
-| `visual-digest` | Opus 4.6 | OCR contextual de 4 pasadas: extracción bruta → carga contexto proyecto → resolución con diccionario de homónimos → verificación cruzada con digests. Pizarras, notas manuscritas, diagramas, capturas |
-| `pdf-digest` | Opus 4.6 | Digestión de PDFs con texto e imágenes — 4 fases: extracción PyMuPDF+Vision → contexto proyecto → análisis/síntesis → actualización de documentos vivos |
-| `word-digest` | Opus 4.6 | Digestión de DOCX: texto, tablas, imágenes — 4 fases con python-docx+Vision → contexto → síntesis → actualización |
-| `excel-digest` | Opus 4.6 | Digestión de XLSX: estructura, fórmulas, reglas de negocio — 4 fases con openpyxl → contexto → extracción reglas → actualización |
-| `pptx-digest` | Opus 4.6 | Digestión de PPTX: slides, notas presentador, gráficos — 4 fases con python-pptx+Vision → contexto → síntesis → actualización |
+| `meeting-risk-analyst` | Opus 4.7 | Análisis de riesgos post-digestión: contradicciones, conflictos, duplicidades, dependencias |
+| `meeting-confidentiality-judge` | Opus 4.7 | Juez de confidencialidad: valida que datos sensibles no se filtren a ficheros del proyecto |
+| `visual-digest` | Opus 4.7 | OCR contextual de 4 pasadas: extracción bruta → carga contexto proyecto → resolución con diccionario de homónimos → verificación cruzada con digests. Pizarras, notas manuscritas, diagramas, capturas |
+| `pdf-digest` | Opus 4.7 | Digestión de PDFs con texto e imágenes — 4 fases: extracción PyMuPDF+Vision → contexto proyecto → análisis/síntesis → actualización de documentos vivos |
+| `word-digest` | Opus 4.7 | Digestión de DOCX: texto, tablas, imágenes — 4 fases con python-docx+Vision → contexto → síntesis → actualización |
+| `excel-digest` | Opus 4.7 | Digestión de XLSX: estructura, fórmulas, reglas de negocio — 4 fases con openpyxl → contexto → extracción reglas → actualización |
+| `pptx-digest` | Opus 4.7 | Digestión de PPTX: slides, notas presentador, gráficos — 4 fases con python-pptx+Vision → contexto → síntesis → actualización |
 | `web-e2e-tester` | Sonnet 4.6 | Testing E2E autónomo de aplicaciones web contra instancias live. Playwright/Cypress con screenshots obligatorios |
-| `confidentiality-auditor` | Opus 4.6 | Auditoría de cumplimiento de niveles de confidencialidad multi-repo (N1-N4b) |
-| `feasibility-probe` | Opus 4.6 | Valida viabilidad de specs con prototipo time-boxed. Produce informe con score, secciones bloqueantes y sugerencias de descomposición. **Requiere `bypassPermissions`** para ejecutar código de prueba de concepto. |
-| `model-upgrade-auditor` | Opus 4.6 | Audita agentes, skills y prompts buscando workarounds que modelos más nuevos ya no necesiten. Propone simplificaciones con evidencia eval-backed. |
-| `legal-compliance` | Opus 4.6 | Auditoría de compliance legal contra legislación española consolidada (legalize-es, 12.235 normas BOE). Cruza reglas de negocio, contratos y políticas contra artículos vigentes. |
+| `confidentiality-auditor` | Opus 4.7 | Auditoría de cumplimiento de niveles de confidencialidad multi-repo (N1-N4b) |
+| `feasibility-probe` | Opus 4.7 | Valida viabilidad de specs con prototipo time-boxed. Produce informe con score, secciones bloqueantes y sugerencias de descomposición. **Requiere `bypassPermissions`** para ejecutar código de prueba de concepto. |
+| `model-upgrade-auditor` | Opus 4.7 | Audita agentes, skills y prompts buscando workarounds que modelos más nuevos ya no necesiten. Propone simplificaciones con evidencia eval-backed. |
+| `legal-compliance` | Opus 4.7 | Auditoría de compliance legal contra legislación española consolidada (legalize-es, 12.235 normas BOE). Cruza reglas de negocio, contratos y políticas contra artículos vigentes. |
 | `correctness-judge` | Sonnet 4.6 | Code Review Court judge — logic, tests, edge cases, error paths |
 | `architecture-judge` | Sonnet 4.6 | Code Review Court judge — boundaries, coupling, layer violations, patterns |
 | `security-judge` | Sonnet 4.6 | Code Review Court judge — OWASP, PII, injection, auth, credentials |
 | `cognitive-judge` | Sonnet 4.6 | Code Review Court judge — debuggability at 3AM, naming, complexity, logs |
 | `spec-judge` | Sonnet 4.6 | Code Review Court judge — implementation vs approved spec, acceptance criteria |
-| `court-orchestrator` | Opus 4.6 | Convenes the Code Review Court, manages fix cycles, produces .review.crc |
+| `court-orchestrator` | Opus 4.7 | Convenes the Code Review Court, manages fix cycles, produces .review.crc |
 | `fix-assigner` | Sonnet 4.6 | Creates fix tasks from Court findings, assigns to dev agents, triggers re-review |
 | `test-architect` | Sonnet 4.6 | Designs and generates highest-quality tests across all 16 language packs and 14 test types |
 

--- a/.claude/rules/domain/consensus-protocol.md
+++ b/.claude/rules/domain/consensus-protocol.md
@@ -25,9 +25,9 @@ context_cost: medium
 
 | Juez | Modelo | Verdicts |
 |---|---|---|
-| **reflection-validator** | Opus 4.6 | VALIDATED / CORRECTED / REQUIRES_RETHINKING |
-| **code-reviewer** | Opus 4.6 | APROBADO / APROBADO_CON_CAMBIOS_MENORES / RECHAZADO |
-| **business-analyst** | Opus 4.6 | VÁLIDO / INCOMPLETO / INVÁLIDO |
+| **reflection-validator** | Opus 4.7 | VALIDATED / CORRECTED / REQUIRES_RETHINKING |
+| **code-reviewer** | Opus 4.7 | APROBADO / APROBADO_CON_CAMBIOS_MENORES / RECHAZADO |
+| **business-analyst** | Opus 4.7 | VÁLIDO / INCOMPLETO / INVÁLIDO |
 
 ---
 

--- a/.claude/rules/domain/pm-config.md
+++ b/.claude/rules/domain/pm-config.md
@@ -58,7 +58,7 @@ WIP_LIMIT_PER_PERSON        = 2
 WIP_LIMIT_PER_COLUMN        = 5
 
 # ── Spec-Driven Development (SDD) ─────────────────────────────────────────────
-CLAUDE_MODEL_AGENT          = "claude-opus-4-6"                   # modelo para agentes de implementación
+CLAUDE_MODEL_AGENT          = "claude-opus-4-7"                   # modelo para agentes de implementación
 CLAUDE_MODEL_MID            = "claude-sonnet-4-6"                 # modelo para tareas medianas/balanceadas
 CLAUDE_MODEL_FAST           = "claude-haiku-4-5-20251001"         # modelo para agentes de tests/scaffolding
 AGENT_LOGS_DIR              = "./output/agent-runs"

--- a/.claude/schemas/agent-result.schema.json
+++ b/.claude/schemas/agent-result.schema.json
@@ -32,7 +32,7 @@
     },
     "model": {
       "type": "string",
-      "description": "Model used (e.g., claude-opus-4-6, claude-sonnet-4-6)"
+      "description": "Model used (e.g., claude-opus-4-7, claude-sonnet-4-6)"
     },
     "tool_calls": { "type": "integer", "minimum": 0 },
     "files_modified": {

--- a/.claude/skills/spec-driven-development/references/agent-team-patterns.md
+++ b/.claude/skills/spec-driven-development/references/agent-team-patterns.md
@@ -33,7 +33,7 @@ BASE="projects/{proyecto}"
 SPEC_FILE="$BASE/specs/{sprint}/{spec_filename}.spec.md"
 LOG_FILE="output/agent-runs/$(date +%Y%m%d-%H%M%S)-{task_id}-single.log"
 
-claude --model claude-opus-4-6 \
+claude --model claude-opus-4-7 \
   --system-prompt "$(cat $BASE/CLAUDE.md)" \
   --max-turns 40 \
   "Implementa la siguiente Spec exactamente como se describe.
@@ -79,7 +79,7 @@ SPEC_FILE="$BASE/specs/{sprint}/{spec_filename}.spec.md"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 # Agente 1: Implementador — solo código de producción, sin tests
-claude --model claude-opus-4-6 \
+claude --model claude-opus-4-7 \
   --system-prompt "Eres un desarrollador .NET 8 senior especializado en Clean Architecture y CQRS.
 Tu único rol es implementar el código de PRODUCCIÓN de la Spec:
 - Ficheros en src/ (NO tests/)
@@ -155,7 +155,7 @@ wait $PID_IMPL $PID_TEST
 IMPL_LOG="output/agent-runs/${TIMESTAMP}-{task_id}-implementador.log"
 TEST_LOG="output/agent-runs/${TIMESTAMP}-{task_id}-tester.log"
 
-claude --model claude-opus-4-6 \
+claude --model claude-opus-4-7 \
   --system-prompt "Eres un Tech Lead .NET revisando código generado por agentes IA.
 Tu rol es SOLO revisar y reportar — NO modificar código.
 Busca específicamente:
@@ -240,7 +240,7 @@ for ROLE in "api" "application" "infrastructure" "tests"; do
       ;;
   esac
 
-  claude --model claude-opus-4-6 \
+  claude --model claude-opus-4-7 \
     --system-prompt "$SYSTEM_PROMPT. $ROLE_PROMPT" \
     "$(cat $SPEC_FILE)" \
     2>&1 | tee "output/agent-runs/${TIMESTAMP}-{task_id}-${ROLE}.log" &
@@ -281,7 +281,7 @@ for SPEC_FILE in $SPRINT_DIR/*.spec.md; do
   fi
 
   echo "🚀 Lanzando agente para: $SPEC_BASENAME"
-  claude --model claude-opus-4-6 \
+  claude --model claude-opus-4-7 \
     --system-prompt "$(cat $BASE/CLAUDE.md)" \
     --max-turns 30 \
     "Implementa esta Spec exactamente. No tomes decisiones fuera de la Spec.
@@ -369,7 +369,7 @@ cat "output/agent-runs/${TIMESTAMP}-${TASK_ID}-summary.md"
 | `full-stack` | 4 | 25-40 c/u | ~180K total | ~90K total | ~$1.80 |
 | `parallel-handlers` (5 specs) | 5 | 20-30 c/u | ~200K total | ~120K total | ~$2.50 |
 
-*Estimaciones con claude-opus-4-6 a $15/MTok input, $75/MTok output.
+*Estimaciones con claude-opus-4-7 a $15/MTok input, $75/MTok output.
 El patrón `tester` usa claude-haiku que es ~20x más barato.*
 
 ---

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=544bd5b6f8fb133a7636dd11a927fdf8da3f7693bca822b68e51d2cd7f42bbec
 timestamp=2026-04-16T15:39:15Z
 branch=feat/spec-082-orphan-skill-fix
-head_commit=dfd9e10
+head_commit=9c36ad8
 signature=ffc2e97a49facb4ea939015f3db33d2a427adc5e7a20283518dc1ba8be84e868

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8ab73ffcf655803cd70901688a9a2a0167b5f7706baabc551000b0671dbaddc3
-timestamp=2026-04-15T20:32:29Z
-branch=feat/spec-106-truth-tribunal-mvp
-head_commit=530757c
-signature=7acf3a777a1875d081976976426790d566cf2acc5fd2175e2e5f99378305b58b
+diff_hash=544bd5b6f8fb133a7636dd11a927fdf8da3f7693bca822b68e51d2cd7f42bbec
+timestamp=2026-04-16T15:39:15Z
+branch=feat/spec-082-orphan-skill-fix
+head_commit=dfd9e10
+signature=ffc2e97a49facb4ea939015f3db33d2a427adc5e7a20283518dc1ba8be84e868

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [4.89.0] — 2026-04-16
+## [4.94.0] — 2026-04-16
 
 Upgrade all Opus agents and workspace configuration to Claude Opus 4.7
 (`claude-opus-4-7`), released 2026-04-16. Same pricing, same 1M context.
@@ -7033,7 +7033,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
-[4.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.88.0...v4.89.0
+[4.94.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.88.0...v4.94.0
 [4.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.87.0...v4.88.0
 [4.87.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.86.0...v4.87.0
 [4.86.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.85.0...v4.86.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.89.0] — 2026-04-16
+
+Upgrade all Opus agents and workspace configuration to Claude Opus 4.7
+(`claude-opus-4-7`), released 2026-04-16. Same pricing, same 1M context.
+Key gains: 21% fewer document reasoning errors, better instruction
+following, enhanced vision (3.75MP), improved autonomous capabilities.
+
+### Changed
+- **`config/model-capabilities.yaml`**: added `claude-opus-4-7` entry (4.6 kept for backward compat)
+- **`pm-config.md`**: `CLAUDE_MODEL_AGENT` upgraded to `claude-opus-4-7`
+- **12 Opus agents**: frontmatter `model:` field updated to `claude-opus-4-7`
+- **`agents-catalog.md`**, **`consensus-protocol.md`**: model references updated
+- **PR scripts**: `Co-Authored-By` updated to Opus 4.7
+- **Docs, READMEs, AGENTS-INDEX**: all opus-4-6 references migrated
+- **BATS tests**: verify both opus-4-7 and backward-compat opus-4-6
+
 ## [4.88.0] — 2026-04-15
 
 SPEC-106 Phase 1 — Truth Tribunal MVP. Seven independent judges evaluate
@@ -7016,6 +7032,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[4.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.88.0...v4.89.0
 [4.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.87.0...v4.88.0
 [4.87.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.86.0...v4.87.0
 [4.86.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v4.85.0...v4.86.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Upgrade all Opus agents and workspace configuration to Claude Opus 4.7
 (`claude-opus-4-7`), released 2026-04-16. Same pricing, same 1M context.
 Key gains: 21% fewer document reasoning errors, better instruction
 following, enhanced vision (3.75MP), improved autonomous capabilities.
+Era 243.
 
 ### Changed
 - **`config/model-capabilities.yaml`**: added `claude-opus-4-7` entry (4.6 kept for backward compat)

--- a/config/model-capabilities.yaml
+++ b/config/model-capabilities.yaml
@@ -7,6 +7,12 @@
 
 models:
   # ── Anthropic Claude ──
+  claude-opus-4-7:
+    context_window: 1000000
+    tier: max
+    supports_extended_thinking: true
+    recommended_compact_threshold_pct: 70
+
   claude-opus-4-6:
     context_window: 1000000
     tier: max

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,16 +6,16 @@ pm-workspace has 33 specialized agents organized into 9 categories. Select by ta
 
 **If you need to:** → **Use agent:**
 
-- **Architecture design, SOLID principles, layering** → `architect` (Opus 4.6)
-- **Extract reglas de negocio, acceptance criteria** → `business-analyst` (Opus 4.6)
-- **Write executable specs for developers** → `sdd-spec-writer` (Opus 4.6)
-- **Code review, OWASP, design review** → `code-reviewer` (Opus 4.6)
+- **Architecture design, SOLID principles, layering** → `architect` (Opus 4.7)
+- **Extract reglas de negocio, acceptance criteria** → `business-analyst` (Opus 4.7)
+- **Write executable specs for developers** → `sdd-spec-writer` (Opus 4.7)
+- **Code review, OWASP, design review** → `code-reviewer` (Opus 4.7)
 - **Implement C# / .NET** → `dotnet-developer` (Sonnet 4.6)
 - **Implement TypeScript, Node.js, NestJS** → `typescript-developer` (Sonnet 4.6)
 - **Implement React, Angular, Vue** → `frontend-developer` (Sonnet 4.6)
 - **Implement Python FastAPI, Django** → `python-developer` (Sonnet 4.6)
 - **Write tests, verify coverage ≥80%** → `test-runner` (Sonnet 4.6)
-- **Analyze security: OWASP, CWE, deps** → `security-guardian` (Opus 4.6)
+- **Analyze security: OWASP, CWE, deps** → `security-guardian` (Opus 4.7)
 - **Pre-commit checks: branch, tests, format** → `commit-guardian` (Sonnet 4.6)
 - **Visual design consistency, wireframes** → `visual-qa-agent` (Sonnet 4.6)
 
@@ -25,9 +25,9 @@ pm-workspace has 33 specialized agents organized into 9 categories. Select by ta
 
 | Name | Model | Description |
 |---|---|---|
-| `architect` | Opus 4.6 | System design, layers, interfaces, patterns, CAP theorem |
-| `business-analyst` | Opus 4.6 | Extract reglas negocio, decompose PBIs, acceptance criteria |
-| `sdd-spec-writer` | Opus 4.6 | Write executable specs from architecture + business rules |
+| `architect` | Opus 4.7 | System design, layers, interfaces, patterns, CAP theorem |
+| `business-analyst` | Opus 4.7 | Extract reglas negocio, decompose PBIs, acceptance criteria |
+| `sdd-spec-writer` | Opus 4.7 | Write executable specs from architecture + business rules |
 | `dev-orchestrator` | Sonnet 4.6 | Plan dev slices, dependency analysis, context budgets |
 
 ### Language-Specific Developers (11)
@@ -44,7 +44,7 @@ pm-workspace has 33 specialized agents organized into 9 categories. Select by ta
 | `php-developer` | Sonnet 4.6 | PHP | Laravel 11, Blade, Eloquent |
 | `mobile-developer` | Sonnet 4.6 | Swift/Kotlin/Flutter | iOS, Android, Dart |
 | `ruby-developer` | Sonnet 4.6 | Ruby | Rails 7, RSpec, ActiveRecord |
-| `cobol-developer` | Opus 4.6 | COBOL | Copybooks, GnuCOBOL, CICS (legacy assistance) |
+| `cobol-developer` | Opus 4.7 | COBOL | Copybooks, GnuCOBOL, CICS (legacy assistance) |
 
 ### Testing & Quality (4)
 
@@ -52,14 +52,14 @@ pm-workspace has 33 specialized agents organized into 9 categories. Select by ta
 |---|---|---|
 | `test-runner` | Sonnet 4.6 | Run all tests, verify coverage ≥80%, orchestrate improvements |
 | `frontend-test-runner` | Sonnet 4.6 | E2E tests (Cypress, Playwright), component tests, a11y |
-| `code-reviewer` | Opus 4.6 | SOLID, design patterns, code quality, security hotspots |
+| `code-reviewer` | Opus 4.7 | SOLID, design patterns, code quality, security hotspots |
 | `coherence-validator` | Sonnet 4.6 | Output ↔ objective alignment, completeness, consistency |
 
 ### Security (3)
 
 | Name | Model | Specialty |
 |---|---|---|
-| `security-guardian` | Opus 4.6 | Pre-commit: OWASP, CWE Top 25, credential scanning |
+| `security-guardian` | Opus 4.7 | Pre-commit: OWASP, CWE Top 25, credential scanning |
 | `security-attacker` | Sonnet 4.6 | Red Team: find vulnerabilities (no fixes) |
 | `security-defender` | Sonnet 4.6 | Blue Team: propose security patches |
 | `security-auditor` | Sonnet 4.6 | Independent evaluation: 0-100 score, gap analysis |
@@ -68,7 +68,7 @@ pm-workspace has 33 specialized agents organized into 9 categories. Select by ta
 
 | Name | Model | Description |
 |---|---|---|
-| `infrastructure-agent` | Opus 4.6 | Detect, create (tier min), escalate for production |
+| `infrastructure-agent` | Opus 4.7 | Detect, create (tier min), escalate for production |
 | `terraform-developer` | Sonnet 4.6 | IaC: writes .tf files (never applies) |
 | `diagram-architect` | Sonnet 4.6 | System diagrams: consistency, layering, feature decomposition |
 
@@ -76,8 +76,8 @@ pm-workspace has 33 specialized agents organized into 9 categories. Select by ta
 
 | Name | Model | Description |
 |---|---|---|
-| `reflection-validator` | Opus 4.6 | System 2 thinking: assumptions, causal chains, gaps |
-| `drift-auditor` | Opus 4.6 | Code ↔ docs ↔ config convergence, detect drift |
+| `reflection-validator` | Opus 4.7 | System 2 thinking: assumptions, causal chains, gaps |
+| `drift-auditor` | Opus 4.7 | Code ↔ docs ↔ config convergence, detect drift |
 | `azure-devops-operator` | Haiku 4.5 | WIQL queries, work items, sprints, capacity |
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, XML docs, technical writing |
 
@@ -149,7 +149,7 @@ security-auditor (score 0-100)
 |---|---|---|
 | **Lightweight** | Haiku 4.5 | azure-devops-operator, tech-writer |
 | **Standard** | Sonnet 4.6 | All developers, test-runner, commit-guardian, visual-qa |
-| **Complex** | Opus 4.6 | architect, business-analyst, code-reviewer, security (all), orchestrators |
+| **Complex** | Opus 4.7 | architect, business-analyst, code-reviewer, security (all), orchestrators |
 
 ### Context Budget
 
@@ -168,7 +168,7 @@ Each agent has:
 ```yaml
 name: agent-name
 role: "Developer|Architect|QA|Security|etc"
-model: "claude-opus-4-6|claude-sonnet-4-6|haiku"
+model: "claude-opus-4-7|claude-sonnet-4-6|haiku"
 description: "One-line purpose"
 max_context_tokens: 8000
 output_max_tokens: 500

--- a/docs/readme/05-sdd.md
+++ b/docs/readme/05-sdd.md
@@ -121,7 +121,7 @@ Revisando calidad de la spec...
 
 **Claude responde:**
 ```
-Lanzando agente claude-opus-4-6 sobre AB302-B3...
+Lanzando agente claude-opus-4-7 sobre AB302-B3...
 Log en tiempo real: output/agent-runs/20260519-094512-AB302-B3-single.log
 
 [09:45:14] Agente iniciado — leyendo spec y contexto del proyecto
@@ -159,7 +159,7 @@ Sí, actualiza el estado
 ✅ AB#302-B3 actualizada en Azure DevOps:
    Estado: In Review
    Tags añadidos: spec-driven; agent-implemented
-   Comentario: "Implementado por claude-opus-4-6. Build OK, 6/6 tests. Pendiente Code Review."
+   Comentario: "Implementado por claude-opus-4-7. Build OK, 6/6 tests. Pendiente Code Review."
 ```
 
 ---
@@ -234,7 +234,7 @@ _Escenario: La task AB#301-B3 "SendCitaConfirmationCommandHandler" es compleja (
 **Claude responde:**
 ```
 Patrón seleccionado: impl-test (código producción + tests en paralelo)
-  Agente 1 — Implementador: claude-opus-4-6  (handler + service)
+  Agente 1 — Implementador: claude-opus-4-7  (handler + service)
   Agente 2 — Tester:        claude-haiku-4-5-20251001 (unit tests + mocks)
 
 Coste estimado: ~$1.40 USD

--- a/docs/readme/06-configuracion-avanzada.md
+++ b/docs/readme/06-configuracion-avanzada.md
@@ -20,7 +20,7 @@ En proyectos de precio fijo, se puede ajustar: más peso en expertise y disponib
 ```yaml
 # En projects/{proyecto}/CLAUDE.md
 sdd_config:
-  model_agent: "claude-opus-4-6"
+  model_agent: "claude-opus-4-7"
   model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   token_budget_usd: 30          # Presupuesto mensual en tokens
@@ -58,7 +58,7 @@ assignment_weights:
   growth:       0.00   # ← baja a 0: no arriesgar horas de aprendizaje
 
 sdd_config:
-  model_agent: "claude-opus-4-6"
+  model_agent: "claude-opus-4-7"
   model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   agentization_target: 0.40    # ← meta conservadora: solo 40% agentizado

--- a/docs/readme/12-comandos-agentes.md
+++ b/docs/readme/12-comandos-agentes.md
@@ -303,12 +303,12 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 
 | Agente | Modelo | Cuándo se usa |
 |---|---|---|
-| `architect` | Opus 4.6 | Diseño de arquitectura multi-lenguaje, asignación de capas, decisiones técnicas |
-| `business-analyst` | Opus 4.6 | Análisis de PBIs, reglas de negocio, criterios de aceptación, JTBD, PRD |
-| `sdd-spec-writer` | Opus 4.6 | Generación y validación de Specs SDD ejecutables |
-| `code-reviewer` | Opus 4.6 | Quality gate: seguridad, SOLID, reglas del lenguaje (`{lang}-rules.md`) |
-| `security-guardian` | Opus 4.6 | Auditoría de seguridad, secrets, y confidencialidad pre-commit |
-| `infrastructure-agent` | Opus 4.6 | Infra multi-cloud: detectar, crear (tier mínimo), escalar (aprobación humana) |
+| `architect` | Opus 4.7 | Diseño de arquitectura multi-lenguaje, asignación de capas, decisiones técnicas |
+| `business-analyst` | Opus 4.7 | Análisis de PBIs, reglas de negocio, criterios de aceptación, JTBD, PRD |
+| `sdd-spec-writer` | Opus 4.7 | Generación y validación de Specs SDD ejecutables |
+| `code-reviewer` | Opus 4.7 | Quality gate: seguridad, SOLID, reglas del lenguaje (`{lang}-rules.md`) |
+| `security-guardian` | Opus 4.7 | Auditoría de seguridad, secrets, y confidencialidad pre-commit |
+| `infrastructure-agent` | Opus 4.7 | Infra multi-cloud: detectar, crear (tier mínimo), escalar (aprobación humana) |
 
 **Agentes de desarrollo (Language Pack):**
 
@@ -324,7 +324,7 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | `php-developer` | Sonnet 4.6 | PHP/Laravel |
 | `mobile-developer` | Sonnet 4.6 | Swift/iOS, Kotlin/Android, Flutter |
 | `ruby-developer` | Sonnet 4.6 | Ruby on Rails |
-| `cobol-developer` | Opus 4.6 | Asistencia COBOL (documentación, copybooks, tests) |
+| `cobol-developer` | Opus 4.7 | Asistencia COBOL (documentación, copybooks, tests) |
 | `terraform-developer` | Sonnet 4.6 | Terraform/IaC (NUNCA ejecuta apply) |
 
 **Agentes de calidad y operaciones:**
@@ -337,9 +337,9 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, docs de proyecto |
 | `azure-devops-operator` | Haiku 4.5 | WIQL, work items, sprint, capacity |
 | `diagram-architect` | Sonnet 4.6 | Diseño de diagramas de arquitectura, C4, flujos de datos |
-| `reflection-validator` | Opus 4.6 | Validación meta-cognitiva (System 2): supuestos, cadena causal, brechas |
+| `reflection-validator` | Opus 4.7 | Validación meta-cognitiva (System 2): supuestos, cadena causal, brechas |
 | `coherence-validator` | Sonnet 4.6 | Coherencia output↔objetivo: cobertura, consistencia, completitud |
-| `drift-auditor` | Opus 4.6 | Auditoría de convergencia repo: detecta drift entre docs, config y código |
+| `drift-auditor` | Opus 4.7 | Auditoría de convergencia repo: detecta drift entre docs, config y código |
 | `dev-orchestrator` | Sonnet 4.6 | Planificación de slices: análisis de specs, dependencias, presupuestos de contexto |
 | `frontend-test-runner` | Sonnet 4.6 | Tests frontend: E2E, componentes, accesibilidad |
 | `visual-qa-agent` | Sonnet 4.6 | Visual QA: screenshot analysis, wireframe comparison, regression detection |
@@ -352,26 +352,26 @@ cada uno optimizado para su tarea con el modelo LLM más adecuado:
 | `security-attacker` | Sonnet 4.6 | Red Team: OWASP Top 10, CWE Top 25, dependency audit |
 | `security-defender` | Sonnet 4.6 | Blue Team: patches, hardening, NIST/CIS |
 | `security-auditor` | Sonnet 4.6 | Auditor independiente: evaluación, score 0-100, gap analysis |
-| `pentester` | Opus 4.6 | Pentesting dinámico: 5 fases, proof-based, "no exploit, no report" |
+| `pentester` | Opus 4.7 | Pentesting dinámico: 5 fases, proof-based, "no exploit, no report" |
 
 **Agentes de digestión de documentos (Document Digest Suite):**
 
 | Agente | Modelo | Cuándo se usa |
 |---|---|---|
 | `meeting-digest` | Sonnet 4.6 | Transcripciones VTT/DOCX/TXT: perfiles, negocio, action items |
-| `meeting-risk-analyst` | Opus 4.6 | Análisis de riesgos post-digestión cruzando contra el proyecto |
-| `meeting-confidentiality-judge` | Opus 4.6 | Juez de confidencialidad: filtra datos sensibles |
-| `visual-digest` | Opus 4.6 | OCR contextual 4 pasadas: pizarras, notas manuscritas, diagramas |
-| `pdf-digest` | Opus 4.6 | PDFs: texto (PyMuPDF) + imágenes (Vision), 4 fases con actualización de contexto |
-| `word-digest` | Opus 4.6 | DOCX: texto, tablas, imágenes (python-docx), 4 fases con actualización |
-| `excel-digest` | Opus 4.6 | XLSX: estructura, fórmulas→reglas de negocio (openpyxl), 4 fases |
-| `pptx-digest` | Opus 4.6 | PPTX: slides, notas presentador, gráficos (python-pptx), 4 fases |
+| `meeting-risk-analyst` | Opus 4.7 | Análisis de riesgos post-digestión cruzando contra el proyecto |
+| `meeting-confidentiality-judge` | Opus 4.7 | Juez de confidencialidad: filtra datos sensibles |
+| `visual-digest` | Opus 4.7 | OCR contextual 4 pasadas: pizarras, notas manuscritas, diagramas |
+| `pdf-digest` | Opus 4.7 | PDFs: texto (PyMuPDF) + imágenes (Vision), 4 fases con actualización de contexto |
+| `word-digest` | Opus 4.7 | DOCX: texto, tablas, imágenes (python-docx), 4 fases con actualización |
+| `excel-digest` | Opus 4.7 | XLSX: estructura, fórmulas→reglas de negocio (openpyxl), 4 fases |
+| `pptx-digest` | Opus 4.7 | PPTX: slides, notas presentador, gráficos (python-pptx), 4 fases |
 
 **Agente de compliance legal:**
 
 | Agente | Modelo | Cuándo se usa |
 |---|---|---|
-| `legal-compliance` | Opus 4.6 | Auditoría contra legislación española consolidada (legalize-es, 12.235 normas BOE) |
+| `legal-compliance` | Opus 4.7 | Auditoría contra legislación española consolidada (legalize-es, 12.235 normas BOE) |
 
 ### Flujo SDD con agentes en paralelo
 

--- a/docs/readme_en/05-sdd.md
+++ b/docs/readme_en/05-sdd.md
@@ -121,7 +121,7 @@ Reviewing spec quality...
 
 **Claude responds:**
 ```
-Launching claude-opus-4-6 agent on AB302-B3...
+Launching claude-opus-4-7 agent on AB302-B3...
 Live log: output/agent-runs/20260519-094512-AB302-B3-single.log
 
 [09:45:14] Agent started — reading spec and project context
@@ -221,7 +221,7 @@ _Scenario: Task AB#301-B3 "SendCitaConfirmationCommandHandler" is complex (6h), 
 **Claude responds:**
 ```
 Selected pattern: impl-test (production code + tests in parallel)
-  Agent 1 — Implementer: claude-opus-4-6  (handler + service)
+  Agent 1 — Implementer: claude-opus-4-7  (handler + service)
   Agent 2 — Tester:      claude-haiku-4-5-20251001 (unit tests + mocks)
 
 Estimated cost: ~$1.40 USD

--- a/docs/readme_en/06-advanced-config.md
+++ b/docs/readme_en/06-advanced-config.md
@@ -20,7 +20,7 @@ For fixed-price projects, you can adjust: higher weight on expertise and availab
 ```yaml
 # In projects/{project}/CLAUDE.md
 sdd_config:
-  model_agent: "claude-opus-4-6"
+  model_agent: "claude-opus-4-7"
   model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   token_budget_usd: 30          # Monthly token budget
@@ -58,7 +58,7 @@ assignment_weights:
   growth:       0.00   # ← zero: no learning-time risk
 
 sdd_config:
-  model_agent: "claude-opus-4-6"
+  model_agent: "claude-opus-4-7"
   model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   agentization_target: 0.40    # ← conservative goal: only 40% agentized

--- a/docs/readme_en/12-commands-agents.md
+++ b/docs/readme_en/12-commands-agents.md
@@ -294,12 +294,12 @@ The workspace includes 43 specialized agents organized in 5 groups, each optimiz
 
 | Agent | Model | When to use |
 |---|---|---|
-| `architect` | Opus 4.6 | Multi-language architecture design, layer assignment, technical decisions |
-| `business-analyst` | Opus 4.6 | PBI analysis, business rules, acceptance criteria, JTBD, PRD, competency assessment |
-| `sdd-spec-writer` | Opus 4.6 | Generation and validation of executable SDD Specs |
-| `infrastructure-agent` | Opus 4.6 | IaC (Terraform, CloudFormation, Bicep), detect + plan multi-cloud infrastructure |
+| `architect` | Opus 4.7 | Multi-language architecture design, layer assignment, technical decisions |
+| `business-analyst` | Opus 4.7 | PBI analysis, business rules, acceptance criteria, JTBD, PRD, competency assessment |
+| `sdd-spec-writer` | Opus 4.7 | Generation and validation of executable SDD Specs |
+| `infrastructure-agent` | Opus 4.7 | IaC (Terraform, CloudFormation, Bicep), detect + plan multi-cloud infrastructure |
 | `diagram-architect` | Sonnet 4.6 | Architecture diagram design, C4, data flows |
-| `reflection-validator` | Opus 4.6 | Meta-cognitive validation (System 2): assumptions, causal chains, gaps |
+| `reflection-validator` | Opus 4.7 | Meta-cognitive validation (System 2): assumptions, causal chains, gaps |
 
 ### Language-Specific Developer Agents (16 Language Packs)
 
@@ -312,14 +312,14 @@ The workspace includes 43 specialized agents organized in 5 groups, each optimiz
 
 | Agent | Model | When to use |
 |---|---|---|
-| `code-reviewer` | Opus 4.6 | Quality gate: security, SOLID, language-specific linting rules |
-| `security-guardian` | Opus 4.6 | Security and confidentiality audit before commit |
+| `code-reviewer` | Opus 4.7 | Quality gate: security, SOLID, language-specific linting rules |
+| `security-guardian` | Opus 4.7 | Security and confidentiality audit before commit |
 | `test-runner` | Sonnet 4.6 | Test execution, coverage verification, test improvement orchestration |
 | `commit-guardian` | Sonnet 4.6 | Pre-commit: 10 checks (branch, security, build, tests, format, code review, README, CLAUDE.md, atomicity, message) |
 | `tech-writer` | Haiku 4.5 | README, CHANGELOG, documentation, code comments |
 | `azure-devops-operator` | Haiku 4.5 | WIQL queries, create/update work items, sprint management |
 | `coherence-validator` | Sonnet 4.6 | Output↔objective coherence: coverage, consistency, completeness |
-| `drift-auditor` | Opus 4.6 | Repo convergence audit: detects drift between docs, config, and code |
+| `drift-auditor` | Opus 4.7 | Repo convergence audit: detects drift between docs, config, and code |
 | `dev-orchestrator` | Sonnet 4.6 | Slice planning: spec analysis, dependencies, context budgets |
 | `frontend-test-runner` | Sonnet 4.6 | Frontend tests: E2E, components, accessibility |
 | `visual-qa-agent` | Sonnet 4.6 | Visual QA: screenshot analysis, wireframe comparison, regression detection |
@@ -332,26 +332,26 @@ The workspace includes 43 specialized agents organized in 5 groups, each optimiz
 | `security-attacker` | Sonnet 4.6 | Red Team: OWASP Top 10, CWE Top 25, dependency audit |
 | `security-defender` | Sonnet 4.6 | Blue Team: patches, hardening, NIST/CIS |
 | `security-auditor` | Sonnet 4.6 | Independent auditor: evaluation, score 0-100, gap analysis |
-| `pentester` | Opus 4.6 | Dynamic pentesting: 5-phase pipeline, proof-based, "no exploit, no report" |
+| `pentester` | Opus 4.7 | Dynamic pentesting: 5-phase pipeline, proof-based, "no exploit, no report" |
 
 ### Document Digest Suite
 
 | Agent | Model | When to use |
 |---|---|---|
 | `meeting-digest` | Sonnet 4.6 | VTT/DOCX/TXT transcriptions: profiles, business context, action items |
-| `meeting-risk-analyst` | Opus 4.6 | Post-digestión risk analysis cross-referencing project state |
-| `meeting-confidentiality-judge` | Opus 4.6 | Confidentiality judge: filters sensitive data from outputs |
-| `visual-digest` | Opus 4.6 | 4-pass contextual OCR: whiteboards, handwritten notes, diagrams |
-| `pdf-digest` | Opus 4.6 | PDFs: text (PyMuPDF) + images (Vision), 4-phase context-aware pipeline |
-| `word-digest` | Opus 4.6 | DOCX: text, tables, images (python-docx), 4-phase with context update |
-| `excel-digest` | Opus 4.6 | XLSX: structure, formulas→business rules (openpyxl), 4-phase pipeline |
-| `pptx-digest` | Opus 4.6 | PPTX: slides, presenter notes, charts (python-pptx), 4-phase pipeline |
+| `meeting-risk-analyst` | Opus 4.7 | Post-digestión risk analysis cross-referencing project state |
+| `meeting-confidentiality-judge` | Opus 4.7 | Confidentiality judge: filters sensitive data from outputs |
+| `visual-digest` | Opus 4.7 | 4-pass contextual OCR: whiteboards, handwritten notes, diagrams |
+| `pdf-digest` | Opus 4.7 | PDFs: text (PyMuPDF) + images (Vision), 4-phase context-aware pipeline |
+| `word-digest` | Opus 4.7 | DOCX: text, tables, images (python-docx), 4-phase with context update |
+| `excel-digest` | Opus 4.7 | XLSX: structure, formulas→business rules (openpyxl), 4-phase pipeline |
+| `pptx-digest` | Opus 4.7 | PPTX: slides, presenter notes, charts (python-pptx), 4-phase pipeline |
 
 **Legal compliance agent:**
 
 | Agent | Model | When to use |
 |---|---|---|
-| `legal-compliance` | Opus 4.6 | Audit against consolidated Spanish legislation (legalize-es, 12,235 BOE norms) |
+| `legal-compliance` | Opus 4.7 | Audit against consolidated Spanish legislation (legalize-es, 12,235 BOE norms) |
 
 ### SDD flow with parallel agents
 

--- a/projects/proyecto-alpha/.agent-maps/INDEX.acm
+++ b/projects/proyecto-alpha/.agent-maps/INDEX.acm
@@ -34,7 +34,7 @@
 
 - Target: 60% backend, 0% Angular, 0% Auth
 - Budget: $30/sprint, max 5 parallel agents
-- Model: claude-opus-4-6 (agent), claude-sonnet-4-6 (mid)
+- Model: claude-opus-4-7 (agent), claude-sonnet-4-6 (mid)
 
 ## Status
 

--- a/projects/proyecto-alpha/CLAUDE.md
+++ b/projects/proyecto-alpha/CLAUDE.md
@@ -180,7 +180,7 @@ tech_lead_alias: "juan.garcia@empresa.com"
 ```yaml
 sdd_config:
   # Modelo de agentes para este proyecto
-  model_agent: "claude-opus-4-6"            # Para código de producción complejo
+  model_agent: "claude-opus-4-7"            # Para código de producción complejo
   model_mid:   "claude-sonnet-4-6"          # Para tareas medianas y balanceadas
   model_fast:  "claude-haiku-4-5-20251001"  # Para tests, DTOs, validators
 

--- a/projects/proyecto-alpha/equipo.md
+++ b/projects/proyecto-alpha/equipo.md
@@ -141,7 +141,7 @@ Tabla de capacity estimada por persona para los próximos sprints:
 ### claude-agent-opus — Implementador Principal
 ```
 ID (Azure DevOps tag):  dev:agent
-Modelo:                 claude-opus-4-6
+Modelo:                 claude-opus-4-7
 Rol:                    Developer virtual — código de producción complejo
 Capacidad efectiva:     Ilimitada (paralelo), limitada por presupuesto de tokens
 Coste estimado:         ~$0.60-1.20 por spec implementada

--- a/projects/proyecto-beta/CLAUDE.md
+++ b/projects/proyecto-beta/CLAUDE.md
@@ -167,7 +167,7 @@ budget_alert: true
 ```yaml
 sdd_config:
   # Modelos
-  model_agent: "claude-opus-4-6"
+  model_agent: "claude-opus-4-7"
   model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
 

--- a/projects/proyecto-beta/equipo.md
+++ b/projects/proyecto-beta/equipo.md
@@ -58,7 +58,7 @@ Carlos Sánchez:  Sin vacaciones planificadas en Q1
 ### claude-agent-opus — Implementador Principal
 ```
 ID (Azure DevOps tag):  dev:agent
-Modelo:                 claude-opus-4-6
+Modelo:                 claude-opus-4-7
 Rol:                    Developer virtual — código de producción
 Coste estimado:         ~$0.60-1.20 por spec
 ```

--- a/projects/sala-reservas/CLAUDE.md
+++ b/projects/sala-reservas/CLAUDE.md
@@ -178,7 +178,7 @@ tech_lead_alias: "carlos.mendoza@empresa.com"
 
 ```yaml
 sdd_config:
-  model_agent: "claude-opus-4-6"
+  model_agent: "claude-opus-4-7"
   model_mid:   "claude-sonnet-4-6"
   model_fast:  "claude-haiku-4-5-20251001"
   specs_dir: "projects/sala-reservas/specs"

--- a/projects/sala-reservas/equipo.md
+++ b/projects/sala-reservas/equipo.md
@@ -127,7 +127,7 @@ Ana:     Sin ausencias
 ### claude-agent-opus — Implementador
 ```
 ID (Azure DevOps tag):  dev:agent
-Modelo:                 claude-opus-4-6
+Modelo:                 claude-opus-4-7
 Rol:                    Application Layer + Infrastructure (cuando hay patrón de referencia)
 Coste estimado:         ~$0.60-1.20 por spec
 ```

--- a/scripts/advisor-config.sh
+++ b/scripts/advisor-config.sh
@@ -6,7 +6,7 @@
 #
 # Options:
 #   --executor MODEL     Executor model. Default: claude-sonnet-4-6
-#   --advisor MODEL      Advisor model. Default: claude-opus-4-6
+#   --advisor MODEL      Advisor model. Default: claude-opus-4-7
 #   --max-uses N         Max advisor calls per request. Default: 3
 #   --enabled BOOL       Enable/disable advisor. Default: true
 #   --output json|yaml   Output format. Default: json
@@ -15,7 +15,7 @@
 #
 # Environment variables (override defaults):
 #   ADVISOR_ENABLED            true|false (default: true)
-#   ADVISOR_MODEL              Full model ID (default: claude-opus-4-6)
+#   ADVISOR_MODEL              Full model ID (default: claude-opus-4-7)
 #   ADVISOR_MAX_USES           Integer (default: 3)
 #   ADVISOR_EXECUTOR_DEFAULT   Full model ID (default: claude-sonnet-4-6)
 #
@@ -39,10 +39,10 @@ cat /dev/stdin > /dev/null 2>&1 || true
 resolve_model() {
   local short="$1"
   case "$short" in
-    opus)   echo "claude-opus-4-6" ;;
+    opus)   echo "claude-opus-4-7" ;;
     sonnet) echo "claude-sonnet-4-6" ;;
     haiku)  echo "claude-haiku-4-5-20251001" ;;
-    claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5-20251001)
+    claude-opus-4-7|claude-sonnet-4-6|claude-haiku-4-5-20251001)
       echo "$short" ;;
     *)
       echo "" ;;
@@ -51,7 +51,7 @@ resolve_model() {
 
 is_opus() {
   local model="$1"
-  [[ "$model" == "opus" || "$model" == "claude-opus-4-6" ]]
+  [[ "$model" == "opus" || "$model" == "claude-opus-4-7" ]]
 }
 
 # ── Frontmatter parser ───────────────────────────────────────────────────────
@@ -113,7 +113,7 @@ emit_yaml() {
 # ── Defaults from env ────────────────────────────────────────────────────────
 
 ENABLED="${ADVISOR_ENABLED:-true}"
-ADVISOR="${ADVISOR_MODEL:-claude-opus-4-6}"
+ADVISOR="${ADVISOR_MODEL:-claude-opus-4-7}"
 MAX_USES="${ADVISOR_MAX_USES:-3}"
 EXECUTOR="${ADVISOR_EXECUTOR_DEFAULT:-claude-sonnet-4-6}"
 OUTPUT_FMT="json"

--- a/scripts/pr-plan.sh
+++ b/scripts/pr-plan.sh
@@ -64,7 +64,7 @@ echo -e "\n  Signing..."
 bash scripts/confidentiality-sign.sh sign 2>&1 | tail -1
 git add .confidentiality-signature 2>/dev/null
 git diff --cached --quiet 2>/dev/null || git commit -m "chore: sign confidentiality audit
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>" --quiet
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" --quiet
 $SKIP_PUSH && { rm -f .pr-plan-ok; echo "  --skip-push: signed only."; exit 0; }
 
 echo "  Pushing + PR..."

--- a/scripts/pr-rebase.sh
+++ b/scripts/pr-rebase.sh
@@ -104,7 +104,7 @@ if ! git diff --quiet "$SIG_FILE" 2>/dev/null; then
   git add "$SIG_FILE"
   git commit --no-verify -m "chore: sign confidentiality audit after rebase
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>" \
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" \
     2>&1 | tail -2
 fi
 

--- a/scripts/push-pr.sh
+++ b/scripts/push-pr.sh
@@ -53,7 +53,7 @@ echo -e "\n=== Step 4: Sign ==="
 bash scripts/confidentiality-sign.sh sign 2>&1 | tail -1; git add .confidentiality-signature
 if ! git diff --cached --quiet; then
   git commit -m "chore: sign confidentiality audit
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 else echo "  Unchanged."; fi
 echo -e "\n=== Step 5: Push ==="; export SAVIA_PUSH_PR=1
 git push origin "$BRANCH" 2>&1 | tail -3 || { echo "  Retrying..."; git push --force-with-lease origin "$BRANCH" 2>&1 | tail -3; }

--- a/scripts/test-reflection-validator.sh
+++ b/scripts/test-reflection-validator.sh
@@ -50,8 +50,8 @@ echo "[Test 3] Agent frontmatter fields"
 AGENT="$PROJECT_DIR/.claude/agents/reflection-validator.md"
 assert "grep -q '^name: reflection-validator' '$AGENT'" \
   "name: reflection-validator"
-assert "grep -q 'model: claude-opus-4-6' '$AGENT'" \
-  "model: claude-opus-4-6"
+assert "grep -q 'model: claude-opus-4-7' '$AGENT'" \
+  "model: claude-opus-4-7"
 assert "grep -q 'color: purple' '$AGENT'" \
   "color: purple"
 assert "grep -q 'memory: project' '$AGENT'" \

--- a/tests/structure/test-model-capabilities.bats
+++ b/tests/structure/test-model-capabilities.bats
@@ -23,6 +23,7 @@ teardown() {
 }
 
 @test "model-capabilities.yaml contains opus, sonnet, haiku" {
+  grep -q "claude-opus-4-7:" "$ROOT/config/model-capabilities.yaml"
   grep -q "claude-opus-4-6:" "$ROOT/config/model-capabilities.yaml"
   grep -q "claude-sonnet-4-6:" "$ROOT/config/model-capabilities.yaml"
   grep -q "claude-haiku-4-5-20251001:" "$ROOT/config/model-capabilities.yaml"
@@ -33,7 +34,7 @@ teardown() {
 }
 
 @test "resolver outputs correct vars for opus (1M, max)" {
-  run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model claude-opus-4-6"
+  run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model claude-opus-4-7"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "SAVIA_CONTEXT_WINDOW=1000000"
   echo "$output" | grep -q "SAVIA_MODEL_TIER=max"
@@ -138,7 +139,7 @@ teardown() {
 # ── Additional coverage ──
 
 @test "resolver outputs SAVIA_DETECTED_MODEL for all models" {
-  for m in claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5-20251001; do
+  for m in claude-opus-4-7 claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5-20251001; do
     run bash -c "echo '' | $ROOT/scripts/model-capability-resolver.sh --model $m"
     [[ "$output" == *"SAVIA_DETECTED_MODEL="* ]]
   done

--- a/tests/test-advisor-config.bats
+++ b/tests/test-advisor-config.bats
@@ -40,7 +40,7 @@ AGENT
   cat > "$MOCK_AGENTS/opus-agent.md" <<'AGENT'
 ---
 name: opus-agent
-model: claude-opus-4-6
+model: claude-opus-4-7
 advisor: opus
 tools:
   - Read
@@ -99,10 +99,10 @@ teardown() {
   [[ "$output" == *'"max_uses"'* ]]
 }
 
-@test "default advisor model is claude-opus-4-6" {
+@test "default advisor model is claude-opus-4-7" {
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'claude-opus-4-6'* ]]
+  [[ "$output" == *'claude-opus-4-7'* ]]
 }
 
 @test "default max_uses is 3" {
@@ -138,7 +138,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *'type: advisor_20260301'* ]]
   [[ "$output" == *'name: advisor'* ]]
-  [[ "$output" == *'model: claude-opus-4-6'* ]]
+  [[ "$output" == *'model: claude-opus-4-7'* ]]
   [[ "$output" == *'max_uses: 3'* ]]
 }
 
@@ -169,7 +169,7 @@ teardown() {
 @test "agent with advisor generates config" {
   run bash "$SCRIPT" --agent sonnet-with-advisor --agents-dir "$MOCK_AGENTS"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'claude-opus-4-6'* ]]
+  [[ "$output" == *'claude-opus-4-7'* ]]
 }
 
 @test "agent frontmatter advisor_max_uses overrides default" {
@@ -207,8 +207,8 @@ teardown() {
   [[ "$output" == *'ADV-04'* ]]
 }
 
-@test "CLI executor claude-opus-4-6 exits 1 with ADV-04" {
-  run bash "$SCRIPT" --executor claude-opus-4-6
+@test "CLI executor claude-opus-4-7 exits 1 with ADV-04" {
+  run bash "$SCRIPT" --executor claude-opus-4-7
   [ "$status" -eq 1 ]
   [[ "$output" == *'ADV-04'* ]]
 }
@@ -279,7 +279,7 @@ teardown() {
   export ADVISOR_MAX_USES=9
   run bash "$SCRIPT" --advisor opus --max-uses 2
   [ "$status" -eq 0 ]
-  [[ "$output" == *'claude-opus-4-6'* ]]
+  [[ "$output" == *'claude-opus-4-7'* ]]
   [[ "$output" == *'2'* ]]
 }
 


### PR DESCRIPTION
## Summary
feat(models): upgrade workspace to Claude Opus 4.7
### Changes
- dfd9e10 docs(changelog): bump to v4.94.0 (next available after open PRs)
- 007ba4a docs(changelog): add Era 243 reference to v4.89.0
- 66f0116 docs(changelog): add v4.89.0 entry for Opus 4.7 upgrade
- 6a9e1b5 feat(models): upgrade workspace to Claude Opus 4.7
### Stats
43 files changed across 4 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
