### PR TITLE
feat(ci): auto-rebase open PRs after main merge (fix raiz definitivo)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=58241b1aeaa3bb15c3eeae7b644dbf3035f54786fc0b7af6efda79fe273cf7b3
-timestamp=2026-04-18T22:03:19Z
+timestamp=2026-04-18T22:03:20Z
 branch=agent/auto-rebase-post-merge-20260418
-head_commit=23f0bc58
+head_commit=402e1df7
 signature=a156488bd90a582ba6369301ccf536a65e5b42b0ef4cbca1a882926c04e3d0f5

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5f38642a42803b5b22d4e39f10d4db6021b452a3aaa61c7a1e2ee99b48580c76
-timestamp=2026-04-18T21:52:04Z
+diff_hash=58241b1aeaa3bb15c3eeae7b644dbf3035f54786fc0b7af6efda79fe273cf7b3
+timestamp=2026-04-18T22:03:19Z
 branch=agent/auto-rebase-post-merge-20260418
-head_commit=e686cd45
-signature=6ce1f84774bd007d97d8de03e5e5c0780f06a819e6b55001f8fda182f00208fc
+head_commit=23f0bc58
+signature=a156488bd90a582ba6369301ccf536a65e5b42b0ef4cbca1a882926c04e3d0f5

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=868cbb1820f0d16803e8e55e53f74601214a082ae8ba4514b0bcdabaff4f745a
-timestamp=2026-04-18T21:24:39Z
-branch=agent/se036-frontmatter-batch-20260418
-head_commit=cc840fc9
-signature=792b3ad4bb2ab21db58b15513d9d1b7d0a669084e62ec76a8d3a7f3a6d1ead2e
+diff_hash=5f38642a42803b5b22d4e39f10d4db6021b452a3aaa61c7a1e2ee99b48580c76
+timestamp=2026-04-18T21:52:04Z
+branch=agent/auto-rebase-post-merge-20260418
+head_commit=e686cd45
+signature=6ce1f84774bd007d97d8de03e5e5c0780f06a819e6b55001f8fda182f00208fc

--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -1,0 +1,135 @@
+name: Auto-rebase open PRs after main merge
+
+# Root cause: GitHub server-side merge does NOT execute custom merge drivers
+# (merge.ours.driver) from .gitattributes. So every time main advances, open
+# PRs that touch .confidentiality-signature show conflicts in the GitHub UI
+# even though .gitattributes declares `merge=ours`.
+#
+# Fix: run the local resolver automatically on main push. Each open PR is
+# rebased, predictable conflicts (.confidentiality-signature, .scm/*,
+# CHANGELOG.md) are resolved via the resolver script, re-signed, and pushed.
+# Same logic as `scripts/resolve-all-open-prs.sh`, automated server-side.
+#
+# Ref: scripts/resolve-pr-conflicts.sh, scripts/resolve-all-open-prs.sh,
+# CHANGELOG.d/README.md
+
+on:
+  push:
+    branches:
+      - main
+
+# Cancel in-flight runs if another main push arrives.
+concurrency:
+  group: auto-rebase-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip auto-rebase]') }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "auto-rebase-bot"
+          git config user.email "auto-rebase@users.noreply.github.com"
+
+      - name: Configure merge drivers (ours = keep branch version)
+        run: |
+          bash scripts/setup-merge-drivers.sh || true
+
+      - name: Install jq (if missing)
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -qq && sudo apt-get install -y jq
+          fi
+
+      - name: List open PRs
+        id: list_prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --state open --json number,headRefName,mergeable,mergeStateStatus 2>/dev/null || echo "[]")
+          echo "Open PRs detected:"
+          echo "$prs" | jq -r '.[] | "  PR #\(.number) \(.headRefName) (\(.mergeable)/\(.mergeStateStatus))"'
+          echo "prs<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$prs" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Rebase each conflicting PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          prs='${{ steps.list_prs.outputs.prs }}'
+          if [[ -z "$prs" || "$prs" == "[]" ]]; then
+            echo "No open PRs — nothing to rebase."
+            exit 0
+          fi
+
+          # Snapshot resolver to tempfile — after we checkout a PR branch
+          # the script may not exist there (older branches predate it).
+          RESOLVER_TMP=$(mktemp --suffix=.sh)
+          cp scripts/resolve-pr-conflicts.sh "$RESOLVER_TMP"
+          chmod +x "$RESOLVER_TMP"
+          trap 'rm -f "$RESOLVER_TMP"' EXIT
+
+          echo "$prs" | jq -r '.[] | "\(.number) \(.headRefName) \(.mergeable) \(.mergeStateStatus)"' | \
+          while read -r num branch mergeable state; do
+            echo ""
+            echo "::group::PR #$num ($branch) — $mergeable/$state"
+
+            if [[ "$mergeable" == "MERGEABLE" && "$state" == "CLEAN" ]]; then
+              echo "Already clean — skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [[ "$mergeable" != "CONFLICTING" ]] && [[ "$state" != "DIRTY" ]] && [[ "$state" != "UNKNOWN" ]]; then
+              echo "State not rebasable — skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            git fetch origin "$branch" 2>&1 | tail -3 || { echo "fetch failed"; echo "::endgroup::"; continue; }
+            git checkout "$branch" 2>&1 | tail -1 || { echo "checkout failed"; echo "::endgroup::"; continue; }
+
+            if bash "$RESOLVER_TMP" --branch "$branch"; then
+              echo "✅ Rebased + pushed"
+            else
+              rc=$?
+              if [[ "$rc" -eq 3 ]]; then
+                echo "⚠️ Manual review required (unexpected conflicts) — skipping"
+                git merge --abort 2>/dev/null || true
+              else
+                echo "❌ Failure (exit $rc)"
+                git merge --abort 2>/dev/null || true
+              fi
+            fi
+            # Return to main for next iteration.
+            git checkout main 2>/dev/null || true
+
+            echo "::endgroup::"
+          done
+
+      - name: Summary
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "## Auto-rebase summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| PR | Branch | State after rebase |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----|--------|--------------------|" >> "$GITHUB_STEP_SUMMARY"
+          gh pr list --state open --json number,headRefName,mergeable,mergeStateStatus \
+            --jq '.[] | "| #\(.number) | \(.headRefName) | \(.mergeable)/\(.mergeStateStatus) |"' \
+            >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -40,8 +40,9 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "auto-rebase-bot"
-          git config user.email "auto-rebase@users.noreply.github.com"
+          # Use GitHub Actions bot identity (matches actions/checkout default semantics).
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Configure merge drivers (ours = keep branch version)
         run: |

--- a/CHANGELOG.d/agent-auto-rebase-post-merge-20260418.md
+++ b/CHANGELOG.d/agent-auto-rebase-post-merge-20260418.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Fixed
+---
+
+### Fixed
+
+- **\`.github/workflows/auto-rebase-open-prs.yml\`**: nuevo workflow que rebased automáticamente PRs abiertos tras cada push a main. Resuelve el problema raíz: \`merge.ours.driver\` en .gitattributes solo funciona local, no en GitHub server-side merge. El workflow ejecuta \`resolve-pr-conflicts.sh\` desde runner GHA (donde sí puede configurar el driver). Elimina la fricción "mergear un PR genera conflicto en todos los demás" — ahora Monica mergea y el auto-rebase resuelve los PRs en cola sin intervención.
+


### PR DESCRIPTION
## Summary
feat(ci): auto-rebase open PRs after main merge (fix raiz definitivo)
### Changes
- 57a8302a fix: use github-actions bot identity (standard email format)
- e686cd45 feat(ci): auto-rebase open PRs after main merge (fix raiz definitivo)
### Stats
3 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
