### PR TITLE
feat: batch 66 SE-074 Slice 2 IMPLEMENTED — PR queue + cascade-rebase

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ded264d7011c95875a5cc5211aa33331ee64502bac813bdeaa43d3efd75ddf72
-timestamp=2026-04-26T14:09:34Z
-branch=agent/se074-polish-20260426
-head_commit=9b963e90
-signature=1eb664621f974d737d89f82798d9866e4a88b88dbf24d51a003a65edac957b4d
+diff_hash=09bd29526bd65c5a59f64b0d782137094a0eb8745775997c174c83317edf9fa5
+timestamp=2026-04-26T15:14:51Z
+branch=agent/se074-slice2-merge-queue-20260426
+head_commit=da612ebb
+signature=bcff73cd4135ac8163ce7a0bed7dffd9c65b0d9afab580d720ba5ef46afc902c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=09bd29526bd65c5a59f64b0d782137094a0eb8745775997c174c83317edf9fa5
-timestamp=2026-04-26T15:14:51Z
+timestamp=2026-04-26T15:14:52Z
 branch=agent/se074-slice2-merge-queue-20260426
-head_commit=da612ebb
+head_commit=829067ef
 signature=bcff73cd4135ac8163ce7a0bed7dffd9c65b0d9afab580d720ba5ef46afc902c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=09bd29526bd65c5a59f64b0d782137094a0eb8745775997c174c83317edf9fa5
-timestamp=2026-04-26T15:14:52Z
+diff_hash=6f4d552561fda427a044892d5573939ada13f5d5d5ce34360849880e780361b0
+timestamp=2026-04-26T16:19:02Z
 branch=agent/se074-slice2-merge-queue-20260426
-head_commit=829067ef
-signature=bcff73cd4135ac8163ce7a0bed7dffd9c65b0d9afab580d720ba5ef46afc902c
+head_commit=84ff1b69
+signature=def8e9be1e7f403bc1abe7434827031729fbb4c7295810489f0a2b258e76f946

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=6f4d552561fda427a044892d5573939ada13f5d5d5ce34360849880e780361b0
-timestamp=2026-04-26T16:19:02Z
+timestamp=2026-04-26T16:19:03Z
 branch=agent/se074-slice2-merge-queue-20260426
-head_commit=84ff1b69
+head_commit=eef58cd2
 signature=def8e9be1e7f403bc1abe7434827031729fbb4c7295810489f0a2b258e76f946

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 6ff9765fd932 | resources: 1090
-> 530 commands · 86 skills · 65 agents · 409 scripts
+> hash: b4d62cb3bed8 | resources: 1091
+> 530 commands · 86 skills · 65 agents · 410 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -195,6 +195,7 @@
 [development] mcp-server — claude,code,expone,herramientas,otros — cmd:.claude/commands/mcp-server.md
 [development] nd-autoconfig — accessibility,auto,autoconfig,configure,neurodivergent — script:scripts/nd-autoconfig.sh
 [development] nidos-dev-lib — lifecycle,nidos,savia,server,spec — script:scripts/nidos-dev-lib.sh
+[development] parallel-specs-merge-queue — cascade,merge,parallel,queue,rebase — script:scripts/parallel-specs-merge-queue.sh
 [development] parallel-specs-orchestrator — execution,orchestrates,orchestrator,parallel,slice — script:scripts/parallel-specs-orchestrator.sh
 [development] pdf-extract-probe — extract,feasibility,probe,slice,spec — script:scripts/pdf-extract-probe.sh
 [development] pipeline-artifacts —  — cmd:.claude/commands/pipeline-artifacts.md

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 121 resources
+> 122 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **Trace Analyze** (cmd): Análisis profundo de trazas específicas con detección de cuellos de botella y cadenas de errores
@@ -57,6 +57,7 @@
 - **mcp-server** (cmd): Expone las herramientas de Savia como MCP server para otros proyectos Claude Code
 - **nd-autoconfig** (script): nd-autoconfig.sh — SPEC-061: Auto-configure accessibility.md from neurodivergent.md
 - **nidos-dev-lib** (script): nidos-dev-lib.sh — Dev server lifecycle for Savia nidos (SPEC-098).
+- **parallel-specs-merge-queue** (script): parallel-specs-merge-queue.sh — SE-074 Slice 2 — PR queue + cascade-rebase
 - **parallel-specs-orchestrator** (script): parallel-specs-orchestrator.sh — SE-074 Slice 1 — orchestrates parallel spec execution
 - **pdf-extract-probe** (script): pdf-extract-probe.sh — SPEC-102 Slice 1 feasibility probe.
 - **pipeline-artifacts** (cmd): >

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "938b37a1cc28",
-  "total": 1090,
+  "hash": "94d4e791cc1d",
+  "total": 1091,
   "resources": [
     {
       "category": "analysis",
@@ -2438,6 +2438,20 @@
       "kind": "script",
       "path": "scripts/nidos-dev-lib.sh",
       "description": "nidos-dev-lib.sh — Dev server lifecycle for Savia nidos (SPEC-098)."
+    },
+    {
+      "category": "development",
+      "name": "parallel-specs-merge-queue",
+      "intents": [
+        "cascade",
+        "merge",
+        "parallel",
+        "queue",
+        "rebase"
+      ],
+      "kind": "script",
+      "path": "scripts/parallel-specs-merge-queue.sh",
+      "description": "parallel-specs-merge-queue.sh — SE-074 Slice 2 — PR queue + cascade-rebase"
     },
     {
       "category": "development",

--- a/CHANGELOG.d/agent-batch66-se074-slice2-merge-queue-20260426.md
+++ b/CHANGELOG.d/agent-batch66-se074-slice2-merge-queue-20260426.md
@@ -1,0 +1,32 @@
+## [6.17.0] — 2026-04-26
+
+Batch 66 — SE-074 Slice 2 IMPLEMENTED — PR queue + cascade-rebase auto-resolve.
+
+### Added
+- `scripts/parallel-specs-merge-queue.sh` — Slice 2 core. Gestiona la cola FIFO de branches producidas por el orchestrator paralelo y aplica el patrón cascade-rebase documentado en `feedback_changelog_cascade_rebase`. Subcomandos: `add`, `remove`, `list`, `status`, `clear --confirm`, `rebase <branch>`, `rebase-next`. Auto-resolve sólo para conflictos restringidos a `CHANGELOG.md` + `CHANGELOG.d/`; cualquier otra divergencia ESCALA con `git rebase --abort` y mensaje detallado a la usuaria.
+- `tests/structure/test-parallel-specs-merge-queue.bats` — 32 tests, score 88 certificado.
+- Sección "Merge queue (Slice 2)" añadida a `docs/rules/domain/parallel-spec-execution.md` con comandos, scope de auto-resolve y límites de seguridad.
+
+### Hard safety boundaries (autonomous-safety.md)
+- NUNCA hace `git push`
+- NUNCA hace `gh pr merge` ni equivalente
+- NUNCA force-pushes
+- NUNCA auto-resuelve un conflicto fuera de `CHANGELOG.md` / `CHANGELOG.d/`
+- Se niega a operar con working tree dirty (vía `git status --porcelain`)
+- `MAX_REBASE_STEPS` (default 30) como guard rail anti-loop
+
+### Acceptance criteria cumplidos (Slice 2)
+- ✅ AC-10 PR queue manager merge-en-orden con cascade-rebase auto-resolve para CHANGELOG
+- ✅ AC-11 Conflictos no-CHANGELOG escalados (no auto-merge), output `ESCALATE: <ficheros>` por stderr
+
+### Tests breakdown (32/32 pass, score 88)
+- 3 dispatch (usage / help / unknown subcmd)
+- 8 queue CRUD (add idempotente, remove idempotente, list missing/merged/ready/needs-rebase, status totales)
+- 2 clear (refusal sin --confirm, success con)
+- 8 rebase (branch missing, dirty tree, ya merged, ahead-only, conflicto CHANGELOG.md, fragment-only, escalación non-CHANGELOG, vuelta a rama original)
+- 3 rebase-next (queue vacía, skip merged + rebase stale, no-op si ready)
+- 3 safety estática (ningún `git push` o `gh pr merge`, `set -uo pipefail`, MAX_REBASE_STEPS guard)
+- 3 spec ref (SE-074 Slice 2, parallel-spec-execution.md, autonomous-safety.md, cascade-rebase header)
+
+### Spec ref
+SE-074 (`docs/propuestas/SE-074-parallel-spec-execution.md`) Slice 2 → IMPLEMENTED. Quedan Slice 3 (resource isolation hardening: DB sandbox, network namespace, cleanup stale worktrees) y la actualización del frontmatter del spec para reflejar Slice 2 completo.

--- a/docs/rules/domain/parallel-spec-execution.md
+++ b/docs/rules/domain/parallel-spec-execution.md
@@ -32,6 +32,26 @@ SPEC_WORKER_CMD='opencode -w {worktree} --spec {spec_id}' \
   bash scripts/parallel-specs-orchestrator.sh SE-073
 ```
 
+### Merge queue (Slice 2)
+
+```bash
+# Encolar branches según orden de finalización
+bash scripts/parallel-specs-merge-queue.sh add agent/se-073-slice1-...
+bash scripts/parallel-specs-merge-queue.sh add agent/se-076-slice1-...
+
+# Ver estado de cada branch (ready / needs-rebase / merged / missing)
+bash scripts/parallel-specs-merge-queue.sh list
+bash scripts/parallel-specs-merge-queue.sh status
+
+# Tras un merge en main, rebase la siguiente en cola con auto-resolve CHANGELOG
+bash scripts/parallel-specs-merge-queue.sh rebase-next
+
+# Rebase explícito de una branch concreta
+bash scripts/parallel-specs-merge-queue.sh rebase agent/se-076-slice1-...
+```
+
+**Auto-resolve scope**: el cascade-rebase resuelve automáticamente conflictos en `CHANGELOG.md` y `CHANGELOG.d/` tomando la versión upstream + asumiendo que el hook post-merge regenera el archivo final. Cualquier conflicto en otro fichero se ESCALA: el rebase aborta, el árbol queda limpio y la usuaria recibe la lista de ficheros conflictivos. NUNCA auto-merge, NUNCA push, NUNCA force.
+
 ## Configuración (env vars)
 
 | Variable | Default | Descripción |

--- a/docs/rules/domain/parallel-spec-execution.md
+++ b/docs/rules/domain/parallel-spec-execution.md
@@ -34,23 +34,7 @@ SPEC_WORKER_CMD='opencode -w {worktree} --spec {spec_id}' \
 
 ### Merge queue (Slice 2)
 
-```bash
-# Encolar branches según orden de finalización
-bash scripts/parallel-specs-merge-queue.sh add agent/se-073-slice1-...
-bash scripts/parallel-specs-merge-queue.sh add agent/se-076-slice1-...
-
-# Ver estado de cada branch (ready / needs-rebase / merged / missing)
-bash scripts/parallel-specs-merge-queue.sh list
-bash scripts/parallel-specs-merge-queue.sh status
-
-# Tras un merge en main, rebase la siguiente en cola con auto-resolve CHANGELOG
-bash scripts/parallel-specs-merge-queue.sh rebase-next
-
-# Rebase explícito de una branch concreta
-bash scripts/parallel-specs-merge-queue.sh rebase agent/se-076-slice1-...
-```
-
-**Auto-resolve scope**: el cascade-rebase resuelve automáticamente conflictos en `CHANGELOG.md` y `CHANGELOG.d/` tomando la versión upstream + asumiendo que el hook post-merge regenera el archivo final. Cualquier conflicto en otro fichero se ESCALA: el rebase aborta, el árbol queda limpio y la usuaria recibe la lista de ficheros conflictivos. NUNCA auto-merge, NUNCA push, NUNCA force.
+Tras `pr-plan` verde, las branches se gestionan vía `scripts/parallel-specs-merge-queue.sh`. Ver regla dedicada en `docs/rules/domain/parallel-spec-merge-queue.md` (auto-resolve restringido a `CHANGELOG.*`, escalación obligatoria fuera de ese scope).
 
 ## Configuración (env vars)
 
@@ -75,11 +59,7 @@ Default 3 reflejado por experiencia operativa.
 
 ## Aislamiento por worker
 
-Cada worker recibe:
-- **Worktree git** propio en `.claude/worktrees/spec-<id>-<timestamp>/`
-- **Tmp dir** aislado en `/tmp/savia-spec-<id>-<timestamp>/` (export `TMPDIR`)
-- **Port range** único derivado de hash(name) — evita colisión bridge/proxy
-- **Budget** de retries computado dinámicamente desde effort field (Slice 1.5)
+Cada worker recibe: worktree git propio, tmp dir aislado (`TMPDIR` exportado), port range único derivado de hash(name), y budget de retries computado dinámicamente desde el effort field (Slice 1.5).
 
 ## Adaptive halting (Slice 1.5)
 

--- a/docs/rules/domain/parallel-spec-merge-queue.md
+++ b/docs/rules/domain/parallel-spec-merge-queue.md
@@ -1,0 +1,84 @@
+# Regla: Parallel Spec Merge Queue
+
+> Coordina el orden de merge de las branches producidas por `parallel-specs-orchestrator.sh`. Operativo desde Slice 2 de SE-074. NUNCA mergea, NUNCA hace push, NUNCA force.
+
+## Cuándo usar
+
+- Tienes ≥2 branches `agent/...` derivadas de paralelismo de specs (SE-074 Slice 1)
+- Quieres rebases en cascada deterministas tras cada merge humano
+
+## Cuándo NO usar
+
+- Branches con cambios no-CHANGELOG en archivos compartidos → resolución humana
+- PRs sin pasar por `pr-plan` antes (la cola asume PRs verdes localmente)
+
+## Comandos
+
+```bash
+# Encolar branches según orden de finalización
+bash scripts/parallel-specs-merge-queue.sh add agent/se-073-slice1-...
+bash scripts/parallel-specs-merge-queue.sh add agent/se-076-slice1-...
+
+# Ver estado de cada branch (ready / needs-rebase / merged / missing)
+bash scripts/parallel-specs-merge-queue.sh list
+bash scripts/parallel-specs-merge-queue.sh status
+
+# Tras un merge en main, rebase la siguiente con auto-resolve CHANGELOG
+bash scripts/parallel-specs-merge-queue.sh rebase-next
+
+# Rebase explícito de una branch concreta
+bash scripts/parallel-specs-merge-queue.sh rebase agent/se-076-slice1-...
+
+# Drop branch de la cola (idempotente)
+bash scripts/parallel-specs-merge-queue.sh remove agent/se-073-slice1-...
+
+# Vaciar cola (requiere --confirm)
+bash scripts/parallel-specs-merge-queue.sh clear --confirm
+```
+
+## Auto-resolve scope
+
+El cascade-rebase resuelve automáticamente conflictos cuyos archivos están TODOS dentro de:
+
+- `CHANGELOG.md`
+- `CHANGELOG.d/`
+
+La resolución es siempre `--ours` (la versión upstream, es decir main + commits ya replayed). El hook post-merge `changelog-consolidate-if-needed.sh` regenera el archivo final.
+
+## Escalación obligatoria
+
+Cualquier conflicto fuera del scope anterior dispara `git rebase --abort` y deja el árbol limpio. Output a stderr:
+
+```
+ESCALATE: non-CHANGELOG conflicts on agent/foo:
+  src/auth/middleware.ts
+  tests/integration/login.bats
+```
+
+La usuaria resuelve manualmente. Sin shortcuts.
+
+## Configuración (env vars)
+
+| Variable | Default | Descripción |
+|---|---|---|
+| `QUEUE_FILE` | `.claude/parallel-merge-queue` | Archivo plano, una branch por línea |
+| `MAIN_BRANCH` | `main` | Rama base |
+| `MAX_REBASE_STEPS` | 30 | Guard rail anti-loop en cascade-rebase |
+
+## Garantías de seguridad (autonomous-safety)
+
+- ❌ NO ejecuta `git push`
+- ❌ NO ejecuta `gh pr merge` ni equivalente
+- ❌ NO ejecuta `git push --force`
+- ❌ NO auto-resuelve un conflicto fuera de `CHANGELOG.*`
+- ✅ Se niega a operar con working tree dirty (`git status --porcelain`)
+- ✅ `MAX_REBASE_STEPS` corta cualquier loop patológico
+- ✅ Vuelve a la rama original tras escalación
+
+## Referencias
+
+- SE-074 Slice 2 spec — `docs/propuestas/SE-074-parallel-spec-execution.md`
+- `feedback_changelog_cascade_rebase` (auto-memory) — patrón ya conocido pre-Slice 2
+- `docs/rules/domain/autonomous-safety.md` — gates inviolables
+- `docs/rules/domain/parallel-spec-execution.md` — orquestador (Slice 1+1.5)
+- `scripts/parallel-specs-merge-queue.sh` — implementación

--- a/scripts/parallel-specs-merge-queue.sh
+++ b/scripts/parallel-specs-merge-queue.sh
@@ -37,7 +37,8 @@
 #   3 — environment error (dirty tree, missing branch, missing main, etc.)
 #
 # Reference: SE-074 Slice 2 (docs/propuestas/SE-074-parallel-spec-execution.md)
-# Reference: docs/rules/domain/parallel-spec-execution.md
+# Reference: docs/rules/domain/parallel-spec-merge-queue.md (canonical doc)
+# Reference: docs/rules/domain/parallel-spec-execution.md (Slice 1+1.5 context)
 # Reference: docs/rules/domain/autonomous-safety.md
 
 set -uo pipefail

--- a/scripts/parallel-specs-merge-queue.sh
+++ b/scripts/parallel-specs-merge-queue.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# parallel-specs-merge-queue.sh — SE-074 Slice 2 — PR queue + cascade-rebase
+#
+# Coordinates the merge order of stacked PRs produced by
+# parallel-specs-orchestrator.sh. Implements the cascade-rebase pattern
+# documented in `feedback_changelog_cascade_rebase` so that, when a PR ahead
+# in the queue lands, the next branch is rebased onto the new main with
+# CHANGELOG.md / CHANGELOG.d/ conflicts auto-resolved (because the conflict
+# is purely mechanical: each batch adds its own fragment file or version
+# block) and EVERYTHING ELSE escalated to the user.
+#
+# Hard safety boundaries (autonomous-safety.md):
+#   - NEVER pushes
+#   - NEVER merges PRs
+#   - NEVER force-pushes
+#   - NEVER auto-resolves a non-CHANGELOG conflict
+#   - Refuses to operate on a dirty working tree
+#
+# Subcommands:
+#   add <branch>       Append a branch to the queue (no-op if already present)
+#   list               Print the queue with each branch's status vs main
+#   remove <branch>    Drop a branch from the queue
+#   rebase <branch>    Rebase one branch onto current main with auto-resolve
+#   rebase-next        Find the first non-merged branch in the queue and rebase it
+#   status             Short summary line (counts of ready / blocked / merged)
+#   clear              Empty the queue (requires --confirm)
+#
+# Env (all optional):
+#   QUEUE_FILE         default .claude/parallel-merge-queue
+#   MAIN_BRANCH        default "main"
+#   MAX_REBASE_STEPS   safeguard against infinite loops, default 30
+#
+# Exit codes:
+#   0 — success (or queue empty / no rebase needed)
+#   1 — escalation: a real conflict was found, user action required
+#   2 — usage error
+#   3 — environment error (dirty tree, missing branch, missing main, etc.)
+#
+# Reference: SE-074 Slice 2 (docs/propuestas/SE-074-parallel-spec-execution.md)
+# Reference: docs/rules/domain/parallel-spec-execution.md
+# Reference: docs/rules/domain/autonomous-safety.md
+
+set -uo pipefail
+
+ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+QUEUE_FILE="${QUEUE_FILE:-${ROOT}/.claude/parallel-merge-queue}"
+MAIN_BRANCH="${MAIN_BRANCH:-main}"
+MAX_REBASE_STEPS="${MAX_REBASE_STEPS:-30}"
+
+usage() {
+  cat <<USG
+Usage: parallel-specs-merge-queue.sh <subcommand> [args]
+
+Subcommands:
+  add <branch>       Append a branch to the queue
+  list               Print queue with per-branch status
+  remove <branch>    Drop a branch from the queue
+  rebase <branch>    Rebase one branch onto ${MAIN_BRANCH}
+  rebase-next        Rebase the first non-merged branch in the queue
+  status             Short summary
+  clear --confirm    Empty the queue
+
+Env (key):
+  QUEUE_FILE        default ${QUEUE_FILE}
+  MAIN_BRANCH       default ${MAIN_BRANCH}
+USG
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+die() { echo "ERROR: $*" >&2; exit "${2:-3}"; }
+
+ensure_queue_file() {
+  local dir; dir=$(dirname "${QUEUE_FILE}")
+  mkdir -p "${dir}"
+  [[ -f "${QUEUE_FILE}" ]] || : > "${QUEUE_FILE}"
+}
+
+read_queue() {
+  ensure_queue_file
+  # Strip blank lines and inline comments (one branch per line)
+  grep -v -E '^\s*(#|$)' "${QUEUE_FILE}" 2>/dev/null || true
+}
+
+queue_contains() {
+  local branch="$1"
+  read_queue | grep -Fxq "${branch}"
+}
+
+require_clean_tree() {
+  # `git status --porcelain` covers tracked diffs AND untracked files; the
+  # weaker `git diff` check missed bare drop-ins like `scratch.txt`.
+  local dirty; dirty=$(git -C "${ROOT}" status --porcelain 2>/dev/null)
+  if [[ -n "${dirty}" ]]; then
+    die "working tree dirty — commit or stash before invoking the queue manager" 3
+  fi
+}
+
+require_branch_exists() {
+  local branch="$1"
+  git -C "${ROOT}" show-ref --verify --quiet "refs/heads/${branch}" \
+    || die "local branch not found: ${branch}" 3
+}
+
+require_main_exists() {
+  git -C "${ROOT}" show-ref --verify --quiet "refs/heads/${MAIN_BRANCH}" \
+    || die "main branch not found locally: ${MAIN_BRANCH}" 3
+}
+
+# Returns 0 when the branch is fully reachable from main (i.e. effectively merged)
+branch_is_merged() {
+  local branch="$1"
+  local merge_base head_main
+  head_main=$(git -C "${ROOT}" rev-parse "${MAIN_BRANCH}")
+  merge_base=$(git -C "${ROOT}" merge-base "${MAIN_BRANCH}" "${branch}" 2>/dev/null || echo "")
+  local head_branch; head_branch=$(git -C "${ROOT}" rev-parse "${branch}")
+  # Either branch HEAD is an ancestor of main, or branch HEAD == main HEAD
+  git -C "${ROOT}" merge-base --is-ancestor "${head_branch}" "${head_main}" 2>/dev/null
+}
+
+# Counts how many commits a branch is ahead/behind main
+branch_ahead_behind() {
+  local branch="$1"
+  git -C "${ROOT}" rev-list --left-right --count "${MAIN_BRANCH}...${branch}" 2>/dev/null \
+    || echo "? ?"
+}
+
+# ── Subcommands ───────────────────────────────────────────────────────────────
+
+cmd_add() {
+  local branch="${1:-}"
+  [[ -z "${branch}" ]] && { usage >&2; exit 2; }
+  ensure_queue_file
+  if queue_contains "${branch}"; then
+    echo "already queued: ${branch}"
+    return 0
+  fi
+  echo "${branch}" >> "${QUEUE_FILE}"
+  echo "queued: ${branch}"
+}
+
+cmd_remove() {
+  local branch="${1:-}"
+  [[ -z "${branch}" ]] && { usage >&2; exit 2; }
+  ensure_queue_file
+  if ! queue_contains "${branch}"; then
+    echo "not queued: ${branch}"
+    return 0
+  fi
+  local tmp; tmp=$(mktemp)
+  grep -Fxv "${branch}" "${QUEUE_FILE}" > "${tmp}" || true
+  mv "${tmp}" "${QUEUE_FILE}"
+  echo "removed: ${branch}"
+}
+
+cmd_list() {
+  ensure_queue_file
+  local count=0
+  echo "queue (${QUEUE_FILE}):"
+  while IFS= read -r branch; do
+    count=$((count + 1))
+    if ! git -C "${ROOT}" show-ref --verify --quiet "refs/heads/${branch}"; then
+      printf "  %2d  %-50s  [missing-branch]\n" "${count}" "${branch}"
+      continue
+    fi
+    if branch_is_merged "${branch}"; then
+      printf "  %2d  %-50s  [merged]\n" "${count}" "${branch}"
+      continue
+    fi
+    local ab; ab=$(branch_ahead_behind "${branch}")
+    local behind ahead
+    behind=$(echo "${ab}" | awk '{print $1}')
+    ahead=$(echo "${ab}" | awk '{print $2}')
+    if [[ "${behind}" == "0" ]]; then
+      printf "  %2d  %-50s  [ready ahead=%s]\n" "${count}" "${branch}" "${ahead}"
+    else
+      printf "  %2d  %-50s  [needs-rebase ahead=%s behind=%s]\n" "${count}" "${branch}" "${ahead}" "${behind}"
+    fi
+  done < <(read_queue)
+  if [[ "${count}" -eq 0 ]]; then
+    echo "  (empty)"
+  fi
+}
+
+cmd_status() {
+  ensure_queue_file
+  local total=0 merged=0 ready=0 blocked=0 missing=0
+  while IFS= read -r branch; do
+    total=$((total + 1))
+    if ! git -C "${ROOT}" show-ref --verify --quiet "refs/heads/${branch}"; then
+      missing=$((missing + 1)); continue
+    fi
+    if branch_is_merged "${branch}"; then
+      merged=$((merged + 1)); continue
+    fi
+    local ab; ab=$(branch_ahead_behind "${branch}")
+    local behind; behind=$(echo "${ab}" | awk '{print $1}')
+    if [[ "${behind}" == "0" ]]; then
+      ready=$((ready + 1))
+    else
+      blocked=$((blocked + 1))
+    fi
+  done < <(read_queue)
+  echo "queue: total=${total} merged=${merged} ready=${ready} needs-rebase=${blocked} missing=${missing}"
+}
+
+cmd_clear() {
+  if [[ "${1:-}" != "--confirm" ]]; then
+    echo "Pass --confirm to actually clear the queue file." >&2
+    exit 2
+  fi
+  ensure_queue_file
+  : > "${QUEUE_FILE}"
+  echo "queue cleared"
+}
+
+# Auto-resolve cascading CHANGELOG conflicts during a rebase. Returns 0 if the
+# rebase finished cleanly, 1 if it had to escalate. The function aborts the
+# rebase before returning 1 so the working tree is left in a sane state.
+attempt_cascade_rebase() {
+  local branch="$1"
+  local rebase_dir
+  local steps=0
+  local non_changelog=""
+
+  if git -C "${ROOT}" rebase "${MAIN_BRANCH}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  while :; do
+    rebase_dir=$(git -C "${ROOT}" rev-parse --git-path rebase-merge 2>/dev/null)
+    [[ -d "${rebase_dir}" ]] || rebase_dir=$(git -C "${ROOT}" rev-parse --git-path rebase-apply 2>/dev/null)
+    [[ -d "${rebase_dir}" ]] || break
+
+    steps=$((steps + 1))
+    if [[ "${steps}" -gt "${MAX_REBASE_STEPS}" ]]; then
+      git -C "${ROOT}" rebase --abort >/dev/null 2>&1 || true
+      echo "ABORT: exceeded MAX_REBASE_STEPS=${MAX_REBASE_STEPS} on ${branch}" >&2
+      return 1
+    fi
+
+    local conflicted; conflicted=$(git -C "${ROOT}" diff --name-only --diff-filter=U)
+    if [[ -z "${conflicted}" ]]; then
+      # No conflicts; rebase paused for some other reason (empty commit, etc.)
+      GIT_EDITOR=true git -C "${ROOT}" rebase --continue >/dev/null 2>&1 || {
+        git -C "${ROOT}" rebase --abort >/dev/null 2>&1 || true
+        echo "ABORT: --continue failed without conflicts on ${branch}" >&2
+        return 1
+      }
+      continue
+    fi
+
+    non_changelog=$(echo "${conflicted}" | grep -v -E '^(CHANGELOG\.md|CHANGELOG\.d/)' || true)
+    if [[ -n "${non_changelog}" ]]; then
+      git -C "${ROOT}" rebase --abort >/dev/null 2>&1 || true
+      echo "ESCALATE: non-CHANGELOG conflicts on ${branch}:" >&2
+      echo "${non_changelog}" | sed 's/^/  /' >&2
+      return 1
+    fi
+
+    # Auto-resolve: take the upstream (main + already-replayed) version verbatim.
+    # Our fragment files in CHANGELOG.d/ are ADDED on this branch — they have no
+    # base, so git keeps them in the working tree without conflict markers.
+    # The conflict, if any, is on CHANGELOG.md (regenerated on both sides) and
+    # we deliberately defer regeneration to the post-merge consolidate hook.
+    local f
+    while IFS= read -r f; do
+      [[ -z "${f}" ]] && continue
+      git -C "${ROOT}" checkout --ours -- "${f}" >/dev/null 2>&1 \
+        || { git -C "${ROOT}" rebase --abort >/dev/null 2>&1 || true; echo "ABORT: checkout --ours failed for ${f}" >&2; return 1; }
+      git -C "${ROOT}" add -- "${f}"
+    done <<< "${conflicted}"
+
+    GIT_EDITOR=true git -C "${ROOT}" rebase --continue >/dev/null 2>&1 || {
+      # If --continue fails, the rebase usually moves to next conflict; loop again.
+      :
+    }
+  done
+
+  return 0
+}
+
+cmd_rebase() {
+  local branch="${1:-}"
+  [[ -z "${branch}" ]] && { usage >&2; exit 2; }
+  require_clean_tree
+  require_main_exists
+  require_branch_exists "${branch}"
+  if branch_is_merged "${branch}"; then
+    echo "skip: ${branch} already merged"
+    return 0
+  fi
+
+  local original_branch; original_branch=$(git -C "${ROOT}" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  git -C "${ROOT}" checkout "${branch}" >/dev/null 2>&1 \
+    || die "could not checkout ${branch}" 3
+
+  if attempt_cascade_rebase "${branch}"; then
+    echo "rebased OK: ${branch}"
+    if [[ -n "${original_branch}" && "${original_branch}" != "${branch}" ]]; then
+      git -C "${ROOT}" checkout "${original_branch}" >/dev/null 2>&1 || true
+    fi
+    return 0
+  else
+    if [[ -n "${original_branch}" && "${original_branch}" != "${branch}" ]]; then
+      git -C "${ROOT}" checkout "${original_branch}" >/dev/null 2>&1 || true
+    fi
+    return 1
+  fi
+}
+
+cmd_rebase_next() {
+  ensure_queue_file
+  while IFS= read -r branch; do
+    if ! git -C "${ROOT}" show-ref --verify --quiet "refs/heads/${branch}"; then
+      continue
+    fi
+    if branch_is_merged "${branch}"; then
+      continue
+    fi
+    local ab; ab=$(branch_ahead_behind "${branch}")
+    local behind; behind=$(echo "${ab}" | awk '{print $1}')
+    if [[ "${behind}" == "0" ]]; then
+      echo "skip: ${branch} already up-to-date with ${MAIN_BRANCH}"
+      return 0
+    fi
+    cmd_rebase "${branch}"
+    return $?
+  done < <(read_queue)
+  echo "no rebase candidate in queue"
+  return 0
+}
+
+# ── Dispatcher ────────────────────────────────────────────────────────────────
+
+CMD="${1:-}"
+shift || true
+
+case "${CMD}" in
+  add)          cmd_add "$@" ;;
+  remove)       cmd_remove "$@" ;;
+  list)         cmd_list "$@" ;;
+  status)       cmd_status "$@" ;;
+  clear)        cmd_clear "$@" ;;
+  rebase)       cmd_rebase "$@" ;;
+  rebase-next)  cmd_rebase_next "$@" ;;
+  --help|-h|help) usage; exit 0 ;;
+  "") usage >&2; exit 2 ;;
+  *)  echo "Unknown subcommand: ${CMD}" >&2; usage >&2; exit 2 ;;
+esac

--- a/tests/structure/test-parallel-specs-merge-queue.bats
+++ b/tests/structure/test-parallel-specs-merge-queue.bats
@@ -1,0 +1,360 @@
+#!/usr/bin/env bats
+# Ref: SE-074 Slice 2 — parallel-specs-merge-queue.sh
+
+setup() {
+  ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$ROOT_DIR/scripts/parallel-specs-merge-queue.sh"
+
+  # Isolated git repo per test
+  REPO=$(mktemp -d)
+  cd "$REPO"
+  git init -q -b main
+  git config user.email "test@savia.local"
+  git config user.name "Savia Test"
+  echo "# repo" > README.md
+  git add README.md
+  git commit -q -m "init"
+
+  # Keep the queue file outside the repo so it never trips the dirty-tree gate
+  QUEUE_FILE=$(mktemp -u --tmpdir parallel-merge-queue.XXXXXX)
+  export QUEUE_FILE
+  export PROJECT_ROOT="$REPO"
+}
+
+teardown() {
+  cd /
+  rm -rf "$REPO"
+  rm -f "$QUEUE_FILE"
+}
+
+# Helper: create a branch from main with a single fragment commit
+make_branch_with_fragment() {
+  local branch="$1" fragname="$2" body="${3:-changelog body}"
+  git checkout -q -b "$branch" main
+  mkdir -p CHANGELOG.d
+  printf "## [%s] — 2026-04-26\n\n%s\n" "$fragname" "$body" > "CHANGELOG.d/${fragname}.md"
+  git add "CHANGELOG.d/${fragname}.md"
+  git commit -q -m "feat: add ${fragname}"
+  git checkout -q main
+}
+
+# Helper: create a branch that ALSO touches CHANGELOG.md (the rebase-conflict scenario)
+make_branch_touching_changelog_md() {
+  local branch="$1" line="$2"
+  git checkout -q -b "$branch" main
+  echo "$line" >> CHANGELOG.md
+  git add CHANGELOG.md
+  git commit -q -m "feat: bump CHANGELOG ($line)"
+  git checkout -q main
+}
+
+# Helper: bump main forward with a CHANGELOG.md change so the branch will conflict
+bump_main_changelog() {
+  local line="$1"
+  git checkout -q main
+  echo "$line" >> CHANGELOG.md
+  git add CHANGELOG.md
+  git commit -q -m "main: bump ${line}"
+}
+
+# Helper: real (non-CHANGELOG) divergence so we test escalation
+make_branch_modifying_readme() {
+  local branch="$1" body="$2"
+  git checkout -q -b "$branch" main
+  echo "$body" >> README.md
+  git add README.md
+  git commit -q -m "feat: edit README"
+  git checkout -q main
+}
+
+bump_main_readme() {
+  local body="$1"
+  git checkout -q main
+  echo "$body" >> README.md
+  git add README.md
+  git commit -q -m "main: edit README"
+}
+
+# ── Usage / dispatch ─────────────────────────────────────────────────────────
+
+@test "queue: prints usage when no args" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "queue: --help exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "queue: rejects unknown subcommand" {
+  run bash "$SCRIPT" frobnicate
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Unknown"* ]]
+}
+
+# ── add / remove / list ──────────────────────────────────────────────────────
+
+@test "queue: add appends branch and is idempotent" {
+  run bash "$SCRIPT" add agent/foo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"queued: agent/foo"* ]]
+  run bash "$SCRIPT" add agent/foo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already queued"* ]]
+  [ "$(grep -c '^agent/foo$' "$QUEUE_FILE")" -eq 1 ]
+}
+
+@test "queue: add requires a branch argument" {
+  run bash "$SCRIPT" add
+  [ "$status" -eq 2 ]
+}
+
+@test "queue: list on empty queue prints (empty)" {
+  run bash "$SCRIPT" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(empty)"* ]]
+}
+
+@test "queue: list shows missing-branch tag for queued-but-deleted branch" {
+  bash "$SCRIPT" add agent/never-existed >/dev/null
+  run bash "$SCRIPT" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"missing-branch"* ]]
+}
+
+@test "queue: list flags branch fully merged into main" {
+  make_branch_with_fragment "agent/already-merged" "1.0.0" "merged body"
+  git merge -q --no-ff agent/already-merged -m "merge"
+  bash "$SCRIPT" add agent/already-merged >/dev/null
+  run bash "$SCRIPT" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"merged"* ]]
+}
+
+@test "queue: list shows ready when branch is ahead 0/N from main" {
+  make_branch_with_fragment "agent/ready" "1.0.0"
+  bash "$SCRIPT" add agent/ready >/dev/null
+  run bash "$SCRIPT" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ready ahead=1"* ]]
+}
+
+@test "queue: list shows needs-rebase when main has moved" {
+  make_branch_with_fragment "agent/stale" "1.0.0"
+  bump_main_changelog "[2.0.0]: link"
+  bash "$SCRIPT" add agent/stale >/dev/null
+  run bash "$SCRIPT" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"needs-rebase"* ]]
+  [[ "$output" == *"behind=1"* ]]
+}
+
+@test "queue: remove drops a branch and is idempotent" {
+  bash "$SCRIPT" add agent/x >/dev/null
+  bash "$SCRIPT" add agent/y >/dev/null
+  run bash "$SCRIPT" remove agent/x
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"removed"* ]]
+  ! grep -q '^agent/x$' "$QUEUE_FILE"
+  grep -q '^agent/y$' "$QUEUE_FILE"
+  run bash "$SCRIPT" remove agent/x
+  [[ "$output" == *"not queued"* ]]
+}
+
+# ── status ───────────────────────────────────────────────────────────────────
+
+@test "queue: status reports zero on empty queue" {
+  run bash "$SCRIPT" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"total=0"* ]]
+}
+
+@test "queue: status counts ready / needs-rebase / merged / missing" {
+  # Order matters: create stale BEFORE bumping main, then merge done so main
+  # advances, THEN branch ready off the new tip so it's at zero-behind.
+  make_branch_with_fragment "agent/stale" "1.0.0"
+  make_branch_with_fragment "agent/done" "2.0.0"
+  git merge -q --no-ff agent/done -m "merge done"
+  make_branch_with_fragment "agent/ready" "3.0.0"
+  bash "$SCRIPT" add agent/ready >/dev/null
+  bash "$SCRIPT" add agent/stale >/dev/null
+  bash "$SCRIPT" add agent/done >/dev/null
+  bash "$SCRIPT" add agent/ghost >/dev/null
+  run bash "$SCRIPT" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"total=4"* ]]
+  [[ "$output" == *"merged=1"* ]]
+  [[ "$output" == *"ready=1"* ]]
+  [[ "$output" == *"needs-rebase=1"* ]]
+  [[ "$output" == *"missing=1"* ]]
+}
+
+# ── clear ────────────────────────────────────────────────────────────────────
+
+@test "queue: clear refuses without --confirm" {
+  bash "$SCRIPT" add agent/foo >/dev/null
+  run bash "$SCRIPT" clear
+  [ "$status" -eq 2 ]
+  grep -q 'agent/foo' "$QUEUE_FILE"
+}
+
+@test "queue: clear --confirm empties queue file" {
+  bash "$SCRIPT" add agent/foo >/dev/null
+  run bash "$SCRIPT" clear --confirm
+  [ "$status" -eq 0 ]
+  [ ! -s "$QUEUE_FILE" ]
+}
+
+# ── rebase ───────────────────────────────────────────────────────────────────
+
+@test "rebase: requires existing local branch" {
+  run bash "$SCRIPT" rebase agent/does-not-exist
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"local branch not found"* ]]
+}
+
+@test "rebase: refuses on dirty working tree" {
+  make_branch_with_fragment "agent/dirty-test" "1.0.0"
+  echo "uncommitted" > scratch.txt
+  run bash "$SCRIPT" rebase agent/dirty-test
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"working tree dirty"* ]]
+  rm -f scratch.txt
+}
+
+@test "rebase: skips branch already merged" {
+  make_branch_with_fragment "agent/done" "1.0.0"
+  git merge -q --no-ff agent/done -m "merge"
+  run bash "$SCRIPT" rebase agent/done
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already merged"* ]]
+}
+
+@test "rebase: no-op when branch is already up-to-date and ahead" {
+  make_branch_with_fragment "agent/ahead" "1.0.0"
+  run bash "$SCRIPT" rebase agent/ahead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rebased OK"* ]]
+}
+
+@test "rebase: auto-resolves CHANGELOG.md conflict (cascade pattern)" {
+  # Both main and branch touch CHANGELOG.md → real rebase conflict.
+  # The script must take main's version and keep going.
+  make_branch_touching_changelog_md "agent/branch-changelog" "[1.0.0]: branch"
+  bump_main_changelog "[2.0.0]: main"
+  run bash "$SCRIPT" rebase agent/branch-changelog
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rebased OK"* ]]
+  # Verify the branch tip has main's CHANGELOG.md content
+  git checkout -q agent/branch-changelog
+  grep -q '\[2.0.0\]: main' CHANGELOG.md
+  git checkout -q main
+}
+
+@test "rebase: auto-resolves when branch only adds a CHANGELOG.d/ fragment" {
+  # Branch adds a fragment; main bumped CHANGELOG.md. No real conflict — fragment
+  # is a new file. Rebase should succeed cleanly.
+  make_branch_with_fragment "agent/fragment-only" "9.9.9"
+  bump_main_changelog "[main-bump]: link"
+  run bash "$SCRIPT" rebase agent/fragment-only
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rebased OK"* ]]
+  git checkout -q agent/fragment-only
+  [ -f "CHANGELOG.d/9.9.9.md" ]
+  git checkout -q main
+}
+
+@test "rebase: ESCALATES on non-CHANGELOG conflict" {
+  make_branch_modifying_readme "agent/readme-edit" "from branch"
+  bump_main_readme "from main"
+  run bash "$SCRIPT" rebase agent/readme-edit
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ESCALATE"* ]]
+  [[ "$output" == *"README.md"* ]]
+  # Working tree must be left clean — rebase aborted
+  run git -C "$REPO" status --porcelain
+  [ -z "$output" ]
+  # And we must not be mid-rebase
+  [ ! -d "$REPO/.git/rebase-merge" ]
+  [ ! -d "$REPO/.git/rebase-apply" ]
+}
+
+@test "rebase: returns to original branch after escalation" {
+  make_branch_modifying_readme "agent/readme-edit-2" "from branch"
+  bump_main_readme "from main"
+  git checkout -q main
+  bash "$SCRIPT" rebase agent/readme-edit-2 || true
+  current=$(git symbolic-ref --short HEAD)
+  [ "$current" = "main" ]
+}
+
+# ── rebase-next ──────────────────────────────────────────────────────────────
+
+@test "rebase-next: empty queue is a no-op" {
+  run bash "$SCRIPT" rebase-next
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no rebase candidate"* ]]
+}
+
+@test "rebase-next: skips merged branches and rebases the first stale one" {
+  make_branch_with_fragment "agent/done-1" "1.0.0"
+  git merge -q --no-ff agent/done-1 -m "merge done-1"
+  make_branch_with_fragment "agent/stale-1" "2.0.0"
+  bump_main_changelog "[main-bump]: link"
+  bash "$SCRIPT" add agent/done-1 >/dev/null
+  bash "$SCRIPT" add agent/stale-1 >/dev/null
+  run bash "$SCRIPT" rebase-next
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rebased OK: agent/stale-1"* ]]
+}
+
+@test "rebase-next: returns 0 when first branch is already up-to-date" {
+  make_branch_with_fragment "agent/ahead" "1.0.0"
+  bash "$SCRIPT" add agent/ahead >/dev/null
+  run bash "$SCRIPT" rebase-next
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already up-to-date"* ]]
+}
+
+# ── safety / hard-cap behaviour ──────────────────────────────────────────────
+
+@test "safety: script never invokes git push or merge" {
+  # Static check — defence in depth alongside the runtime tests
+  ! grep -E '^[^#]*git[[:space:]]+(push|merge[[:space:]]+--no-ff[[:space:]]+--no-edit)' "$SCRIPT"
+  ! grep -E '^[^#]*gh[[:space:]]+pr[[:space:]]+merge' "$SCRIPT"
+}
+
+@test "safety: script has set -uo pipefail" {
+  grep -q 'set -uo pipefail' "$SCRIPT"
+}
+
+@test "safety: max-rebase-steps guard rail prevents infinite loop" {
+  # If the auto-resolve loop ever spins, MAX_REBASE_STEPS=1 + a deliberate
+  # CHANGELOG.md conflict that can't be resolved in one pass should abort
+  # cleanly. We synthesise that by setting the cap to 0.
+  make_branch_touching_changelog_md "agent/spin" "[1.0.0]: branch"
+  bump_main_changelog "[2.0.0]: main"
+  MAX_REBASE_STEPS=0 run bash "$SCRIPT" rebase agent/spin
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"MAX_REBASE_STEPS"* ]]
+  [ ! -d "$REPO/.git/rebase-merge" ]
+  [ ! -d "$REPO/.git/rebase-apply" ]
+}
+
+# ── spec references ─────────────────────────────────────────────────────────
+
+@test "spec ref: SE-074 Slice 2 cited in script header" {
+  grep -q "SE-074 Slice 2" "$SCRIPT"
+}
+
+@test "spec ref: parallel-spec-execution.md and autonomous-safety.md referenced" {
+  grep -q "parallel-spec-execution.md" "$SCRIPT"
+  grep -q "autonomous-safety.md" "$SCRIPT"
+}
+
+@test "spec ref: cascade-rebase pattern named in header" {
+  grep -qi "cascade-rebase" "$SCRIPT"
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR ejecuta el segundo y tercer item del Critical Path: SE-074 paralelismo de specs (Slice 1) y adaptive halting (Slice 1.5). Cambia la forma en que Savia trabaja: de procesar un plan a la vez a procesar hasta 5 simultáneamente, con criterios inteligentes para saber cuándo cada worker ha terminado de verdad.

Hasta ahora, cuando había varios specs aprobados pendientes de implementar, Savia los hacía uno tras otro. Cada plan tarda cinco a treinta minutos entre escribir código, correr tests, ajustar y abrir PR. Tres planes seguidos son fácilmente media tarde. Con paralelismo, esos tres planes pueden ejecutarse simultáneamente en sesiones aisladas y terminar en el tiempo del más largo, no la suma de los tres. La ganancia real es entre tres y cuatro veces, no cinco lineales, porque hay coordinación que no paraleliza (revisar PRs, resolver conflictos de cascade rebase, esperar CI).

El orquestador (parallel-specs-orchestrator.sh) recibe una lista de specs, crea un worktree git aislado para cada uno, le asigna un rango de puertos único y un directorio temporal propio, y lanza un comando configurable (por defecto Claude Code, pero puede ser OpenCode o cualquier CLI). Tiene cap duro de 5 workers concurrentes — más allá de eso ni la RAM de la máquina ni los rate-limits del LLM lo soportan. El default es 3 por experiencia operativa. Si un worker falla, los demás siguen sin tocarse — failure aislado por diseño.

La parte de adaptive halting (Slice 1.5) viene del paper Kohli et al. 2026 (arXiv:2604.07822) sobre transformers recurrentes. La idea trasplantada es que un worker NO debe declarar "hecho" la primera vez que los tests pasen, porque a veces los tests pasan en una iteración pero el worker sigue ajustando archivos en la siguiente. El criterio de parada exige dos cosas a la vez: convergencia (el árbol de archivos no cambia entre iteraciones) Y confianza alta (≥75% por defecto, configurable). Esto evita PRs flaky que parecían listos pero no lo estaban.

La otra pieza del paper es el presupuesto de reintentos dinámico. En lugar de un máximo fijo de 3 intentos por worker, cada spec recibe un budget calculado por una distribución Poisson recortada según su effort field (S, M, o L). Specs pequeños tienen budget 2; los grandes hasta 8. El modo determinístico por defecto devuelve siempre el lambda recortado para que CI/tests sean reproducibles, pero hay opción opt-in de muestreo estocástico seedeado por el spec ID si se quisiera variabilidad.

Acompaña 56 tests BATS distribuidos en tres suites (orchestrator, budget, halting), todas certified por test-auditor con scores 88, 85 y 81. La regla operativa queda documentada en docs/rules/domain/parallel-spec-execution.md con todos los flags, garantías de seguridad (no auto-merge, AUTONOMOUS_REVIEWER intacto, hard cap), y casos en los que NO usar paralelismo (specs con dependencias entre sí, o que tocan los mismos archivos).

SE-074 pasa a IMPLEMENTED para Slices 1 y 1.5; las Slices 2 (PR queue cascade-rebase auto) y 3 (DB sandbox + cleanup async) quedan diferidas a batches futuros — el paralelismo ya es funcional sin ellas, esos slices son hardening adicional.

Esta funcionalidad es portable a cualquier proyecto: el comando del worker es configurable, y los workers no asumen ninguna infraestructura específica de pm-workspace más allá de git worktrees y un directorio para logs.
## Summary
feat: batch 66 SE-074 Slice 2 IMPLEMENTED — PR queue + cascade-rebase
### Changes
- da612ebb chore: regenerate .scm capability map for parallel-specs-merge-queue
- 1446a2a3 feat: batch 66 SE-074 Slice 2 IMPLEMENTED — PR queue + cascade-rebase
### Stats
8 files changed across 2 commits.
## Test plan
- [x] CI passed  - [x] Signed

Generated with [Claude Code](https://claude.com/claude-code)
