### PR TITLE
feat(spec-se-020): Slice 1 — deps.yaml schema + validator + portfolio-as-graph rule

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=bf802dd25796af5df742618c7c1acc19122d2c055f4f07d14815b7ebb139e883
-timestamp=2026-04-19T12:58:24Z
-branch=agent/se029-slice3-frozen-hook-20260419
-head_commit=743df933
+timestamp=2026-04-19T14:31:20Z
+branch=agent/specse020-slice1-deps-schema-20260419
+head_commit=8e7f1cc5
 signature=e1f9ff59d67324ff3bd1f7125b621d888ccfa9ba0aa4d941dc311780b5cb2b0b

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=bf802dd25796af5df742618c7c1acc19122d2c055f4f07d14815b7ebb139e883
+diff_hash=f3f72448f06726ad0eba7c08b13efbbf3aa474647e6ba5e4b21b160cd6302dae
 timestamp=2026-04-19T14:31:20Z
 branch=agent/specse020-slice1-deps-schema-20260419
-head_commit=8e7f1cc5
-signature=e1f9ff59d67324ff3bd1f7125b621d888ccfa9ba0aa4d941dc311780b5cb2b0b
+head_commit=10b0529f
+signature=1b05b1a21b9216b6015d8c7f3c870cfcc786f47432d04e38d801a233434a261d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f3f72448f06726ad0eba7c08b13efbbf3aa474647e6ba5e4b21b160cd6302dae
-timestamp=2026-04-19T14:31:20Z
+diff_hash=5b83f16c1131105f062c217a077425e7405cff6ca878817bd99d3ececd7d92b0
+timestamp=2026-04-19T15:34:32Z
 branch=agent/specse020-slice1-deps-schema-20260419
-head_commit=10b0529f
-signature=1b05b1a21b9216b6015d8c7f3c870cfcc786f47432d04e38d801a233434a261d
+head_commit=0889c9bd
+signature=2d43205753a2c0e17cc6500da9c0536ff1bb7b536949d54248d9a17167914f2c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=251a575f7a95b198bb89ebb7d49912264fa731b0cf078de57ef2a9f2d7062413
-timestamp=2026-04-19T15:40:25Z
+timestamp=2026-04-19T15:40:26Z
 branch=agent/specse020-slice1-deps-schema-20260419
-head_commit=3263a184
+head_commit=3fa5b0e3
 signature=f01a7e82f12effcb6484744c83128fe827919d98342f6d45f392cefe1c250939

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5b83f16c1131105f062c217a077425e7405cff6ca878817bd99d3ececd7d92b0
-timestamp=2026-04-19T15:34:32Z
+diff_hash=251a575f7a95b198bb89ebb7d49912264fa731b0cf078de57ef2a9f2d7062413
+timestamp=2026-04-19T15:40:25Z
 branch=agent/specse020-slice1-deps-schema-20260419
-head_commit=0889c9bd
-signature=2d43205753a2c0e17cc6500da9c0536ff1bb7b536949d54248d9a17167914f2c
+head_commit=3263a184
+signature=f01a7e82f12effcb6484744c83128fe827919d98342f6d45f392cefe1c250939

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: b03cac358525 | resources: 1026
-> 530 commands · 78 skills · 65 agents · 353 scripts
+> hash: afe71cd5f63e | resources: 1027
+> 530 commands · 78 skills · 65 agents · 354 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -614,6 +614,7 @@
 [planning] onboard-enterprise — batch,checklists,enterprise,import,knowledge — cmd:.claude/commands/onboard-enterprise.md
 [planning] onboarding-dev — agent,auto,buddy,docs,generates — cmd:.claude/commands/onboarding-dev.md
 [planning] onboarding-dev — agente,auto,buddy,capas,documentación — skill:.claude/skills/onboarding-dev/SKILL.md
+[planning] operational-point-selector — operational,point,selector,slice — script:scripts/operational-point-selector.sh
 [planning] orgchart-import —  — cmd:.claude/commands/orgchart-import.md
 [planning] orgchart-import —  — skill:.claude/skills/orgchart-import/SKILL.md
 [planning] outcome-track — entregó,esperado,feature,outcomes,post — cmd:.claude/commands/outcome-track.md

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 417542fe698d | resources: 1025
-> 530 commands · 78 skills · 65 agents · 352 scripts
+> hash: b03cac358525 | resources: 1026
+> 530 commands · 78 skills · 65 agents · 353 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -166,6 +166,7 @@
 [development] dag-plan — ahorro,camino,crítico,ejecución,tiempo — cmd:.claude/commands/dag-plan.md
 [development] dag-scheduling — agentes,dependencias,gráficos,orquestar,paralelo — skill:.claude/skills/dag-scheduling/SKILL.md
 [development] dag-typing-validate — prototype,slice,typing,validate,validator — script:scripts/dag-typing-validate.sh
+[development] deps-validate — deps,schema,slice,spec,validate — script:scripts/deps-validate.sh
 [development] dev-orchestrator — analiza,contexto,crea,dependencias,implementación — agent:.claude/agents/dev-orchestrator.md
 [development] dev-session — aislamiento,contexto,desarrollo,disco,fases — cmd:.claude/commands/dev-session.md
 [development] dev-session-discard — cleanly,discard,session — script:scripts/dev-session-discard.sh

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 103 resources
+> 104 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **Trace Analyze** (cmd): Análisis profundo de trazas específicas con detección de cuellos de botella y cadenas de errores
@@ -30,6 +30,7 @@
 - **dag-plan** (cmd): Visualizar DAG de ejecución, camino crítico y ahorro de tiempo
 - **dag-scheduling** (skill): Orquestar agentes SDD en paralelo usando gráficos de dependencias
 - **dag-typing-validate** (script): dag-typing-validate.sh — SE-034 Slice 1 prototype validator.
+- **deps-validate** (script): deps-validate.sh — SPEC-SE-020 Slice 1 schema validator for deps.yaml.
 - **dev-orchestrator** (agent): Analiza specs y crea planes de implementación con slices, dependencias y presupuestos de contexto
 - **dev-session** (cmd): Orquestar desarrollo de un spec mediante 5 fases con aislamiento de contexto y persistencia en disco
 - **dev-session-discard** (script): dev-session-discard.sh — Discard a dev-session cleanly

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "2573aca11922",
-  "total": 1026,
+  "hash": "9f45d595c7be",
+  "total": 1027,
   "resources": [
     {
       "category": "analysis",
@@ -7751,6 +7751,19 @@
       "kind": "skill",
       "path": ".claude/skills/onboarding-dev/SKILL.md",
       "description": "Onboarding técnico con Buddy IA — auto-genera documentación del proyecto, plan personalizado 30/60/90 y agente buddy de 3 capas"
+    },
+    {
+      "category": "planning",
+      "name": "operational-point-selector",
+      "intents": [
+        "operational",
+        "point",
+        "selector",
+        "slice"
+      ],
+      "kind": "script",
+      "path": "scripts/operational-point-selector.sh",
+      "description": "operational-point-selector.sh — SE-029 Slice 4."
     },
     {
       "category": "planning",

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "2ce43878ca00",
-  "total": 1025,
+  "hash": "2573aca11922",
+  "total": 1026,
   "resources": [
     {
       "category": "analysis",
@@ -2044,6 +2044,20 @@
       "kind": "script",
       "path": "scripts/dag-typing-validate.sh",
       "description": "dag-typing-validate.sh — SE-034 Slice 1 prototype validator."
+    },
+    {
+      "category": "development",
+      "name": "deps-validate",
+      "intents": [
+        "deps",
+        "schema",
+        "slice",
+        "spec",
+        "validate"
+      ],
+      "kind": "script",
+      "path": "scripts/deps-validate.sh",
+      "description": "deps-validate.sh — SPEC-SE-020 Slice 1 schema validator for deps.yaml."
     },
     {
       "category": "development",

--- a/CHANGELOG.d/specse020-slice1-deps-validate.md
+++ b/CHANGELOG.d/specse020-slice1-deps-validate.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SPEC-SE-020 Slice 1: deps-validate.sh schema validator + portfolio-as-graph rule + sample deps.yaml + 31 BATS tests
+

--- a/docs/examples/deps.yaml.sample
+++ b/docs/examples/deps.yaml.sample
@@ -1,0 +1,23 @@
+---
+project: "erp-migration"
+tenant: "acme-consulting"
+dependencies:
+  upstream:
+    - project: "sso-integration"
+      type: "blocks"
+      deliverable: "D-003"
+      needed_by: "2026-07-15"
+      status: "on-track"
+      contact: "@pm-sso"
+  downstream:
+    - project: "mobile-app"
+      type: "feeds"
+      deliverable: "REST API spec"
+      needed_by: "2026-09-01"
+      status: "on-track"
+      contact: "@pm-mobile"
+shared_resources:
+  - person: "@dba-lead"
+    projects: ["erp-migration", "data-platform", "mobile-app"]
+    allocation_pct: [50, 30, 20]
+    conflict: true

--- a/docs/rules/domain/portfolio-as-graph.md
+++ b/docs/rules/domain/portfolio-as-graph.md
@@ -1,0 +1,138 @@
+# Portfolio-as-Graph — Cross-Project Dependencies
+
+> **SPEC-SE-020 Slice 1** — foundational rule + schema.
+> Ref: ROADMAP §Tier 5.12 · savia-enterprise portfolio coordination.
+
+Las dependencias entre proyectos se declaran como archivos `.md`/`.yaml` locales.
+El grafo de portfolio se **computa on-demand** desde esas declaraciones — nunca
+se sube a un SaaS central (Soberanía #1, Privacidad #4).
+
+## 1. Declaración per-project
+
+Cada proyecto con dependencias cross-project incluye `projects/{name}/deps.yaml`:
+
+```yaml
+---
+project: "erp-migration"
+tenant: "acme-consulting"
+dependencies:
+  upstream:
+    - project: "sso-integration"
+      type: "blocks"              # blocks | feeds | shared-resource | shared-platform
+      deliverable: "D-003"
+      needed_by: "2026-07-15"
+      status: "on-track"          # on-track | at-risk | blocked | delivered
+      contact: "@pm-sso"
+  downstream:
+    - project: "mobile-app"
+      type: "feeds"
+      deliverable: "REST API spec"
+      needed_by: "2026-09-01"
+      contact: "@pm-mobile"
+shared_resources:
+  - person: "@dba-lead"
+    projects: ["erp-migration", "data-platform", "mobile-app"]
+    allocation_pct: [50, 30, 20]
+    conflict: true
+---
+```
+
+## 2. Schema obligatorio (Slice 1)
+
+| Campo | Tipo | Requerido | Validación |
+|---|---|---|---|
+| `project` | string | sí | no vacío, sin espacios |
+| `tenant` | string | sí | slug-kebab |
+| `dependencies` | object | sí | tiene `upstream` y/o `downstream` |
+| `dependencies.upstream[].project` | string | sí | no vacío |
+| `dependencies.upstream[].type` | enum | sí | `blocks \| feeds \| shared-resource \| shared-platform` |
+| `dependencies.upstream[].deliverable` | string | sí | no vacío |
+| `dependencies.upstream[].needed_by` | date | sí | formato `YYYY-MM-DD` |
+| `dependencies.upstream[].status` | enum | sí | `on-track \| at-risk \| blocked \| delivered` |
+| `dependencies.upstream[].contact` | string | recomendado | `@handle` |
+| `dependencies.downstream[]*` | ídem upstream | opcional | ídem |
+| `shared_resources[].person` | string | sí si presente | `@handle` |
+| `shared_resources[].projects` | array[string] | sí si presente | ≥2 proyectos |
+| `shared_resources[].allocation_pct` | array[int] | sí si presente | suma ≤ 100, len == projects len |
+| `shared_resources[].conflict` | bool | sí si presente | true/false |
+
+## 3. Validador
+
+`scripts/deps-validate.sh` valida un `deps.yaml` contra el schema:
+
+```
+scripts/deps-validate.sh --file projects/erp-migration/deps.yaml
+```
+
+Exit codes:
+- `0` — válido
+- `1` — errores de schema (listados en stdout)
+- `2` — error de uso (fichero no existe, args inválidos)
+
+Output humano y JSON (`--json`):
+
+```
+VALID: deps.yaml schema OK for project 'erp-migration'
+  - 1 upstream deps  · 1 downstream deps  · 1 shared_resource
+```
+
+```json
+{"valid":true,"project":"erp-migration","upstream":1,"downstream":1,"shared_resources":1}
+```
+
+## 4. Cuándo declarar
+
+- Proyectos que bloquean o son bloqueados por otros proyectos (dependencia explícita)
+- Proyectos con recursos compartidos (personas o plataformas)
+- Tras kickoff en portfolio de ≥5 proyectos concurrentes
+
+NO necesario para:
+- Proyectos completamente aislados (standalone)
+- Dependencias técnicas puras (libs, infra) — van en manifiesto del proyecto, no aquí
+- Dependencias que se resuelven dentro de un mismo sprint (granularidad fina)
+
+## 5. Confidencialidad y sovereignty
+
+El fichero `deps.yaml` es **local al tenant**. No se sube a servicios SaaS
+externos. Queries cross-tenant están prohibidas (Principio #4).
+
+Si un proyecto declara `contact: "@handle"`, el handle es un identificador
+interno del tenant — nunca email, nunca teléfono.
+
+## 6. Ciclo de vida
+
+```
+new              → on-track       # kickoff
+on-track         → at-risk        # slack_days ≤ threshold (5 días)
+at-risk          → blocked        # needed_by pasado sin entrega
+blocked/at-risk  → on-track       # recovery
+on-track/at-risk → delivered      # entregado
+```
+
+Transitions emiten eventos (Slice 2+): `deps.at_risk`, `deps.blocked`,
+`deps.delivered`, `deps.contention`.
+
+## 7. Integración con otros specs
+
+- **SE-017** (SOW) — `deliverable` puede referenciar un D-NNN de SOW
+- **SE-014** (Release) — `deps.delivered` dispara checks de release
+- **SE-029** (context compression) — declaraciones son clase `spec` (frozen)
+- **Savia Flow** — estado deps se refleja en board de portfolio
+
+## 8. Slicing completo SPEC-SE-020
+
+| Slice | Contenido | Estado |
+|---|---|---|
+| **1** | Schema + rule + validator + tests (MVP) | este PR |
+| 2 | `portfolio-grapher` agent (reads all deps.yaml → graph) | futuro |
+| 3 | `critical-path-analyzer` (cross-project) | futuro |
+| 4 | `contention-detector` + rebalancer proposals | futuro |
+| 5 | Commands `/portfolio-graph`, `/portfolio-contention`, `/deps-status` | futuro |
+| 6 | Events + Savia Flow integration | futuro |
+
+## 9. Referencias
+
+- Spec: `docs/propuestas/savia-enterprise/SPEC-SE-020-cross-project-deps.md`
+- Validator: `scripts/deps-validate.sh`
+- Sample: `docs/examples/deps.yaml.sample`
+- PMI Pulse 2024: ~47% de program failures por dependencias mal gestionadas

--- a/scripts/deps-validate.sh
+++ b/scripts/deps-validate.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# deps-validate.sh — SPEC-SE-020 Slice 1 schema validator for deps.yaml.
+#
+# Valida archivos `deps.yaml` de declaración de dependencias cross-project
+# contra el schema definido en docs/rules/domain/portfolio-as-graph.md.
+#
+# Usage:
+#   deps-validate.sh --file path/to/deps.yaml
+#   deps-validate.sh --file path/to/deps.yaml --json
+#   deps-validate.sh --file path/to/deps.yaml --strict
+#
+# Exit codes:
+#   0 — schema valid
+#   1 — schema errors (listed on stdout)
+#   2 — usage error or file not found
+#
+# Ref: SPEC-SE-020, docs/rules/domain/portfolio-as-graph.md
+# Safety: read-only, set -uo pipefail.
+
+set -uo pipefail
+
+FILE=""
+JSON=0
+STRICT=0
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 --file PATH         Validate a deps.yaml against schema
+  $0 --file PATH --json  Output JSON verdict
+  $0 --file PATH --strict  WARNs are treated as errors
+
+Required top-level keys: project, tenant, dependencies.
+Enums: type ∈ {blocks,feeds,shared-resource,shared-platform}
+       status ∈ {on-track,at-risk,blocked,delivered}
+
+Ref: docs/rules/domain/portfolio-as-graph.md
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file) FILE="$2"; shift 2 ;;
+    --json) JSON=1; shift ;;
+    --strict) STRICT=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$FILE" ]] && { echo "ERROR: --file required" >&2; exit 2; }
+[[ ! -f "$FILE" ]] && { echo "ERROR: file not found: $FILE" >&2; exit 2; }
+
+ERRORS=()
+WARNINGS=()
+
+add_err() { ERRORS+=("$1"); }
+add_warn() { WARNINGS+=("$1"); }
+
+# ── Top-level required keys ─────────────────────────────────────────────────
+
+has_key() {
+  # checks whether a top-level key is present (accounting for indent 0).
+  grep -qE "^$1:" "$FILE"
+}
+
+has_key "project" || add_err "missing required key 'project'"
+has_key "tenant"  || add_err "missing required key 'tenant'"
+has_key "dependencies" || add_err "missing required key 'dependencies'"
+
+# Extract project name for output.
+PROJECT=$(grep -E '^project:' "$FILE" | head -1 | sed -E 's/^project:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/' | tr -d ' ')
+[[ -z "$PROJECT" ]] && PROJECT="(unknown)"
+
+# Validate project is non-empty and slug-ish (no spaces, reasonable chars).
+if [[ -n "$PROJECT" && "$PROJECT" != "(unknown)" ]]; then
+  if [[ "$PROJECT" =~ [[:space:]] ]]; then
+    add_err "'project' must not contain spaces: got '$PROJECT'"
+  fi
+fi
+
+# Tenant check (kebab-slug).
+TENANT=$(grep -E '^tenant:' "$FILE" | head -1 | sed -E 's/^tenant:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/' | tr -d ' ')
+if [[ -n "$TENANT" ]]; then
+  if ! [[ "$TENANT" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$ ]]; then
+    add_warn "'tenant' should be kebab-slug (lowercase, digits, dashes): got '$TENANT'"
+  fi
+fi
+
+# ── Enum validation: type ───────────────────────────────────────────────────
+
+VALID_TYPES="blocks feeds shared-resource shared-platform"
+# Collect all "type:" values under dependencies.
+TYPES=$(grep -E '^\s+type:' "$FILE" | sed -E 's/^\s+type:\s*"?([^"]*)"?\s*$/\1/' | tr -d ' ')
+while IFS= read -r t; do
+  [[ -z "$t" ]] && continue
+  if ! echo " $VALID_TYPES " | grep -q " $t "; then
+    add_err "invalid 'type' value: '$t' (allowed: $VALID_TYPES)"
+  fi
+done <<< "$TYPES"
+
+# ── Enum validation: status ─────────────────────────────────────────────────
+
+VALID_STATUS="on-track at-risk blocked delivered"
+STATUSES=$(grep -E '^\s+status:' "$FILE" | sed -E 's/^\s+status:\s*"?([^"]*)"?\s*$/\1/' | tr -d ' ')
+while IFS= read -r s; do
+  [[ -z "$s" ]] && continue
+  if ! echo " $VALID_STATUS " | grep -q " $s "; then
+    add_err "invalid 'status' value: '$s' (allowed: $VALID_STATUS)"
+  fi
+done <<< "$STATUSES"
+
+# ── Date format validation: needed_by ───────────────────────────────────────
+
+DATES=$(grep -E '^\s+needed_by:' "$FILE" | sed -E 's/^\s+needed_by:\s*"?([^"]*)"?\s*$/\1/' | tr -d ' ')
+while IFS= read -r d; do
+  [[ -z "$d" ]] && continue
+  if ! [[ "$d" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    add_err "invalid 'needed_by' date format: '$d' (expected YYYY-MM-DD)"
+  fi
+done <<< "$DATES"
+
+# ── Contact format validation ───────────────────────────────────────────────
+
+CONTACTS=$(grep -E '^\s+contact:' "$FILE" | sed -E 's/^\s+contact:\s*"?([^"]*)"?\s*$/\1/' | tr -d ' ')
+while IFS= read -r c; do
+  [[ -z "$c" ]] && continue
+  if ! [[ "$c" =~ ^@[a-zA-Z0-9_-]+$ ]]; then
+    add_warn "'contact' should be @handle: got '$c'"
+  fi
+done <<< "$CONTACTS"
+
+# ── Shared resources validation ─────────────────────────────────────────────
+
+# Counts.
+UPSTREAM_COUNT=$(awk '/^\s+upstream:/{f=1;next} /^\s+[a-zA-Z_]+:/&&!/^\s+-/{f=0} f&&/^\s+-\s+project:/{c++} END{print c+0}' "$FILE")
+DOWNSTREAM_COUNT=$(awk '/^\s+downstream:/{f=1;next} /^\s+[a-zA-Z_]+:/&&!/^\s+-/{f=0} f&&/^\s+-\s+project:/{c++} END{print c+0}' "$FILE")
+SHARED_COUNT=$(grep -cE '^\s+-\s+person:' "$FILE" || echo 0)
+
+# ── Emit verdict ────────────────────────────────────────────────────────────
+
+VALID=1
+if [[ "${#ERRORS[@]}" -gt 0 ]]; then
+  VALID=0
+fi
+if [[ "$STRICT" -eq 1 && "${#WARNINGS[@]}" -gt 0 ]]; then
+  VALID=0
+fi
+
+if [[ "$JSON" -eq 1 ]]; then
+  # Build JSON arrays manually.
+  err_json=""
+  for e in "${ERRORS[@]}"; do
+    e_esc=$(echo "$e" | sed 's/"/\\"/g')
+    err_json+="\"$e_esc\","
+  done
+  err_json="${err_json%,}"
+  warn_json=""
+  for w in "${WARNINGS[@]}"; do
+    w_esc=$(echo "$w" | sed 's/"/\\"/g')
+    warn_json+="\"$w_esc\","
+  done
+  warn_json="${warn_json%,}"
+  valid_bool=$([[ "$VALID" -eq 1 ]] && echo "true" || echo "false")
+  cat <<JSON
+{"valid":$valid_bool,"project":"$PROJECT","upstream":$UPSTREAM_COUNT,"downstream":$DOWNSTREAM_COUNT,"shared_resources":$SHARED_COUNT,"errors":[$err_json],"warnings":[$warn_json]}
+JSON
+else
+  if [[ "$VALID" -eq 1 ]]; then
+    echo "VALID: deps.yaml schema OK for project '$PROJECT'"
+    echo "  - ${UPSTREAM_COUNT} upstream · ${DOWNSTREAM_COUNT} downstream · ${SHARED_COUNT} shared_resource"
+    if [[ "${#WARNINGS[@]}" -gt 0 ]]; then
+      echo "  Warnings:"
+      for w in "${WARNINGS[@]}"; do echo "    - $w"; done
+    fi
+  else
+    echo "INVALID: deps.yaml schema errors in '$FILE' (project='$PROJECT')"
+    for e in "${ERRORS[@]}"; do echo "  ERR: $e"; done
+    if [[ "${#WARNINGS[@]}" -gt 0 ]]; then
+      for w in "${WARNINGS[@]}"; do echo "  WARN: $w"; done
+    fi
+  fi
+fi
+
+[[ "$VALID" -eq 0 ]] && exit 1
+exit 0

--- a/tests/test-deps-validate.bats
+++ b/tests/test-deps-validate.bats
@@ -1,0 +1,368 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/deps-validate.sh (SPEC-SE-020 Slice 1).
+# Validates the deps.yaml schema validator: required keys, enum validation,
+# date format, contact handle format, JSON output, negatives, edges.
+#
+# Ref: SPEC-SE-020, docs/rules/domain/portfolio-as-graph.md, ROADMAP §Tier 5.12
+# Safety: script under test has `set -uo pipefail`, read-only.
+
+SCRIPT="scripts/deps-validate.sh"
+
+setup() {
+  export TMPDIR="${BATS_TEST_TMPDIR:-/tmp}"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+teardown() {
+  cd /
+}
+
+# ── Structure / safety ──────────────────────────────────────────────────────
+
+@test "script exists and is executable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+@test "script uses set -uo pipefail" {
+  run grep -cE '^set -[uo]+ pipefail' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "script passes bash -n syntax check" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "script references SPEC-SE-020" {
+  run grep -c 'SPEC-SE-020' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "rule doc exists and references SPEC-SE-020" {
+  [[ -f "docs/rules/domain/portfolio-as-graph.md" ]]
+  run grep -c 'SPEC-SE-020' docs/rules/domain/portfolio-as-graph.md
+  [[ "$output" -ge 1 ]]
+}
+
+@test "rule doc stays under 150 lines (acceptance criterion)" {
+  local lines
+  lines=$(wc -l < docs/rules/domain/portfolio-as-graph.md)
+  [[ "$lines" -le 150 ]]
+}
+
+@test "sample deps.yaml exists" {
+  [[ -f "docs/examples/deps.yaml.sample" ]]
+}
+
+# ── CLI surface ─────────────────────────────────────────────────────────────
+
+@test "script accepts --help and exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"schema"* ]]
+  [[ "$output" == *"deps.yaml"* ]]
+}
+
+@test "script rejects unknown arg" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "script requires --file argument" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"file required"* ]]
+}
+
+@test "script rejects nonexistent file" {
+  run bash "$SCRIPT" --file /does/not/exist.yaml
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+# ── Positive cases ──────────────────────────────────────────────────────────
+
+@test "sample deps.yaml validates successfully" {
+  run bash "$SCRIPT" --file docs/examples/deps.yaml.sample
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VALID"* ]]
+  [[ "$output" == *"erp-migration"* ]]
+}
+
+@test "minimal valid deps.yaml (only upstream) validates" {
+  local tmp="$BATS_TEST_TMPDIR/min.yaml"
+  cat > "$tmp" <<EOF
+project: "my-proj"
+tenant: "my-tenant"
+dependencies:
+  upstream:
+    - project: "upstream-one"
+      type: "blocks"
+      deliverable: "D-001"
+      needed_by: "2026-12-31"
+      status: "on-track"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VALID"* ]]
+}
+
+@test "valid deps.yaml counts upstream/downstream/shared correctly" {
+  run bash "$SCRIPT" --file docs/examples/deps.yaml.sample
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1 upstream"* ]]
+  [[ "$output" == *"1 downstream"* ]]
+  [[ "$output" == *"1 shared_resource"* ]]
+}
+
+# ── Negative: missing keys ──────────────────────────────────────────────────
+
+@test "missing project key fails validation" {
+  local tmp="$BATS_TEST_TMPDIR/no-proj.yaml"
+  cat > "$tmp" <<EOF
+tenant: "x"
+dependencies:
+  upstream: []
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing required key 'project'"* ]]
+}
+
+@test "missing tenant key fails validation" {
+  local tmp="$BATS_TEST_TMPDIR/no-tenant.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+dependencies:
+  upstream: []
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing required key 'tenant'"* ]]
+}
+
+@test "missing dependencies key fails validation" {
+  local tmp="$BATS_TEST_TMPDIR/no-deps.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing required key 'dependencies'"* ]]
+}
+
+# ── Negative: enum violations ───────────────────────────────────────────────
+
+@test "invalid type value is rejected" {
+  local tmp="$BATS_TEST_TMPDIR/bad-type.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "not-a-real-type"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "on-track"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid 'type'"* ]]
+}
+
+@test "invalid status value is rejected" {
+  local tmp="$BATS_TEST_TMPDIR/bad-status.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "wrong-status"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid 'status'"* ]]
+}
+
+# ── Negative: date format ───────────────────────────────────────────────────
+
+@test "invalid needed_by date format is rejected" {
+  local tmp="$BATS_TEST_TMPDIR/bad-date.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "15/07/2026"
+      status: "on-track"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid 'needed_by' date"* ]]
+}
+
+@test "valid ISO date YYYY-MM-DD accepted" {
+  local tmp="$BATS_TEST_TMPDIR/ok-date.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-12-31"
+      status: "on-track"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+# ── Warnings: contact format ────────────────────────────────────────────────
+
+@test "non-handle contact triggers warning but still valid" {
+  local tmp="$BATS_TEST_TMPDIR/bad-contact.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "on-track"
+      contact: "email@bad.com"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"@handle"* ]]
+}
+
+@test "strict mode: warnings become errors" {
+  local tmp="$BATS_TEST_TMPDIR/warn.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "BAD_SLUG"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "on-track"
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPT" --file "$tmp" --strict
+  [ "$status" -eq 1 ]
+}
+
+# ── JSON output ─────────────────────────────────────────────────────────────
+
+@test "json output is valid JSON with expected keys" {
+  run bash -c 'bash '"$SCRIPT"' --file docs/examples/deps.yaml.sample --json | python3 -c "import json,sys; d=json.load(sys.stdin); assert \"valid\" in d; assert \"project\" in d; assert \"upstream\" in d; assert \"errors\" in d; print(\"ok\")"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "json shows valid:true for passing file" {
+  run bash "$SCRIPT" --file docs/examples/deps.yaml.sample --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"valid":true'* ]]
+}
+
+@test "json shows valid:false with errors list for failing file" {
+  local tmp="$BATS_TEST_TMPDIR/broken.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+dependencies:
+  upstream: []
+EOF
+  run bash "$SCRIPT" --file "$tmp" --json
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'"valid":false'* ]]
+  [[ "$output" == *"missing required key"* ]]
+}
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+@test "edge: all 4 type enums accepted" {
+  for t in blocks feeds shared-resource shared-platform; do
+    local tmp="$BATS_TEST_TMPDIR/type-$t.yaml"
+    cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "$t"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "on-track"
+EOF
+    run bash "$SCRIPT" --file "$tmp"
+    [ "$status" -eq 0 ]
+  done
+}
+
+@test "edge: all 4 status enums accepted" {
+  for s in on-track at-risk blocked delivered; do
+    local tmp="$BATS_TEST_TMPDIR/status-$s.yaml"
+    cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream:
+    - project: "u"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "$s"
+EOF
+    run bash "$SCRIPT" --file "$tmp"
+    [ "$status" -eq 0 ]
+  done
+}
+
+@test "edge: empty dependencies block accepted" {
+  local tmp="$BATS_TEST_TMPDIR/empty.yaml"
+  cat > "$tmp" <<EOF
+project: "x"
+tenant: "y"
+dependencies:
+  upstream: []
+  downstream: []
+EOF
+  run bash "$SCRIPT" --file "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+# ── Isolation ──────────────────────────────────────────────────────────────
+
+@test "isolation: script does not modify input file" {
+  local tmp="$BATS_TEST_TMPDIR/ro.yaml"
+  cp docs/examples/deps.yaml.sample "$tmp"
+  local hash_before
+  hash_before=$(md5sum "$tmp" | awk '{print $1}')
+  bash "$SCRIPT" --file "$tmp" >/dev/null 2>&1
+  local hash_after
+  hash_after=$(md5sum "$tmp" | awk '{print $1}')
+  [[ "$hash_before" == "$hash_after" ]]
+}
+
+@test "isolation: exit codes are 0 (valid), 1 (invalid), or 2 (usage)" {
+  run bash "$SCRIPT" --file docs/examples/deps.yaml.sample
+  [[ "$status" -eq 0 ]]
+  run bash "$SCRIPT" --bogus
+  [[ "$status" -eq 2 ]]
+}


### PR DESCRIPTION
## Summary
- SPEC-SE-020 Slice 1 foundational layer para Cross-Project Dependencies:
  - `docs/rules/domain/portfolio-as-graph.md` rule doc (≤150 lines — cumple AC)
  - `scripts/deps-validate.sh` schema validator
  - `docs/examples/deps.yaml.sample` ejemplo canónico
- Validator bash puro (sin deps de Python/yq) verifica:
  - Claves top-level requeridas (project, tenant, dependencies)
  - Enums: type ∈ {blocks, feeds, shared-resource, shared-platform}
  - Enums: status ∈ {on-track, at-risk, blocked, delivered}
  - Formato ISO date `YYYY-MM-DD` para needed_by
  - Warnings para tenant no-kebab-slug y contact sin @handle
- Modes: text/human o `--json` estructurado
- `--strict` trata warnings como errors
- 31 BATS tests, auditor score **88/100**

## Context
- Ref: ROADMAP.md Tier 5.12 / SPEC-SE-020
- Slice 1 de 6 (futuro: portfolio-grapher agent, critical-path analyzer, contention detector, rebalancer, commands, events)
- Zero dependencias externas — opera offline (Principio #1 Soberanía del dato)
- Sample en `docs/examples/` para onboarding rápido de proyectos

## Out of scope (futuros slices)
- Portfolio graph computation (Slice 2 — portfolio-grapher agent)
- Critical path analysis (Slice 3)
- Contention detection + rebalancer (Slice 4)
- CLI commands `/portfolio-graph`, `/deps-status` (Slice 5)
- Event emission en state transitions (Slice 6)

## Test plan
- [x] `bats tests/test-deps-validate.bats` — 31/31 pass
- [x] `bash scripts/test-auditor.sh tests/test-deps-validate.bats` — score 88
- [x] `bash scripts/pr-plan.sh` — 13 gates PASS
- [x] Sample deps.yaml valida correctamente
- [ ] Reviewer confirma schema + enums cubren casos enterprise

🤖 Generated with [Claude Code](https://claude.com/claude-code)