### PR TITLE
feat(se-034): Slice 1 — dag-typing-validate prototype + 27 BATS tests

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=1f8442cc1afbd375f3df0e0e7d8dbda1d86e23068d2241c57d77f71f8b6fbb13
+diff_hash=aaf5b93b49b29324066655ed581a7c6c50660cc21c39c7b0226a7482079f105d
 timestamp=2026-04-19T07:29:27Z
 branch=agent/se034-workflow-typing-slice1-20260419
-head_commit=ca92dd35
-signature=6807c3a35c1e08d72fb0b8a05a2a5a534ad699a3b84bf92aad69aba1f5556af1
+head_commit=44118446
+signature=5e3335d156d48c0778b25eabbf10b16d8a4300f2976696dd51b52206201baa88

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=1f8442cc1afbd375f3df0e0e7d8dbda1d86e23068d2241c57d77f71f8b6fbb13
-timestamp=2026-04-19T06:47:07Z
-branch=agent/se036-frontmatter-batch2-20260418
-head_commit=4b214edb
+timestamp=2026-04-19T07:29:27Z
+branch=agent/se034-workflow-typing-slice1-20260419
+head_commit=ca92dd35
 signature=6807c3a35c1e08d72fb0b8a05a2a5a534ad699a3b84bf92aad69aba1f5556af1

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: ffd6303aebf8 | resources: 1021
-> 530 commands · 77 skills · 65 agents · 349 scripts
+> hash: 13a107d36de7 | resources: 1022
+> 530 commands · 77 skills · 65 agents · 350 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -165,6 +165,7 @@
 [development] dag-execute — agentes,ejecutar,paralelo,pipeline,según — cmd:.claude/commands/dag-execute.md
 [development] dag-plan — ahorro,camino,crítico,ejecución,tiempo — cmd:.claude/commands/dag-plan.md
 [development] dag-scheduling — agentes,dependencias,gráficos,orquestar,paralelo — skill:.claude/skills/dag-scheduling/SKILL.md
+[development] dag-typing-validate — prototype,slice,typing,validate,validator — script:scripts/dag-typing-validate.sh
 [development] dev-orchestrator — analiza,contexto,crea,dependencias,implementación — agent:.claude/agents/dev-orchestrator.md
 [development] dev-session — aislamiento,contexto,desarrollo,disco,fases — cmd:.claude/commands/dev-session.md
 [development] dev-session-discard — cleanly,discard,session — script:scripts/dev-session-discard.sh

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 102 resources
+> 103 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **Trace Analyze** (cmd): Análisis profundo de trazas específicas con detección de cuellos de botella y cadenas de errores
@@ -29,6 +29,7 @@
 - **dag-execute** (cmd): Ejecutar pipeline SDD con agentes en paralelo según DAG
 - **dag-plan** (cmd): Visualizar DAG de ejecución, camino crítico y ahorro de tiempo
 - **dag-scheduling** (skill): Orquestar agentes SDD en paralelo usando gráficos de dependencias
+- **dag-typing-validate** (script): dag-typing-validate.sh — SE-034 Slice 1 prototype validator.
 - **dev-orchestrator** (agent): Analiza specs y crea planes de implementación con slices, dependencias y presupuestos de contexto
 - **dev-session** (cmd): Orquestar desarrollo de un spec mediante 5 fases con aislamiento de contexto y persistencia en disco
 - **dev-session-discard** (script): dev-session-discard.sh — Discard a dev-session cleanly

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "6beea65373d2",
-  "total": 1021,
+  "hash": "a4e7b2213601",
+  "total": 1022,
   "resources": [
     {
       "category": "analysis",
@@ -2030,6 +2030,20 @@
       "kind": "skill",
       "path": ".claude/skills/dag-scheduling/SKILL.md",
       "description": "Orquestar agentes SDD en paralelo usando gráficos de dependencias"
+    },
+    {
+      "category": "development",
+      "name": "dag-typing-validate",
+      "intents": [
+        "prototype",
+        "slice",
+        "typing",
+        "validate",
+        "validator"
+      ],
+      "kind": "script",
+      "path": "scripts/dag-typing-validate.sh",
+      "description": "dag-typing-validate.sh — SE-034 Slice 1 prototype validator."
     },
     {
       "category": "development",

--- a/CHANGELOG.d/se034-slice1-dag-typing-validator.md
+++ b/CHANGELOG.d/se034-slice1-dag-typing-validator.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SE-034 Slice 1: dag-typing-validate.sh validator (audit/validate/infer modes, 6 canonical types text|json|markdown|yaml|binary|any) + 27 BATS tests (auditor score 87)
+

--- a/scripts/dag-typing-validate.sh
+++ b/scripts/dag-typing-validate.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# dag-typing-validate.sh — SE-034 Slice 1 prototype validator.
+#
+# Reads skill frontmatter for declared `input:` and `output:` types. Given
+# a DAG of skills (via `dag-plan` output or manual --upstream/--downstream),
+# validates that downstream's `input:` is compatible with upstream's `output:`.
+#
+# Schema subset (inspired by Dify workflow nodes): types are string keys
+# "text" | "json" | "markdown" | "yaml" | "binary" | "any".
+# Compatibility: `any` accepts anything; same-type is direct match.
+#
+# Usage:
+#   dag-typing-validate.sh --skills skill-a,skill-b    # validate pair
+#   dag-typing-validate.sh --audit                      # scan all skills, report gaps
+#   dag-typing-validate.sh --infer skill-a             # print declared I/O
+#
+# Ref: SE-034, ROADMAP.md §Tier 4.3
+# Safety: `set -uo pipefail`. Read-only.
+
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SKILLS_DIR="$REPO_ROOT/.claude/skills"
+OUTPUT_DIR="$REPO_ROOT/output"
+DATE_STR="$(date +%Y%m%d)"
+REPORT="$OUTPUT_DIR/dag-typing-audit-$DATE_STR.md"
+
+MODE=""
+SKILLS_ARG=""
+INFER_SKILL=""
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 --skills SKILL_A,SKILL_B    Validate edge A→B
+  $0 --audit                      Scan all skills, report which lack I/O typing
+  $0 --infer SKILL                Print declared I/O for SKILL
+
+Types: text | json | markdown | yaml | binary | any
+Compatibility: same type direct, 'any' accepts anything.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skills) SKILLS_ARG="$2"; MODE="validate"; shift 2 ;;
+    --audit) MODE="audit"; shift ;;
+    --infer) INFER_SKILL="$2"; MODE="infer"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown arg '$1'" >&2; usage; exit 2 ;;
+  esac
+done
+
+[[ -z "$MODE" ]] && { usage; exit 2; }
+
+mkdir -p "$OUTPUT_DIR"
+
+# Read I/O declaration from skill's SKILL.md frontmatter.
+# Recognizes: input: <type>, output: <type>, or multi-line block.
+read_io() {
+  local skill="$1"
+  local file="$SKILLS_DIR/$skill/SKILL.md"
+  if [[ ! -f "$file" ]]; then
+    echo "__missing__|__missing__"
+    return
+  fi
+  # Only parse first 30 lines (frontmatter area).
+  local input output
+  input=$(head -30 "$file" | grep -E '^input:' | head -1 | sed 's/^input:[[:space:]]*//' | tr -d '"' | tr -d "'" | awk '{print $1}')
+  output=$(head -30 "$file" | grep -E '^output:' | head -1 | sed 's/^output:[[:space:]]*//' | tr -d '"' | tr -d "'" | awk '{print $1}')
+  echo "${input:-__untyped__}|${output:-__untyped__}"
+}
+
+type_compatible() {
+  local from="$1"
+  local to="$2"
+  [[ "$to" == "any" ]] && return 0
+  [[ "$from" == "any" ]] && return 0
+  [[ "$from" == "$to" ]] && return 0
+  # markdown is a superset of text.
+  [[ "$from" == "markdown" && "$to" == "text" ]] && return 0
+  return 1
+}
+
+case "$MODE" in
+  infer)
+    io=$(read_io "$INFER_SKILL")
+    in="${io%|*}"
+    out="${io#*|}"
+    echo "Skill: $INFER_SKILL"
+    echo "  input:  $in"
+    echo "  output: $out"
+    ;;
+
+  validate)
+    a="${SKILLS_ARG%,*}"
+    b="${SKILLS_ARG#*,}"
+    if [[ "$a" == "$b" ]]; then
+      echo "ERROR: need two distinct skills" >&2
+      exit 2
+    fi
+    io_a=$(read_io "$a")
+    io_b=$(read_io "$b")
+    out_a="${io_a#*|}"
+    in_b="${io_b%|*}"
+    echo "Edge: $a → $b"
+    echo "  $a output: $out_a"
+    echo "  $b input:  $in_b"
+    if [[ "$out_a" == "__untyped__" ]] || [[ "$in_b" == "__untyped__" ]]; then
+      echo "  VERDICT: UNTYPED (either skill missing declaration) — advisory only"
+      exit 0
+    fi
+    if type_compatible "$out_a" "$in_b"; then
+      echo "  VERDICT: COMPATIBLE"
+      exit 0
+    else
+      echo "  VERDICT: MISMATCH — $a outputs '$out_a' but $b expects '$in_b'"
+      exit 1
+    fi
+    ;;
+
+  audit)
+    total=0
+    typed=0
+    untyped=0
+    missing=0
+    UNTYPED_LIST=()
+    TYPED_LIST=()
+
+    for dir in "$SKILLS_DIR"/*/; do
+      [[ -d "$dir" ]] || continue
+      skill=$(basename "$dir")
+      [[ "$skill" == "_archived" ]] && continue
+      total=$((total+1))
+      io=$(read_io "$skill")
+      in="${io%|*}"
+      out="${io#*|}"
+      if [[ "$in" == "__missing__" ]]; then
+        missing=$((missing+1))
+      elif [[ "$in" == "__untyped__" && "$out" == "__untyped__" ]]; then
+        untyped=$((untyped+1))
+        UNTYPED_LIST+=("$skill")
+      else
+        typed=$((typed+1))
+        TYPED_LIST+=("$skill|$in|$out")
+      fi
+    done
+
+    {
+      echo "# DAG Typing Audit — $DATE_STR"
+      echo ""
+      echo "- Skills scanned: $total"
+      echo "- Typed (input + output declared): $typed"
+      echo "- Untyped (no I/O frontmatter): $untyped"
+      echo "- Missing SKILL.md: $missing"
+      echo ""
+      pct=0
+      [[ "$total" -gt 0 ]] && pct=$(( typed * 100 / total ))
+      echo "Coverage: $pct% (target ≥ 40% para Slice 2 viability)"
+      echo ""
+
+      if (( typed > 0 )); then
+        echo "## Typed skills"
+        echo ""
+        echo "| Skill | input | output |"
+        echo "|---|---|---|"
+        for entry in "${TYPED_LIST[@]}"; do
+          IFS='|' read -r s in out <<< "$entry"
+          echo "| \`$s\` | \`$in\` | \`$out\` |"
+        done
+        echo ""
+      fi
+
+      if (( untyped > 0 )); then
+        echo "## Untyped skills (candidates for Slice 2 migration)"
+        echo ""
+        for s in "${UNTYPED_LIST[@]}"; do
+          echo "- \`$s\`"
+        done
+        echo ""
+      fi
+
+      echo "## Interpretation"
+      echo ""
+      if (( pct >= 40 )); then
+        echo "Coverage $pct% ≥ 40% target. SE-034 Slice 2 (validator integration in dag-plan) viable."
+      else
+        echo "Coverage $pct% < 40% target. SE-034 Slice 2 blocked; Slice 1 remediation needed: extend frontmatter of at least $(( total * 40 / 100 - typed )) additional skills."
+      fi
+      echo ""
+      echo "---"
+      echo "Generated by scripts/dag-typing-validate.sh --audit — $DATE_STR"
+    } > "$REPORT"
+
+    echo "dag-typing-validate: total=$total typed=$typed untyped=$untyped missing=$missing"
+    echo "  coverage=${pct}%  report: ${REPORT#$REPO_ROOT/}"
+    ;;
+esac
+
+exit 0

--- a/tests/test-dag-typing-validate.bats
+++ b/tests/test-dag-typing-validate.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/dag-typing-validate.sh (SE-034 Slice 1).
+# Validates the DAG typing validator: audit mode, validate edge mode,
+# infer mode, and type-compatibility rules (any, markdown→text subset).
+#
+# Ref: SE-034, ROADMAP.md §Tier 4.3
+# Safety: script under test has `set -uo pipefail`.
+
+SCRIPT="scripts/dag-typing-validate.sh"
+
+setup() {
+  export TMPDIR="${BATS_TEST_TMPDIR:-/tmp}"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+teardown() {
+  cd /
+}
+
+# ── Structure / safety ──────────────────────────────────────────────────────
+
+@test "script exists and is executable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+@test "script uses set -uo pipefail" {
+  run grep -cE '^set -[uo]+ pipefail' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "script passes bash -n syntax check" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# ── CLI surface ─────────────────────────────────────────────────────────────
+
+@test "script accepts --help and exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"audit"* ]]
+  [[ "$output" == *"skills"* ]]
+  [[ "$output" == *"infer"* ]]
+}
+
+@test "script rejects unknown arg" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "script rejects no-args invocation" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+# ── Audit mode (real repo) ─────────────────────────────────────────────────
+
+@test "audit mode exits 0 and writes a report" {
+  run bash "$SCRIPT" --audit
+  [ "$status" -eq 0 ]
+  local latest
+  latest=$(ls -t output/dag-typing-audit-*.md 2>/dev/null | head -1)
+  [[ -f "$latest" ]]
+}
+
+@test "audit report contains coverage percentage" {
+  bash "$SCRIPT" --audit >/dev/null 2>&1
+  local latest
+  latest=$(ls -t output/dag-typing-audit-*.md 2>/dev/null | head -1)
+  run grep -cE 'Coverage:' "$latest"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "audit report includes Interpretation section" {
+  bash "$SCRIPT" --audit >/dev/null 2>&1
+  local latest
+  latest=$(ls -t output/dag-typing-audit-*.md 2>/dev/null | head -1)
+  run grep -c 'Interpretation' "$latest"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "audit mode does NOT modify .claude/skills/" {
+  local before_hash after_hash
+  before_hash=$(find .claude/skills -type f -name 'SKILL.md' -exec md5sum {} \; 2>/dev/null | sort | md5sum | awk '{print $1}')
+  bash "$SCRIPT" --audit >/dev/null 2>&1 || true
+  after_hash=$(find .claude/skills -type f -name 'SKILL.md' -exec md5sum {} \; 2>/dev/null | sort | md5sum | awk '{print $1}')
+  [[ "$before_hash" == "$after_hash" ]]
+}
+
+# ── Type compatibility (sandbox with fake skills) ──────────────────────────
+
+@test "same types are compatible (text→text)" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/skill-a" "$sandbox/skill-b"
+  printf -- '---\nname: skill-a\ninput: text\noutput: text\n---\n' > "$sandbox/skill-a/SKILL.md"
+  printf -- '---\nname: skill-b\ninput: text\noutput: text\n---\n' > "$sandbox/skill-b/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --skills skill-a,skill-b
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"COMPATIBLE"* ]]
+}
+
+@test "any type is universally compatible" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/a-any" "$sandbox/b-json"
+  printf -- '---\noutput: any\n---\n' > "$sandbox/a-any/SKILL.md"
+  printf -- '---\ninput: json\n---\n' > "$sandbox/b-json/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --skills a-any,b-json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"COMPATIBLE"* ]]
+}
+
+@test "mismatch types exit 1 and report" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/src-json" "$sandbox/dst-text"
+  printf -- '---\noutput: json\n---\n' > "$sandbox/src-json/SKILL.md"
+  printf -- '---\ninput: text\n---\n' > "$sandbox/dst-text/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --skills src-json,dst-text
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"MISMATCH"* ]]
+}
+
+@test "markdown output is accepted by text input (subset rule)" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/md-out" "$sandbox/txt-in"
+  printf -- '---\noutput: markdown\n---\n' > "$sandbox/md-out/SKILL.md"
+  printf -- '---\ninput: text\n---\n' > "$sandbox/txt-in/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --skills md-out,txt-in
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"COMPATIBLE"* ]]
+}
+
+@test "untyped skills produce UNTYPED verdict (advisory)" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/untyped-a" "$sandbox/untyped-b"
+  printf -- '---\nname: untyped-a\n---\n' > "$sandbox/untyped-a/SKILL.md"
+  printf -- '---\nname: untyped-b\n---\n' > "$sandbox/untyped-b/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --skills untyped-a,untyped-b
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"UNTYPED"* ]]
+}
+
+# ── Infer mode ─────────────────────────────────────────────────────────────
+
+@test "infer mode prints declared I/O" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/my-skill"
+  printf -- '---\ninput: yaml\noutput: json\n---\n' > "$sandbox/my-skill/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --infer my-skill
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"input:  yaml"* ]]
+  [[ "$output" == *"output: json"* ]]
+}
+
+@test "infer mode on missing skill reports __missing__" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --infer nonexistent-skill
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"__missing__"* ]]
+}
+
+# ── Negative cases ─────────────────────────────────────────────────────────
+
+@test "negative: --skills with identical pair rejected" {
+  run bash "$SCRIPT" --skills same,same
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"distinct"* ]]
+}
+
+@test "negative: empty sandbox audit reports total=0 gracefully" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --audit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"total=0"* ]]
+}
+
+@test "negative: binary+text mismatch exits 1" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/bin-out" "$sandbox/txt-in-v2"
+  printf -- '---\noutput: binary\n---\n' > "$sandbox/bin-out/SKILL.md"
+  printf -- '---\ninput: text\n---\n' > "$sandbox/txt-in-v2/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --skills bin-out,txt-in-v2
+  [ "$status" -eq 1 ]
+}
+
+@test "negative: skill without SKILL.md handled in audit (counted as missing)" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/empty-skill"
+  # no SKILL.md created
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --audit
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"missing=1"* ]]
+}
+
+@test "negative: script is read-only (no modifications)" {
+  local before_hash after_hash
+  before_hash=$(find scripts .claude/skills -type f -name '*.md' -o -name '*.sh' 2>/dev/null | xargs -I{} md5sum {} 2>/dev/null | sort | md5sum | awk '{print $1}')
+  bash "$SCRIPT" --audit >/dev/null 2>&1 || true
+  after_hash=$(find scripts .claude/skills -type f -name '*.md' -o -name '*.sh' 2>/dev/null | xargs -I{} md5sum {} 2>/dev/null | sort | md5sum | awk '{print $1}')
+  [[ "$before_hash" == "$after_hash" ]]
+}
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+@test "edge: quoted types in frontmatter are parsed correctly" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/quoted-skill"
+  printf -- '---\ninput: "json"\noutput: "text"\n---\n' > "$sandbox/quoted-skill/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --infer quoted-skill
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"input:  json"* ]]
+}
+
+@test "edge: single-quoted types are parsed correctly" {
+  local sandbox="$BATS_TEST_TMPDIR/.claude/skills"
+  mkdir -p "$sandbox/sq-skill"
+  printf -- "---\ninput: 'markdown'\noutput: 'yaml'\n---\n" > "$sandbox/sq-skill/SKILL.md"
+  run env REPO_ROOT="$BATS_TEST_TMPDIR" bash "$SCRIPT" --infer sq-skill
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"input:  markdown"* ]]
+}
+
+@test "edge: _archived skill directory is skipped in audit" {
+  run grep -c '_archived' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "edge: audit report links to SE-034 ROADMAP §Tier 4.3" {
+  run grep -c 'SE-034\|Tier 4.3' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "edge: 6 canonical types referenced in script header" {
+  run grep -cE 'text|json|markdown|yaml|binary|any' "$SCRIPT"
+  [[ "$output" -ge 6 ]]
+}


### PR DESCRIPTION
## Summary
- SE-034 Slice 1 validator: `scripts/dag-typing-validate.sh` with three modes (`--audit`, `--skills A,B`, `--infer SKILL`)
- 6 canonical types (text | json | markdown | yaml | binary | any) inspired by Dify node schema
- Compatibility rules: same-type direct, `any` universal, markdown→text (subset)
- 27 BATS tests, auditor score **87/100** (certified)
- Initial audit: 77 skills scanned, 0 typed (0% coverage) → establece baseline para Slice 2

## Context
- Ref: ROADMAP.md Tier 4.3 / SE-034
- Slice 2 viability: requires ≥40% typing coverage → Slice 2 blocked until SE-034 Slice 1.5 (frontmatter migration of core skills)
- Read-only script, zero side effects on `.claude/skills/`

## Test plan
- [x] `bats tests/test-dag-typing-validate.bats` — 27/27 pass
- [x] `bash scripts/test-auditor.sh tests/test-dag-typing-validate.bats` — score 87 ≥ 80
- [x] `bash scripts/pr-plan.sh` — 13 gates PASS
- [ ] Reviewer @gonzalezpazmonica to confirm Slice 1 baseline report acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)