### PR TITLE
fix(signature): use content-addressed tree hash (SPEC-111 item 4)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=4a19f846150bebc88945866f6b2d000d024cc59661baceb29d29be6f5f9adf39
 timestamp=2026-04-17T14:11:28Z
 branch=spec/111-a-signature-stable
-head_commit=4c00c4d0
+head_commit=4d685943
 signature=4e6838c58c2309a74d66e31c4a9a26f6f697a645290f0d1397a3eea274dd0f1e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f14808308417cce7f1fb4dcdc0dd5aaea486d391413543b35c7ac2b523493afb
-timestamp=2026-04-17T13:19:40Z
-branch=spec/109-d-drift-check
-head_commit=60c2b72c
-signature=715e61a2d1dcf4daff2a8215c5e303c3c104230d7f1451718044713b717dedac
+diff_hash=72b52842d7c9f90d2f6dce6f768c1c64563188760ea7a7da9488c71b1224657f
+timestamp=2026-04-17T14:06:10Z
+branch=spec/111-a-signature-stable
+head_commit=c226a975
+signature=36216a59557a3aa027df2475e6b322f436f278c3cbf37f750c0892df74b78905

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=4a19f846150bebc88945866f6b2d000d024cc59661baceb29d29be6f5f9adf39
-timestamp=2026-04-17T14:06:17Z
+timestamp=2026-04-17T14:11:28Z
 branch=spec/111-a-signature-stable
-head_commit=68c5a4ae
+head_commit=4c00c4d0
 signature=4e6838c58c2309a74d66e31c4a9a26f6f697a645290f0d1397a3eea274dd0f1e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=4a19f846150bebc88945866f6b2d000d024cc59661baceb29d29be6f5f9adf39
-timestamp=2026-04-17T14:45:37Z
+diff_hash=edb6a06739d89bf4a18d0c17a5fd4923068419c1c645e42c393573603b6833e9
+timestamp=2026-04-17T14:45:43Z
 branch=spec/111-a-signature-stable
-head_commit=9df86bbc
-signature=4e6838c58c2309a74d66e31c4a9a26f6f697a645290f0d1397a3eea274dd0f1e
+head_commit=a0e24552
+signature=622abb1be8d944c3978c58f7f7c0dff518b4dc8b7f133682386ab542f8854955

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=72b52842d7c9f90d2f6dce6f768c1c64563188760ea7a7da9488c71b1224657f
-timestamp=2026-04-17T14:06:10Z
+diff_hash=4a19f846150bebc88945866f6b2d000d024cc59661baceb29d29be6f5f9adf39
+timestamp=2026-04-17T14:06:17Z
 branch=spec/111-a-signature-stable
-head_commit=c226a975
-signature=36216a59557a3aa027df2475e6b322f436f278c3cbf37f750c0892df74b78905
+head_commit=68c5a4ae
+signature=4e6838c58c2309a74d66e31c4a9a26f6f697a645290f0d1397a3eea274dd0f1e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=4a19f846150bebc88945866f6b2d000d024cc59661baceb29d29be6f5f9adf39
-timestamp=2026-04-17T14:11:28Z
+timestamp=2026-04-17T14:45:37Z
 branch=spec/111-a-signature-stable
-head_commit=4d685943
+head_commit=9df86bbc
 signature=4e6838c58c2309a74d66e31c4a9a26f6f697a645290f0d1397a3eea274dd0f1e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.12.0] — 2026-04-17
+
+SPEC-111 Debt cleanup — item 4 (CI signature env bug). Era 234.
+
+### Fixed
+- **`scripts/confidentiality-sign.sh`**: reemplazado `git diff base..HEAD` por `git ls-tree -r HEAD` (content-addressed blob SHAs). Elimina divergencia local/CI del hash de firma — git diff tenía dependencias no deterministas (merge-base volatility tras merges paralelos, formato de diff sensible a entorno). Nuevo enfoque: firma aprueba un estado de árbol específico; cualquier cambio en ficheros trackeados invalida firma; rebase/merge que no toca ficheros trackeados preserva firma.
+
+### Rationale
+Post SPEC-109, 5 PRs consecutivos requirieron `--admin` merge por fallos en "Verify Audit Signature". Root cause: hash del diff variaba entre local (donde se firma) y CI (donde se verifica) incluso para el mismo commit. El fix usa objetos git content-addressed que son estables por construcción.
+
 ## [5.10.0] — 2026-04-17
 
 SPEC-109 Savia Self-Excellence — action 7 (drift-check CI). Era 234.
@@ -7315,6 +7325,7 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[5.12.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.11.0...v5.12.0
 [5.10.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.9.0...v5.10.0
 [5.9.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.8.0...v5.9.0
 [5.8.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.7.0...v5.8.0

--- a/scripts/confidentiality-sign.sh
+++ b/scripts/confidentiality-sign.sh
@@ -10,18 +10,15 @@ ACTION="${1:-status}"
 
 get_diff_hash() {
   cd "$ROOT_DIR" || exit 2
-  # Diff: merge-base(origin/main, HEAD)..HEAD excluding self-referencing files.
-  # Using merge-base (STABLE across main advances) instead of origin/main (MOVES
-  # after each PR merge) prevents signature invalidation when a queued PR
-  # becomes next-in-line. The merge-base only changes if the branch itself
-  # rebases onto new main content — which is the only legitimate case for
-  # re-signing. See SPEC-105.
-  local base
-  base=$(git merge-base origin/main HEAD 2>/dev/null) || base="origin/main"
-  git diff "$base..HEAD" -- . \
-    ':!.confidentiality-signature' \
-    ':!.github/workflows/confidentiality-gate.yml' \
-    2>/dev/null | sha256sum | awk '{print $1}'
+  # Hash the HEAD tree of all tracked files, excluding self-referencing files.
+  # Uses git's content-addressed blob SHAs (ls-tree output) — fully deterministic
+  # across environments (no diff format dependencies, no merge-base volatility).
+  # Rationale: signature asserts approval of a specific tree state. Any commit
+  # that changes tracked files → tree changes → sig invalid. Rebase/merge that
+  # doesn't touch tracked files → tree unchanged → sig still valid. See SPEC-111.
+  git ls-tree -r HEAD \
+    | awk -F'\t' '$2 != ".confidentiality-signature" && $2 != ".github/workflows/confidentiality-gate.yml"' \
+    | sha256sum | awk '{print $1}'
 }
 
 ensure_secret() {

--- a/tests/test-pr-rebase.bats
+++ b/tests/test-pr-rebase.bats
@@ -54,19 +54,19 @@ teardown() {
   done
 }
 
-# ── confidentiality-sign.sh uses merge-base (stable hash) ───────────────────
+# ── confidentiality-sign.sh uses content-addressed tree hash (SPEC-111) ─────
 
-@test "confidentiality-sign.sh uses merge-base for stable hash" {
-  grep -q "merge-base" "$SIGN_SCRIPT"
+@test "confidentiality-sign.sh uses ls-tree for deterministic hash" {
+  grep -q "git ls-tree" "$SIGN_SCRIPT"
 }
 
-@test "confidentiality-sign.sh references SPEC-105 rationale" {
-  grep -qE "SPEC-105|stable.*main advances|queued PR" "$SIGN_SCRIPT"
+@test "confidentiality-sign.sh references SPEC-111 rationale" {
+  grep -qE "SPEC-111|content-addressed|deterministic" "$SIGN_SCRIPT"
 }
 
-@test "confidentiality-sign.sh no longer relies on moving origin/main directly" {
-  # Should use merge-base as the base ref, not origin/main..HEAD directly
-  grep -qE 'git merge-base origin/main HEAD' "$SIGN_SCRIPT"
+@test "confidentiality-sign.sh excludes self-referencing files" {
+  grep -qE '\.confidentiality-signature' "$SIGN_SCRIPT"
+  grep -qE 'confidentiality-gate\.yml' "$SIGN_SCRIPT"
 }
 
 # ── .gitattributes auto-resolves signature conflicts ────────────────────────


### PR DESCRIPTION
## Summary
fix(signature): use content-addressed tree hash (SPEC-111 item 4)
### Changes
- 4c00c4d0 chore: re-sign after commit
- 68c5a4ae fix(signature): use content-addressed tree hash (SPEC-111 item 4)
### Stats
3 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
