### PR TITLE
fix: batch 65 SE-074 polish — plan ports match spawn ports

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -2,5 +2,5 @@
 diff_hash=ded264d7011c95875a5cc5211aa33331ee64502bac813bdeaa43d3efd75ddf72
 timestamp=2026-04-26T14:09:34Z
 branch=agent/se074-polish-20260426
-head_commit=224dc603
+head_commit=9b963e90
 signature=1eb664621f974d737d89f82798d9866e4a88b88dbf24d51a003a65edac957b4d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=515639476e7422b706e24163afa286a964dc61b5f3e3ed51fe550d39293a2da7
-timestamp=2026-04-26T13:32:13Z
-branch=agent/se074-fixes-20260426
-head_commit=3b2b922c
-signature=f19fc664804f9959fc054fb1c3f11262135bdac1d201037f0b81ec039af10f06
+diff_hash=ded264d7011c95875a5cc5211aa33331ee64502bac813bdeaa43d3efd75ddf72
+timestamp=2026-04-26T14:09:34Z
+branch=agent/se074-polish-20260426
+head_commit=224dc603
+signature=1eb664621f974d737d89f82798d9866e4a88b88dbf24d51a003a65edac957b4d

--- a/CHANGELOG.d/agent-batch65-se074-polish-20260426.md
+++ b/CHANGELOG.d/agent-batch65-se074-polish-20260426.md
@@ -1,0 +1,18 @@
+## [6.16.0] — 2026-04-26
+
+Batch 65 — SE-074 polish — alineación timestamp/ports plan↔spawn (deja la herramienta sin roces para empezar a usarla en serio mañana).
+
+### Fixed
+- `scripts/parallel-specs-orchestrator.sh` — el bloque `Plan per spec` mostraba puertos que no se acababan usando. La causa: la fase de plan y `spawn_worker` llamaban a `date(1)` por separado y con formatos distintos (`%Y%m%d%H%M%S` vs `%Y%m%d-%H%M%S` UTC), de modo que `allocate_ports` hashing producía dos asignaciones diferentes. Ahora se calcula un único `RUN_TS` al inicio del script y `SPEC_WORKTREE_NAMES` + `SPEC_PORTS` se rellenan una vez en la fase de validación; tanto el plan como el spawn leen de esos maps. Plan output ahora coincide con la realidad (verificado con regression test #27).
+
+### Changed
+- `scripts/parallel-specs-orchestrator.sh` — el header del plan incluye una línea `run timestamp : <RUN_TS>` para correlacionar el output con los worktrees creados en disco (`.claude/worktrees/spec-<id>-<RUN_TS>/`).
+
+### Tests
+- `tests/structure/test-parallel-specs-orchestrator.bats` — 2 regression tests añadidos:
+  - `#27 plan ports match spawn ports for every spec` — corre el orchestrator real con 3 specs y verifica que cada `Plan per spec` line tenga los mismos `ports=` que la `spawned` line correspondiente.
+  - `#28 plan run-timestamp line is printed` — sanity check del header.
+- 28/28 pasan. 18/18 adaptive-halting + 33/33 spec-budget también pasan.
+
+### Spec ref
+SE-074 (`docs/propuestas/SE-074-parallel-spec-execution.md`) — IMPLEMENTED. Polish dentro del scope de Slices 1+1.5; ningún AC nuevo, ningún cambio de comportamiento funcional (los puertos asignados a cada spec son los mismos que antes en spawn — sólo la línea informativa del plan estaba desalineada).

--- a/scripts/parallel-specs-orchestrator.sh
+++ b/scripts/parallel-specs-orchestrator.sh
@@ -142,8 +142,14 @@ resolve_cmd() {
 
 mkdir -p "${PARALLEL_RUNS_DIR}" "${WORKTREES_DIR}"
 
+# Single timestamp for the whole invocation — keeps plan output and the
+# worktree/tmp/port allocation in spawn_worker in lock-step. Without this,
+# plan and spawn called date(1) independently and produced different
+# worktree names → different port hashes → plan output became misleading.
+RUN_TS=$(date -u +%Y%m%d-%H%M%S)
+
 # Validate all specs first (fail-fast before spawning)
-declare -A SPEC_FILES SPEC_EFFORTS SPEC_BUDGETS
+declare -A SPEC_FILES SPEC_EFFORTS SPEC_BUDGETS SPEC_WORKTREE_NAMES SPEC_PORTS
 for spec_id in "${SPEC_LIST[@]}"; do
   spec_file=$(locate_spec "${spec_id}") || { echo "ERROR: spec not found: ${spec_id}" >&2; exit 1; }
   SPEC_FILES["${spec_id}"]="${spec_file}"
@@ -156,6 +162,9 @@ for spec_id in "${SPEC_LIST[@]}"; do
   SPEC_EFFORTS["${spec_id}"]="${effort_tier}"
   budget=$(bash "${ROOT}/scripts/spec-budget.sh" "${effort_tier}" "${spec_id}")
   SPEC_BUDGETS["${spec_id}"]="${budget}"
+  worktree_name="spec-${spec_id}-${RUN_TS}"
+  SPEC_WORKTREE_NAMES["${spec_id}"]="${worktree_name}"
+  SPEC_PORTS["${spec_id}"]=$(allocate_ports "${worktree_name}")
 done
 
 # Plan summary
@@ -164,13 +173,12 @@ echo "  specs queued       : ${#SPEC_LIST[@]}"
 echo "  max parallel       : ${MAX_PARALLEL_SPECS}"
 echo "  max runtime/worker : ${MAX_RUNTIME_MINUTES}m"
 echo "  worker cmd template: ${SPEC_WORKER_CMD}"
+echo "  run timestamp      : ${RUN_TS}"
 echo ""
 echo "  Plan per spec:"
 for spec_id in "${SPEC_LIST[@]}"; do
-  worktree_name="spec-${spec_id}-$(date +%Y%m%d%H%M%S)"
-  ports=$(allocate_ports "${worktree_name}")
   printf "    %-12s  effort=%s budget=%s ports=%s\n" \
-    "${spec_id}" "${SPEC_EFFORTS[${spec_id}]}" "${SPEC_BUDGETS[${spec_id}]}" "${ports}"
+    "${spec_id}" "${SPEC_EFFORTS[${spec_id}]}" "${SPEC_BUDGETS[${spec_id}]}" "${SPEC_PORTS[${spec_id}]}"
 done
 
 if [[ "${DRY_RUN}" == "1" ]]; then
@@ -193,10 +201,11 @@ FAILURES=0
 
 spawn_worker() {
   local spec_id="$1"
-  local timestamp; timestamp=$(date -u +%Y%m%d-%H%M%S)
-  local worktree_name="spec-${spec_id}-${timestamp}"
+  # Read pre-computed names from the plan stage so plan output and actual
+  # spawn share one timestamp and the same port allocation.
+  local worktree_name="${SPEC_WORKTREE_NAMES[${spec_id}]}"
   local worktree="${WORKTREES_DIR}/${worktree_name}"
-  local ports; ports=$(allocate_ports "${worktree_name}")
+  local ports="${SPEC_PORTS[${spec_id}]}"
   local budget="${SPEC_BUDGETS[${spec_id}]}"
   local effort="${SPEC_EFFORTS[${spec_id}]}"
   local tmp_dir="/tmp/savia-${worktree_name}"

--- a/tests/structure/test-parallel-specs-orchestrator.bats
+++ b/tests/structure/test-parallel-specs-orchestrator.bats
@@ -274,3 +274,32 @@ SPEC
   [[ "$output" == *"effort=S budget=2"* ]]
   [[ "$output" == *"effort=M budget=3"* ]]
 }
+
+@test "regression: plan ports match spawn ports for every spec" {
+  # Bug: the plan loop and spawn_worker each computed their own date(1) timestamp
+  # in different formats, so allocate_ports hashed two different worktree names
+  # and the "Plan per spec" line printed ports that were never used. Now both
+  # read from a single pre-computed SPEC_PORTS map keyed by spec_id.
+  make_spec "SE-145" "S"
+  make_spec "SE-146" "M"
+  make_spec "SE-147" "L"
+  MAX_RUNTIME_MINUTES=1 SPEC_WORKER_CMD='bash -c "echo OK-{spec_id}"' \
+    run bash "$SCRIPT" SE-145 SE-146 SE-147
+  [ "$status" -eq 0 ]
+  for spec in SE-145 SE-146 SE-147; do
+    plan_ports=$(echo "$output" | awk -v s="$spec" '$1==s { for(i=2;i<=NF;i++) if ($i ~ /^ports=/) print $i }' | head -1)
+    spawn_ports=$(echo "$output" | awk -v s="$spec" '$1=="spawned" && $2==s { for(i=3;i<=NF;i++) if ($i ~ /^ports=/) print $i }' | head -1)
+    [ -n "$plan_ports" ]
+    [ -n "$spawn_ports" ]
+    [ "$plan_ports" = "$spawn_ports" ]
+  done
+}
+
+@test "regression: plan run-timestamp line is printed" {
+  # Sanity: plan summary now exposes the single RUN_TS used across spawn,
+  # so users can correlate plan output with the worktree dirs on disk.
+  make_spec "SE-148" "M"
+  run bash "$SCRIPT" --dry-run SE-148
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"run timestamp"* ]]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR ejecuta el segundo y tercer item del Critical Path: SE-074 paralelismo de specs (Slice 1) y adaptive halting (Slice 1.5). Cambia la forma en que Savia trabaja: de procesar un plan a la vez a procesar hasta 5 simultáneamente, con criterios inteligentes para saber cuándo cada worker ha terminado de verdad.

Hasta ahora, cuando había varios specs aprobados pendientes de implementar, Savia los hacía uno tras otro. Cada plan tarda cinco a treinta minutos entre escribir código, correr tests, ajustar y abrir PR. Tres planes seguidos son fácilmente media tarde. Con paralelismo, esos tres planes pueden ejecutarse simultáneamente en sesiones aisladas y terminar en el tiempo del más largo, no la suma de los tres. La ganancia real es entre tres y cuatro veces, no cinco lineales, porque hay coordinación que no paraleliza (revisar PRs, resolver conflictos de cascade rebase, esperar CI).

El orquestador (parallel-specs-orchestrator.sh) recibe una lista de specs, crea un worktree git aislado para cada uno, le asigna un rango de puertos único y un directorio temporal propio, y lanza un comando configurable (por defecto Claude Code, pero puede ser OpenCode o cualquier CLI). Tiene cap duro de 5 workers concurrentes — más allá de eso ni la RAM de la máquina ni los rate-limits del LLM lo soportan. El default es 3 por experiencia operativa. Si un worker falla, los demás siguen sin tocarse — failure aislado por diseño.

La parte de adaptive halting (Slice 1.5) viene del paper Kohli et al. 2026 (arXiv:2604.07822) sobre transformers recurrentes. La idea trasplantada es que un worker NO debe declarar "hecho" la primera vez que los tests pasen, porque a veces los tests pasan en una iteración pero el worker sigue ajustando archivos en la siguiente. El criterio de parada exige dos cosas a la vez: convergencia (el árbol de archivos no cambia entre iteraciones) Y confianza alta (≥75% por defecto, configurable). Esto evita PRs flaky que parecían listos pero no lo estaban.

La otra pieza del paper es el presupuesto de reintentos dinámico. En lugar de un máximo fijo de 3 intentos por worker, cada spec recibe un budget calculado por una distribución Poisson recortada según su effort field (S, M, o L). Specs pequeños tienen budget 2; los grandes hasta 8. El modo determinístico por defecto devuelve siempre el lambda recortado para que CI/tests sean reproducibles, pero hay opción opt-in de muestreo estocástico seedeado por el spec ID si se quisiera variabilidad.

Acompaña 56 tests BATS distribuidos en tres suites (orchestrator, budget, halting), todas certified por test-auditor con scores 88, 85 y 81. La regla operativa queda documentada en docs/rules/domain/parallel-spec-execution.md con todos los flags, garantías de seguridad (no auto-merge, AUTONOMOUS_REVIEWER intacto, hard cap), y casos en los que NO usar paralelismo (specs con dependencias entre sí, o que tocan los mismos archivos).

SE-074 pasa a IMPLEMENTED para Slices 1 y 1.5; las Slices 2 (PR queue cascade-rebase auto) y 3 (DB sandbox + cleanup async) quedan diferidas a batches futuros — el paralelismo ya es funcional sin ellas, esos slices son hardening adicional.

Esta funcionalidad es portable a cualquier proyecto: el comando del worker es configurable, y los workers no asumen ninguna infraestructura específica de pm-workspace más allá de git worktrees y un directorio para logs.
## Summary
fix: batch 65 SE-074 polish — plan ports match spawn ports
### Changes
- 224dc603 fix: batch 65 SE-074 polish — plan ports match spawn ports
### Stats
4 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
