### PR TITLE
feat(se-031): query library + NL-to-query + fork-bomb fix (3 slices)

### DIFF
--- a/.claude/commands/backlog-groom.md
+++ b/.claude/commands/backlog-groom.md
@@ -37,16 +37,15 @@ Grupo: **Backlog Intelligence** — cargar:
 
 ### Paso 1 — Cargar backlog
 
-Ejecutar WIQL query:
-```wiql
-SELECT [System.Id], [System.Title], [System.State], [System.AreaPath],
-       [System.CreatedDate], [System.ChangedDate], [Microsoft.VSTS.Scheduling.StoryPoints]
-FROM WorkItems
-WHERE [System.TeamProject] = @project
-  AND [System.WorkItemType] IN ('User Story', 'Feature', 'Bug')
-  AND [System.State] NOT IN ('Done', 'Closed')
-ORDER BY [System.CreatedDate] ASC
+La WIQL vive en la Query Library (SE-031). Resolverla inyectando el proyecto activo:
+
+```bash
+QUERY=$(bash scripts/query-lib-resolve.sh --id backlog-groom-open --param project="$PROJECT_NAME")
+curl -u ":$(cat $PAT_FILE)" -X POST -H "Content-Type: application/json" \
+  -d "{\"query\":\"$QUERY\"}" "$ORG_URL/$PROJECT_NAME/_apis/wiql?api-version=7.0"
 ```
+
+Snippet canonico: `.claude/queries/azure-devops/backlog-groom-open.wiql`. Cambios de schema → editar el snippet, no este doc.
 
 Limitar a los últimos 500 items si el backlog es muy grande.
 

--- a/.claude/queries/INDEX.md
+++ b/.claude/queries/INDEX.md
@@ -1,0 +1,15 @@
+# Query Library — INDEX
+
+Auto-generated. 9 queries. Regen: scripts/query-lib-index.sh. CI check: --check flag. SPEC-SE-031.
+
+| ID | Lang | Tags | Description | File |
+|---|---|---|---|---|
+| active-sprint-items | wiql | azure-devops, sprint, status | Items del sprint activo con estado y asignación | [azure-devops/active-sprint-items.wiql](./azure-devops/active-sprint-items.wiql) |
+| blocked-issues-jira | jql | jira, blocked, sla | Issues bloqueados en Jira sprint actual | [jira/blocked-issues.jql](./jira/blocked-issues.jql) |
+| blocked-pbis-over-3d | wiql | azure-devops, blocked, sla, sprint | PBIs bloqueados más de 3 días sin actualización en el sprint activo | [azure-devops/blocked-pbis-over-3d.wiql](./azure-devops/blocked-pbis-over-3d.wiql) |
+| bugs-open-by-severity | wiql | azure-devops, bugs, quality | Bugs abiertos agrupables por severidad | [azure-devops/bugs-open-by-severity.wiql](./azure-devops/bugs-open-by-severity.wiql) |
+| my-open-issues-jira | jql | jira, owner, workload | Issues asignados al usuario actual, activos | [jira/my-open-issues.jql](./jira/my-open-issues.jql) |
+| pbis-by-owner | wiql | azure-devops, owner, workload | PBIs asignados a un owner específico, activos o pendientes | [azure-devops/pbis-by-owner.wiql](./azure-devops/pbis-by-owner.wiql) |
+| pending-reviews-savia | savia-flow | savia-flow, review, bottleneck | Items en estado Review esperando aprobación | [savia-flow/pending-reviews.yaml](./savia-flow/pending-reviews.yaml) |
+| tasks-no-estimate | wiql | azure-devops, estimation, quality | Tasks del sprint sin OriginalEstimate (requieren estimación) | [azure-devops/tasks-no-estimate.wiql](./azure-devops/tasks-no-estimate.wiql) |
+| velocity-last-3-sprints | savia-flow | savia-flow, velocity, planning | Velocity de los últimos 3 sprints cerrados para proyección | [savia-flow/velocity-last-3-sprints.yaml](./savia-flow/velocity-last-3-sprints.yaml) |

--- a/.claude/queries/INDEX.md
+++ b/.claude/queries/INDEX.md
@@ -1,15 +1,18 @@
 # Query Library — INDEX
 
-Auto-generated. 9 queries. Regen: scripts/query-lib-index.sh. CI check: --check flag. SPEC-SE-031.
+Auto-generated. 12 queries. Regen: scripts/query-lib-index.sh. CI check: --check flag. SPEC-SE-031.
 
 | ID | Lang | Tags | Description | File |
 |---|---|---|---|---|
 | active-sprint-items | wiql | azure-devops, sprint, status | Items del sprint activo con estado y asignación | [azure-devops/active-sprint-items.wiql](./azure-devops/active-sprint-items.wiql) |
+| backlog-groom-open | wiql | azure-devops, backlog, grooming | Items abiertos candidatos a grooming (User Story, Feature, Bug no cerrados) orde | [azure-devops/backlog-groom-open.wiql](./azure-devops/backlog-groom-open.wiql) |
 | blocked-issues-jira | jql | jira, blocked, sla | Issues bloqueados en Jira sprint actual | [jira/blocked-issues.jql](./jira/blocked-issues.jql) |
 | blocked-pbis-over-3d | wiql | azure-devops, blocked, sla, sprint | PBIs bloqueados más de 3 días sin actualización en el sprint activo | [azure-devops/blocked-pbis-over-3d.wiql](./azure-devops/blocked-pbis-over-3d.wiql) |
+| board-status-not-done | wiql | azure-devops, board, kanban, sprint | Items del board del sprint activo excluyendo Epic/Feature y estados terminales — | [azure-devops/board-status-not-done.wiql](./azure-devops/board-status-not-done.wiql) |
 | bugs-open-by-severity | wiql | azure-devops, bugs, quality | Bugs abiertos agrupables por severidad | [azure-devops/bugs-open-by-severity.wiql](./azure-devops/bugs-open-by-severity.wiql) |
 | my-open-issues-jira | jql | jira, owner, workload | Issues asignados al usuario actual, activos | [jira/my-open-issues.jql](./jira/my-open-issues.jql) |
 | pbis-by-owner | wiql | azure-devops, owner, workload | PBIs asignados a un owner específico, activos o pendientes | [azure-devops/pbis-by-owner.wiql](./azure-devops/pbis-by-owner.wiql) |
 | pending-reviews-savia | savia-flow | savia-flow, review, bottleneck | Items en estado Review esperando aprobación | [savia-flow/pending-reviews.yaml](./savia-flow/pending-reviews.yaml) |
+| sprint-items-detailed | wiql | azure-devops, sprint, tracking, detailed | Items del sprint activo con trabajo completado, restante, story points y activit | [azure-devops/sprint-items-detailed.wiql](./azure-devops/sprint-items-detailed.wiql) |
 | tasks-no-estimate | wiql | azure-devops, estimation, quality | Tasks del sprint sin OriginalEstimate (requieren estimación) | [azure-devops/tasks-no-estimate.wiql](./azure-devops/tasks-no-estimate.wiql) |
 | velocity-last-3-sprints | savia-flow | savia-flow, velocity, planning | Velocity de los últimos 3 sprints cerrados para proyección | [savia-flow/velocity-last-3-sprints.yaml](./savia-flow/velocity-last-3-sprints.yaml) |

--- a/.claude/queries/azure-devops/active-sprint-items.wiql
+++ b/.claude/queries/azure-devops/active-sprint-items.wiql
@@ -1,0 +1,14 @@
+---
+id: active-sprint-items
+lang: wiql
+description: Items del sprint activo con estado y asignación
+params:
+  - sprint: IterationPath del sprint
+returns: [id, title, type, state, assignedTo, storyPoints]
+tags: [azure-devops, sprint, status]
+---
+SELECT [System.Id], [System.Title], [System.WorkItemType], [System.State], [System.AssignedTo], [Microsoft.VSTS.Scheduling.StoryPoints]
+FROM WorkItems
+WHERE [System.IterationPath] UNDER '{{sprint}}'
+  AND [System.State] <> 'Removed'
+ORDER BY [System.WorkItemType], [System.State]

--- a/.claude/queries/azure-devops/backlog-groom-open.wiql
+++ b/.claude/queries/azure-devops/backlog-groom-open.wiql
@@ -1,0 +1,16 @@
+---
+id: backlog-groom-open
+lang: wiql
+description: Items abiertos candidatos a grooming (User Story, Feature, Bug no cerrados) ordenados por antiguedad
+params:
+  - project: Nombre del team project de Azure DevOps
+returns: [id, title, state, areaPath, createdDate, changedDate, storyPoints]
+tags: [azure-devops, backlog, grooming]
+---
+SELECT [System.Id], [System.Title], [System.State], [System.AreaPath],
+       [System.CreatedDate], [System.ChangedDate], [Microsoft.VSTS.Scheduling.StoryPoints]
+FROM WorkItems
+WHERE [System.TeamProject] = '{{project}}'
+  AND [System.WorkItemType] IN ('User Story', 'Feature', 'Bug')
+  AND [System.State] NOT IN ('Done', 'Closed')
+ORDER BY [System.CreatedDate] ASC

--- a/.claude/queries/azure-devops/blocked-pbis-over-3d.wiql
+++ b/.claude/queries/azure-devops/blocked-pbis-over-3d.wiql
@@ -1,0 +1,16 @@
+---
+id: blocked-pbis-over-3d
+lang: wiql
+description: PBIs bloqueados más de 3 días sin actualización en el sprint activo
+params:
+  - sprint: IterationPath del sprint (ej. "ProjectX\\Sprint 2026-04")
+returns: [id, title, state, assignedTo, changedDate]
+tags: [azure-devops, blocked, sla, sprint]
+---
+SELECT [System.Id], [System.Title], [System.State], [System.AssignedTo], [System.ChangedDate]
+FROM WorkItems
+WHERE [System.WorkItemType] = 'Product Backlog Item'
+  AND [System.IterationPath] UNDER '{{sprint}}'
+  AND [System.State] = 'Blocked'
+  AND [System.ChangedDate] < @Today - 3
+ORDER BY [System.ChangedDate] ASC

--- a/.claude/queries/azure-devops/board-status-not-done.wiql
+++ b/.claude/queries/azure-devops/board-status-not-done.wiql
@@ -1,0 +1,16 @@
+---
+id: board-status-not-done
+lang: wiql
+description: Items del board del sprint activo excluyendo Epic/Feature y estados terminales — vista kanban operativa
+params:
+  - project: Team project de Azure DevOps
+  - team: Team dentro del project
+returns: [id, title, state, assignedTo, changedDate]
+tags: [azure-devops, board, kanban, sprint]
+---
+SELECT [System.Id], [System.Title], [System.State], [System.AssignedTo], [System.ChangedDate]
+FROM WorkItems
+WHERE [System.IterationPath] UNDER @CurrentIteration('[{{project}}\{{team}}]')
+  AND [System.State] NOT IN ('Done', 'Closed', 'Removed')
+  AND [System.WorkItemType] NOT IN ('Epic', 'Feature')
+ORDER BY [System.State] ASC

--- a/.claude/queries/azure-devops/bugs-open-by-severity.wiql
+++ b/.claude/queries/azure-devops/bugs-open-by-severity.wiql
@@ -1,0 +1,15 @@
+---
+id: bugs-open-by-severity
+lang: wiql
+description: Bugs abiertos agrupables por severidad
+params:
+  - project: Project area path
+returns: [id, title, severity, state, priority, createdDate]
+tags: [azure-devops, bugs, quality]
+---
+SELECT [System.Id], [System.Title], [Microsoft.VSTS.Common.Severity], [System.State], [Microsoft.VSTS.Common.Priority], [System.CreatedDate]
+FROM WorkItems
+WHERE [System.WorkItemType] = 'Bug'
+  AND [System.AreaPath] UNDER '{{project}}'
+  AND [System.State] IN ('New', 'Active', 'Resolved')
+ORDER BY [Microsoft.VSTS.Common.Severity], [System.CreatedDate]

--- a/.claude/queries/azure-devops/pbis-by-owner.wiql
+++ b/.claude/queries/azure-devops/pbis-by-owner.wiql
@@ -1,0 +1,17 @@
+---
+id: pbis-by-owner
+lang: wiql
+description: PBIs asignados a un owner específico, activos o pendientes
+params:
+  - owner: Handle del asignado (ej. "laura@company.com")
+  - sprint: IterationPath (opcional; si vacío → todos los sprints activos)
+returns: [id, title, state, priority, storyPoints, iterationPath]
+tags: [azure-devops, owner, workload]
+---
+SELECT [System.Id], [System.Title], [System.State], [Microsoft.VSTS.Common.Priority], [Microsoft.VSTS.Scheduling.StoryPoints], [System.IterationPath]
+FROM WorkItems
+WHERE [System.WorkItemType] = 'Product Backlog Item'
+  AND [System.AssignedTo] = '{{owner}}'
+  AND [System.State] IN ('New', 'Active', 'Committed')
+  AND [System.IterationPath] UNDER '{{sprint}}'
+ORDER BY [Microsoft.VSTS.Common.Priority], [System.Id]

--- a/.claude/queries/azure-devops/sprint-items-detailed.wiql
+++ b/.claude/queries/azure-devops/sprint-items-detailed.wiql
@@ -1,0 +1,20 @@
+---
+id: sprint-items-detailed
+lang: wiql
+description: Items del sprint activo con trabajo completado, restante, story points y activity — para tracking detallado
+params:
+  - project: Nombre del team project
+  - team: Nombre del team dentro del project
+returns: [id, title, state, assignedTo, type, completedWork, remainingWork, storyPoints, activity]
+tags: [azure-devops, sprint, tracking, detailed]
+---
+SELECT [System.Id], [System.Title], [System.State], [System.AssignedTo],
+       [System.WorkItemType],
+       [Microsoft.VSTS.Scheduling.CompletedWork],
+       [Microsoft.VSTS.Scheduling.RemainingWork],
+       [Microsoft.VSTS.Scheduling.StoryPoints],
+       [Microsoft.VSTS.Common.Activity]
+FROM WorkItems
+WHERE [System.IterationPath] UNDER @CurrentIteration('[{{project}}\{{team}}]')
+  AND [System.TeamProject] = '{{project}}'
+ORDER BY [System.AssignedTo] ASC

--- a/.claude/queries/azure-devops/tasks-no-estimate.wiql
+++ b/.claude/queries/azure-devops/tasks-no-estimate.wiql
@@ -1,0 +1,16 @@
+---
+id: tasks-no-estimate
+lang: wiql
+description: Tasks del sprint sin OriginalEstimate (requieren estimación)
+params:
+  - sprint: IterationPath del sprint
+returns: [id, title, parent, assignedTo]
+tags: [azure-devops, estimation, quality]
+---
+SELECT [System.Id], [System.Title], [System.Parent], [System.AssignedTo]
+FROM WorkItems
+WHERE [System.WorkItemType] = 'Task'
+  AND [System.IterationPath] UNDER '{{sprint}}'
+  AND [Microsoft.VSTS.Scheduling.OriginalEstimate] = ''
+  AND [System.State] NOT IN ('Closed', 'Removed')
+ORDER BY [System.Parent], [System.Id]

--- a/.claude/queries/jira/blocked-issues.jql
+++ b/.claude/queries/jira/blocked-issues.jql
@@ -1,0 +1,10 @@
+---
+id: blocked-issues-jira
+lang: jql
+description: Issues bloqueados en Jira sprint actual
+params:
+  - project: Project key (ej. "PROJ")
+returns: [key, summary, status, assignee, updated]
+tags: [jira, blocked, sla]
+---
+project = {{project}} AND status = "Blocked" AND sprint in openSprints() ORDER BY updated ASC

--- a/.claude/queries/jira/my-open-issues.jql
+++ b/.claude/queries/jira/my-open-issues.jql
@@ -1,0 +1,9 @@
+---
+id: my-open-issues-jira
+lang: jql
+description: Issues asignados al usuario actual, activos
+params: []
+returns: [key, summary, status, priority, updated]
+tags: [jira, owner, workload]
+---
+assignee = currentUser() AND resolution = Unresolved ORDER BY priority DESC, updated DESC

--- a/.claude/queries/savia-flow/pending-reviews.yaml
+++ b/.claude/queries/savia-flow/pending-reviews.yaml
@@ -1,0 +1,16 @@
+---
+id: pending-reviews-savia
+lang: savia-flow
+description: Items en estado Review esperando aprobación
+params:
+  - board: Board name (ej. "Stories")
+returns: [id, title, reviewer, daysInReview]
+tags: [savia-flow, review, bottleneck]
+---
+filter:
+  board: "{{board}}"
+  state: "Review"
+  updated_before: "@today - 1"
+sort:
+  by: "daysInReview"
+  order: "desc"

--- a/.claude/queries/savia-flow/velocity-last-3-sprints.yaml
+++ b/.claude/queries/savia-flow/velocity-last-3-sprints.yaml
@@ -1,0 +1,19 @@
+---
+id: velocity-last-3-sprints
+lang: savia-flow
+description: Velocity de los últimos 3 sprints cerrados para proyección
+params:
+  - project: Project name
+returns: [sprint, planned, completed, velocity]
+tags: [savia-flow, velocity, planning]
+---
+filter:
+  project: "{{project}}"
+  state: "Closed"
+aggregate:
+  group_by: "sprint"
+  metrics: ["planned_sp", "completed_sp", "velocity"]
+limit: 3
+sort:
+  by: "end_date"
+  order: "desc"

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=3afebec6374ffffcf3afab707676d9c90c8ffe4465cbfb2682e34955561f9574
-timestamp=2026-04-18T09:51:19Z
+timestamp=2026-04-18T09:56:31Z
 branch=agent/query-library-20260418
-head_commit=d6945f77
+head_commit=1e22a2b1
 signature=62e0ca741a7638f937189c261e76288716ae6bdad98b283a505f971ca88af8d6

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=3e33d5990a166c81016c7a75939a94c7ab1255b894f31683145caa245513d17e
-timestamp=2026-04-18T07:26:36Z
-branch=agent/superpowers-p2-20260418
-head_commit=93b5f56e
-signature=cd04add9d61b3de821fb7c1a71c88fb974de25ff7924bb73cd1a6c557a25cfc3
+timestamp=2026-04-18T09:41:51Z
+branch=agent/query-library-20260418
+head_commit=b3d1ce77
+signature=6615f1b46f8653e72501eb44552ada98235a9790a6957b5f5c194a9e00940ddc

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=3afebec6374ffffcf3afab707676d9c90c8ffe4465cbfb2682e34955561f9574
-timestamp=2026-04-18T09:56:31Z
+timestamp=2026-04-18T10:02:11Z
 branch=agent/query-library-20260418
-head_commit=1e22a2b1
+head_commit=559ff088
 signature=62e0ca741a7638f937189c261e76288716ae6bdad98b283a505f971ca88af8d6

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=3afebec6374ffffcf3afab707676d9c90c8ffe4465cbfb2682e34955561f9574
 timestamp=2026-04-18T10:02:11Z
 branch=agent/query-library-20260418
-head_commit=559ff088
+head_commit=8594b4e8
 signature=62e0ca741a7638f937189c261e76288716ae6bdad98b283a505f971ca88af8d6

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=3e33d5990a166c81016c7a75939a94c7ab1255b894f31683145caa245513d17e
-timestamp=2026-04-18T09:41:51Z
+diff_hash=3afebec6374ffffcf3afab707676d9c90c8ffe4465cbfb2682e34955561f9574
+timestamp=2026-04-18T09:51:19Z
 branch=agent/query-library-20260418
-head_commit=b3d1ce77
-signature=6615f1b46f8653e72501eb44552ada98235a9790a6957b5f5c194a9e00940ddc
+head_commit=d6945f77
+signature=62e0ca741a7638f937189c261e76288716ae6bdad98b283a505f971ca88af8d6

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=3afebec6374ffffcf3afab707676d9c90c8ffe4465cbfb2682e34955561f9574
-timestamp=2026-04-18T10:02:11Z
+diff_hash=84dfd2df560e1daedb0e6ed20ee4cb8bc9e846fb54b585cfb508fca94f3a032b
+timestamp=2026-04-18T10:23:39Z
 branch=agent/query-library-20260418
-head_commit=8594b4e8
-signature=62e0ca741a7638f937189c261e76288716ae6bdad98b283a505f971ca88af8d6
+head_commit=de04ca5f
+signature=3b4b7260b2955d5d3cede47ce5b5a5c8bc5ed23b456e7af50d68049887d254c1

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=84dfd2df560e1daedb0e6ed20ee4cb8bc9e846fb54b585cfb508fca94f3a032b
-timestamp=2026-04-18T10:23:39Z
+diff_hash=bfa1b00bf015c80f4f21d7c7cd7a07c96da4eedb67fecf734904dcd0babe6405
+timestamp=2026-04-18T10:32:30Z
 branch=agent/query-library-20260418
-head_commit=de04ca5f
-signature=3b4b7260b2955d5d3cede47ce5b5a5c8bc5ed23b456e7af50d68049887d254c1
+head_commit=27ed6e22
+signature=dc95c94f67e805d96e5c68a390f2c8cf3bc851eb2d2c2aaae6c946815c9c1400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.28.0] — 2026-04-18
+
+SE-031 Query Library slice 1 — snippets canonicos + resolver + INDEX generator + 31 tests. Era 234.
+
+### Added
+- **`.claude/queries/{azure-devops,jira,savia-flow}/`**: 9 snippets canonicos (5 WIQL, 2 JQL, 2 Savia Flow YAML) con frontmatter `id/lang/description/params/returns/tags`. Reemplazan WIQL inline disperso en commands.
+- **`scripts/query-lib-resolve.sh`**: resolver por ID con `--param`, `--list`, `--lang`, `--json`. Exit codes 0/1/2. Warning stderr para placeholders no sustituidos.
+- **`scripts/query-lib-index.sh`**: regenerador determinista de `.claude/queries/INDEX.md` con modo `--check` para CI.
+- **`docs/rules/domain/query-library-protocol.md`**: protocolo canonico — formato frontmatter, uso desde commands, hygiene rules, lesson learned del fork bomb.
+- **`docs/propuestas/SE-031-query-library-nl.md`**: spec con 3 slices (library, resolver, NL-to-query).
+- **`tests/test-query-lib.bats`**: 31 tests — structure/safety (5), resolve modes (8), param substitution (4), list modes (6), index generator (5), integration (3). Incluye test de regresion fork-bomb.
+
+### Fixed
+- **Fork bomb en query-lib-index.sh**: el heredoc `python3 <<PY` (no quoted) interpretaba backticks del cuerpo python como command substitution bash, ejecutando el script recursivamente (15k+ procesos spawn). Fix: `<<'PY'` + `export REPO_ROOT` + `os.environ.get`. Test de regresion cubre el patron.
+
 ## [5.27.0] — 2026-04-18
 
 Close SPEC-115/122/124 + SE-028 slice 1 — 4 specs cerrados. Era 234.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7566,6 +7566,9 @@ Initial public release of PM-Workspace.
 [2.90.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.89.0...v2.90.0
 [2.89.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.88.0...v2.89.0
 [2.88.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v2.87.0...v2.88.0
+[5.30.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.29.0...v5.30.0
+[5.29.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.28.0...v5.29.0
+[5.28.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.27.0...v5.28.0
 [5.27.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.26.0...v5.27.0
 [5.26.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.25.0...v5.26.0
 [5.25.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.24.0...v5.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.30.0] — 2026-04-18
+
+SE-031 Query Library slice 3 — 3 snippets mas + migracion backlog-groom + 4 tests integracion. Era 234.
+
+### Added
+- **`.claude/queries/azure-devops/backlog-groom-open.wiql`**: items abiertos (User Story/Feature/Bug) para grooming por antiguedad.
+- **`.claude/queries/azure-devops/sprint-items-detailed.wiql`**: items del sprint con CompletedWork/RemainingWork/StoryPoints/Activity — para tracking detallado.
+- **`.claude/queries/azure-devops/board-status-not-done.wiql`**: items del board excluyendo Epic/Feature y estados terminales — vista kanban operativa.
+- **4 tests integracion** en `tests/test-query-lib.bats` validando resolve + param substitution de las 3 nuevas queries + migracion del command.
+
+### Changed
+- **`.claude/commands/backlog-groom.md`**: WIQL inline reemplazada por call a `query-lib-resolve.sh --id backlog-groom-open`.
+
+### Scope honesto
+Slice 3 target spec: "≥5 commands migrados". Entregado: 1 command migrado + 3 snippets canonicos que cubren queries existentes en `scripts/azdevops-queries.sh`. La migracion del script es deferida — tiene callers multiples (13+ commands) y requiere integration tests dedicados antes de refactorizar call-sites. Los snippets creados dejan el camino sembrado para ese PR de seguimiento.
+
 ## [5.29.0] — 2026-04-18
 
 SE-031 Query Library slice 2 — NL-to-query heuristico deterministico + 23 tests. Era 234.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.29.0] — 2026-04-18
+
+SE-031 Query Library slice 2 — NL-to-query heuristico deterministico + 23 tests. Era 234.
+
+### Added
+- **`scripts/query-lib-nl.sh`**: NL → query ID con pipeline normalizacion + alias expansion ES/EN + F1/Dice scoring + shingle boost + disambiguacion. Exit codes 0 (match), 1 (fallback), 2 (ambiguo), 3 (error). Flags: `--lang`, `--json`, `--min-score`, `--topk`.
+- **`tests/test-query-lib-nl.bats`**: 23 tests — estructura, validacion input, matching (ES/EN/savia-flow), fallback schema prompt, lang filter, JSON output, threshold tuning, ambiguedad, pipe e2e con resolver.
+- **Docs**: seccion "NL-to-query (slice 2)" en `docs/rules/domain/query-library-protocol.md` con algoritmo documentado (6 pasos).
+
 ## [5.28.0] — 2026-04-18
 
 SE-031 Query Library slice 1 — snippets canonicos + resolver + INDEX generator + 31 tests. Era 234.

--- a/docs/propuestas/SE-031-query-library-nl.md
+++ b/docs/propuestas/SE-031-query-library-nl.md
@@ -1,0 +1,160 @@
+---
+id: SE-031
+title: Query Library + NL-to-WIQL/JQL — Retool-inspired patterns
+status: PROPOSED
+origin: Retool research (2026-04-18) — roba Query Library + NL-to-SQL patterns
+author: Savia
+related: nl-query skill, azure-devops-queries skill, savia-flow skill
+---
+
+# SE-031 — Query Library + NL-to-WIQL/JQL
+
+## Why
+
+Retool y sus clones OSS destacan 2 patrones con fit real para Savia (el resto es GUI que no necesitamos):
+
+1. **Query Library** — snippets reusables por ID, evita copy-paste de WIQL/JQL/SQL en 532 commands.
+2. **Text-to-query** — un PM escribe "PBIs bloqueados > 3 días" y obtiene WIQL/JQL ejecutable.
+
+Savia hoy: cada command tiene WIQL inline. Cuando el schema de Azure DevOps cambia, hay drift en 10+ sitios. `nl-query` skill existe pero sin grammar training WIQL específica.
+
+## Scope
+
+### 1. Query Library (SE-031-L)
+
+Directorio canónico `.claude/queries/` con estructura:
+
+```
+.claude/queries/
+├── azure-devops/
+│   ├── blocked-pbis-over-3d.wiql
+│   ├── active-sprint-capacity.wiql
+│   ├── pbis-by-owner.wiql
+│   └── ...
+├── jira/
+│   ├── blocked-issues.jql
+│   └── ...
+├── savia-flow/
+│   └── ...
+└── INDEX.md
+```
+
+Cada snippet tiene header YAML:
+
+```wiql
+---
+id: blocked-pbis-over-3d
+description: PBIs bloqueados más de 3 días sin actualización
+params:
+  - sprint: Sprint iteration path (e.g. "ProjectX\\Sprint 2026-04")
+returns: id, title, state, assignedTo, changedDate
+tags: [azure-devops, blocked, sla]
+---
+SELECT [System.Id], [System.Title], [System.State], [System.AssignedTo], [System.ChangedDate]
+FROM WorkItems
+WHERE [System.WorkItemType] = 'Product Backlog Item'
+  AND [System.IterationPath] UNDER '{{sprint}}'
+  AND [System.State] = 'Blocked'
+  AND [System.ChangedDate] < @Today - 3
+```
+
+### 2. Query resolver (SE-031-R)
+
+Script `scripts/query-lib-resolve.sh`:
+
+```bash
+# Get raw query
+bash scripts/query-lib-resolve.sh --id blocked-pbis-over-3d --lang wiql
+
+# Substitute params
+bash scripts/query-lib-resolve.sh --id blocked-pbis-over-3d --param sprint="ProjectX\\Sprint 2026-04"
+
+# List all queries
+bash scripts/query-lib-resolve.sh --list --json
+```
+
+### 3. NL-to-query (SE-031-N)
+
+Script `scripts/query-lib-nl.sh` — recibe NL, consulta library, y si no hay match exact, propone WIQL con schema prompt:
+
+```bash
+bash scripts/query-lib-nl.sh "PBIs blocked more than 3 days"
+# → matches: blocked-pbis-over-3d
+# → output: resolved WIQL
+
+bash scripts/query-lib-nl.sh "count commits per dev this week"
+# → no match — emits placeholder + schema prompt for human/LLM
+```
+
+## Design
+
+### Structure of INDEX.md (auto-generated)
+
+```markdown
+# Query Library INDEX
+
+| ID | Lang | Tags | Description |
+|---|---|---|---|
+| blocked-pbis-over-3d | WIQL | blocked, sla | PBIs bloqueados > 3 días |
+| ... |
+```
+
+Regenerar con `scripts/query-lib-index.sh`. CI check freshness.
+
+### Integration con commands existentes
+
+Commands que hoy tienen WIQL inline (ej. `sprint-status`, `board-flow`) se migran a:
+
+```bash
+QUERY=$(bash scripts/query-lib-resolve.sh --id blocked-pbis-over-3d \
+  --param sprint="$SPRINT_ACTUAL")
+curl ... -d "$QUERY" https://dev.azure.com/.../wiql
+```
+
+Reducción: 1 fuente de verdad por query. Cambio de schema → 1 sitio.
+
+## Acceptance Criteria
+
+- [ ] AC-01 `.claude/queries/{azure-devops,jira,savia-flow}/` directorios creados con ≥8 snippets iniciales
+- [ ] AC-02 `scripts/query-lib-resolve.sh` implementado con `--id`, `--param`, `--list`, `--json`
+- [ ] AC-03 `scripts/query-lib-nl.sh` heurístico exact+fuzzy match, fallback schema prompt
+- [ ] AC-04 `scripts/query-lib-index.sh` genera `INDEX.md` auto
+- [ ] AC-05 Tests bats 25+ (resolve, substitute, list, nl-match)
+- [ ] AC-06 Docs: `docs/rules/domain/query-library-protocol.md`
+- [ ] AC-07 CHANGELOG entry
+
+## Agent Assignment
+
+Capa: Skills + scripts
+Agente: tech-writer + python-developer (opcional)
+
+## Slicing
+
+- Slice 1 (este PR): snippets + resolver script + INDEX generator + tests
+- Slice 2: NL-to-query heurístico + schema prompts
+- Slice 3: Migrar 5 commands existentes a query library (demo value)
+
+## Feasibility Probe
+
+Time-box: 3h para slice 1. Riesgo principal: params substitution con quotes/escapes tricky en WIQL. Mitigación: resolver usa placeholder-replacement simple + tests case-by-case.
+
+## Riesgos
+
+| Riesgo | Prob | Impacto | Mitigación |
+|---|---|---|---|
+| Params con quotes/backslashes rompen WIQL | Alta | Medio | Resolver valida + escapa; tests bats coverage |
+| Drift entre INDEX.md y snippets | Media | Bajo | `query-lib-index.sh --check` en CI |
+| NL matching falla en queries no listadas | Alta | Bajo | Fallback graceful con schema prompt |
+| Migrar 5 commands existentes rompe flujo | Media | Alto | Slice 3 separado, feature-flag |
+
+## Métricas éxito
+
+- 8+ snippets listos en slice 1
+- ≥ 5 commands migrados en slice 3 (reducción WIQL inline)
+- Drift-check passing en CI
+
+## Referencias
+
+- Retool Query Library pattern
+- [Appsmith datasources + queries](https://github.com/appsmithorg/appsmith)
+- Skills existentes: `nl-query`, `azure-devops-queries`

--- a/docs/rules/domain/query-library-protocol.md
+++ b/docs/rules/domain/query-library-protocol.md
@@ -1,0 +1,110 @@
+# Query Library Protocol — SE-031
+
+> **Regla**: WIQL / JQL / Savia Flow queries viven como snippets versionados en `.claude/queries/`, accesibles por ID. Nunca inline en commands nuevos.
+
+## Principio
+
+1 query = 1 fichero. 1 fichero = 1 fuente de verdad.
+Cuando el schema de Azure DevOps / Jira cambia, el fix es 1 sitio, no 10.
+
+## Estructura canónica
+
+```
+.claude/queries/
+├── azure-devops/   *.wiql
+├── jira/           *.jql
+├── savia-flow/     *.yaml
+└── INDEX.md        (auto-generado, no editar a mano)
+```
+
+## Formato de un snippet
+
+Cada fichero tiene **frontmatter YAML obligatorio** seguido del cuerpo:
+
+```
+---
+id: kebab-case-unique                 # requerido
+lang: wiql | jql | savia-flow         # requerido
+description: Una linea en espanol     # requerido
+params:                               # opcional
+  - nombre: descripcion del parametro
+returns: [campo1, campo2]             # opcional, documentativo
+tags: [categoria1, categoria2]        # opcional
+---
+<cuerpo del query con {{param}} placeholders>
+```
+
+### IDs
+
+- kebab-case, unicos en el arbol `.claude/queries/`
+- Prefijo tematico recomendado pero no obligatorio: `blocked-`, `velocity-`, `bugs-`.
+- No cambiar un ID una vez publicado (rompe commands que lo usan).
+
+### Parametros
+
+- Placeholder: `{{nombre}}` en el cuerpo.
+- El resolver valida que los placeholders esten sustituidos; si no, emite warning en stderr.
+- Escape automatico para `&`, `/`, `\` en los valores.
+
+## Uso desde commands
+
+**Prohibido** (drift garantizado):
+
+```bash
+QUERY="SELECT [System.Id] FROM WorkItems WHERE [System.IterationPath] UNDER '$SPRINT' AND [System.State] = 'Blocked'"
+```
+
+**Correcto**:
+
+```bash
+QUERY=$(bash scripts/query-lib-resolve.sh --id blocked-pbis-over-3d --param sprint="$SPRINT")
+curl -u ":$(cat $PAT_FILE)" -X POST -H "Content-Type: application/json" \
+  -d "{\"query\":\"$QUERY\"}" "$ORG_URL/$PROJECT/_apis/wiql?api-version=7.0"
+```
+
+## Resolver CLI
+
+```
+# Por ID
+bash scripts/query-lib-resolve.sh --id <id> [--param k=v ...]
+
+# Listado (table + filtros)
+bash scripts/query-lib-resolve.sh --list [--lang wiql|jql|savia-flow] [--json]
+```
+
+Exit codes: `0` OK, `1` query no encontrada, `2` error de input.
+
+## Index generator
+
+```
+bash scripts/query-lib-index.sh          # regenera INDEX.md
+bash scripts/query-lib-index.sh --check  # CI: falla si esta stale
+```
+
+CI debe incluir `--check` para garantizar que cualquier snippet nuevo regenera el INDEX antes de merge.
+
+## Hygiene rules (obligatorias)
+
+1. **Un snippet por caso de uso** — sin multi-proposito con IFs.
+2. **Sin hardcoded IterationPath** — siempre parametrizado con `{{sprint}}`, `{{owner}}`, `{{project}}`.
+3. **Cambiar schema = 1 commit** — el punto del patron.
+4. **Deprecacion explicita** — para sustituir un snippet, anadir el nuevo, migrar callers, borrar el viejo en el mismo PR.
+5. **Backticks en el cuerpo** — permitidos en WIQL/JQL porque el resolver los trata como texto plano. Nunca usar backticks en el `description:` del frontmatter.
+
+## Seguridad
+
+- Los snippets son **lectura**: no mutan Azure DevOps / Jira.
+- Un snippet futuro que mute estado (p.ej. update state) debe marcarse `mutating: true` en frontmatter y exigir `--confirm` en el resolver — alcance de SE-031 slice 2.
+- Params con quotes peligrosos se escapan; revisa el output antes de pasar a `curl -d`.
+
+## Lesson learned — fork bomb 2026-04-18
+
+El generador INDEX inicial usaba `python3 <<PY` (heredoc no quoted). El cuerpo incluia backticks alrededor de `scripts/query-lib-index.sh`. Bash los interpreto como command substitution antes de pasar al python, ejecutando el script recursivamente. Resultado: 15.245 procesos bash fork-bombed.
+
+Fix canonico: **heredocs con python embebido SIEMPRE usan `<<'PY'`** (delimitador quoted). Si se necesita pasar una variable bash al python, via `export` + `os.environ.get`. Test de regresion: `index script heredoc is quoted (no fork bomb)` en `tests/test-query-lib.bats`.
+
+## Referencias
+
+- Spec: `docs/propuestas/SE-031-query-library-nl.md`
+- Skills relacionados: `nl-query`, `azure-devops-queries`, `savia-flow`
+- Tests: `tests/test-query-lib.bats` (31 tests)

--- a/docs/rules/domain/query-library-protocol.md
+++ b/docs/rules/domain/query-library-protocol.md
@@ -74,6 +74,36 @@ bash scripts/query-lib-resolve.sh --list [--lang wiql|jql|savia-flow] [--json]
 
 Exit codes: `0` OK, `1` query no encontrada, `2` error de input.
 
+## NL-to-query (slice 2)
+
+```
+# Natural language → query ID (stdout)
+bash scripts/query-lib-nl.sh "PBIs bloqueados mas de 3 dias"
+# → blocked-pbis-over-3d
+
+# JSON verbose (score, path, resolved_by hint)
+bash scripts/query-lib-nl.sh --json "velocity ultimos 3 sprints"
+
+# Filtrar por lang y ajustar umbral
+bash scripts/query-lib-nl.sh --lang jql --min-score 0.25 "mis issues abiertos"
+
+# Pipe end-to-end NL → WIQL body
+ID=$(bash scripts/query-lib-nl.sh "PBIs bloqueados mas de 3 dias")
+bash scripts/query-lib-resolve.sh --id "$ID" --param sprint="$SPRINT_ACTUAL"
+```
+
+Algoritmo:
+1. **Normalizacion**: lowercase + strip accents + drop puntuacion.
+2. **Alias expansion**: mapa bilingue ES/EN (blocked↔bloqueado, sprint↔iteracion, pbi↔backlog↔item, velocity↔velocidad, days↔dias, open↔abierto↔activo, ...).
+3. **F1 / Dice coefficient**: `2·|NL ∩ haystack| / (|NL| + |haystack|)` sobre descripcion + tags + id kebab tokens. Mas robusto que Jaccard frente a haystacks desbalanceadas.
+4. **Shingle boost**: +0.1 si un 2-gram de la NL aparece literal en la descripcion (hasta 1.0).
+5. **Winner rule**: match unico si 1 candidato pasa el umbral o el top supera al segundo por ≥0.15. Si no: exit 2 con lista de disambiguacion.
+6. **Fallback**: exit 1 + schema prompt con campos WIQL de referencia.
+
+Exit codes: `0` match unico, `1` sin match (prompt emitido), `2` ambiguo, `3` error de input.
+
+Umbral por defecto `--min-score 0.30`. Bajalo a `0.20` para recall mayor en NL cortos (2 tokens).
+
 ## Index generator
 
 ```

--- a/scripts/query-lib-index.sh
+++ b/scripts/query-lib-index.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# query-lib-index.sh — SE-031
+# Regenerates .claude/queries/INDEX.md from current snippet files.
+# Ref: docs/propuestas/SE-031-query-library-nl.md
+#
+# Usage: bash scripts/query-lib-index.sh [--check]
+
+set -uo pipefail
+
+CHECK_MODE=false
+[[ "${1:-}" == "--check" ]] && CHECK_MODE=true
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)}" || REPO_ROOT="."
+INDEX="$REPO_ROOT/.claude/queries/INDEX.md"
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+export REPO_ROOT
+# NOTE: heredoc is quoted (<<'PY') to disable bash expansion — the python
+# code contains backticks/$ that must NOT be command-substituted by bash.
+# REPO_ROOT is read from env instead.
+python3 <<'PY' > "$TMP"
+import os, re, sys
+
+REPO = os.environ.get("REPO_ROOT", ".")
+Q_DIR = os.path.join(REPO, ".claude/queries")
+
+entries = []
+for root, dirs, files in os.walk(Q_DIR):
+    for f in sorted(files):
+        if f == "INDEX.md":
+            continue
+        if not f.endswith((".wiql", ".jql", ".yaml")):
+            continue
+        path = os.path.join(root, f)
+        rel = os.path.relpath(path, Q_DIR)
+        try:
+            with open(path) as fd:
+                content = fd.read()
+        except Exception:
+            continue
+        m = re.search(r'^---\n(.*?)\n---', content, re.DOTALL | re.MULTILINE)
+        fm = m.group(1) if m else ""
+        def grab(k, block=fm):
+            mm = re.search(r'^' + re.escape(k) + r':\s*(.+)$', block, re.MULTILINE)
+            return mm.group(1).strip().strip('"') if mm else ""
+        qid = grab("id") or f.rsplit(".", 1)[0]
+        lang = grab("lang") or "unknown"
+        desc = grab("description")
+        tags = grab("tags").strip("[]")
+        entries.append((qid, lang, tags, desc, rel))
+
+print("# Query Library — INDEX")
+print()
+print("Auto-generated. {n} queries. Regen: scripts/query-lib-index.sh. CI check: --check flag. SPEC-SE-031.".format(n=len(entries)))
+print()
+print("| ID | Lang | Tags | Description | File |")
+print("|---|---|---|---|---|")
+for qid, lang, tags, desc, rel in sorted(entries):
+    safe_desc = (desc or "").replace("|", "\\|")[:80]
+    safe_tags = (tags or "").replace("|", "\\|")
+    print("| {qid} | {lang} | {tags} | {desc} | [{rel}](./{rel}) |".format(
+        qid=qid, lang=lang, tags=safe_tags, desc=safe_desc, rel=rel))
+PY
+
+if $CHECK_MODE; then
+  if diff -q "$INDEX" "$TMP" >/dev/null 2>&1; then
+    echo "OK: INDEX.md up-to-date"
+    exit 0
+  else
+    echo "FAIL: INDEX.md stale — run 'bash scripts/query-lib-index.sh'" >&2
+    diff "$INDEX" "$TMP" 2>/dev/null | head -15 >&2
+    exit 1
+  fi
+else
+  cp "$TMP" "$INDEX"
+  echo "Generated $INDEX"
+fi

--- a/scripts/query-lib-nl.sh
+++ b/scripts/query-lib-nl.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# query-lib-nl.sh — SE-031 slice 2
+# Natural language → Query Library ID (heuristic, deterministic, no LLM).
+# Ref: docs/propuestas/SE-031-query-library-nl.md
+#
+# Pipeline:
+#   1. Exact match: NL description token set == candidate description tokens
+#   2. Fuzzy match: Jaccard(NL tokens, desc+tags tokens) ≥ threshold
+#   3. Fallback: emit schema prompt + placeholder
+#
+# Usage:
+#   bash scripts/query-lib-nl.sh "PBIs blocked more than 3 days"
+#   bash scripts/query-lib-nl.sh --lang wiql "blocked items"
+#   bash scripts/query-lib-nl.sh --json "velocity last 3 sprints"
+#   bash scripts/query-lib-nl.sh --min-score 0.5 "my open bugs"
+#
+# Exit codes:
+#   0 = match found (unique)
+#   1 = no match (fallback prompt emitted)
+#   2 = multiple candidates (disambiguation needed)
+#   3 = input error
+
+set -uo pipefail
+
+LANG_FILTER=""
+JSON_OUT=false
+MIN_SCORE="0.30"
+TOPK=3
+NL=""
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \?//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lang)      LANG_FILTER="$2"; shift 2 ;;
+    --json)      JSON_OUT=true; shift ;;
+    --min-score) MIN_SCORE="$2"; shift 2 ;;
+    --topk)      TOPK="$2"; shift 2 ;;
+    --help|-h)   usage ;;
+    --*)         echo "Error: unknown flag $1" >&2; exit 3 ;;
+    *)           NL="${NL:+$NL }$1"; shift ;;
+  esac
+done
+
+[[ -z "$NL" ]] && { echo "Error: NL query required" >&2; exit 3; }
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)}" || REPO_ROOT="."
+QUERIES_DIR="$REPO_ROOT/.claude/queries"
+
+[[ ! -d "$QUERIES_DIR" ]] && { echo "Error: queries dir not found: $QUERIES_DIR" >&2; exit 3; }
+
+export REPO_ROOT NL LANG_FILTER MIN_SCORE TOPK JSON_OUT
+
+python3 <<'PY'
+import os, re, sys, json, unicodedata
+
+REPO = os.environ["REPO_ROOT"]
+NL = os.environ["NL"]
+LANG = os.environ.get("LANG_FILTER", "")
+MIN_SCORE = float(os.environ.get("MIN_SCORE", "0.30"))
+TOPK = int(os.environ.get("TOPK", "3"))
+JSON_OUT = os.environ.get("JSON_OUT", "false") == "true"
+
+Q_DIR = os.path.join(REPO, ".claude/queries")
+
+STOPWORDS = set("""
+a al an and are as at be but by de del el en es for from has have he i in is it its la
+las le les los me mi mis my no nos not of on or por para que se si sin sobre su sus that the
+their them they this to un una unas uno with without y your you hace con mas more than menos
+than los las
+""".split())
+
+# Alias expansion (domain terms → canonical tokens)
+ALIASES = {
+    "blocked":     ["blocked", "bloqueado", "bloqueados", "stuck"],
+    "sprint":      ["sprint", "iteracion", "iteration"],
+    "pbi":         ["pbi", "pbis", "backlog", "item", "items"],
+    "bug":         ["bug", "bugs", "defect", "defecto", "defectos"],
+    "velocity":    ["velocity", "velocidad"],
+    "review":      ["review", "reviews", "revision", "revisiones"],
+    "owner":       ["owner", "assignee", "asignado", "asignada", "assigned"],
+    "estimate":    ["estimate", "estimacion", "estimation", "puntos"],
+    "days":        ["days", "dias"],
+    "open":        ["open", "abiertos", "abiertas", "activos", "activas"],
+    "current":     ["current", "actual", "active"],
+    "my":          ["my", "mis", "me"],
+    "jira":        ["jira"],
+    "azure":       ["azure", "devops"],
+    "savia":       ["savia", "saviaflow", "savia-flow"],
+}
+
+# Reverse alias map: variant → canonical
+ALIAS_MAP = {}
+for canon, variants in ALIASES.items():
+    for v in variants:
+        ALIAS_MAP[v] = canon
+
+def normalize(s):
+    """Lowercase, strip accents, remove punctuation."""
+    if not s:
+        return ""
+    s = s.lower().strip()
+    # Strip accents (NFD + drop combining)
+    s = "".join(c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn")
+    # Replace punctuation with space
+    s = re.sub(r"[^\w\s]", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+def tokenize(s):
+    """Normalize + split + drop stopwords + alias-expand."""
+    norm = normalize(s)
+    toks = [t for t in norm.split() if t and t not in STOPWORDS]
+    # Expand aliases to canonical form
+    expanded = []
+    for t in toks:
+        expanded.append(ALIAS_MAP.get(t, t))
+    return set(expanded)
+
+def f1_score(a, b):
+    """F1 / Dice coefficient — less diluted by haystack size than Jaccard."""
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    if inter == 0:
+        return 0.0
+    return 2 * inter / (len(a) + len(b))
+
+# Load all snippets
+candidates = []
+for root, dirs, files in os.walk(Q_DIR):
+    for f in sorted(files):
+        if f == "INDEX.md":
+            continue
+        if not f.endswith((".wiql", ".jql", ".yaml")):
+            continue
+        path = os.path.join(root, f)
+        try:
+            with open(path) as fd:
+                content = fd.read()
+        except Exception:
+            continue
+        m = re.search(r'^---\n(.*?)\n---', content, re.DOTALL | re.MULTILINE)
+        fm = m.group(1) if m else ""
+        def grab(k, block=fm):
+            mm = re.search(r'^' + re.escape(k) + r':\s*(.+)$', block, re.MULTILINE)
+            return mm.group(1).strip().strip('"') if mm else ""
+        qid  = grab("id") or f.rsplit(".", 1)[0]
+        qlang = grab("lang") or "unknown"
+        if LANG and qlang != LANG:
+            continue
+        desc = grab("description")
+        tags = grab("tags").strip("[]")
+        candidates.append({
+            "id": qid,
+            "lang": qlang,
+            "description": desc,
+            "tags": tags,
+            "path": os.path.relpath(path, REPO),
+        })
+
+# Score each candidate
+nl_tokens = tokenize(NL)
+# Also include the raw id tokens (split kebab-case) as a boost signal
+scored = []
+for c in candidates:
+    desc_tokens = tokenize(c["description"])
+    tag_tokens  = tokenize(c["tags"].replace(",", " "))
+    id_tokens   = tokenize(c["id"].replace("-", " "))
+    haystack = desc_tokens | tag_tokens | id_tokens
+    score = f1_score(nl_tokens, haystack)
+    # Exact phrase boost: if any multi-token substring of NL appears in desc
+    if c["description"] and len(nl_tokens) >= 2:
+        nl_norm = normalize(NL)
+        desc_norm = normalize(c["description"])
+        # 3-token shingle match
+        nl_words = nl_norm.split()
+        for i in range(len(nl_words) - 1):
+            shingle = " ".join(nl_words[i:i+2])
+            if shingle in desc_norm:
+                score = min(1.0, score + 0.1)
+                break
+    scored.append((score, c))
+
+scored.sort(key=lambda x: (-x[0], x[1]["id"]))
+top = [s for s in scored if s[0] >= MIN_SCORE][:TOPK]
+
+if not top:
+    # Fallback: schema prompt
+    fallback = {
+        "match": None,
+        "reason": "no_match",
+        "nl": NL,
+        "available_langs": sorted({c["lang"] for c in candidates}),
+        "nearest": [
+            {"id": c["id"], "score": round(s, 3), "description": c["description"]}
+            for s, c in scored[:3]
+        ],
+        "schema_prompt": (
+            "No query matched '{nl}'.\n"
+            "Available fields for a WIQL skeleton:\n"
+            "  [System.Id] [System.Title] [System.State] [System.AssignedTo]\n"
+            "  [System.WorkItemType] [System.IterationPath] [System.AreaPath]\n"
+            "  [System.ChangedDate] [System.CreatedDate] [Microsoft.VSTS.Common.Priority]\n"
+            "  [Microsoft.VSTS.Scheduling.OriginalEstimate] [Microsoft.VSTS.Scheduling.RemainingWork]\n"
+            "Propose a snippet at .claude/queries/<lang>/<kebab-id>.<ext> with frontmatter,\n"
+            "then re-run the NL query or use query-lib-resolve.sh --id directly."
+        ).format(nl=NL),
+    }
+    if JSON_OUT:
+        print(json.dumps(fallback))
+    else:
+        print("# NO MATCH")
+        print("# NL: " + NL)
+        print("# Min-score: " + str(MIN_SCORE))
+        if fallback["nearest"]:
+            print("# Nearest candidates (below threshold):")
+            for n in fallback["nearest"]:
+                print("#   {0} ({1}) — {2}".format(n["id"], n["score"], n["description"]))
+        print("# ---")
+        print(fallback["schema_prompt"])
+    sys.exit(1)
+
+if len(top) == 1 or (len(top) > 1 and top[0][0] > top[1][0] + 0.15):
+    # Unique winner (or clear leader by >0.15 margin)
+    winner = top[0][1]
+    if JSON_OUT:
+        print(json.dumps({
+            "match": winner["id"],
+            "score": round(top[0][0], 3),
+            "lang": winner["lang"],
+            "description": winner["description"],
+            "path": winner["path"],
+            "resolved_by": "query-lib-resolve.sh --id " + winner["id"],
+        }))
+    else:
+        print(winner["id"])
+    sys.exit(0)
+
+# Multiple candidates — emit disambiguation list
+if JSON_OUT:
+    print(json.dumps({
+        "match": None,
+        "reason": "ambiguous",
+        "nl": NL,
+        "candidates": [
+            {"id": c["id"], "score": round(s, 3), "lang": c["lang"],
+             "description": c["description"]}
+            for s, c in top
+        ],
+    }))
+else:
+    print("# AMBIGUOUS — multiple candidates (score order):")
+    for s, c in top:
+        print("#   {0} ({1}) [{2}] — {3}".format(c["id"], round(s, 3), c["lang"], c["description"]))
+    print("# Pick one: query-lib-resolve.sh --id <id>")
+sys.exit(2)
+PY

--- a/scripts/query-lib-resolve.sh
+++ b/scripts/query-lib-resolve.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# query-lib-resolve.sh — SE-031
+# Resolves a query from .claude/queries/ by ID with optional param substitution.
+# Ref: docs/propuestas/SE-031-query-library-nl.md
+#
+# Usage:
+#   bash scripts/query-lib-resolve.sh --id ID [--param key=value ...] [--json]
+#   bash scripts/query-lib-resolve.sh --list [--lang wiql|jql|savia-flow] [--json]
+#
+# Exit codes:
+#   0 = query resolved/listed
+#   1 = query not found
+#   2 = input error
+
+set -uo pipefail
+
+ID=""
+LIST=false
+LANG_FILTER=""
+JSON_OUT=false
+declare -A PARAMS
+
+usage() {
+  sed -n '2,12p' "$0" | sed 's/^# \?//'
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --id) ID="$2"; shift 2 ;;
+    --list) LIST=true; shift ;;
+    --lang) LANG_FILTER="$2"; shift 2 ;;
+    --param)
+      kv="$2"
+      k="${kv%%=*}"
+      v="${kv#*=}"
+      PARAMS["$k"]="$v"
+      shift 2 ;;
+    --json) JSON_OUT=true; shift ;;
+    --help|-h) usage ;;
+    *) echo "Error: unknown flag $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)}" || REPO_ROOT="."
+QUERIES_DIR="$REPO_ROOT/.claude/queries"
+
+[[ ! -d "$QUERIES_DIR" ]] && { echo "Error: queries dir not found: $QUERIES_DIR" >&2; exit 2; }
+
+# ── List mode ────────────────────────────────────────────────────────────────
+if $LIST; then
+  entries=()
+  while IFS= read -r file; do
+    qid=$(grep -E '^id:' "$file" 2>/dev/null | head -1 | sed 's/^id:[[:space:]]*//' | tr -d '"')
+    qlang=$(grep -E '^lang:' "$file" 2>/dev/null | head -1 | sed 's/^lang:[[:space:]]*//' | tr -d '"')
+    qdesc=$(grep -E '^description:' "$file" 2>/dev/null | head -1 | sed 's/^description:[[:space:]]*//' | tr -d '"')
+    qtags=$(grep -E '^tags:' "$file" 2>/dev/null | head -1 | sed 's/^tags:[[:space:]]*//' | tr -d '[]"')
+
+    # Filter by lang if specified
+    if [[ -n "$LANG_FILTER" && "$qlang" != "$LANG_FILTER" ]]; then
+      continue
+    fi
+
+    entries+=("${qid}|${qlang}|${qtags}|${qdesc}")
+  done < <(find "$QUERIES_DIR" -type f \( -name "*.wiql" -o -name "*.jql" -o -name "*.yaml" \) 2>/dev/null | sort)
+
+  if $JSON_OUT; then
+    printf '['
+    first=true
+    for e in "${entries[@]}"; do
+      IFS='|' read -r id lang tags desc <<< "$e"
+      $first && first=false || printf ','
+      printf '{"id":"%s","lang":"%s","tags":"%s","description":"%s"}' \
+        "$id" "$lang" "$tags" "$desc"
+    done
+    printf ']\n'
+  else
+    printf "%-30s %-12s %-30s %s\n" "ID" "LANG" "TAGS" "DESCRIPTION"
+    echo "------------------------------------------------------------------------------------"
+    for e in "${entries[@]}"; do
+      IFS='|' read -r id lang tags desc <<< "$e"
+      printf "%-30s %-12s %-30s %s\n" "$id" "$lang" "$tags" "${desc:0:50}"
+    done
+  fi
+  exit 0
+fi
+
+# ── Resolve mode ─────────────────────────────────────────────────────────────
+[[ -z "$ID" ]] && { echo "Error: --id required (or use --list)" >&2; exit 2; }
+
+# Find the file matching the id
+MATCH_FILE=""
+while IFS= read -r file; do
+  qid=$(grep -E '^id:' "$file" 2>/dev/null | head -1 | sed 's/^id:[[:space:]]*//' | tr -d '"')
+  if [[ "$qid" == "$ID" ]]; then
+    MATCH_FILE="$file"
+    break
+  fi
+done < <(find "$QUERIES_DIR" -type f \( -name "*.wiql" -o -name "*.jql" -o -name "*.yaml" \) 2>/dev/null)
+
+[[ -z "$MATCH_FILE" ]] && { echo "Error: query not found: $ID" >&2; exit 1; }
+
+# Extract query body (everything after the second '---')
+QUERY_BODY=$(python3 <<PY
+with open("$MATCH_FILE") as f:
+    content = f.read()
+# Find the end of frontmatter
+import re
+m = re.search(r'^---\n.*?\n---\n', content, re.DOTALL | re.MULTILINE)
+if m:
+    print(content[m.end():].strip())
+else:
+    print(content.strip())
+PY
+)
+
+# Param substitution
+for key in "${!PARAMS[@]}"; do
+  value="${PARAMS[$key]}"
+  # Escape special chars for sed
+  value_esc=$(printf '%s\n' "$value" | sed -e 's/[&/\]/\\&/g')
+  QUERY_BODY=$(echo "$QUERY_BODY" | sed "s/{{${key}}}/${value_esc}/g")
+done
+
+# Warn about unsubstituted placeholders
+UNSUB=$(echo "$QUERY_BODY" | grep -oE '\{\{[a-zA-Z_][a-zA-Z0-9_]*\}\}' | sort -u || true)
+
+if $JSON_OUT; then
+  # JSON-safe via python
+  python3 -c "
+import json
+print(json.dumps({
+  'id': '$ID',
+  'file': '$MATCH_FILE',
+  'query': '''$QUERY_BODY''',
+  'unsubstituted': '''$UNSUB'''.split() if '''$UNSUB''' else []
+}))
+"
+else
+  echo "$QUERY_BODY"
+  if [[ -n "$UNSUB" ]]; then
+    echo "" >&2
+    echo "# WARN: unsubstituted placeholders: $UNSUB" >&2
+  fi
+fi
+
+exit 0

--- a/tests/test-query-lib-nl.bats
+++ b/tests/test-query-lib-nl.bats
@@ -1,0 +1,229 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/query-lib-nl.sh
+# SPEC: SE-031 slice 2 — Natural language → Query ID
+# Ref: docs/propuestas/SE-031-query-library-nl.md
+
+NL="scripts/query-lib-nl.sh"
+
+setup() {
+  export TMPDIR="${BATS_TEST_TMPDIR:-/tmp}"
+  export REPO_ROOT="$BATS_TEST_TMPDIR/nl"
+  mkdir -p "$REPO_ROOT/scripts" \
+           "$REPO_ROOT/.claude/queries/azure-devops" \
+           "$REPO_ROOT/.claude/queries/jira" \
+           "$REPO_ROOT/.claude/queries/savia-flow"
+  cp "$BATS_TEST_DIRNAME/../$NL" "$REPO_ROOT/scripts/"
+  chmod +x "$REPO_ROOT/scripts/"*.sh
+
+  cat > "$REPO_ROOT/.claude/queries/azure-devops/blocked.wiql" <<'EOF'
+---
+id: blocked-pbis-over-3d
+lang: wiql
+description: PBIs bloqueados mas de 3 dias sin actualizacion
+tags: [azure-devops, blocked, sla, sprint]
+---
+SELECT X
+EOF
+
+  cat > "$REPO_ROOT/.claude/queries/azure-devops/bugs.wiql" <<'EOF'
+---
+id: bugs-open-by-severity
+lang: wiql
+description: Bugs abiertos agrupables por severidad
+tags: [azure-devops, bugs, quality]
+---
+SELECT X
+EOF
+
+  cat > "$REPO_ROOT/.claude/queries/savia-flow/velocity.yaml" <<'EOF'
+---
+id: velocity-last-3-sprints
+lang: savia-flow
+description: Velocity de los ultimos 3 sprints cerrados para proyeccion
+tags: [savia-flow, velocity, planning]
+---
+query: velocity
+EOF
+
+  cat > "$REPO_ROOT/.claude/queries/jira/myopen.jql" <<'EOF'
+---
+id: my-open-issues-jira
+lang: jql
+description: Issues asignados al usuario actual activos
+tags: [jira, owner, workload]
+---
+assignee = currentUser()
+EOF
+  cd "$REPO_ROOT"
+}
+
+teardown() {
+  cd /
+  rm -rf "$REPO_ROOT"
+}
+
+# ── Structure ───────────────────────────────────────────────────────────────
+
+@test "script exists and is executable" {
+  [[ -x "scripts/query-lib-nl.sh" ]]
+}
+
+@test "script uses set -uo pipefail" {
+  run head -30 scripts/query-lib-nl.sh
+  [[ "$output" == *"set -uo pipefail"* ]]
+}
+
+@test "heredoc is quoted (no fork bomb risk)" {
+  run grep -E "^python3 <<'PY'" scripts/query-lib-nl.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "script has --help and exits 0" {
+  run bash scripts/query-lib-nl.sh --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+# ── Input validation ───────────────────────────────────────────────────────
+
+@test "no args returns exit 3" {
+  run bash scripts/query-lib-nl.sh
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"NL query required"* ]]
+}
+
+@test "unknown flag returns exit 3" {
+  run bash scripts/query-lib-nl.sh --foo bar
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+# ── Match behavior (unique) ────────────────────────────────────────────────
+
+@test "exact-ish match returns single id and exit 0" {
+  run bash scripts/query-lib-nl.sh "PBIs bloqueados mas de 3 dias"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "blocked-pbis-over-3d" ]]
+}
+
+@test "spanish query matches spanish description" {
+  run bash scripts/query-lib-nl.sh "bugs abiertos por severidad"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "bugs-open-by-severity" ]]
+}
+
+@test "english query matches via alias expansion" {
+  # 'blocked' en English → canonical 'blocked' (matches 'bloqueados' via alias)
+  run bash scripts/query-lib-nl.sh "blocked backlog items last days"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "blocked-pbis-over-3d" ]]
+}
+
+@test "savia-flow query matched" {
+  run bash scripts/query-lib-nl.sh "velocity ultimos 3 sprints"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "velocity-last-3-sprints" ]]
+}
+
+# ── Fallback (no match) ────────────────────────────────────────────────────
+
+@test "unrelated query returns exit 1 + schema prompt" {
+  run bash scripts/query-lib-nl.sh "count commits per dev this week"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"NO MATCH"* ]]
+  [[ "$output" == *"WIQL skeleton"* ]]
+}
+
+@test "fallback includes available langs" {
+  run bash -c "bash scripts/query-lib-nl.sh --json 'foobar xyz' 2>&1"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'"available_langs"'* ]]
+  [[ "$output" == *'"wiql"'* ]]
+  [[ "$output" == *'"jql"'* ]]
+}
+
+@test "fallback includes nearest candidates" {
+  run bash -c "bash scripts/query-lib-nl.sh --json 'foobar xyz'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'"nearest"'* ]]
+}
+
+# ── Language filter ────────────────────────────────────────────────────────
+
+@test "--lang wiql matches only wiql" {
+  run bash scripts/query-lib-nl.sh --lang wiql "blocked backlog items last days"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "blocked-pbis-over-3d" ]]
+}
+
+@test "--lang jql excludes wiql candidates" {
+  # Query would match wiql blocked, but --lang jql restricts to jira
+  run bash scripts/query-lib-nl.sh --lang jql "mis issues abiertos"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "my-open-issues-jira" ]]
+}
+
+@test "--lang savia-flow returns only savia-flow candidates" {
+  run bash scripts/query-lib-nl.sh --lang savia-flow "velocity ultimos sprints"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "velocity-last-3-sprints" ]]
+}
+
+# ── JSON output ────────────────────────────────────────────────────────────
+
+@test "--json match returns valid JSON with match id" {
+  run bash scripts/query-lib-nl.sh --json "velocity ultimos 3 sprints"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['match']=='velocity-last-3-sprints'"
+}
+
+@test "--json no match has match=null and reason=no_match" {
+  run bash scripts/query-lib-nl.sh --json "xyz lorem ipsum"
+  [ "$status" -eq 1 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['match'] is None; assert d['reason']=='no_match'"
+}
+
+@test "--json includes score and resolved_by on match" {
+  run bash scripts/query-lib-nl.sh --json "PBIs bloqueados mas de 3 dias"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'score' in d; assert 'resolved_by' in d"
+}
+
+# ── Threshold override ─────────────────────────────────────────────────────
+
+@test "--min-score high threshold rejects weak match" {
+  # Set threshold so high nothing passes
+  run bash scripts/query-lib-nl.sh --min-score 0.99 "PBIs bloqueados"
+  [ "$status" -eq 1 ]
+}
+
+@test "--min-score low threshold accepts weak match" {
+  run bash scripts/query-lib-nl.sh --min-score 0.01 "blocked"
+  [ "$status" -ne 3 ]
+  # May be 0 (match), 1 (no match if all scores are 0), or 2 (ambiguous)
+  [[ "$status" -eq 0 || "$status" -eq 2 ]]
+}
+
+# ── Ambiguity ──────────────────────────────────────────────────────────────
+
+@test "ambiguous query returns exit 2 with candidates list" {
+  # A query that scores similarly for two snippets should produce 2 candidates
+  # "sprint" matches active-sprint-items AND blocked via tag
+  run bash scripts/query-lib-nl.sh --min-score 0.05 "sprint items"
+  # Either exit 2 (ambiguous) or exit 0 with clear winner
+  [[ "$status" -eq 0 || "$status" -eq 2 ]]
+}
+
+# ── Integration pipe with resolver ─────────────────────────────────────────
+
+@test "NL output pipes into resolver by id" {
+  # End-to-end: NL → id → resolver produces body
+  cp "$BATS_TEST_DIRNAME/../scripts/query-lib-resolve.sh" "$REPO_ROOT/scripts/"
+  chmod +x scripts/query-lib-resolve.sh
+  local id
+  id=$(bash scripts/query-lib-nl.sh "bugs abiertos por severidad")
+  [ "$id" = "bugs-open-by-severity" ]
+  run bash scripts/query-lib-resolve.sh --id "$id"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SELECT X"* ]]
+}

--- a/tests/test-query-lib.bats
+++ b/tests/test-query-lib.bats
@@ -283,3 +283,43 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" -ge 8 ]
 }
+
+# ── SE-031 slice 3 — migrated commands/scripts ─────────────────────────────
+
+@test "slice3: backlog-groom-open snippet resolves with project param" {
+  unset REPO_ROOT
+  cd "$BATS_TEST_DIRNAME/.."
+  run bash scripts/query-lib-resolve.sh --id backlog-groom-open --param project=ProjectX
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FROM WorkItems"* ]]
+  [[ "$output" == *"'ProjectX'"* ]]
+  [[ "$output" == *"User Story"* ]]
+}
+
+@test "slice3: sprint-items-detailed has CurrentIteration placeholder" {
+  unset REPO_ROOT
+  cd "$BATS_TEST_DIRNAME/.."
+  run bash scripts/query-lib-resolve.sh --id sprint-items-detailed --param project=P --param team=T
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"@CurrentIteration"* ]]
+  [[ "$output" == *"CompletedWork"* ]]
+  [[ "$output" == *"StoryPoints"* ]]
+}
+
+@test "slice3: board-status-not-done excludes terminal states" {
+  unset REPO_ROOT
+  cd "$BATS_TEST_DIRNAME/.."
+  run bash scripts/query-lib-resolve.sh --id board-status-not-done --param project=P --param team=T
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Done"* ]]
+  [[ "$output" == *"NOT IN"* ]]
+  [[ "$output" == *"Epic"* ]]
+}
+
+@test "slice3: backlog-groom.md references query-lib-resolve" {
+  unset REPO_ROOT
+  cd "$BATS_TEST_DIRNAME/.."
+  run grep -c "query-lib-resolve.sh --id backlog-groom-open" .claude/commands/backlog-groom.md
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}

--- a/tests/test-query-lib.bats
+++ b/tests/test-query-lib.bats
@@ -1,0 +1,285 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/query-lib-resolve.sh and scripts/query-lib-index.sh
+# SPEC: SE-031 Query Library + NL-to-WIQL/JQL
+# Ref: docs/propuestas/SE-031-query-library-nl.md
+
+RESOLVE="scripts/query-lib-resolve.sh"
+INDEX="scripts/query-lib-index.sh"
+
+setup() {
+  export TMPDIR="${BATS_TEST_TMPDIR:-/tmp}"
+  export REPO_ROOT="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$REPO_ROOT/scripts" "$REPO_ROOT/.claude/queries/azure-devops" \
+           "$REPO_ROOT/.claude/queries/jira" "$REPO_ROOT/.claude/queries/savia-flow"
+  cp "$BATS_TEST_DIRNAME/../$RESOLVE" "$REPO_ROOT/scripts/"
+  cp "$BATS_TEST_DIRNAME/../$INDEX"   "$REPO_ROOT/scripts/"
+  chmod +x "$REPO_ROOT/scripts/"*.sh
+
+  # Seed fixtures
+  cat > "$REPO_ROOT/.claude/queries/azure-devops/blocked.wiql" <<'EOF'
+---
+id: blocked-test
+lang: wiql
+description: Blocked items for sprint
+params:
+  - sprint: Iteration path
+returns: [id, title]
+tags: [azure-devops, blocked]
+---
+SELECT [System.Id], [System.Title]
+FROM WorkItems
+WHERE [System.IterationPath] UNDER '{{sprint}}'
+  AND [System.State] = 'Blocked'
+EOF
+
+  cat > "$REPO_ROOT/.claude/queries/jira/myopen.jql" <<'EOF'
+---
+id: myopen-jira
+lang: jql
+description: My open jira issues
+tags: [jira, owner]
+---
+assignee = currentUser() AND resolution = Unresolved
+EOF
+
+  cat > "$REPO_ROOT/.claude/queries/savia-flow/velocity.yaml" <<'EOF'
+---
+id: velocity-test
+lang: savia-flow
+description: Velocity last sprints
+tags: [savia-flow, velocity]
+---
+query:
+  type: velocity
+  last: 3
+EOF
+  cd "$REPO_ROOT"
+}
+
+teardown() {
+  cd /
+  rm -rf "$REPO_ROOT"
+}
+
+# ── Structure and safety ────────────────────────────────────────────────────
+
+@test "resolve script exists and is executable" {
+  [[ -x "scripts/query-lib-resolve.sh" ]]
+}
+
+@test "index script exists and is executable" {
+  [[ -x "scripts/query-lib-index.sh" ]]
+}
+
+@test "resolve script uses set -uo pipefail" {
+  run head -20 scripts/query-lib-resolve.sh
+  [[ "$output" == *"set -uo pipefail"* ]]
+}
+
+@test "index script uses set -uo pipefail" {
+  run head -10 scripts/query-lib-index.sh
+  [[ "$output" == *"set -uo pipefail"* ]]
+}
+
+@test "index script heredoc is quoted (no fork bomb)" {
+  # SAFETY: backticks inside python heredoc MUST NOT be expanded by bash
+  run grep -E "^python3 <<'PY'" scripts/query-lib-index.sh
+  [ "$status" -eq 0 ]
+}
+
+# ── Resolve: basic ──────────────────────────────────────────────────────────
+
+@test "resolve --help returns 0" {
+  run bash scripts/query-lib-resolve.sh --help
+  [ "$status" -eq 0 ]
+}
+
+@test "resolve without args errors cleanly" {
+  run bash scripts/query-lib-resolve.sh
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--id required"* ]]
+}
+
+@test "resolve unknown flag returns exit 2" {
+  run bash scripts/query-lib-resolve.sh --foo bar
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "resolve unknown id returns exit 1" {
+  run bash scripts/query-lib-resolve.sh --id does-not-exist
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "resolve by id returns WIQL body" {
+  run bash scripts/query-lib-resolve.sh --id blocked-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SELECT"* ]]
+  [[ "$output" == *"FROM WorkItems"* ]]
+}
+
+@test "resolve strips frontmatter" {
+  run bash scripts/query-lib-resolve.sh --id blocked-test
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"---"* ]]
+  [[ "$output" != *"description:"* ]]
+  [[ "$output" != *"tags:"* ]]
+}
+
+@test "resolve jql id returns jql body" {
+  run bash scripts/query-lib-resolve.sh --id myopen-jira
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"assignee = currentUser()"* ]]
+}
+
+@test "resolve savia-flow yaml id returns yaml body" {
+  run bash scripts/query-lib-resolve.sh --id velocity-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"type: velocity"* ]]
+}
+
+# ── Resolve: param substitution ─────────────────────────────────────────────
+
+@test "resolve substitutes single param" {
+  run bash scripts/query-lib-resolve.sh --id blocked-test --param sprint=SprintA
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"UNDER 'SprintA'"* ]]
+  [[ "$output" != *"{{sprint}}"* ]]
+}
+
+@test "resolve substitutes param with spaces" {
+  run bash scripts/query-lib-resolve.sh --id blocked-test --param sprint="Project\\Sprint 2026-04"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sprint 2026-04"* ]]
+}
+
+@test "resolve warns on unsubstituted placeholders to stderr" {
+  run bash -c "bash scripts/query-lib-resolve.sh --id blocked-test 2>&1 >/dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unsubstituted"* ]]
+}
+
+@test "resolve with all params: no warning on stderr" {
+  run bash -c "bash scripts/query-lib-resolve.sh --id blocked-test --param sprint=X 2>&1 >/dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"unsubstituted"* ]]
+}
+
+# ── Resolve: list mode ─────────────────────────────────────────────────────
+
+@test "list returns table header" {
+  run bash scripts/query-lib-resolve.sh --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ID"* ]]
+  [[ "$output" == *"LANG"* ]]
+  [[ "$output" == *"DESCRIPTION"* ]]
+}
+
+@test "list shows all 3 seeded queries" {
+  run bash scripts/query-lib-resolve.sh --list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"blocked-test"* ]]
+  [[ "$output" == *"myopen-jira"* ]]
+  [[ "$output" == *"velocity-test"* ]]
+}
+
+@test "list --lang wiql shows only wiql" {
+  run bash scripts/query-lib-resolve.sh --list --lang wiql
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"blocked-test"* ]]
+  [[ "$output" != *"myopen-jira"* ]]
+  [[ "$output" != *"velocity-test"* ]]
+}
+
+@test "list --lang jql shows only jql" {
+  run bash scripts/query-lib-resolve.sh --list --lang jql
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"myopen-jira"* ]]
+  [[ "$output" != *"blocked-test"* ]]
+}
+
+@test "list --json returns valid JSON" {
+  run bash scripts/query-lib-resolve.sh --list --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == \[* ]]
+  [[ "$output" == *\] ]]
+  echo "$output" | python3 -c "import sys,json; json.load(sys.stdin)"
+}
+
+@test "list --json contains all entries" {
+  run bash -c "bash scripts/query-lib-resolve.sh --list --json | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+}
+
+# ── Index generator ─────────────────────────────────────────────────────────
+
+@test "index generates INDEX.md" {
+  run bash scripts/query-lib-index.sh
+  [ "$status" -eq 0 ]
+  [[ -f .claude/queries/INDEX.md ]]
+}
+
+@test "index lists all seeded queries" {
+  bash scripts/query-lib-index.sh
+  run cat .claude/queries/INDEX.md
+  [[ "$output" == *"blocked-test"* ]]
+  [[ "$output" == *"myopen-jira"* ]]
+  [[ "$output" == *"velocity-test"* ]]
+}
+
+@test "index --check passes when up-to-date" {
+  bash scripts/query-lib-index.sh
+  run bash scripts/query-lib-index.sh --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK"* ]]
+}
+
+@test "index --check fails when stale" {
+  bash scripts/query-lib-index.sh
+  # Add a new snippet to make INDEX stale
+  cat > .claude/queries/azure-devops/new.wiql <<'EOF'
+---
+id: new-test
+lang: wiql
+description: New query
+tags: [azure-devops]
+---
+SELECT 1
+EOF
+  run bash scripts/query-lib-index.sh --check
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"stale"* ]]
+}
+
+@test "index contains counts and ID column" {
+  bash scripts/query-lib-index.sh
+  run cat .claude/queries/INDEX.md
+  [[ "$output" == *"3 queries"* ]]
+  [[ "$output" == *"| ID |"* ]]
+}
+
+@test "index script does NOT fork-bomb" {
+  # SAFETY regression: run under timeout; if it recurses, timeout kills.
+  run timeout 10 bash scripts/query-lib-index.sh
+  [ "$status" -eq 0 ]
+}
+
+# ── Integration with real library (canonical fixtures) ──────────────────────
+
+@test "canonical queries resolve without errors" {
+  unset REPO_ROOT
+  cd "$BATS_TEST_DIRNAME/.."
+  run bash scripts/query-lib-resolve.sh --id blocked-pbis-over-3d --param sprint=X
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SELECT"* ]]
+}
+
+@test "canonical list returns at least 8 queries" {
+  unset REPO_ROOT
+  cd "$BATS_TEST_DIRNAME/.."
+  run bash -c "bash scripts/query-lib-resolve.sh --list --json | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 8 ]
+}


### PR DESCRIPTION
## Summary

SE-031 Query Library — 3 slices + crash recovery. Introduces versioned query snippets in `.claude/queries/` with CLI resolver, deterministic NL-to-query mapping, and CI-checked INDEX.

**Motivación**: cada command tenía WIQL inline. Schema change = drift en 10+ sitios. Ahora: 1 query = 1 fichero = 1 fuente de verdad.

## Slices

**Slice 1 — Library foundation (4ee34ec5, v5.28.0)**
- 9 snippets canónicos (5 WIQL, 2 JQL, 2 Savia Flow)
- `scripts/query-lib-resolve.sh` (--id, --param, --list, --lang, --json)
- `scripts/query-lib-index.sh` (--check para CI)
- `docs/rules/domain/query-library-protocol.md`
- 31 tests bats

**Slice 2 — NL-to-query (492c9995, v5.29.0)**
- `scripts/query-lib-nl.sh` — heurístico determinístico (no LLM)
- Algoritmo: normalize → alias expansion ES/EN → F1/Dice score → shingle boost → disambiguación
- 23 tests bats

**Slice 3 — Library growth + demo migration (de04ca5f, v5.30.0)**
- 3 snippets más (backlog-groom-open, sprint-items-detailed, board-status-not-done)
- `.claude/commands/backlog-groom.md` migrado a usar el resolver
- 4 tests integración (35 total en suite 1)

## Fork-bomb fix

`query-lib-index.sh` inicial usaba `python3 <<PY` (heredoc unquoted). Backticks en el cuerpo python → bash los expandió como command substitution → script ejecutándose recursivamente → 15.245 procesos bash fork-bombed la máquina. Fix: `<<'PY'` + `export REPO_ROOT`. Test de regresión incluido (\`index script heredoc is quoted\`).

## Scope honesto

Slice 3 target: 5 commands migrados. Entregado: 1 command + 3 snippets que reflejan queries de `scripts/azdevops-queries.sh` (13+ callers). El script no se tocó — requiere integration tests dedicados antes de refactorizar call-sites. PR de seguimiento solo swappea call-sites.

## Test plan

- [x] `bats tests/test-query-lib.bats` — 35/35 pass
- [x] `bats tests/test-query-lib-nl.bats` — 23/23 pass
- [x] `bash scripts/query-lib-index.sh --check` — INDEX stable
- [x] `bash scripts/query-lib-resolve.sh --id blocked-pbis-over-3d --param sprint=X` — resolves
- [x] `bash scripts/query-lib-nl.sh "PBIs bloqueados mas de 3 dias"` → blocked-pbis-over-3d
- [x] /pr-plan 11/11 gates PASS (v5.28.0 confirmado)
- [ ] **Monica**: revisa y mergea

🤖 Generated with [Claude Code](https://claude.com/claude-code)