### PR TITLE
feat(se-029): Slice 2 — context-task-classifier (6 classes + 34 BATS tests)

### DIFF
--- a/.claude/skills/context-task-classifier/DOMAIN.md
+++ b/.claude/skills/context-task-classifier/DOMAIN.md
@@ -1,0 +1,58 @@
+# Context Task Classifier — Dominio
+
+## Por que existe esta skill
+
+La compresión de contexto genérica (summarization) trata todos los turnos igual, perdiendo señal crítica: una decisión de arquitectura comprimida 40:1 se degrada al mismo ratio que un "gracias". SE-029 (rate-distortion-aware compression) requiere clasificar cada turno en una clase de tarea para aplicar el ratio máximo correcto — decisiones y specs se preservan (ratio bajo), chitchat se colapsa (ratio alto). Esta skill es el clasificador determinístico de entrada del pipeline SE-029, sin dependencia de LLM para el caso común (6 clases con heurísticas regex).
+
+## Cuando usar
+
+Activar cuando:
+- Se va a compactar una sesión larga y el compresor necesita saber qué ratio aplicar por turno
+- `/context-compress` o `/context-budget` orquestan una pasada de compresión consciente de la tarea
+- Se analiza una transcripción para medir distribución de clases (¿cuánto chitchat vs cuánto code?)
+- Debugging de distortion: un turno comprimido mal quiere saber a qué clase pertenecía
+
+NO usar cuando:
+- No hay presupuesto de contexto comprometido (sesión pequeña < 20% del budget) — la compresión genérica sirve
+- El turno es el input activo del modelo (compresión aplica a turns ya archivados, no al input current)
+- Se requiere clasificación semántica fina (p.ej. distinguir "decisión de arquitectura" vs "decisión de naming") — el clasificador es de 6 clases, no jerárquico
+
+## Limites
+
+- Determinístico solo — sin LLM fallback en este slice. Caso híbrido (turn contiene código Y decisión) se resuelve por scoring aditivo + tie-breaking que favorece la clase más estricta. En casos muy ambiguos el clasificador puede sobre-preservar (conservador por diseño).
+- No entiende contexto cross-turn — clasifica cada turno aislado. Un turno de "ok" después de una decisión no heredará clase `decision`; queda como `chitchat`. Para correlación multi-turn usar session-level analyzer (fuera de scope de este slice).
+- Patrones regex específicos a este workspace (SPEC-NNN, SE-NNN, PBI-NNN, etc.). Aplicable a otros repos requeriría ajustar los patrones de la clase `spec`.
+- Falsos positivos en `code`: líneas con `function foo` en prosa técnica pueden disparar scoring; el filtro actual exige el keyword al inicio de línea seguido de nombre + `[({:=]` para reducir ruido.
+- Clase `chitchat` tiene threshold en 8 palabras — turnos muy cortos pero técnicos ("AC-03 wrong") pueden caer ahí sin patrones, pero el scoring `spec` dispara primero.
+
+## Confidencialidad
+
+El clasificador opera sobre el texto del turno en stdin o fichero. NO persiste datos: ni caché, ni log, ni envío externo. Read-only determinístico. Apto para turnos N2+ (los patrones regex son locales, sin llamadas a red).
+
+Auditable: cada invocación en modo `--json` emite el score por clase, lo que permite verificar POR QUÉ un turno se clasificó de cierta manera — útil para compliance evidence en sesiones de Court.
+
+## Integración con SE-029
+
+Pipeline completo de SE-029 (Slices 1-5):
+
+```
+Turn → context-task-classify.sh (este skill, Slice 2)
+     → clase + max_ratio + frozen flag
+     → compress-skip-frozen.sh hook (Slice 3) — skip si frozen
+     → operational-point-selector (Slice 4) — ratio = min(budget, max_ratio_class)
+     → context-compress existente — compresión real con el ratio elegido
+     → context-distortion-measure.sh (Slice 1) — mide D post
+     → re-state anchor (Slice 5) si ratio > 20:1
+```
+
+Este skill es el **primer gate**: clasificación determinística de entrada.
+El resto del pipeline puede ser más caro (operational-point selector usa
+optimización, distortion measure usa LLM-judge) — filtrar bien aquí
+reduce la carga del resto.
+
+## Referencias
+
+- `docs/propuestas/SE-029-rate-distortion-context.md` §2 — SE-029-C task classifier spec
+- `scripts/context-task-classify.sh` — implementación
+- `tests/test-context-task-classify.bats` — 34 tests (auditor score 98)
+- `scripts/context-distortion-measure.sh` — SE-029 Slice 1, mide el resultado

--- a/.claude/skills/context-task-classifier/SKILL.md
+++ b/.claude/skills/context-task-classifier/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: context-task-classifier
+description: Clasifica un turno en una de 6 clases de tarea (decision, spec, code, review, context, chitchat) para decidir ratio de compresión máximo. SE-029 §2 (SE-029-C).
+input: text
+output: json
+---
+
+# context-task-classifier
+
+Clasificador determinístico de turnos para rate-distortion-aware compression
+(SE-029). Cada clase tiene un ratio máximo de compresión y una marca
+`frozen` que indica si el contenido queda exento de compactación.
+
+## Input
+
+Un turno de conversación (texto, markdown, diff, o stack trace) pasado
+por `--stdin` o `--input FILE`.
+
+## Output
+
+Una sola línea con la clase (modo texto) o JSON con detalles (modo `--json`):
+
+```json
+{
+  "class": "decision",
+  "max_ratio": 5,
+  "frozen": "true",
+  "words": 4,
+  "lines": 1,
+  "scores": {
+    "decision": 3,
+    "spec": 0,
+    "code": 0,
+    "review": 0,
+    "context": 0,
+    "chitchat": 0
+  }
+}
+```
+
+## 6 clases de tarea
+
+| Clase | max_ratio | frozen | Señales principales |
+|---|---|---|---|
+| `decision` | 5:1 | true | APPROVED/merge/commit, yes/no verdicts |
+| `spec` | 3:1 | true | SPEC-NNN, SE-NNN, PBI-NNN, AC-MM, frontmatter |
+| `code` | 10:1 | partial | fences ```, diff markers, Traceback/Error |
+| `review` | 15:1 | false | PASS/FAIL/WARN, G\d+ gates, judge findings |
+| `context` | 25:1 | false | markdown largo, headings, bullets, >100 words |
+| `chitchat` | 80:1 | false | ≤8 words, thanks/ok/gracias/hi |
+
+## Ejemplos de uso
+
+```bash
+# Clasifica un mensaje de chat
+echo "APPROVED — merge PR #624" | scripts/context-task-classify.sh --stdin
+# → decision
+
+# Clasifica un diff file en JSON
+scripts/context-task-classify.sh --input /tmp/pr.diff --json
+
+# Integración con context-budget (SE-029 Slice 4, futuro):
+#   foreach turn in session:
+#     class = classify(turn)
+#     apply max_ratio[class] when compacting
+#     skip if frozen[class]
+```
+
+## Reglas de clasificación
+
+1. **Scoring aditivo** — cada patrón matched suma puntos a su clase.
+2. **Tie-breaking por prioridad** — empates se resuelven a favor de la
+   clase más estricta (decision > spec > code > review > context >
+   chitchat). Err del lado de preservar contenido.
+3. **Fallback** — sin señal: ≤15 words → chitchat, else context.
+
+## Integración con SE-029
+
+Este clasificador es el input del **operational point selector**
+(SE-029-O, Slice 4) que elige R(D) óptimo por turn:
+
+```
+Turn → classify() → max_ratio_class
+                 → frozen? → compress-skip-frozen.sh hook
+                 → else: compress(ratio = min(budget_target, max_ratio_class))
+```
+
+## Ref
+
+- `scripts/context-task-classify.sh` — implementación
+- `tests/test-context-task-classify.bats` — 34 tests (auditor score 98)
+- `docs/propuestas/SE-029-rate-distortion-context.md` §2
+- `scripts/context-distortion-measure.sh` — SE-029 Slice 1 (distortion metric)

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=8fe147164d4fdd95cd96cd013b38f79632578eef30acb2475bc58aa63bab39d9
-timestamp=2026-04-19T09:59:52Z
-branch=agent/se034-workflow-typing-slice1-20260419
-head_commit=4a4772e7
+timestamp=2026-04-19T10:28:32Z
+branch=agent/se030-slice1-receipts-20260419
+head_commit=2fc71d2e
 signature=12d62a3048c657c13bf4547ba5885fabe1ff4d5e392bdca0ff9b0a43fa12b58b

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8fe147164d4fdd95cd96cd013b38f79632578eef30acb2475bc58aa63bab39d9
-timestamp=2026-04-19T10:28:32Z
+diff_hash=d00cc7d6ff781b91f2afdfd0221bc72207561d464838f901b5476b01ae116616
+timestamp=2026-04-19T10:28:33Z
 branch=agent/se030-slice1-receipts-20260419
-head_commit=2fc71d2e
-signature=12d62a3048c657c13bf4547ba5885fabe1ff4d5e392bdca0ff9b0a43fa12b58b
+head_commit=05376de5
+signature=29ea5a79041db8fd50ed4cb2e9adbc66242c3cd4be71ddb269e5c2f3f5da3b90

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ea65612da252425afc095d55eb5aad5a1290de07470e1e892afb400807ad2b33
-timestamp=2026-04-19T10:54:31Z
+diff_hash=427b750c3b90486d755501d56d517c8d20e54249905ad8f0f0d77020820f8bf4
+timestamp=2026-04-19T11:08:10Z
 branch=agent/se030-slice1-receipts-20260419
-head_commit=f6a6231d
-signature=9d35e58b4fd1d4fb92d14b5d9e54f10ecae6018f360a85a2f1a3a5af4daa691c
+head_commit=5e683d23
+signature=41cb629801d1159c8321bbe08feba7931b0834bd99c1efbd576abd995f6e5603

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d00cc7d6ff781b91f2afdfd0221bc72207561d464838f901b5476b01ae116616
-timestamp=2026-04-19T10:28:33Z
+diff_hash=ea65612da252425afc095d55eb5aad5a1290de07470e1e892afb400807ad2b33
+timestamp=2026-04-19T10:54:31Z
 branch=agent/se030-slice1-receipts-20260419
-head_commit=05376de5
-signature=29ea5a79041db8fd50ed4cb2e9adbc66242c3cd4be71ddb269e5c2f3f5da3b90
+head_commit=f6a6231d
+signature=9d35e58b4fd1d4fb92d14b5d9e54f10ecae6018f360a85a2f1a3a5af4daa691c

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 13a107d36de7 | resources: 1022
-> 530 commands · 77 skills · 65 agents · 350 scripts
+> hash: 81a3cebc6040 | resources: 1024
+> 530 commands · 78 skills · 65 agents · 351 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -302,7 +302,9 @@
 [memory] context-rotation — automated,context,daily,monthly,rotation — script:scripts/context-rotation.sh
 [memory] context-snapshot — between,context,load,save,session — script:scripts/context-snapshot.sh
 [memory] context-status — context,model,optimization,recommendations,show — cmd:.claude/commands/context-status.md
+[memory] context-task-classifier — chitchat,clases,clasifica,code,compresión — skill:.claude/skills/context-task-classifier/SKILL.md
 [memory] context-task-classifier — classifier,context,task — script:scripts/context-task-classifier.sh
+[memory] context-task-classify — class,classifier,classify,context,slice — script:scripts/context-task-classify.sh
 [memory] context-tracker — context,tracker — script:scripts/context-tracker.sh
 [memory] cross-project-search — búsqueda,conocimiento,portfolio,proyectos,transversal — cmd:.claude/commands/cross-project-search.md
 [memory] digest-to-memory — agents,bridge,digest,graph,memory — script:scripts/digest-to-memory.sh

--- a/.scm/categories/memory.scm
+++ b/.scm/categories/memory.scm
@@ -1,5 +1,5 @@
 # memory — Savia Capability Map (L1)
-> 87 resources
+> 89 resources
 
 - **auto-compact** (script): auto-compact.sh — Disparado automáticamente cuando contexto > 85%
 - **biblio-search** (cmd): >
@@ -32,7 +32,9 @@
 - **context-rotation** (script): context-rotation.sh — SE-033: Automated context rotation (daily/weekly/monthly)
 - **context-snapshot** (script): context-snapshot.sh — Save/load session context between sessions
 - **context-status** (cmd): Show context window usage, model tier, and optimization recommendations
+- **context-task-classifier** (skill): Clasifica un turno en una de 6 clases de tarea (decision, spec, code, review, context, chitchat) para decidir ratio de compresión máximo. SE-029 §2 (SE-029-C).
 - **context-task-classifier** (script): context-task-classifier.sh — SE-029-C
+- **context-task-classify** (script): context-task-classify.sh — SE-029 Slice 2 task-class classifier.
 - **context-tracker** (script): ── context-tracker.sh ─────────────────────────────────────────────────────
 - **cross-project-search** (cmd): Búsqueda transversal de conocimiento entre todos los proyectos del portfolio
 - **digest-to-memory** (script): digest-to-memory.sh — Bridge: digest agents -> memory-store + graph

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "a4e7b2213601",
-  "total": 1022,
+  "hash": "c969d79ffce3",
+  "total": 1024,
   "resources": [
     {
       "category": "analysis",
@@ -3830,6 +3830,20 @@
       "category": "memory",
       "name": "context-task-classifier",
       "intents": [
+        "chitchat",
+        "clases",
+        "clasifica",
+        "code",
+        "compresión"
+      ],
+      "kind": "skill",
+      "path": ".claude/skills/context-task-classifier/SKILL.md",
+      "description": "Clasifica un turno en una de 6 clases de tarea (decision, spec, code, review, context, chitchat) para decidir ratio de compresión máximo. SE-029 §2 (SE-029-C)."
+    },
+    {
+      "category": "memory",
+      "name": "context-task-classifier",
+      "intents": [
         "classifier",
         "context",
         "task"
@@ -3837,6 +3851,20 @@
       "kind": "script",
       "path": "scripts/context-task-classifier.sh",
       "description": "context-task-classifier.sh — SE-029-C"
+    },
+    {
+      "category": "memory",
+      "name": "context-task-classify",
+      "intents": [
+        "class",
+        "classifier",
+        "classify",
+        "context",
+        "slice"
+      ],
+      "kind": "script",
+      "path": "scripts/context-task-classify.sh",
+      "description": "context-task-classify.sh — SE-029 Slice 2 task-class classifier."
     },
     {
       "category": "memory",

--- a/CHANGELOG.d/se029-slice2-task-classifier.md
+++ b/CHANGELOG.d/se029-slice2-task-classifier.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SE-029 Slice 2: context-task-classify.sh (6 classes deterministic) + SKILL.md + 34 BATS tests (auditor 98)
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(65), commands(532), profiles, hooks(56/60reg), rules/{domain,languages}, skills(77), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(65), commands(532), profiles, hooks(56/60reg), rules/{domain,languages}, skills(78), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/scripts/context-task-classify.sh
+++ b/scripts/context-task-classify.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# context-task-classify.sh — SE-029 Slice 2 task-class classifier.
+#
+# Clasifica un turno de conversación en una de 6 clases de tarea, que
+# determinan el ratio máximo de compresión permitido (ver SE-029 §2):
+#
+#   decision  → ratio ≤ 5:1  · frozen=true  (approvals, merges, commits)
+#   spec      → ratio ≤ 3:1  · frozen=true  (SPEC-NNN, AC-MM, frontmatter)
+#   code      → ratio ≤ 10:1 · frozen=parcial (diffs, tracebacks, fences)
+#   review    → ratio ≤ 15:1 · (court findings, PASS/FAIL/WARN)
+#   context   → ratio ≤ 25:1 · (explicaciones, markdown largo)
+#   chitchat  → ratio ≤ 80:1 · (thanks, ok, si, saludos)
+#
+# Usage:
+#   context-task-classify.sh --input turn.txt
+#   context-task-classify.sh --input turn.txt --json
+#   echo "text" | context-task-classify.sh --stdin
+#
+# Output (texto): "decision"
+# Output (json):  {"class":"decision","max_ratio":5,"frozen":true,"score":{...}}
+#
+# Ref: SE-029 §2, SE-029-C (task-class classifier)
+# Safety: read-only, set -uo pipefail.
+
+set -uo pipefail
+
+INPUT=""
+STDIN=0
+JSON=0
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 --input FILE         Classify the contents of FILE
+  $0 --stdin              Classify stdin (pipe a turn in)
+  $0 --input FILE --json  Emit JSON with class, max_ratio, frozen, score
+
+Classes: decision | spec | code | review | context | chitchat
+Ref: SE-029 §2 (SE-029-C)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input) INPUT="$2"; shift 2 ;;
+    --stdin) STDIN=1; shift ;;
+    --json) JSON=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown arg '$1'" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ "$STDIN" -eq 1 ]]; then
+  TEXT=$(cat)
+elif [[ -n "$INPUT" ]]; then
+  [[ ! -f "$INPUT" ]] && { echo "ERROR: input file not found: $INPUT" >&2; exit 2; }
+  TEXT=$(cat "$INPUT")
+else
+  usage; exit 2
+fi
+
+WORDS=$(echo "$TEXT" | wc -w | tr -d ' ')
+LINES=$(echo "$TEXT" | wc -l | tr -d ' ')
+
+# Scoring: each class gets a positive integer. Highest score wins.
+# Ties broken by priority: decision > spec > code > review > context > chitchat
+# (stricter classes first — err toward less compression).
+
+score_decision=0
+score_spec=0
+score_code=0
+score_review=0
+score_context=0
+score_chitchat=0
+
+# decision: approvals, merges, commits, yes/no verdicts
+echo "$TEXT" | grep -qiE '\b(approve|approved|approving|merge|merged|commit|decid[eoi]|decision:|ship it|lgtm|go ahead|bloqueado|aprobad[oa])\b' && score_decision=$((score_decision+3))
+echo "$TEXT" | grep -qE '\b(APPROVED|MERGED|BLOCKED|SHIP)\b' && score_decision=$((score_decision+2))
+echo "$TEXT" | grep -qE '^\s*(yes|no|si|sí|ok)\s*[.!]?$' && score_decision=$((score_decision+2))
+
+# spec: SPEC-NNN, AC-MM, spec_id frontmatter
+echo "$TEXT" | grep -qE 'SPEC-[0-9]+|SE-[0-9]+|PBI-[0-9]+' && score_spec=$((score_spec+3))
+echo "$TEXT" | grep -qE 'AC-[0-9]+|acceptance criteria' && score_spec=$((score_spec+2))
+echo "$TEXT" | grep -qE '^spec_id:|^status:|^origin:' && score_spec=$((score_spec+2))
+echo "$TEXT" | grep -qE '^---$' && score_spec=$((score_spec+1))
+
+# code: code fences, diff markers, tracebacks
+echo "$TEXT" | grep -qE '^```' && score_code=$((score_code+3))
+echo "$TEXT" | grep -qE '^\+\+\+|^---|^diff --git|^@@ ' && score_code=$((score_code+3))
+echo "$TEXT" | grep -qiE 'Traceback|\bError:|Exception|stack trace|segmentation fault' && score_code=$((score_code+3))
+echo "$TEXT" | grep -qE '^\s*(function|def|class|const|let|var|import)\s+\w+\s*[({:=]' && score_code=$((score_code+1))
+
+# review: court findings, PASS/FAIL/WARN, judge verdicts
+echo "$TEXT" | grep -qE '\b(PASS|FAIL|WARN|BLOCK|VERDICT):' && score_review=$((score_review+3))
+echo "$TEXT" | grep -qiE 'judge|review finding|code review court|truth tribunal' && score_review=$((score_review+2))
+echo "$TEXT" | grep -qE '\bG[0-9]+\s+(PASS|FAIL|WARN)' && score_review=$((score_review+2))
+echo "$TEXT" | grep -qiE 'score: [0-9]+|auditor|certified' && score_review=$((score_review+1))
+
+# context: long markdown, headings, bullet lists
+echo "$TEXT" | grep -qE '^#{1,6} ' && score_context=$((score_context+1))
+echo "$TEXT" | grep -qE '^\s*[-*] ' && score_context=$((score_context+1))
+[[ "$WORDS" -gt 100 ]] && score_context=$((score_context+2))
+[[ "$LINES" -gt 10 ]] && score_context=$((score_context+1))
+
+# chitchat: very short, greetings, acknowledgements
+[[ "$WORDS" -le 8 ]] && score_chitchat=$((score_chitchat+3))
+echo "$TEXT" | grep -qiE '^\s*(thanks|gracias|thank you|ok|okay|perfect|bien|nice|cool|de nada)\s*[.!]?\s*$' && score_chitchat=$((score_chitchat+3))
+echo "$TEXT" | grep -qiE '^\s*(hi|hello|hola|bye|adios|goodbye)' && score_chitchat=$((score_chitchat+2))
+
+# Apply tie-breaking priority: if scores are equal, stricter class wins.
+# We pick the max; in a tie, we walk the classes in stricter-first order.
+best_class=""
+best_score=-1
+for pair in "decision:$score_decision" "spec:$score_spec" "code:$score_code" "review:$score_review" "context:$score_context" "chitchat:$score_chitchat"; do
+  cls="${pair%:*}"
+  sc="${pair#*:}"
+  if [[ "$sc" -gt "$best_score" ]]; then
+    best_class="$cls"
+    best_score="$sc"
+  fi
+done
+
+# Fallback: no signal at all → default to chitchat if very short, else context.
+if [[ "$best_score" -le 0 ]]; then
+  if [[ "$WORDS" -le 15 ]]; then
+    best_class="chitchat"
+  else
+    best_class="context"
+  fi
+fi
+
+# Derive max_ratio and frozen flag.
+case "$best_class" in
+  decision) max_ratio=5;  frozen=true ;;
+  spec)     max_ratio=3;  frozen=true ;;
+  code)     max_ratio=10; frozen=partial ;;
+  review)   max_ratio=15; frozen=false ;;
+  context)  max_ratio=25; frozen=false ;;
+  chitchat) max_ratio=80; frozen=false ;;
+esac
+
+if [[ "$JSON" -eq 1 ]]; then
+  cat <<JSON
+{"class":"$best_class","max_ratio":$max_ratio,"frozen":"$frozen","words":$WORDS,"lines":$LINES,"scores":{"decision":$score_decision,"spec":$score_spec,"code":$score_code,"review":$score_review,"context":$score_context,"chitchat":$score_chitchat}}
+JSON
+else
+  echo "$best_class"
+fi
+
+exit 0

--- a/tests/test-context-task-classify.bats
+++ b/tests/test-context-task-classify.bats
@@ -1,0 +1,268 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/context-task-classify.sh (SE-029 Slice 2).
+# Validates the task-class classifier: 6 classes, scoring, frozen/ratio
+# mapping, JSON output, stdin + file input, safety, edge cases.
+#
+# Ref: SE-029 §2 (SE-029-C), ROADMAP §Tier 4.1
+# Safety: script under test has `set -uo pipefail`, read-only.
+
+SCRIPT="scripts/context-task-classify.sh"
+
+setup() {
+  export TMPDIR="${BATS_TEST_TMPDIR:-/tmp}"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+teardown() {
+  cd /
+}
+
+# ── Structure / safety ──────────────────────────────────────────────────────
+
+@test "script exists and is executable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+@test "script uses set -uo pipefail" {
+  run grep -cE '^set -[uo]+ pipefail' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "script passes bash -n syntax check" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "script references SE-029" {
+  run grep -c 'SE-029' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+# ── CLI surface ─────────────────────────────────────────────────────────────
+
+@test "script accepts --help and exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Classify"* ]]
+  [[ "$output" == *"decision"* ]]
+  [[ "$output" == *"chitchat"* ]]
+}
+
+@test "script rejects unknown arg" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "script rejects no-args invocation" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "script rejects nonexistent input file" {
+  run bash "$SCRIPT" --input /nonexistent/path.txt
+  [ "$status" -eq 2 ]
+}
+
+# ── Classification — positive cases ─────────────────────────────────────────
+
+@test "classifies approval as decision" {
+  run bash -c 'echo "APPROVED — ship it" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "decision" ]]
+}
+
+@test "classifies SPEC reference as spec" {
+  run bash -c 'echo "Implementing SPEC-120 AC-03 with new handler" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "spec" ]]
+}
+
+@test "classifies code fence as code" {
+  local tmp="$BATS_TEST_TMPDIR/turn.txt"
+  printf '%s\n' '```python' 'def foo():' '    pass' '```' > "$tmp"
+  run bash "$SCRIPT" --input "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "code" ]]
+}
+
+@test "classifies diff marker as code" {
+  local tmp="$BATS_TEST_TMPDIR/diff.txt"
+  printf '%s\n' 'diff --git a/foo b/foo' '@@ -1 +1 @@' '-old' '+new' > "$tmp"
+  run bash "$SCRIPT" --input "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "code" ]]
+}
+
+@test "classifies traceback as code" {
+  run bash -c 'echo "Traceback (most recent call last): Error: foo" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "code" ]]
+}
+
+@test "classifies PASS/FAIL verdict as review" {
+  run bash -c 'echo "G6 BATS tests PASS: 227/227 suites" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "review" ]]
+}
+
+@test "classifies court judge output as review" {
+  run bash -c 'echo "correctness-judge VERDICT: issues in line 42" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "review" ]]
+}
+
+@test "classifies long markdown as context" {
+  local tmp="$BATS_TEST_TMPDIR/long.txt"
+  printf '# Heading\n\n' > "$tmp"
+  for i in $(seq 1 30); do echo "- bullet item number $i with some explanation text here" >> "$tmp"; done
+  run bash "$SCRIPT" --input "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "context" ]]
+}
+
+@test "classifies thanks as chitchat" {
+  run bash -c 'echo "thanks!" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "chitchat" ]]
+}
+
+@test "classifies short ok as chitchat" {
+  run bash -c 'echo "ok" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "chitchat" ]]
+}
+
+# ── JSON output ─────────────────────────────────────────────────────────────
+
+@test "json output is valid JSON with expected fields" {
+  run bash -c 'echo "APPROVED" | bash '"$SCRIPT"' --stdin --json'
+  [ "$status" -eq 0 ]
+  run bash -c 'echo "APPROVED" | bash '"$SCRIPT"' --stdin --json | python3 -c "import json,sys; d=json.load(sys.stdin); assert \"class\" in d; assert \"max_ratio\" in d; assert \"frozen\" in d; assert \"scores\" in d; print(\"ok\")"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "json decision has max_ratio 5 and frozen true" {
+  run bash -c 'echo "APPROVED — merge" | bash '"$SCRIPT"' --stdin --json'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"class":"decision"'* ]]
+  [[ "$output" == *'"max_ratio":5'* ]]
+  [[ "$output" == *'"frozen":"true"'* ]]
+}
+
+@test "json spec has max_ratio 3 and frozen true" {
+  run bash -c 'echo "SPEC-120 AC-01 implemented" | bash '"$SCRIPT"' --stdin --json'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"class":"spec"'* ]]
+  [[ "$output" == *'"max_ratio":3'* ]]
+}
+
+@test "json chitchat has max_ratio 80 and frozen false" {
+  run bash -c 'echo "thanks" | bash '"$SCRIPT"' --stdin --json'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"class":"chitchat"'* ]]
+  [[ "$output" == *'"max_ratio":80'* ]]
+  [[ "$output" == *'"frozen":"false"'* ]]
+}
+
+# ── Tie-breaking / priority ─────────────────────────────────────────────────
+
+@test "tie-breaking favors stricter class (decision over code on tie)" {
+  # Contains both "APPROVED" (decision +3) and code fence (code +3)
+  local tmp="$BATS_TEST_TMPDIR/tie.txt"
+  printf '%s\n' 'APPROVED' '```' 'code' '```' > "$tmp"
+  run bash "$SCRIPT" --input "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "decision" ]]
+}
+
+# ── Fallback / defaults ─────────────────────────────────────────────────────
+
+@test "fallback: very short unknown input defaults to chitchat" {
+  run bash -c 'echo "hmm" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "chitchat" ]]
+}
+
+@test "fallback: longer unknown input defaults to context" {
+  run bash -c 'echo "This is a longer explanation about something that has no particular keywords matching any class pattern at all here" | bash '"$SCRIPT"' --stdin'
+  [ "$status" -eq 0 ]
+  [[ "$output" == "context" ]]
+}
+
+# ── Negative cases ─────────────────────────────────────────────────────────
+
+@test "negative: unknown flag returns exit 2" {
+  run bash "$SCRIPT" --unknown-flag
+  [ "$status" -eq 2 ]
+}
+
+@test "negative: missing input argument returns exit 2" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "negative: nonexistent input file returns exit 2" {
+  run bash "$SCRIPT" --input /does/not/exist.txt
+  [ "$status" -eq 2 ]
+}
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+@test "edge: empty input is handled gracefully" {
+  local tmp="$BATS_TEST_TMPDIR/empty.txt"
+  : > "$tmp"
+  run bash "$SCRIPT" --input "$tmp"
+  [ "$status" -eq 0 ]
+  # Empty defaults to chitchat (very short)
+  [[ "$output" == "chitchat" ]]
+}
+
+@test "edge: input with only whitespace defaults to chitchat" {
+  local tmp="$BATS_TEST_TMPDIR/ws.txt"
+  printf '   \n  \n' > "$tmp"
+  run bash "$SCRIPT" --input "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "chitchat" ]]
+}
+
+@test "edge: 6 task classes are declared in script" {
+  run grep -cE '\b(decision|spec|code|review|context|chitchat)\b' "$SCRIPT"
+  [[ "$output" -ge 6 ]]
+}
+
+@test "edge: max_ratio mapping is consistent with SE-029 §2" {
+  # Verify the case block maps each class to the documented ratio.
+  run grep -E 'decision\).*max_ratio=5' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -E 'spec\).*max_ratio=3' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -E 'code\).*max_ratio=10' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -E 'review\).*max_ratio=15' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -E 'context\).*max_ratio=25' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -E 'chitchat\).*max_ratio=80' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# ── Isolation ──────────────────────────────────────────────────────────────
+
+@test "isolation: script does not modify input file" {
+  local tmp="$BATS_TEST_TMPDIR/readonly.txt"
+  echo "APPROVED" > "$tmp"
+  local hash_before
+  hash_before=$(md5sum "$tmp" | awk '{print $1}')
+  bash "$SCRIPT" --input "$tmp" >/dev/null 2>&1
+  local hash_after
+  hash_after=$(md5sum "$tmp" | awk '{print $1}')
+  [[ "$hash_before" == "$hash_after" ]]
+}
+
+@test "isolation: exit codes are 0 (success) or 2 (usage)" {
+  run bash "$SCRIPT" --help
+  [[ "$status" -eq 0 ]]
+  run bash "$SCRIPT" --bogus
+  [[ "$status" -eq 2 ]]
+}


### PR DESCRIPTION
## Summary

- SE-029 Slice 2 task-class classifier: `scripts/context-task-classify.sh` + `.claude/skills/context-task-classifier/SKILL.md`
- 6 clases deterministas con ratio máximo de compresión y flag `frozen`:
  - `decision` (5:1, frozen) · `spec` (3:1, frozen) · `code` (10:1, partial)
  - `review` (15:1) · `context` (25:1) · `chitchat` (80:1)
- Modos: `--stdin`, `--input FILE`, `--json`
- Scoring aditivo con patrones regex + tie-breaking por prioridad (stricter wins)
- 34 BATS tests, auditor score **98/100**

## Context
- Ref: ROADMAP.md Tier 4.1 / SE-029 §2 (SE-029-C)
- Depende de SE-029 Slice 1 (distortion measure) — ya merged
- Próximo slice: SE-029 Slice 4 operational point selector (integración con `context-budget`)
- Branch heredada de SE-030 Slice 1 que resultó ya merged en v5.27.0 — reasignada a SE-029 Slice 2

## Test plan
- [x] `bats tests/test-context-task-classify.bats` — 34/34 pass
- [x] `bash scripts/test-auditor.sh tests/test-context-task-classify.bats` — score 98
- [x] `bash scripts/pr-plan.sh` — 13 gates PASS
- [ ] Reviewer confirma que las 6 clases cubren el espectro de turns real

🤖 Generated with [Claude Code](https://claude.com/claude-code)