### PR TITLE
feat: batch 80 SPEC-SE-036 Slice 2 IMPLEMENTED — API key CLI suite (create/list/revoke)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e638fd3c109665793e339ae8c739c6703081f0aad6d445019e378c50c983677c
-timestamp=2026-04-28T13:27:34Z
+diff_hash=65166b6cf04e28d98fda61896a2571ddb46a617b079d5a19341c6fbb8391a329
+timestamp=2026-04-28T13:27:35Z
 branch=agent/spec-se-036-slice-2-cli-20260428
-head_commit=9f79e80a
-signature=c390deefb01b0794498c1586ebff966cc3f10f789dbd106d59cc2d613ea1bd70
+head_commit=e74fbcb6
+signature=2ba83ed73fe1a145a8ea7cb7829695b16a4af0c767a058330eea7af39c37be3f

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=e638fd3c109665793e339ae8c739c6703081f0aad6d445019e378c50c983677c
-timestamp=2026-04-28T10:32:14Z
-branch=agent/spec-se-036-jwt-mint-20260428
-head_commit=7808f490
+timestamp=2026-04-28T13:27:34Z
+branch=agent/spec-se-036-slice-2-cli-20260428
+head_commit=9f79e80a
 signature=c390deefb01b0794498c1586ebff966cc3f10f789dbd106d59cc2d613ea1bd70

--- a/CHANGELOG.d/agent-batch80-spec-se-036-slice-2-cli-20260428.md
+++ b/CHANGELOG.d/agent-batch80-spec-se-036-slice-2-cli-20260428.md
@@ -1,0 +1,52 @@
+---
+version_bump: minor
+section: Added
+---
+
+## [6.19.0] — 2026-04-28
+
+Batch 80 — SPEC-SE-036 Slice 2 IMPLEMENTED. Tres CLIs operacionales para gestionar API keys (create / list / revoke). Cierra AC-03 de SPEC-SE-036; completa el flujo CRUD que faltaba sobre la primitiva del Slice 1 (jwt-mint). Slice 3 (sunset PAT files + hooks) follow-up.
+
+### Added
+
+#### Operational CLIs
+
+- `scripts/enterprise/api-key-create.sh` — genera key fresca de 32 bytes urandom (base64url, prefijo `savia_`), inserta `sha256(plaintext)` + `key_prefix` (8 chars UX) en `api_keys`, e **imprime el plaintext exactamente una vez** con warning destructivo. Soporta `--tenant <uuid>` (validado RFC4122 shape), `--scope <csv>`, `--desc "..."`. Exit codes 2 (usage) / 3 (DSN) / 4 (psql/openssl) / 5 (insert fail).
+- `scripts/enterprise/api-key-list.sh` — inventario tabular o JSON. Filtros: `--tenant <uuid>`, `--active`, `--revoked`, `--json`. NUNCA muestra `key_hash` ni plaintext (zero-leakage por construcción). Mutually exclusive `--active` y `--revoked`. Validación UUID antes de DSN/psql checks.
+- `scripts/enterprise/api-key-revoke.sh` — revoca por prefix de 8 chars con 4 safety layers:
+  - `--prefix` requerido (no bulk)
+  - REFUSES `all` / `*` / `%` / `""` (exit 6)
+  - REFUSES wildcard chars (exit 6)
+  - Dry-run por defecto (preview row + exit 0); requiere `--confirm` para ejecutar `CALL api_key_revoke(prefix, actor)`
+  - `--actor` default `${USER}`, override para service accounts
+  - WARNING explícito post-revoke: JWTs ya minteados sobreviven hasta TTL expiry (≤ 60 min)
+
+#### Tests
+
+- `tests/structure/test-api-key-cli-suite.bats` — 35 tests certified. Cubre file-level safety×6, create negative×5, list negative×4, revoke negative×5, edge×8 (boundary, no-leak, dry-run, ttl-warning), spec ref×3, exit code documentation×3.
+
+#### Doc updates
+
+- `docs/rules/domain/savia-enterprise/agent-jwt-mint.md` — sección "CLIs operacionales (Slice 2)" añadida; "No hace" actualizado para reflejar que solo Slice 3 queda pendiente.
+
+### Acceptance criteria
+
+#### SPEC-SE-036 Slice 2 cierre
+
+- ✅ AC-03 4 CLI commands (create, list, revoke, mint) — Slice 1 ya hizo `mint`; Slice 2 completa los 3 restantes
+- 〰 AC-06 Hook `block-pat-file-write.sh` — **DEFERRED** Slice 3
+- 〰 AC-07 `block-credential-leak.sh` PAT-shaped detection — **DEFERRED** Slice 3
+- ✅ AC-09 Doc actualizado con Slice 2
+
+### Hard safety boundaries (autonomous-safety.md)
+
+- `set -uo pipefail` en los 3 CLIs.
+- `api-key-create.sh`: plaintext printado exactamente UNA vez, sin escritura a disco. Recuperación = revoke + recreate.
+- `api-key-list.sh`: zero-leakage — la SQL SELECT explícitamente excluye `key_hash` y plaintext (`grep -qE "SELECT.*key_hash"` falla, enforced por test).
+- `api-key-revoke.sh`: 4 safety layers (prefix required, no bulk, no wildcards, dry-run default + actor logging).
+- Cero red, cero git operations.
+- Cumple `docs/rules/domain/autonomous-safety.md`: rama `agent/spec-se-036-slice-2-...`, sin push automático ni merge.
+
+### Spec ref
+
+SPEC-SE-036 Slice 2 (`docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md`) → IMPLEMENTED 2026-04-28. Status spec: Slice 1 ✓ (batch 79), Slice 2 ✓ (batch 80), Slice 3 (hooks + sunset PAT) follow-up. Era 232: SE-037 closed (batch 78), SE-036 ~80% closed (queda Slice 3), próximo SE-035 reconciliation delta.

--- a/docs/rules/domain/savia-enterprise/agent-jwt-mint.md
+++ b/docs/rules/domain/savia-enterprise/agent-jwt-mint.md
@@ -111,9 +111,14 @@ Re-implementación clean-room de `dreamxist/balance` `supabase/migrations/202604
 
 ---
 
+## CLIs operacionales (Slice 2)
+
+- `scripts/enterprise/api-key-create.sh` — genera key fresca (32 bytes urandom, base64url, prefijo `savia_`), inserta `sha256(key)` + `key_prefix` en `api_keys`, **imprime el plaintext exactamente una vez**. Si la operadora pierde la key: revocar y recrear (no hay recuperación).
+- `scripts/enterprise/api-key-list.sh` — inventario filtrable por `--tenant`, `--active`, `--revoked`, `--json`. Nunca muestra `key_hash` ni plaintext (zero-leakage).
+- `scripts/enterprise/api-key-revoke.sh` — revoca por `--prefix` (8 chars). 4 safety layers: `--prefix` requerido, no bulk patterns (`all`/`*`/`%`), no wildcards, dry-run por defecto. Llama `CALL api_key_revoke(prefix, actor)`. WARNING explícito: JWTs minteados pre-revoke siguen vivos hasta TTL expiry (≤ 60 min).
+
 ## No hace (esta Slice)
 
-- NO implementa los CLI `api-key-create.sh` / `-list.sh` / `-revoke.sh` (Slice 2).
 - NO implementa hook `block-pat-file-write.sh` (Slice 3).
 - NO sunset de `~/.azure/devops-pat` (Slice 3, opt-in tras 1 sprint canary verde).
 - NO añade dependencia auth provider externo (Auth0 / Okta) — JWT firmado localmente.

--- a/scripts/enterprise/api-key-create.sh
+++ b/scripts/enterprise/api-key-create.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# api-key-create.sh — SPEC-SE-036 Slice 2: API key creation CLI.
+#
+# Generates a fresh API key (32 bytes urandom, base64url), inserts the
+# sha256 hash + key_prefix into api_keys with the requested scope, and
+# prints the plaintext **exactly once** to stdout. The plaintext is NEVER
+# stored — if the operator loses it, the only recovery is revoke + recreate.
+#
+# Requires:
+#   - SAVIA_ENTERPRISE_DSN     Postgres DSN
+#   - psql, openssl
+#
+# Usage:
+#   api-key-create.sh --tenant <uuid> --scope <s1,s2,...> [--desc "..."]
+#
+# Exit codes:
+#   0  ok (plaintext on stdout)
+#   2  usage / args invalid
+#   3  SAVIA_ENTERPRISE_DSN missing
+#   4  psql/openssl missing
+#   5  insertion failed (DSN reachable but DB error)
+#
+# Reference: SPEC-SE-036 (`docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md`)
+# Pattern source: `dreamxist/balance` `supabase/migrations/20260404000002_api_keys.sql` (MIT, clean-room)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TENANT=""
+SCOPE_CSV=""
+DESC=""
+
+usage() {
+  sed -n '2,21p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tenant) TENANT="$2"; shift 2 ;;
+    --scope)  SCOPE_CSV="$2"; shift 2 ;;
+    --desc)   DESC="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "ERROR: unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+
+if [[ -z "$TENANT" ]]; then
+  echo "ERROR: --tenant <uuid> required" >&2
+  exit 2
+fi
+
+# Loose UUID shape check (no rfc4122 strict — just sanity vs typos)
+if ! [[ "$TENANT" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "ERROR: --tenant must be a UUID (got: $TENANT)" >&2
+  exit 2
+fi
+
+if [[ -z "$SCOPE_CSV" ]]; then
+  echo "ERROR: --scope required (e.g. 'azure-devops:read,github:write')" >&2
+  exit 2
+fi
+
+if [[ -z "${SAVIA_ENTERPRISE_DSN:-}" ]]; then
+  echo "ERROR: SAVIA_ENTERPRISE_DSN env not set." >&2
+  exit 3
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql not found." >&2
+  exit 4
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "ERROR: openssl not found — required for randomness + hashing." >&2
+  exit 4
+fi
+
+# ── Generate key ─────────────────────────────────────────────────────────────
+
+# 32 random bytes → base64url. Strip padding. Prefix with 'savia_' for grep-ability.
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+RANDOM_PART=$(openssl rand 32 | b64url)
+PLAINTEXT="savia_${RANDOM_PART}"
+KEY_PREFIX="${PLAINTEXT:0:8}"
+KEY_HASH=$(printf '%s' "$PLAINTEXT" | openssl dgst -sha256 -hex | awk '{print $NF}')
+
+# Build SQL scope array literal
+SCOPE_ARR=$(printf '%s' "$SCOPE_CSV" | awk -F, '
+  BEGIN { printf "ARRAY[" }
+  {
+    for (i=1;i<=NF;i++) {
+      gsub(/^[ \t]+|[ \t]+$/, "", $i)
+      if ($i == "") continue
+      gsub(/\x27/, "\x27\x27", $i)
+      if (printed) printf ","
+      printf "\x27%s\x27", $i
+      printed=1
+    }
+  }
+  END { printf "]::text[]" }
+')
+
+DESC_LIT="NULL"
+[[ -n "$DESC" ]] && DESC_LIT="'${DESC//\'/\'\'}'"
+
+INSERT_SQL=$(cat <<SQL
+INSERT INTO api_keys (tenant_id, key_prefix, key_hash, scope, description)
+VALUES ('${TENANT//\'/\'\'}'::uuid, '$KEY_PREFIX', '$KEY_HASH', $SCOPE_ARR, $DESC_LIT)
+RETURNING id::text, key_prefix
+SQL
+)
+
+OUT=$(psql "$SAVIA_ENTERPRISE_DSN" -At -F'|' -c "$INSERT_SQL" 2>&1) || {
+  echo "ERROR: insert failed: $OUT" >&2
+  exit 5
+}
+
+# ── Output (plaintext shown ONCE) ────────────────────────────────────────────
+
+echo "============================================================"
+echo "API KEY CREATED — copy it NOW. It will not be shown again."
+echo "============================================================"
+echo "  key:      $PLAINTEXT"
+echo "  prefix:   $KEY_PREFIX"
+echo "  scope:    $SCOPE_CSV"
+echo "  tenant:   $TENANT"
+echo "  row:      $OUT"
+echo "============================================================"
+echo "Storage suggestion: ~/.savia/secrets/agent.key (mode 600)"

--- a/scripts/enterprise/api-key-list.sh
+++ b/scripts/enterprise/api-key-list.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# api-key-list.sh — SPEC-SE-036 Slice 2: API key inventory CLI.
+#
+# Lists API keys with prefix, scope, last_used_at, and revoked status. The
+# plaintext is NEVER displayed (it is not stored). Filters: --tenant, --active,
+# --revoked. Default: all keys for the connected DSN, sorted by last_used DESC.
+#
+# Requires:
+#   - SAVIA_ENTERPRISE_DSN     Postgres DSN
+#   - psql
+#
+# Usage:
+#   api-key-list.sh                          # all keys, both active and revoked
+#   api-key-list.sh --tenant <uuid>          # filter by tenant
+#   api-key-list.sh --active                 # only active (revoked_at IS NULL)
+#   api-key-list.sh --revoked                # only revoked
+#   api-key-list.sh --json                   # JSON output for tooling
+#
+# Exit codes:
+#   0  ok
+#   2  usage / args invalid
+#   3  SAVIA_ENTERPRISE_DSN missing
+#   4  psql missing
+#   5  query failed
+#
+# Reference: SPEC-SE-036 (`docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md`)
+# Pattern source: `dreamxist/balance` (MIT, clean-room)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TENANT=""
+ACTIVE_ONLY=0
+REVOKED_ONLY=0
+JSON_OUT=0
+
+usage() {
+  sed -n '2,23p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tenant)  TENANT="$2"; shift 2 ;;
+    --active)  ACTIVE_ONLY=1; shift ;;
+    --revoked) REVOKED_ONLY=1; shift ;;
+    --json)    JSON_OUT=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "ERROR: unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [[ "$ACTIVE_ONLY" -eq 1 && "$REVOKED_ONLY" -eq 1 ]]; then
+  echo "ERROR: --active and --revoked are mutually exclusive" >&2
+  exit 2
+fi
+
+# Validate UUID shape before any env/DSN/psql checks (cheap arg validation first)
+if [[ -n "$TENANT" ]] && \
+   ! [[ "$TENANT" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "ERROR: --tenant must be a UUID" >&2
+  exit 2
+fi
+
+if [[ -z "${SAVIA_ENTERPRISE_DSN:-}" ]]; then
+  echo "ERROR: SAVIA_ENTERPRISE_DSN env not set." >&2
+  exit 3
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql not found." >&2
+  exit 4
+fi
+
+# ── Build WHERE ──────────────────────────────────────────────────────────────
+
+WHERE="WHERE 1=1"
+[[ -n "$TENANT" ]] && WHERE="$WHERE AND tenant_id = '${TENANT//\'/\'\'}'::uuid"
+[[ "$ACTIVE_ONLY"  -eq 1 ]] && WHERE="$WHERE AND revoked_at IS NULL"
+[[ "$REVOKED_ONLY" -eq 1 ]] && WHERE="$WHERE AND revoked_at IS NOT NULL"
+
+# ── Run query ────────────────────────────────────────────────────────────────
+
+if [[ "$JSON_OUT" -eq 1 ]]; then
+  SQL="SELECT to_jsonb(row_to_json(t)) FROM (
+    SELECT key_prefix, tenant_id::text, scope, description,
+           created_at, last_used_at, revoked_at, revoked_by
+    FROM api_keys
+    $WHERE
+    ORDER BY last_used_at DESC NULLS LAST, created_at DESC
+  ) t"
+  out=$(psql "$SAVIA_ENTERPRISE_DSN" -At -c "$SQL" 2>&1) || {
+    echo "ERROR: query failed: $out" >&2
+    exit 5
+  }
+  printf '%s\n' "$out"
+else
+  SQL="SELECT key_prefix,
+              array_to_string(scope, ',') AS scope,
+              COALESCE(description, '-') AS description,
+              created_at::date AS created,
+              COALESCE(last_used_at::text, '-') AS last_used,
+              CASE WHEN revoked_at IS NULL THEN 'active' ELSE 'revoked' END AS status
+       FROM api_keys
+       $WHERE
+       ORDER BY last_used_at DESC NULLS LAST, created_at DESC"
+  psql "$SAVIA_ENTERPRISE_DSN" -P pager=off -P border=2 -c "$SQL" || {
+    echo "ERROR: query failed" >&2
+    exit 5
+  }
+fi

--- a/scripts/enterprise/api-key-revoke.sh
+++ b/scripts/enterprise/api-key-revoke.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# api-key-revoke.sh — SPEC-SE-036 Slice 2: API key revocation CLI.
+#
+# Marks an API key as revoked by its 8-char prefix. After revocation, future
+# calls to api_key_verify() return NULL — downstream JWTs already minted
+# remain valid until their TTL expires (max 60 minutes per SE-036 clamp).
+#
+# Requires:
+#   - SAVIA_ENTERPRISE_DSN     Postgres DSN
+#   - psql
+#
+# Safety layers:
+#   - REFUSES without --prefix
+#   - REFUSES without --confirm (default is dry-run with row preview)
+#   - REFUSES bulk patterns (--prefix all, --prefix *, --prefix '')
+#   - Defaults --actor to ${USER:-unknown}; can be overridden for service accounts
+#
+# Usage:
+#   api-key-revoke.sh --prefix <prefix>                       # dry-run
+#   api-key-revoke.sh --prefix <prefix> --confirm             # actually revoke
+#   api-key-revoke.sh --prefix <prefix> --actor svc-rotation --confirm
+#
+# Exit codes:
+#   0  ok
+#   2  usage / args invalid
+#   3  SAVIA_ENTERPRISE_DSN missing
+#   4  psql missing
+#   5  no active key with that prefix
+#   6  bulk-revoke or self-purge attempt refused
+#   7  database error
+#
+# Reference: SPEC-SE-036 (`docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md`)
+# Pattern source: `dreamxist/balance` (MIT, clean-room)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PREFIX=""
+ACTOR="${USER:-unknown}"
+CONFIRM=0
+
+usage() {
+  sed -n '2,28p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)  PREFIX="$2"; shift 2 ;;
+    --actor)   ACTOR="$2"; shift 2 ;;
+    --confirm) CONFIRM=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "ERROR: unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+
+if [[ -z "$PREFIX" ]]; then
+  echo "ERROR: --prefix required" >&2
+  usage
+fi
+
+# Refuse bulk-revoke patterns
+case "$PREFIX" in
+  ""|"*"|"all"|"%")
+    echo "ERROR: bulk revoke refused (got: '$PREFIX')" >&2
+    exit 6
+    ;;
+esac
+
+# Sanity: prefix should be the 8-char key_prefix exactly. Reject obvious wildcards.
+if [[ "$PREFIX" == *"*"* || "$PREFIX" == *"%"* ]]; then
+  echo "ERROR: wildcard refused in --prefix" >&2
+  exit 6
+fi
+
+if [[ -z "${SAVIA_ENTERPRISE_DSN:-}" ]]; then
+  echo "ERROR: SAVIA_ENTERPRISE_DSN env not set." >&2
+  exit 3
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql not found." >&2
+  exit 4
+fi
+
+# ── Pre-revoke preview ───────────────────────────────────────────────────────
+
+PREFIX_ESC="${PREFIX//\'/\'\'}"
+ACTOR_ESC="${ACTOR//\'/\'\'}"
+
+PREVIEW_SQL="SELECT key_prefix, tenant_id::text,
+                    array_to_string(scope, ',') AS scope,
+                    COALESCE(description, '-') AS description,
+                    CASE WHEN revoked_at IS NULL THEN 'active' ELSE 'already revoked at ' || revoked_at::text END AS status
+             FROM api_keys
+             WHERE key_prefix = '$PREFIX_ESC'"
+PREVIEW=$(psql "$SAVIA_ENTERPRISE_DSN" -P pager=off -P border=2 -c "$PREVIEW_SQL" 2>&1) || {
+  echo "ERROR: preview query failed: $PREVIEW" >&2
+  exit 7
+}
+
+# Check whether the key exists + is active
+COUNT_SQL="SELECT count(*) FROM api_keys WHERE key_prefix = '$PREFIX_ESC' AND revoked_at IS NULL"
+COUNT=$(psql "$SAVIA_ENTERPRISE_DSN" -At -c "$COUNT_SQL" 2>&1) || {
+  echo "ERROR: count query failed: $COUNT" >&2
+  exit 7
+}
+
+if [[ "$COUNT" -eq 0 ]]; then
+  echo "$PREVIEW"
+  echo "ERROR: no active key with prefix '$PREFIX'" >&2
+  exit 5
+fi
+
+echo "Pre-revoke preview:"
+echo "$PREVIEW"
+echo "Actor: $ACTOR"
+
+if [[ "$CONFIRM" -ne 1 ]]; then
+  echo ""
+  echo "DRY-RUN. Re-run with --confirm to proceed."
+  exit 0
+fi
+
+# ── Execute revoke ───────────────────────────────────────────────────────────
+
+REVOKE_SQL="CALL api_key_revoke('$PREFIX_ESC', '$ACTOR_ESC')"
+RESULT=$(psql "$SAVIA_ENTERPRISE_DSN" -At -c "$REVOKE_SQL" 2>&1) || {
+  echo "ERROR: revoke failed: $RESULT" >&2
+  exit 7
+}
+
+echo "OK: revoked key with prefix '$PREFIX' (actor: $ACTOR)."
+echo "Note: JWTs already minted from this key remain valid until their TTL expires (max 60 min)."

--- a/tests/structure/test-api-key-cli-suite.bats
+++ b/tests/structure/test-api-key-cli-suite.bats
@@ -1,0 +1,236 @@
+#!/usr/bin/env bats
+# Ref: SPEC-SE-036 — Slice 2 — API key CLI suite (create / list / revoke)
+# Spec: docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md
+# Pattern source: dreamxist/balance MIT (clean-room re-implementation).
+
+setup() {
+  ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="scripts/enterprise/api-key-create.sh"
+  CREATE_ABS="$ROOT_DIR/$SCRIPT"
+  LIST_ABS="$ROOT_DIR/scripts/enterprise/api-key-list.sh"
+  REVOKE_ABS="$ROOT_DIR/scripts/enterprise/api-key-revoke.sh"
+  TEMPLATE_SQL="$ROOT_DIR/docs/propuestas/savia-enterprise/templates/api-keys.sql"
+  RULE_DOC="$ROOT_DIR/docs/rules/domain/savia-enterprise/agent-jwt-mint.md"
+  TMPDIR_T=$(mktemp -d)
+  VALID_UUID="11111111-2222-3333-4444-555555555555"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_T"
+}
+
+# ── C1 — file-level safety + identity ──────────────────────────────────────
+
+@test "api-key-create.sh: file exists, has shebang, executable" {
+  [ -f "$CREATE_ABS" ]
+  head -1 "$CREATE_ABS" | grep -q '^#!'
+  [ -x "$CREATE_ABS" ]
+}
+
+@test "api-key-list.sh: file exists, has shebang, executable" {
+  [ -f "$LIST_ABS" ]
+  head -1 "$LIST_ABS" | grep -q '^#!'
+  [ -x "$LIST_ABS" ]
+}
+
+@test "api-key-revoke.sh: file exists, has shebang, executable" {
+  [ -f "$REVOKE_ABS" ]
+  head -1 "$REVOKE_ABS" | grep -q '^#!'
+  [ -x "$REVOKE_ABS" ]
+}
+
+@test "all 3 CLIs declare 'set -uo pipefail'" {
+  grep -q "set -[uo]o pipefail" "$CREATE_ABS"
+  grep -q "set -[uo]o pipefail" "$LIST_ABS"
+  grep -q "set -[uo]o pipefail" "$REVOKE_ABS"
+}
+
+@test "all 3 CLIs pass bash -n syntax check" {
+  bash -n "$CREATE_ABS"
+  bash -n "$LIST_ABS"
+  bash -n "$REVOKE_ABS"
+}
+
+@test "spec ref: SPEC-SE-036 cited in all 3 CLIs" {
+  grep -q "SPEC-SE-036" "$CREATE_ABS"
+  grep -q "SPEC-SE-036" "$LIST_ABS"
+  grep -q "SPEC-SE-036" "$REVOKE_ABS"
+}
+
+@test "attribution: dreamxist/balance MIT pattern source cited in all 3 CLIs" {
+  grep -qF "dreamxist/balance" "$CREATE_ABS"
+  grep -qF "dreamxist/balance" "$LIST_ABS"
+  grep -qF "dreamxist/balance" "$REVOKE_ABS"
+}
+
+# ── C2 — Negative paths: api-key-create.sh ──────────────────────────────────
+
+@test "create: rejects unknown CLI argument (no-arg)" {
+  run bash "$CREATE_ABS" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown arg"* ]]
+}
+
+@test "create: zero-arg invocation exits 2 (boundary)" {
+  run bash "$CREATE_ABS"
+  [ "$status" -eq 2 ]
+}
+
+@test "create: rejects non-UUID --tenant value (invalid input)" {
+  run bash "$CREATE_ABS" --tenant not-a-uuid --scope github:read
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"UUID"* ]]
+}
+
+@test "create: missing --scope exits 2 (empty)" {
+  run bash "$CREATE_ABS" --tenant "$VALID_UUID"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--scope"* ]]
+}
+
+@test "create: missing SAVIA_ENTERPRISE_DSN exits 3" {
+  run env -u SAVIA_ENTERPRISE_DSN bash "$CREATE_ABS" --tenant "$VALID_UUID" --scope github:read
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"SAVIA_ENTERPRISE_DSN"* ]]
+}
+
+# ── C3 — Negative paths: api-key-list.sh ────────────────────────────────────
+
+@test "list: rejects unknown argument" {
+  run bash "$LIST_ABS" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown arg"* ]]
+}
+
+@test "list: --active and --revoked are mutually exclusive (refuse boundary)" {
+  run env SAVIA_ENTERPRISE_DSN=dummy bash "$LIST_ABS" --active --revoked
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "list: missing SAVIA_ENTERPRISE_DSN exits 3" {
+  run env -u SAVIA_ENTERPRISE_DSN bash "$LIST_ABS"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"SAVIA_ENTERPRISE_DSN"* ]]
+}
+
+@test "list: rejects non-UUID --tenant filter" {
+  run env SAVIA_ENTERPRISE_DSN=dummy bash "$LIST_ABS" --tenant not-a-uuid
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"UUID"* ]]
+}
+
+# ── C4 — Negative paths: api-key-revoke.sh ──────────────────────────────────
+
+@test "revoke: REFUSES without --prefix (no bulk)" {
+  run bash "$REVOKE_ABS"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--prefix"* ]]
+}
+
+@test "revoke: REFUSES bulk patterns (--prefix all / * / %)" {
+  run env SAVIA_ENTERPRISE_DSN=dummy bash "$REVOKE_ABS" --prefix all
+  [ "$status" -eq 6 ]
+  run env SAVIA_ENTERPRISE_DSN=dummy bash "$REVOKE_ABS" --prefix "*"
+  [ "$status" -eq 6 ]
+  run env SAVIA_ENTERPRISE_DSN=dummy bash "$REVOKE_ABS" --prefix "%"
+  [ "$status" -eq 6 ]
+}
+
+@test "revoke: REFUSES wildcard chars inside prefix (boundary)" {
+  run env SAVIA_ENTERPRISE_DSN=dummy bash "$REVOKE_ABS" --prefix "savia_*"
+  [ "$status" -eq 6 ]
+  [[ "$output" == *"wildcard"* ]]
+}
+
+@test "revoke: missing SAVIA_ENTERPRISE_DSN exits 3" {
+  run env -u SAVIA_ENTERPRISE_DSN bash "$REVOKE_ABS" --prefix savia_ab
+  [ "$status" -eq 3 ]
+}
+
+@test "revoke: rejects unknown argument" {
+  run bash "$REVOKE_ABS" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown arg"* ]]
+}
+
+# ── C5 — Edge cases / structural assertions ─────────────────────────────────
+
+@test "edge: create generates random key with savia_ prefix (grep-able)" {
+  grep -qE 'PLAINTEXT="savia_' "$CREATE_ABS"
+}
+
+@test "edge: create extracts first 8 chars as key_prefix (UX visible)" {
+  grep -qE 'KEY_PREFIX=.*PLAINTEXT:0:8' "$CREATE_ABS"
+}
+
+@test "edge: create stores ONLY sha256 hash, never plaintext" {
+  grep -qF "openssl dgst -sha256" "$CREATE_ABS"
+  grep -qF "INSERT INTO api_keys" "$CREATE_ABS"
+  grep -qF "key_hash" "$CREATE_ABS"
+  # Plaintext should appear in the printf-to-stdout block, not in the SQL
+  ! grep -qE "INSERT INTO api_keys.*PLAINTEXT" "$CREATE_ABS"
+}
+
+@test "edge: create prints plaintext exactly ONCE with destructive warning" {
+  grep -qiE "will not be shown again|copy it now" "$CREATE_ABS"
+}
+
+@test "edge: list never prints plaintext or key_hash columns (no leakage)" {
+  ! grep -qE "SELECT.*key_hash" "$LIST_ABS"
+  ! grep -qE "SELECT.*plaintext" "$LIST_ABS"
+  grep -qF "key_prefix" "$LIST_ABS"
+}
+
+@test "edge: revoke calls SQL procedure api_key_revoke with prefix + actor" {
+  grep -qF "CALL api_key_revoke" "$REVOKE_ABS"
+  grep -qF "PREFIX_ESC" "$REVOKE_ABS"
+  grep -qF "ACTOR_ESC" "$REVOKE_ABS"
+}
+
+@test "edge: revoke is dry-run by default (DRY-RUN message + exit 0 without --confirm)" {
+  grep -qF "DRY-RUN" "$REVOKE_ABS"
+  grep -qF -- "--confirm" "$REVOKE_ABS"
+}
+
+@test "edge: revoke warns about already-minted JWTs surviving until TTL expiry" {
+  grep -qiE "TTL expires|already minted|remain valid" "$REVOKE_ABS"
+}
+
+# ── C6 — Spec ref + cross-doc consistency ───────────────────────────────────
+
+@test "spec ref: docs/propuestas/savia-enterprise/SPEC-SE-036 referenced in this test file" {
+  grep -q "docs/propuestas/savia-enterprise/SPEC-SE-036" "$BATS_TEST_FILENAME"
+}
+
+@test "rule doc: agent-jwt-mint.md references all 3 Slice 2 CLIs" {
+  [ -f "$RULE_DOC" ]
+  # The rule doc was written in Slice 1 referring to Slice 2 by name
+  grep -qiE "api-key-create|api-key-list|api-key-revoke" "$RULE_DOC"
+}
+
+@test "template SQL: api_key_revoke procedure exists (target of revoke CLI)" {
+  grep -qF "PROCEDURE api_key_revoke" "$TEMPLATE_SQL"
+}
+
+# ── C7 — exit code documentation reinforcement ──────────────────────────────
+
+@test "create: documents exit codes 2,3,4,5 in header comment" {
+  grep -qE "^#.*\b2\b" "$CREATE_ABS"
+  grep -qE "^#.*\b3\b" "$CREATE_ABS"
+  grep -qE "^#.*\b4\b" "$CREATE_ABS"
+  grep -qE "^#.*\b5\b" "$CREATE_ABS"
+}
+
+@test "revoke: documents 7 exit codes (0,2,3,4,5,6,7)" {
+  for code in 2 3 4 5 6 7; do
+    grep -qE "exit $code|^#.*\b$code\b" "$REVOKE_ABS"
+  done
+}
+
+@test "all 3 CLIs: refuse to run without DSN — graceful, documented exit 3" {
+  for f in "$CREATE_ABS" "$LIST_ABS" "$REVOKE_ABS"; do
+    grep -qE "exit 3" "$f"
+    grep -qF "SAVIA_ENTERPRISE_DSN" "$f"
+  done
+}


### PR DESCRIPTION
# Batch 80 — SPEC-SE-036 Slice 2 IMPLEMENTED (API key CLI suite)

## Qué hace este PR (en lenguaje no técnico)

Esta PR cierra Slice 2 de SPEC-SE-036, completando el flujo CRUD de API keys que el Slice 1 (PR #723, batch 79) había dejado a medias. El Slice 1 puso la primitiva (`jwt-mint.sh` que firma JWTs efímeros desde una API key validada); este Slice 2 pone los tres CLIs que la operadora humana usa para gestionar el inventario de keys: crear, listar, revocar.

La idea: una organización que despliegue Savia Enterprise tiene N agentes (overnight-sprint, code-improvement-loop, tech-research-agent, MCP servers, etc.). Cada agente recibe su propia API key con el scope mínimo que necesita ("github:write", "azure-devops:read", "mcp:tools"). Hoy esto se hacía con PATs file-based de 6-12 meses; con SPEC-SE-036 se hace con API keys hashed en DB que generan JWTs efímeros de 15 min cada uno. Los tres CLIs de este Slice son las herramientas operacionales:

- **`api-key-create.sh`**: genera una key fresca (32 bytes urandom, prefijo `savia_` para grep-ability), guarda solo el `sha256(key)` + 8 chars de prefix visible, e **imprime el plaintext exactamente una vez** con un warning destructivo ("copy it NOW. It will not be shown again"). Si la operadora pierde la key, no hay recuperación: la única vía es revocar y crear otra.
- **`api-key-list.sh`**: inventario filtrable por tenant, activas/revocadas, JSON o tabla. **Nunca** muestra `key_hash` ni plaintext — un test BATS específico verifica que el SELECT no incluye esas columnas (zero-leakage por construcción, no por convención).
- **`api-key-revoke.sh`**: revoca por prefix de 8 chars con cuatro capas de seguridad. Refuses sin `--prefix`, refuses bulk patterns (`all` / `*` / `%`), refuses wildcards, dry-run por defecto. Requiere `--confirm` explícito para ejecutar `CALL api_key_revoke(prefix, actor)`. Tras revocar, imprime un WARNING explícito: los JWTs que ya se firmaron desde esa key siguen vivos hasta que expire su TTL (≤ 60 min). Esto es por diseño — el modelo es "revoke + wait", no "revoke = instant kill" (lo segundo requeriría un revocation list distribuido, complejidad innecesaria con TTLs cortos).

Lo que NO está aquí (deferred a Slice 3): el hook `block-pat-file-write.sh` que bloquea escrituras a paths con `pat` en el nombre fuera de gitignore, la extensión de `block-credential-leak.sh` para detectar PAT-shaped strings (40+ chars hex/base64) en diff, y el sunset opt-in de `~/.azure/devops-pat` tras un sprint de canary verde con el nuevo modelo.

Trabajo verificado: 35 tests BATS pasan certified.

## Spec refs

- SPEC-SE-036 — `docs/propuestas/savia-enterprise/SPEC-SE-036-api-key-jwt-mint.md` (Slice 2 IMPLEMENTED, AC-03 cerrado; AC-06 / AC-07 + sunset DEFERRED a Slice 3)

## What's in scope

- `scripts/enterprise/api-key-create.sh` — generar key + insertar hash + imprimir plaintext una vez
- `scripts/enterprise/api-key-list.sh` — listar con filtros, sin leak de hash/plaintext
- `scripts/enterprise/api-key-revoke.sh` — revocar con 4 safety layers + dry-run default
- `tests/structure/test-api-key-cli-suite.bats` — 35 tests certified
- `docs/rules/domain/savia-enterprise/agent-jwt-mint.md` — sección "CLIs operacionales (Slice 2)" añadida
- `CHANGELOG.d/agent-batch80-spec-se-036-slice-2-cli-20260428.md` — fragment

## What's out of scope (intentionally)

- **AC-06 hook block-pat-file-write**: Slice 3 — bloquea `Write` a paths con `pat` en el nombre fuera de gitignore.
- **AC-07 block-credential-leak PAT-shaped**: Slice 3 — extiende patrón existente para detectar 40+ char hex/base64 en diff.
- **Sunset `~/.azure/devops-pat`**: Slice 3, opt-in tras 1 sprint canary verde.
- **Revocation list / instant kill**: descartado por diseño — el modelo es "revoke + TTL expiry" (≤ 60 min). Lista de revocación distribuida añadiría complejidad sin beneficio claro dado TTLs cortos.
- **pgTAP tests**: pm-workspace no tiene Postgres en CI.

## Safety boundaries

- `set -uo pipefail` en los 3 CLIs.
- `create`: plaintext printado UNA vez, nunca escrito a disco; warning destructivo en stdout.
- `list`: zero-leakage enforced por test (`! grep -qE "SELECT.*key_hash"` falla).
- `revoke`: 4 safety layers (prefix required, no bulk, no wildcards, dry-run default), actor logged.
- Cero red, cero git operations.
- Cumple `docs/rules/domain/autonomous-safety.md`: rama `agent/spec-se-036-slice-2-...`, sin push automático ni merge.
- Atribución MIT a `dreamxist/balance` explícita en los 3 CLIs (precedente: SE-035/036/037).
