### PR TITLE
feat(spec-se-020): Slice 2 — portfolio-graph grapher (ASCII/Mermaid/JSON)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=69affb73f6996722869d8a0dbc5cbdf96c7d58443dc21ae1965147f6bce84c2c
+diff_hash=37083c9c557198ea131131930c396e6745847197e902f552deec17223edfdb45
 timestamp=2026-04-19T14:39:30Z
 branch=agent/specse020-slice2-portfolio-grapher-20260419
-head_commit=9415258a
-signature=b86cfd155ffbdd0575d900497c48b52c04c3b924dc813a036dff013bc80550c7
+head_commit=78538bd7
+signature=cf1d07b3d0867834cb8a9374e4d81b484e41360f20080a9be52aa5f96b07da8d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=5068f55c205b914a7de89dae88510e5e48d7b97c200f7778390e4755afd4987e
-timestamp=2026-04-19T17:58:58Z
+timestamp=2026-04-19T18:41:30Z
 branch=agent/specse020-slice2-portfolio-grapher-20260419
-head_commit=9f897095
-signature=a13d5cea92edaa8181866673b3d53d83cd892471dc47618a76cc93659d054b11
+head_commit=af74dec4
+signature=da893d5cb4afa2aca077993bf3628deeb2a7269634eba1c0baa249605c6f1ea4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=37083c9c557198ea131131930c396e6745847197e902f552deec17223edfdb45
-timestamp=2026-04-19T14:39:30Z
+diff_hash=5068f55c205b914a7de89dae88510e5e48d7b97c200f7778390e4755afd4987e
+timestamp=2026-04-19T17:58:58Z
 branch=agent/specse020-slice2-portfolio-grapher-20260419
-head_commit=78538bd7
-signature=cf1d07b3d0867834cb8a9374e4d81b484e41360f20080a9be52aa5f96b07da8d
+head_commit=9f897095
+signature=a13d5cea92edaa8181866673b3d53d83cd892471dc47618a76cc93659d054b11

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=69affb73f6996722869d8a0dbc5cbdf96c7d58443dc21ae1965147f6bce84c2c
-timestamp=2026-04-19T14:09:00Z
-branch=agent/se029-slice4-operational-point-20260419
-head_commit=bb037a81
+timestamp=2026-04-19T14:39:30Z
+branch=agent/specse020-slice2-portfolio-grapher-20260419
+head_commit=9415258a
 signature=b86cfd155ffbdd0575d900497c48b52c04c3b924dc813a036dff013bc80550c7

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: e409eb7166a6 | resources: 1026
-> 530 commands · 78 skills · 65 agents · 353 scripts
+> hash: 60869c133e86 | resources: 1027
+> 530 commands · 78 skills · 65 agents · 354 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -199,6 +199,7 @@
 [development] pipeline-stage-runner — execute,pipeline,runner,single,stage — script:scripts/pipeline-stage-runner.sh
 [development] pipeline-status —  — cmd:.claude/commands/pipeline-status.md
 [development] pipeline-view — active,ascii,probability,pursuits,stage — cmd:.claude/commands/pipeline-view.md
+[development] portfolio-graph — builder,dependency,graph,portfolio,slice — script:scripts/portfolio-graph.sh
 [development] pre-push-bats-critical — bats,critical,module,push,spec — script:scripts/pre-push-bats-critical.sh
 [development] prompt-suggestion-engine — driven,engine,optimization,phase,prompt — script:scripts/prompt-suggestion-engine.sh
 [development] reaction-engine — engine,phase,reaction,spec — script:scripts/reaction-engine.sh

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 60869c133e86 | resources: 1027
-> 530 commands · 78 skills · 65 agents · 354 scripts
+> hash: d48053bb0269 | resources: 1028
+> 530 commands · 78 skills · 65 agents · 355 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -166,6 +166,7 @@
 [development] dag-plan — ahorro,camino,crítico,ejecución,tiempo — cmd:.claude/commands/dag-plan.md
 [development] dag-scheduling — agentes,dependencias,gráficos,orquestar,paralelo — skill:.claude/skills/dag-scheduling/SKILL.md
 [development] dag-typing-validate — prototype,slice,typing,validate,validator — script:scripts/dag-typing-validate.sh
+[development] deps-validate — deps,schema,slice,spec,validate — script:scripts/deps-validate.sh
 [development] dev-orchestrator — analiza,contexto,crea,dependencias,implementación — agent:.claude/agents/dev-orchestrator.md
 [development] dev-session — aislamiento,contexto,desarrollo,disco,fases — cmd:.claude/commands/dev-session.md
 [development] dev-session-discard — cleanly,discard,session — script:scripts/dev-session-discard.sh

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 103 resources
+> 104 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **Trace Analyze** (cmd): Análisis profundo de trazas específicas con detección de cuellos de botella y cadenas de errores
@@ -63,6 +63,7 @@
 - **pipeline-stage-runner** (script): pipeline-stage-runner.sh — Execute a single pipeline stage
 - **pipeline-status** (cmd): >
 - **pipeline-view** (cmd): ASCII table of all active pursuits with stage, value, and probability
+- **portfolio-graph** (script): portfolio-graph.sh — SPEC-SE-020 Slice 2 dependency graph builder.
 - **pre-push-bats-critical** (script): pre-push-bats-critical.sh — SPEC-SE-012 Module 3.
 - **prompt-suggestion-engine** (script): prompt-suggestion-engine.sh — SPEC-044 Phase 2: trace-driven prompt optimization
 - **reaction-engine** (script): reaction-engine.sh — SPEC-050 Phase 1: Reaction Engine

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 104 resources
+> 105 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **Trace Analyze** (cmd): Análisis profundo de trazas específicas con detección de cuellos de botella y cadenas de errores

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "ea89b1676dbb",
-  "total": 1026,
+  "hash": "127d8177bc26",
+  "total": 1027,
   "resources": [
     {
       "category": "analysis",
@@ -2464,6 +2464,20 @@
       "kind": "cmd",
       "path": ".claude/commands/pipeline-view.md",
       "description": "ASCII table of all active pursuits with stage, value, and probability"
+    },
+    {
+      "category": "development",
+      "name": "portfolio-graph",
+      "intents": [
+        "builder",
+        "dependency",
+        "graph",
+        "portfolio",
+        "slice"
+      ],
+      "kind": "script",
+      "path": "scripts/portfolio-graph.sh",
+      "description": "portfolio-graph.sh — SPEC-SE-020 Slice 2 dependency graph builder."
     },
     {
       "category": "development",

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "127d8177bc26",
-  "total": 1027,
+  "hash": "9b9e38f5af79",
+  "total": 1028,
   "resources": [
     {
       "category": "analysis",
@@ -2044,6 +2044,20 @@
       "kind": "script",
       "path": "scripts/dag-typing-validate.sh",
       "description": "dag-typing-validate.sh — SE-034 Slice 1 prototype validator."
+    },
+    {
+      "category": "development",
+      "name": "deps-validate",
+      "intents": [
+        "deps",
+        "schema",
+        "slice",
+        "spec",
+        "validate"
+      ],
+      "kind": "script",
+      "path": "scripts/deps-validate.sh",
+      "description": "deps-validate.sh — SPEC-SE-020 Slice 1 schema validator for deps.yaml."
     },
     {
       "category": "development",

--- a/CHANGELOG.d/specse020-slice2-portfolio-grapher.md
+++ b/CHANGELOG.d/specse020-slice2-portfolio-grapher.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SPEC-SE-020 Slice 2: portfolio-graph.sh (ASCII/Mermaid/JSON) + 29 BATS tests
+

--- a/scripts/portfolio-graph.sh
+++ b/scripts/portfolio-graph.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# portfolio-graph.sh — SPEC-SE-020 Slice 2 dependency graph builder.
+#
+# Escanea todos los `deps.yaml` en `<root>/<project-name>/deps.yaml` y
+# construye el grafo de dependencias cross-project, rendereado como ASCII
+# o Mermaid. Computed, not stored — zero egress.
+#
+# Usage:
+#   portfolio-graph.sh --root projects/
+#   portfolio-graph.sh --root projects/ --format mermaid
+#   portfolio-graph.sh --root projects/ --json
+#
+# Exit codes:
+#   0 — graph rendered (incluso si no hay deps encontradas)
+#   2 — usage error
+#
+# Ref: SPEC-SE-020 §Portfolio graph, ROADMAP §Tier 5.12
+# Dep: ninguna (standalone). Lee YAML con grep/sed.
+# Safety: read-only, set -uo pipefail.
+
+set -uo pipefail
+
+ROOT=""
+FORMAT="ascii"
+JSON=0
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 --root DIR [--format ascii|mermaid] [--json]
+
+  --root DIR      Directorio con subcarpetas <project>/deps.yaml
+  --format        'ascii' (default), 'mermaid'
+  --json          Output JSON (nodes + edges)
+
+Ref: SPEC-SE-020 §Portfolio graph
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root) ROOT="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    --json) JSON=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$ROOT" ]] && { echo "ERROR: --root required" >&2; exit 2; }
+[[ ! -d "$ROOT" ]] && { echo "ERROR: root directory not found: $ROOT" >&2; exit 2; }
+
+case "$FORMAT" in
+  ascii|mermaid) ;;
+  *) echo "ERROR: invalid --format '$FORMAT' (allowed: ascii, mermaid)" >&2; exit 2 ;;
+esac
+
+# Collect all deps.yaml files under root.
+mapfile -t DEPS_FILES < <(find "$ROOT" -mindepth 2 -maxdepth 2 -name 'deps.yaml' 2>/dev/null | sort)
+N_FILES=${#DEPS_FILES[@]}
+
+# Arrays to collect nodes (projects) and edges (from → to via type:deliverable).
+declare -A PROJECTS_SEEN
+NODES=()
+EDGES=()
+
+# Parse one deps.yaml: emit project name + upstream deps as lines.
+parse_deps() {
+  local file="$1"
+  local proj
+  proj=$(grep -E '^project:' "$file" | head -1 | sed -E 's/^project:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  proj="${proj// /}"
+  [[ -z "$proj" ]] && return
+
+  # Track project node.
+  if [[ -z "${PROJECTS_SEEN[$proj]:-}" ]]; then
+    PROJECTS_SEEN[$proj]=1
+    NODES+=("$proj")
+  fi
+
+  # Walk upstream section: lines that start with "    - project:" under upstream:.
+  # We use awk to collect tuples (upstream_project, type, status).
+  local in_upstream=0
+  local cur_project="" cur_type="" cur_status=""
+  while IFS= read -r line; do
+    # Top-level section detection.
+    if [[ "$line" =~ ^[[:space:]]{2}upstream: ]]; then
+      in_upstream=1; continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]{2}(downstream|shared_resources): ]]; then
+      in_upstream=0; continue
+    fi
+    [[ "$in_upstream" -ne 1 ]] && continue
+    # New upstream entry starts with "    - project:".
+    if [[ "$line" =~ ^[[:space:]]+-[[:space:]]+project:[[:space:]]+\"?([^\"]+)\"? ]]; then
+      # Flush previous.
+      if [[ -n "$cur_project" ]]; then
+        EDGES+=("$cur_project|$proj|$cur_type|$cur_status")
+        # Also register upstream project as node.
+        if [[ -z "${PROJECTS_SEEN[$cur_project]:-}" ]]; then
+          PROJECTS_SEEN[$cur_project]=1
+          NODES+=("$cur_project")
+        fi
+      fi
+      cur_project="${BASH_REMATCH[1]}"
+      cur_project="${cur_project// /}"
+      cur_type=""; cur_status=""
+      continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]+type:[[:space:]]+\"?([^\"]+)\"? ]]; then
+      cur_type="${BASH_REMATCH[1]}"; cur_type="${cur_type// /}"
+    fi
+    if [[ "$line" =~ ^[[:space:]]+status:[[:space:]]+\"?([^\"]+)\"? ]]; then
+      cur_status="${BASH_REMATCH[1]}"; cur_status="${cur_status// /}"
+    fi
+  done < "$file"
+  # Flush last.
+  if [[ -n "$cur_project" ]]; then
+    EDGES+=("$cur_project|$proj|$cur_type|$cur_status")
+    if [[ -z "${PROJECTS_SEEN[$cur_project]:-}" ]]; then
+      PROJECTS_SEEN[$cur_project]=1
+      NODES+=("$cur_project")
+    fi
+  fi
+}
+
+for f in "${DEPS_FILES[@]}"; do
+  parse_deps "$f"
+done
+
+# Render output.
+N_NODES=${#NODES[@]}
+N_EDGES=${#EDGES[@]}
+
+if [[ "$JSON" -eq 1 ]]; then
+  # Nodes JSON.
+  nodes_json=""
+  for n in "${NODES[@]}"; do
+    n_esc=$(echo "$n" | sed 's/"/\\"/g')
+    nodes_json+="\"$n_esc\","
+  done
+  nodes_json="${nodes_json%,}"
+  # Edges JSON.
+  edges_json=""
+  for e in "${EDGES[@]}"; do
+    IFS='|' read -r from to etype est <<< "$e"
+    edges_json+="{\"from\":\"$from\",\"to\":\"$to\",\"type\":\"$etype\",\"status\":\"$est\"},"
+  done
+  edges_json="${edges_json%,}"
+  cat <<JSON
+{"root":"$ROOT","n_files":$N_FILES,"n_nodes":$N_NODES,"n_edges":$N_EDGES,"nodes":[$nodes_json],"edges":[$edges_json]}
+JSON
+  exit 0
+fi
+
+if [[ "$FORMAT" == "mermaid" ]]; then
+  echo "graph LR"
+  for n in "${NODES[@]}"; do
+    echo "  ${n//-/_}[\"$n\"]"
+  done
+  for e in "${EDGES[@]}"; do
+    IFS='|' read -r from to etype est <<< "$e"
+    f_id="${from//-/_}"
+    t_id="${to//-/_}"
+    label="$etype"
+    [[ -n "$est" && "$est" != "on-track" ]] && label+=" ($est)"
+    echo "  ${f_id} -->|${label}| ${t_id}"
+  done
+  exit 0
+fi
+
+# ASCII default.
+echo "=== Portfolio Graph ==="
+echo "Root:       $ROOT"
+echo "Files:      $N_FILES deps.yaml parsed"
+echo "Nodes:      $N_NODES projects"
+echo "Edges:      $N_EDGES dependencies"
+echo ""
+
+if [[ "$N_NODES" -eq 0 ]]; then
+  echo "(no deps.yaml found under $ROOT)"
+  exit 0
+fi
+
+echo "Projects:"
+for n in "${NODES[@]}"; do
+  echo "  • $n"
+done
+
+if [[ "$N_EDGES" -gt 0 ]]; then
+  echo ""
+  echo "Dependencies (upstream → downstream):"
+  for e in "${EDGES[@]}"; do
+    IFS='|' read -r from to etype est <<< "$e"
+    status_badge=""
+    case "$est" in
+      at-risk)  status_badge=" [AT-RISK]" ;;
+      blocked)  status_badge=" [BLOCKED]" ;;
+      delivered) status_badge=" [DELIVERED]" ;;
+    esac
+    echo "  $from --[$etype]--> $to${status_badge}"
+  done
+fi
+
+exit 0

--- a/tests/test-portfolio-graph.bats
+++ b/tests/test-portfolio-graph.bats
@@ -1,0 +1,371 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/portfolio-graph.sh (SPEC-SE-020 Slice 2).
+# Validates the portfolio-grapher: deps.yaml parsing, graph construction,
+# ASCII/Mermaid/JSON output, safety, edge cases.
+#
+# Ref: SPEC-SE-020 §Portfolio graph, ROADMAP §Tier 5.12
+# Safety: script under test `set -uo pipefail`, read-only.
+
+SCRIPT="scripts/portfolio-graph.sh"
+
+setup() {
+  export TMPDIR="${BATS_TEST_TMPDIR:-/tmp}"
+  cd "$BATS_TEST_DIRNAME/.."
+}
+
+teardown() {
+  cd /
+}
+
+# Helper: build a sandbox with N projects + deps.yaml.
+build_sandbox() {
+  local sb="$1"
+  mkdir -p "$sb/proj-a" "$sb/proj-b" "$sb/proj-c"
+  cat > "$sb/proj-a/deps.yaml" <<YAML
+project: "proj-a"
+tenant: "sandbox"
+dependencies:
+  upstream:
+    - project: "proj-b"
+      type: "blocks"
+      deliverable: "D-001"
+      needed_by: "2026-12-31"
+      status: "on-track"
+YAML
+  cat > "$sb/proj-b/deps.yaml" <<YAML
+project: "proj-b"
+tenant: "sandbox"
+dependencies:
+  upstream:
+    - project: "proj-c"
+      type: "feeds"
+      deliverable: "D-002"
+      needed_by: "2026-11-30"
+      status: "at-risk"
+YAML
+  cat > "$sb/proj-c/deps.yaml" <<YAML
+project: "proj-c"
+tenant: "sandbox"
+dependencies:
+  upstream: []
+YAML
+}
+
+# ── Structure / safety ──────────────────────────────────────────────────────
+
+@test "script exists and is executable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+@test "script uses set -uo pipefail" {
+  run grep -cE '^set -[uo]+ pipefail' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "script passes bash -n syntax check" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "script references SPEC-SE-020 and Slice 2" {
+  run grep -c 'SPEC-SE-020' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+  run grep -c 'Slice 2\|Portfolio graph' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+# ── CLI surface ─────────────────────────────────────────────────────────────
+
+@test "script accepts --help and exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"root"* ]]
+  [[ "$output" == *"ascii"* ]]
+  [[ "$output" == *"mermaid"* ]]
+}
+
+@test "script rejects unknown arg" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "script requires --root" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"root required"* ]]
+}
+
+@test "script rejects nonexistent root directory" {
+  run bash "$SCRIPT" --root /does/not/exist
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "script rejects invalid format" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$sb"
+  run bash "$SCRIPT" --root "$sb" --format svg
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid"* ]]
+}
+
+# ── Empty root ─────────────────────────────────────────────────────────────
+
+@test "empty root directory returns zero-node graph gracefully" {
+  local sb="$BATS_TEST_TMPDIR/empty"
+  mkdir -p "$sb"
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nodes:      0"* ]]
+  [[ "$output" == *"Edges:      0"* ]]
+}
+
+# ── ASCII output ────────────────────────────────────────────────────────────
+
+@test "ascii output lists all 3 projects from sandbox" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"proj-a"* ]]
+  [[ "$output" == *"proj-b"* ]]
+  [[ "$output" == *"proj-c"* ]]
+}
+
+@test "ascii output shows Nodes:3 and Edges:2 for sandbox" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nodes:      3"* ]]
+  [[ "$output" == *"Edges:      2"* ]]
+}
+
+@test "ascii output renders upstream→downstream edges" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"proj-b --[blocks]--> proj-a"* ]]
+  [[ "$output" == *"proj-c --[feeds]--> proj-b"* ]]
+}
+
+@test "ascii output flags at-risk status badge" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AT-RISK"* ]]
+}
+
+@test "ascii output flags blocked status badge" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$sb/p1" "$sb/p2"
+  cat > "$sb/p1/deps.yaml" <<YAML
+project: "p1"
+tenant: "t"
+dependencies:
+  upstream:
+    - project: "p2"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "blocked"
+YAML
+  cat > "$sb/p2/deps.yaml" <<YAML
+project: "p2"
+tenant: "t"
+dependencies:
+  upstream: []
+YAML
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+}
+
+# ── Mermaid output ──────────────────────────────────────────────────────────
+
+@test "mermaid output starts with 'graph LR'" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb" --format mermaid
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"graph LR"* ]]
+}
+
+@test "mermaid output contains node declarations" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb" --format mermaid
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'proj_a["proj-a"]'* ]]
+  [[ "$output" == *'proj_b["proj-b"]'* ]]
+}
+
+@test "mermaid output contains edge with label" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb" --format mermaid
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"proj_b -->|blocks| proj_a"* ]]
+}
+
+@test "mermaid output annotates non-on-track status in label" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb" --format mermaid
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feeds (at-risk)"* ]]
+}
+
+# ── JSON output ─────────────────────────────────────────────────────────────
+
+@test "json output is valid JSON with expected keys" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash -c 'bash '"$SCRIPT"' --root '"$sb"' --json | python3 -c "import json,sys; d=json.load(sys.stdin); assert \"nodes\" in d; assert \"edges\" in d; assert \"n_nodes\" in d; print(\"ok\")"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "json output contains 3 nodes and 2 edges for sandbox" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"n_nodes":3'* ]]
+  [[ "$output" == *'"n_edges":2'* ]]
+}
+
+@test "json edge objects have from/to/type/status" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"from":"proj-b"'* ]]
+  [[ "$output" == *'"to":"proj-a"'* ]]
+  [[ "$output" == *'"type":"blocks"'* ]]
+  [[ "$output" == *'"status":"on-track"'* ]]
+}
+
+# ── Multi-upstream ──────────────────────────────────────────────────────────
+
+@test "project with multiple upstream deps creates multiple edges" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$sb/hub" "$sb/a" "$sb/b"
+  cat > "$sb/hub/deps.yaml" <<YAML
+project: "hub"
+tenant: "t"
+dependencies:
+  upstream:
+    - project: "a"
+      type: "blocks"
+      deliverable: "D-A"
+      needed_by: "2026-01-01"
+      status: "on-track"
+    - project: "b"
+      type: "feeds"
+      deliverable: "D-B"
+      needed_by: "2026-02-01"
+      status: "on-track"
+YAML
+  cat > "$sb/a/deps.yaml" <<YAML
+project: "a"
+tenant: "t"
+dependencies:
+  upstream: []
+YAML
+  cat > "$sb/b/deps.yaml" <<YAML
+project: "b"
+tenant: "t"
+dependencies:
+  upstream: []
+YAML
+  run bash "$SCRIPT" --root "$sb" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"n_nodes":3'* ]]
+  [[ "$output" == *'"n_edges":2'* ]]
+}
+
+# ── Negative ───────────────────────────────────────────────────────────────
+
+@test "negative: project without deps.yaml is not included" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$sb/standalone"
+  # No deps.yaml.
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Nodes:      0"* ]]
+}
+
+@test "negative: unknown flag rejected" {
+  run bash "$SCRIPT" --some-flag
+  [ "$status" -eq 2 ]
+}
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+@test "edge: deep nested dirs are ignored (only depth 2)" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$sb/valid" "$sb/deep/nested/path"
+  cat > "$sb/valid/deps.yaml" <<YAML
+project: "valid"
+tenant: "t"
+dependencies:
+  upstream: []
+YAML
+  cat > "$sb/deep/nested/path/deps.yaml" <<YAML
+project: "ignored-deep"
+tenant: "t"
+dependencies:
+  upstream: []
+YAML
+  run bash "$SCRIPT" --root "$sb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"valid"* ]]
+  [[ "$output" != *"ignored-deep"* ]]
+}
+
+@test "edge: upstream project not declared elsewhere is still added as node" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  mkdir -p "$sb/only"
+  cat > "$sb/only/deps.yaml" <<YAML
+project: "only"
+tenant: "t"
+dependencies:
+  upstream:
+    - project: "external-dep"
+      type: "blocks"
+      deliverable: "D"
+      needed_by: "2026-01-01"
+      status: "on-track"
+YAML
+  run bash "$SCRIPT" --root "$sb" --json
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"external-dep"* ]]
+  [[ "$output" == *'"n_nodes":2'* ]]
+}
+
+# ── Isolation ──────────────────────────────────────────────────────────────
+
+@test "isolation: script does not modify any deps.yaml" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  local hash_before
+  hash_before=$(find "$sb" -name 'deps.yaml' -exec md5sum {} \; | md5sum | awk '{print $1}')
+  bash "$SCRIPT" --root "$sb" >/dev/null 2>&1
+  bash "$SCRIPT" --root "$sb" --format mermaid >/dev/null 2>&1
+  bash "$SCRIPT" --root "$sb" --json >/dev/null 2>&1
+  local hash_after
+  hash_after=$(find "$sb" -name 'deps.yaml' -exec md5sum {} \; | md5sum | awk '{print $1}')
+  [[ "$hash_before" == "$hash_after" ]]
+}
+
+@test "isolation: all 3 output formats reflect same n_edges" {
+  local sb="$BATS_TEST_TMPDIR/sb"
+  build_sandbox "$sb"
+  run bash "$SCRIPT" --root "$sb"
+  [[ "$output" == *"Edges:      2"* ]]
+  run bash "$SCRIPT" --root "$sb" --json
+  [[ "$output" == *'"n_edges":2'* ]]
+}


### PR DESCRIPTION
## Summary
- SPEC-SE-020 Slice 2 portfolio-grapher: `scripts/portfolio-graph.sh`
- Escanea `<root>/<project>/deps.yaml` (depth 2 únicamente) y construye grafo de dependencias
- 3 formatos de output: ASCII (default), Mermaid (`--format mermaid`), JSON (`--json`)
- Zero dependencias externas: bash + grep + find + regex
- Badges de estado: `[AT-RISK]`, `[BLOCKED]`, `[DELIVERED]` en ASCII
- Mermaid anota status no-on-track en edge labels
- 29 BATS tests, auditor score **88/100**

## Context
- Ref: ROADMAP.md Tier 5.12 / SPEC-SE-020 §Portfolio graph
- Continuación de Slice 1 (schema + validator — PR #631)
- Independiente de Slice 1: puede operar sobre cualquier estructura `<root>/<project>/deps.yaml`
- Próximos slices: critical-path-analyzer, contention-detector, commands `/portfolio-graph`

## Test plan
- [x] `bats tests/test-portfolio-graph.bats` — 29/29 pass
- [x] `bash scripts/test-auditor.sh tests/test-portfolio-graph.bats` — score 88
- [x] `bash scripts/pr-plan.sh` — 13 gates PASS
- [ ] Reviewer confirma output ASCII + Mermaid ante escenario real

🤖 Generated with [Claude Code](https://claude.com/claude-code)