### PR TITLE
feat: batch 53 SPEC-121 IMPLEMENTED — handoff-as-function 6/6 ACs

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -141,3 +141,23 @@ See `docs/rules/domain/agent-prompt-xml-structure.md` for canonical 6-tag patter
 ## Reporting Policy (SE-066)
 
 Coverage-first review under Opus 4.7. Ver `docs/rules/domain/review-agents-reporting-policy.md`. Cada finding con `{confidence, severity}`; filter downstream rankea.
+
+## Handoff Format (SPEC-121)
+
+E3→E4 handoff to `test-engineer` after review PASS (no REJECT):
+
+```yaml
+---
+handoff:
+  to: test-engineer
+  spec: SPEC-NNN
+  stage: E4
+  context_hash: sha256:<8-char-prefix>
+  reason: "Code review PASS, ready for final test validation"
+  termination_reason: completed
+  artifacts:
+    - .review.crc
+---
+```
+
+If verdict is REJECT, use `termination_reason: unrecoverable_error` and route back to developer. See `docs/rules/domain/agent-handoff-protocol.md`.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -142,22 +142,7 @@ See `docs/rules/domain/agent-prompt-xml-structure.md` for canonical 6-tag patter
 
 Coverage-first review under Opus 4.7. Ver `docs/rules/domain/review-agents-reporting-policy.md`. Cada finding con `{confidence, severity}`; filter downstream rankea.
 
-## Handoff Format (SPEC-121)
+## Handoff (SPEC-121)
 
-E3→E4 handoff to `test-engineer` after review PASS (no REJECT):
-
-```yaml
----
-handoff:
-  to: test-engineer
-  spec: SPEC-NNN
-  stage: E4
-  context_hash: sha256:<8-char-prefix>
-  reason: "Code review PASS, ready for final test validation"
-  termination_reason: completed
-  artifacts:
-    - .review.crc
----
-```
-
-If verdict is REJECT, use `termination_reason: unrecoverable_error` and route back to developer. See `docs/rules/domain/agent-handoff-protocol.md`.
+PASS→`test-engineer` E4 · REJECT→developer `termination_reason: unrecoverable_error`.
+See `docs/rules/domain/agent-handoff-protocol.md`.

--- a/.claude/agents/court-orchestrator.md
+++ b/.claude/agents/court-orchestrator.md
@@ -94,3 +94,23 @@ Opus 4.7 under-spawns by default. Fan-out paralelo en un turno para items indepe
 ## Reporting Policy (SE-066)
 
 Coverage-first review under Opus 4.7. Ver `docs/rules/domain/review-agents-reporting-policy.md`. Cada finding con `{confidence, severity}`; filter downstream rankea.
+
+## Handoff Format (SPEC-121)
+
+When routing results back to the PM or spawning developer fix cycles:
+
+```yaml
+---
+handoff:
+  to: dotnet-developer
+  spec: SPEC-NNN
+  stage: E3
+  context_hash: sha256:<8-char-prefix>
+  reason: "Court REJECT: 2 blockers require fix before merge"
+  termination_reason: unrecoverable_error
+  artifacts:
+    - .review.crc
+---
+```
+
+See `docs/rules/domain/agent-handoff-protocol.md` for fields and validator.

--- a/.claude/agents/dotnet-developer.md
+++ b/.claude/agents/dotnet-developer.md
@@ -116,3 +116,24 @@ Implement exactly what the spec defines — no more, no less — with zero compi
 - All tests pass on first run after implementation
 - Coverage >= 80% for new code
 - Code review approval without REJECT verdict
+
+## Handoff Format (SPEC-121)
+
+E2→E3 handoff to `code-reviewer` after implementation + tests pass:
+
+```yaml
+---
+handoff:
+  to: code-reviewer
+  spec: SPEC-NNN
+  stage: E3
+  context_hash: sha256:<8-char-prefix>
+  reason: "Implementation complete, tests green, ready for review"
+  termination_reason: completed
+  artifacts:
+    - src/Feature/ServiceFile.cs
+    - tests/Feature/ServiceTests.cs
+---
+```
+
+See `docs/rules/domain/agent-handoff-protocol.md` for fields and validator.

--- a/.claude/agents/sdd-spec-writer.md
+++ b/.claude/agents/sdd-spec-writer.md
@@ -122,3 +122,23 @@ Produce specs so unambiguous that any developer — human or AI — can implemen
 - Developer agents implement from spec without follow-up questions
 - All test cases include concrete data (no "valid input" placeholders)
 - Zero spec rewrites caused by missing context
+
+## Handoff Format (SPEC-121)
+
+E1→E2 handoff to `dotnet-developer` or `frontend-developer` after spec approval:
+
+```yaml
+---
+handoff:
+  to: dotnet-developer
+  spec: SPEC-NNN
+  stage: E2
+  context_hash: sha256:<8-char-prefix>
+  reason: "Spec approved, ready for implementation"
+  termination_reason: completed
+  artifacts:
+    - docs/propuestas/SPEC-NNN-title.md
+---
+```
+
+See `docs/rules/domain/agent-handoff-protocol.md` for fields and validator.

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -130,3 +130,23 @@ En flujo SDD, los tests se escriben **ANTES** del código de producción:
 - **Un assert lógico por test** (puede haber múltiples líneas de assertion si van juntas)
 - **Tests deterministas**: si un test falla intermitentemente, es un bug en el test
 - **No testar implementación, testar comportamiento**: si cambias el nombre de un método privado, ningún test debería romperse
+
+## Handoff Format (SPEC-121)
+
+E4 completion handoff to orchestrator after all tests validated:
+
+```yaml
+---
+handoff:
+  to: court-orchestrator
+  spec: SPEC-NNN
+  stage: E4
+  context_hash: sha256:<8-char-prefix>
+  reason: "All tests pass, coverage ≥80%, spec complete"
+  termination_reason: completed
+  artifacts:
+    - tests/FeatureTests.cs
+---
+```
+
+See `docs/rules/domain/agent-handoff-protocol.md` for fields and validator.

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -131,22 +131,7 @@ En flujo SDD, los tests se escriben **ANTES** del código de producción:
 - **Tests deterministas**: si un test falla intermitentemente, es un bug en el test
 - **No testar implementación, testar comportamiento**: si cambias el nombre de un método privado, ningún test debería romperse
 
-## Handoff Format (SPEC-121)
+## Handoff (SPEC-121)
 
-E4 completion handoff to orchestrator after all tests validated:
-
-```yaml
----
-handoff:
-  to: court-orchestrator
-  spec: SPEC-NNN
-  stage: E4
-  context_hash: sha256:<8-char-prefix>
-  reason: "All tests pass, coverage ≥80%, spec complete"
-  termination_reason: completed
-  artifacts:
-    - tests/FeatureTests.cs
----
-```
-
-See `docs/rules/domain/agent-handoff-protocol.md` for fields and validator.
+E4 completion → `court-orchestrator` when tests pass and coverage ≥80%.
+See `docs/rules/domain/agent-handoff-protocol.md`.

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=79c5e7e6835924ade2249074a627ae35409c1bc4a117e8ad0c47aa0794f3384e
 timestamp=2026-04-25T11:52:49Z
 branch=agent/batch53-spec121-handoff-completion-20260425
-head_commit=0468baf2
+head_commit=0f4e579c
 signature=ffb6e698e6a325770743f757fa249a56fb756dd3ebced7aa7f2d4391e7795d66

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=44a1b09d6266ea5d7d0e89311cd0b7aaecf20583d881449367508fb1be926ccc
-timestamp=2026-04-25T11:10:35Z
-branch=agent/batch52-spec055-drift-era186-closure-20260425
-head_commit=69536f7c
-signature=8a3dcc66b5b45f732a127dfcf90b1cb197a048b4b66572933bd92145fceba3bf
+diff_hash=79c5e7e6835924ade2249074a627ae35409c1bc4a117e8ad0c47aa0794f3384e
+timestamp=2026-04-25T11:52:49Z
+branch=agent/batch53-spec121-handoff-completion-20260425
+head_commit=0468baf2
+signature=ffb6e698e6a325770743f757fa249a56fb756dd3ebced7aa7f2d4391e7795d66

--- a/CHANGELOG.d/agent-batch53-spec121-handoff-completion-20260425.md
+++ b/CHANGELOG.d/agent-batch53-spec121-handoff-completion-20260425.md
@@ -1,0 +1,19 @@
+## [6.4.0] — 2026-04-25
+
+Batch 53 — SPEC-121 handoff-as-function convention **IMPLEMENTED** (3 ACs faltantes completados).
+
+### Changed
+- `.claude/agents/sdd-spec-writer.md` — sección "Handoff Format (SPEC-121)" añadida: E1→E2 handoff a dotnet-developer tras spec approval.
+- `.claude/agents/dotnet-developer.md` — sección "Handoff Format (SPEC-121)" añadida: E2→E3 handoff a code-reviewer tras implementation + tests green.
+- `.claude/agents/code-reviewer.md` — sección "Handoff Format (SPEC-121)" añadida: E3→E4 a test-engineer (PASS) o developer (REJECT con termination_reason=unrecoverable_error).
+- `.claude/agents/test-engineer.md` — sección "Handoff Format (SPEC-121)" añadida: E4 completion a court-orchestrator.
+- `.claude/agents/court-orchestrator.md` — sección "Handoff Format (SPEC-121)" añadida: REJECT routing back a dotnet-developer.
+- `docs/agent-notes-protocol.md` — sección "Cuándo usar agent-notes vs handoff-as-function" añadida con tabla de decisión y regla práctica ("si cabe en 7 campos, usa handoff-as-function").
+- `docs/propuestas/SPEC-121-handoff-convention.md` — status PROPOSED → IMPLEMENTED. Resolution section con 6/6 ACs cumplidos.
+
+### Context
+SPEC-121 AC-01/03/04 ya estaban implementados desde batches previos (validator extendido, bats certified 81, protocol doc). Este PR completó los 3 AC faltantes: actualizaciones de los 5 agentes piloto (AC-02), cross-doc en agent-notes-protocol (AC-05), y CHANGELOG (AC-06).
+
+Diseño aditivo: los cambios son secciones opcionales que guían el output del agente. Sin ruptura de comportamiento existente. El protocolo longform agent-notes se mantiene para casos que requieren párrafos.
+
+Version bump 6.3.0 → 6.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [6.4.0] — 2026-04-25
+
+Batch 53 — SPEC-121 handoff-as-function convention **IMPLEMENTED** (3 ACs faltantes completados).
+
+### Changed
+- 5 agentes SDD actualizados con sección "Handoff Format (SPEC-121)": sdd-spec-writer, dotnet-developer, code-reviewer, test-engineer, court-orchestrator.
+- `docs/agent-notes-protocol.md`: tabla de decisión handoff-as-function vs agent-notes longform.
+- `docs/propuestas/SPEC-121-handoff-convention.md`: status PROPOSED → IMPLEMENTED, 6/6 ACs cumplidos.
+
+### Context
+ACs 01/03/04 ya implementados; completados AC-02/05/06. Aditivo, sin ruptura.
+
+Version bump 6.3.0 → 6.4.0.
+
 ## [6.3.0] — 2026-04-25
 
 Batch 52 — SPEC-055 status drift correction + Era 186 hook ratchet **CLOSURE** + sweep bug fix + baseline tighten.
@@ -28,20 +42,6 @@ PR-A del plan post-#695. Era 186 hook coverage ratchet finales:
 Próximo: SPEC-121 (3 ACs), SPEC-122 (4 ACs).
 
 Version bump 6.2.0 → 6.3.0.
-## [6.4.0] — 2026-04-25
-
-Batch 53 — SPEC-121 handoff-as-function convention **IMPLEMENTED** (3 ACs faltantes completados).
-
-### Changed
-- 5 agentes SDD actualizados con sección "Handoff Format (SPEC-121)": sdd-spec-writer, dotnet-developer, code-reviewer, test-engineer, court-orchestrator.
-- `docs/agent-notes-protocol.md`: tabla de decisión handoff-as-function vs agent-notes longform.
-- `docs/propuestas/SPEC-121-handoff-convention.md`: status PROPOSED → IMPLEMENTED, 6/6 ACs cumplidos.
-
-### Context
-ACs 01/03/04 ya implementados; completados AC-02/05/06. Aditivo, sin ruptura.
-
-Version bump 6.3.0 → 6.4.0.
-
 ## [6.2.0] — 2026-04-25
 
 Batch 51 — Hook coverage +3: token-tracker-middleware, subagent-lifecycle, task-lifecycle. **100% HOOK COVERAGE — 58/58.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ PR-A del plan post-#695. Era 186 hook coverage ratchet finales:
 Próximo: SPEC-121 (3 ACs), SPEC-122 (4 ACs).
 
 Version bump 6.2.0 → 6.3.0.
+## [6.4.0] — 2026-04-25
+
+Batch 53 — SPEC-121 handoff-as-function convention **IMPLEMENTED** (3 ACs faltantes completados).
+
+### Changed
+- 5 agentes SDD actualizados con sección "Handoff Format (SPEC-121)": sdd-spec-writer, dotnet-developer, code-reviewer, test-engineer, court-orchestrator.
+- `docs/agent-notes-protocol.md`: tabla de decisión handoff-as-function vs agent-notes longform.
+- `docs/propuestas/SPEC-121-handoff-convention.md`: status PROPOSED → IMPLEMENTED, 6/6 ACs cumplidos.
+
+### Context
+ACs 01/03/04 ya implementados; completados AC-02/05/06. Aditivo, sin ruptura.
+
+Version bump 6.3.0 → 6.4.0.
 
 ## [6.2.0] — 2026-04-25
 
@@ -8446,6 +8459,7 @@ Initial public release of PM-Workspace.
 - **Documentation** with methodology
 
 [6.3.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.2.0...v6.3.0
+[6.4.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.3.0...v6.4.0
 [6.2.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v6.1.0...v6.2.0
 [6.1.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.98.0...v6.1.0
 [5.98.0]: https://github.com/gonzalezpazmonica/pm-workspace/compare/v5.97.0...v5.98.0

--- a/docs/agent-notes-protocol.md
+++ b/docs/agent-notes-protocol.md
@@ -102,3 +102,19 @@ Si existen, las lee como contexto. Si no, procede con el contexto estándar (spe
 ## Limpieza
 
 Las agent-notes de sprints cerrados se archivan en `agent-notes/archive/{sprint}/` al final de cada sprint review. El PM puede archivar manualmente con `/agent-notes-archive`.
+
+---
+
+## Cuándo usar agent-notes vs handoff-as-function
+
+SPEC-121 introduce `handoff-as-function` como protocolo ligero para transiciones simples E1→E2→E3→E4:
+
+| Situación | Protocolo | Documento |
+|---|---|---|
+| Handoff simple con artefactos claros (≤7 campos) | **handoff-as-function** | `docs/rules/domain/agent-handoff-protocol.md` |
+| Research multi-turn, decisión compleja, discusión | **agent-notes** (este doc) | `docs/agent-notes-protocol.md` |
+| Broadcasting a múltiples agentes | **agent-notes** (este doc) | `docs/agent-notes-protocol.md` |
+
+**Regla práctica**: si el handoff cabe en 7 campos YAML, usa `handoff-as-function`. Si necesitas párrafos explicativos, análisis de contexto o múltiples receptores, usa agent-notes.
+
+Validación de handoff-as-function: `bash scripts/validate-handoff.sh --file handoff.yaml`.

--- a/docs/propuestas/SPEC-121-handoff-convention.md
+++ b/docs/propuestas/SPEC-121-handoff-convention.md
@@ -1,11 +1,14 @@
 ---
 id: SPEC-121
 title: Handoff-as-function convention para SDD E1→E2→E3
-status: PROPOSED
+status: IMPLEMENTED
 origin: Savia autonomous roadmap — Top pick #8 del research 2026-04-17
 author: Savia
 related: SAVIA-SUPERPOWERS-ROADMAP.md
 priority: alta
+applied_at: "2026-04-25"
+implemented_at: "2026-04-25"
+era: 187
 ---
 
 # SPEC-121 — Handoff Convention
@@ -104,3 +107,16 @@ Time-box: 45 min. Riesgo principal: ruptura de agentes existentes que dependan d
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) — patrón original
 - `docs/agent-notes-protocol.md` — protocolo longform existente
 - `scripts/validate-handoff.sh` — validator existente
+
+## Resolution (2026-04-25)
+
+SPEC-121 completado en Era 187 (batch 53). Todos los 6 AC cumplidos:
+
+- [x] AC-01 `docs/rules/domain/agent-handoff-protocol.md` — creado, formato canónico con 7 campos, tabla cuándo-usar-cuál
+- [x] AC-02 5 agentes actualizados con sección "Handoff Format" — sdd-spec-writer (E1→E2), dotnet-developer (E2→E3), code-reviewer (E3→E4 o REJECT), test-engineer (E4→completion), court-orchestrator (REJECT→developer)
+- [x] AC-03 `scripts/validate-handoff.sh` extendido — extrae to/spec/stage/context_hash/reason via grep-regex
+- [x] AC-04 `tests/test-handoff-as-function.bats` — certified score 81 (verifica handoff válido pasa, malformado falla)
+- [x] AC-05 `docs/agent-notes-protocol.md` — sección "Cuándo usar agent-notes vs handoff-as-function" añadida con tabla de decisión
+- [x] AC-06 CHANGELOG entry — batch 53
+
+Diseño aditivo: ningún agente rompió. Handoff-as-function es sección opcional que guía el output del agente cuando necesita transferir control. El protocol longform (agent-notes) se mantiene para casos complejos.


### PR DESCRIPTION
## Summary
feat: batch 53 SPEC-121 IMPLEMENTED — handoff-as-function 6/6 ACs
### Changes
- ecc63e3e fix(ci): trim code-reviewer (163→148) and test-engineer (152→137) under 150-line limit
- 25427d4c feat: batch 53 SPEC-121 IMPLEMENTED — handoff-as-function 6/6 ACs
### Stats
10 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
