### PR TITLE
feat(scripts): batch 81 SPEC-SE-035 Slice 1+3 IMPLEMENTED — reconciliation delta engine (CLI wrapper + rule doc)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=9b75a1c5b62e4b808bd98054ecb3ba32e730595d4d9c84e86c25c58c19c59148
-timestamp=2026-04-28T21:29:19Z
+diff_hash=86057e302c618485e581f9b3aa47fcd96b0e11e8c41da155ff189b9ef001b3fe
+timestamp=2026-04-28T21:29:20Z
 branch=agent/spec-se-035-reconciliation-slice-1-20260428
-head_commit=15b77f45
-signature=4cd50ad66da74ab75f74b9c4b7c49e1458eba635913958cc166a165a1671ad72
+head_commit=0ab977dd
+signature=c81856c7e23c3d59d7cfb3df8fd0bd60031b77d223a192ad4c1d14ad2f6c5f85

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=9b75a1c5b62e4b808bd98054ecb3ba32e730595d4d9c84e86c25c58c19c59148
-timestamp=2026-04-28T14:04:21Z
-branch=agent/spec-125-recommendation-tribunal-20260428
-head_commit=73ca6f20
+timestamp=2026-04-28T21:29:19Z
+branch=agent/spec-se-035-reconciliation-slice-1-20260428
+head_commit=15b77f45
 signature=4cd50ad66da74ab75f74b9c4b7c49e1458eba635913958cc166a165a1671ad72

--- a/CHANGELOG.d/agent-batch81-spec-se-035-slice-1-reconciliation-20260428.md
+++ b/CHANGELOG.d/agent-batch81-spec-se-035-slice-1-reconciliation-20260428.md
@@ -1,0 +1,66 @@
+---
+version_bump: minor
+section: Added
+---
+
+## [6.21.0] — 2026-04-28
+
+Batch 81 — SPEC-SE-035 Slice 1+3 IMPLEMENTED. Reconciliation Delta Engine: primitive `tenant_reconciliation_status()` (template SQL ya existente desde batch 71) + CLI wrapper `reconciliation-status.sh` que renderiza tabla colored o JSON con tier verde/ámbar/rojo por dimensión + canonical rule doc. Cierra Era 232 (SE-035 + SE-036 + SE-037 todos parcial o totalmente cerrados). Critical Path #10 partial. Slice 2 (dispatch registry seed), Slice 4 (webhook+alerting), Slice 5 (CI ratchet baseline) follow-up.
+
+### Added
+
+#### CLI wrapper
+
+- `scripts/enterprise/reconciliation-status.sh` — wrapper bash que itera dimensiones activas para un tenant y renderiza:
+  - Tabla colored ANSI (verde/ámbar/rojo símbolo `●`) por defecto
+  - `--json` mode con `jsonb_agg` para integración con dashboards externos
+  - `--fail-on red|amber|green` modo CI gate: exit 7 si ≥1 dimensión está en el tier solicitado (precursor del Slice 5 ratchet baseline)
+  - `--dimension <name>` filtra a una sola dimensión (útil para CI gates específicos)
+  - Validación UUID antes de DSN/psql checks (fail-fast en arg validation)
+  - 6 exit codes documentados: 2 (usage), 3 (DSN), 4 (psql), 5 (DB error), 7 (alarm triggered)
+
+#### Canonical rule
+
+- `docs/rules/domain/savia-enterprise/reconciliation-delta-engine.md` — define el modelo:
+  - Tesis: dos imágenes del mundo (declared / computed), drift silencioso erosiona credibilidad/margen, primitive convierte drift en alerta del mismo día
+  - Storage: `reconciliation_dimensions` registry + `reconciliation_alerts` append-only log
+  - Primitive: `STABLE` no `IMMUTABLE` (queries leen tablas vivas) ni `VOLATILE` (permite cache intra-statement)
+  - Plan de seed Slice 2: 4 dimensiones con queries conceptuales (backlog_sp, budget, capacity, knowledge_catalog_hash)
+  - Estrategia recompute (on-demand / materialized view / trigger AFTER) con coste y trade-off por opción
+  - Mitigaciones de recursión + race + webhook abuse (deferred a Slice 4)
+  - Cross-refs SPEC-SE-002 (RLS), SPEC-SE-018 (billing consumer), SPEC-SE-022 (resource-bench consumer), SPEC-SE-023 (knowledge-federation consumer), SPEC-SE-024 (client-health rollup), SPEC-SE-037 (audit attach)
+
+#### Tests
+
+- `tests/structure/test-reconciliation-delta-engine.bats` — 40 tests certified. Cubre file-level safety×7, SQL template structure×5, delta-tier helper positive+edge×8, status CLI negative×6, edge structural×5, rule doc structure×6, exit codes + spec ref×3.
+
+### Re-implementation attribution
+
+`dreamxist/balance` (MIT) — patrón fuente position-vs-accumulated y función `get_reconciliation_status()`. Clean-room: el SQL template `reconciliation.sql` (batch 71) y el CLI `reconciliation-status.sh` son re-implementación; aquí se **generaliza** a una primitiva tenant-aware con dispatch por dimensión, no se copia código verbatim. Helper `delta-tier.sh` también pre-existente.
+
+### Acceptance criteria
+
+#### SPEC-SE-035 Slice 1+3 (4/10 + 4 deferred a Slices 2/4/5)
+
+- ✅ AC-01 Función `tenant_reconciliation_status()` definida con 3 tiers (en template, batch 71)
+- 〰 AC-02 4 dimensiones seed — **DEFERRED** Slice 2 (rule doc lista plan conceptual)
+- 〰 AC-03 Vista materializada — **DEFERRED** Slice 3 follow-up (Slice 1+3 entregan on-demand CLI; vista materializada es optimización posterior)
+- ✅ AC-04 CLI `reconciliation-status.sh <tenant>` con output ANSI
+- 〰 AC-05 Trigger recompute on-write con webhook — **DEFERRED** Slice 4
+- 〰 AC-06 Baseline ratchet bloquea regresión — **DEFERRED** Slice 5 (precursor: `--fail-on` exit 7 ya implementado)
+- 〰 AC-07 pgTAP ≥10 — **DEFERRED** (no Postgres en pm-workspace CI); BATS ≥8 ✅ cumplido (40 tests certified)
+- ✅ AC-08 Doc `docs/rules/domain/savia-enterprise/reconciliation-delta-engine.md`
+- ✅ AC-09 SQL template `docs/propuestas/savia-enterprise/templates/reconciliation.sql` (batch 71)
+- ✅ AC-10 CHANGELOG entry (este fragmento)
+
+### Hard safety boundaries (autonomous-safety.md)
+
+- `set -uo pipefail` en `reconciliation-status.sh` y `delta-tier.sh`.
+- UUID validation antes de DSN/psql checks (fail-fast en arg validation).
+- `--fail-on` solo acepta `green|amber|red` (no levels custom; mantiene API limpia).
+- Cero red, cero git operations.
+- Cumple `docs/rules/domain/autonomous-safety.md`: rama `agent/spec-se-035-...`, sin push automático ni merge.
+
+### Spec ref
+
+SPEC-SE-035 (`docs/propuestas/savia-enterprise/SPEC-SE-035-reconciliation-delta-engine.md`) → Slice 1+3 IMPLEMENTED 2026-04-28. Status spec: Slice 1 ✓, Slice 3 ✓ on-demand CLI, Slice 2 (seed) + Slice 3 (materialized view) + Slice 4 (webhook) + Slice 5 (ratchet) follow-up. Era 232 cierra: SE-037 ✓ (batch 78), SE-036 Slice 1+2 ✓ (batches 79+80, Slice 3 follow-up), SE-035 Slice 1+3 ✓ (batch 81). Critical Path #6 + #7 + #10 todos parcial o totalmente cerrados.

--- a/docs/rules/domain/savia-enterprise/reconciliation-delta-engine.md
+++ b/docs/rules/domain/savia-enterprise/reconciliation-delta-engine.md
@@ -1,0 +1,144 @@
+# Reconciliation Delta Engine — declared vs computed invariant
+
+> **SPEC**: SPEC-SE-035 (`docs/propuestas/savia-enterprise/SPEC-SE-035-reconciliation-delta-engine.md`)
+> **Slice**: 1 (primitive `tenant_reconciliation_status`) + 3 (CLI wrapper). Slices 2 (dispatch registry seed), 4 (webhook+alerting), 5 (ratchet baseline) follow.
+> **Status**: canonical. Convierte drift silencioso entre estado declarado y computado en alerta del mismo día.
+
+---
+
+## Tesis (one paragraph)
+
+Una organización Enterprise mantiene **dos imágenes** del mundo: lo que dice tener (header del backlog SP, budget firmado, headcount declarado, KPIs publicados, hash del catálogo de conocimiento) y lo que **realmente tiene** (suma de PBI estimates, hours ledger × tarifa, asignaciones activas, métricas computadas en runtime, hash del estado actual). El silencio entre ambas imágenes es donde acumula el riesgo: cada unidad de drift sin detectar es credibilidad o margen erosionados, y normalmente sale a la luz en una review trimestral incómoda. El patrón opuesto — Balance (`dreamxist/balance`) — se niega a mentir sobre el dinero: si la posición real no cuadra con la suma de transacciones, el sistema bloquea. SPEC-SE-035 generaliza esa disciplina a portfolio health: una **función invariant tenant-level** que computa `declared - computed = delta` por dimensión, asigna un tier (green / amber / red) según thresholds configurables, y deja que el resto del sistema decida qué hacer con el resultado (dashboard, alerta, gate de release).
+
+---
+
+## Diseño
+
+### 1. Storage — `reconciliation_dimensions` registry + `reconciliation_alerts` log
+
+Tabla de origen: `docs/propuestas/savia-enterprise/templates/reconciliation.sql` (template canónico, MIT clean-room re-implementación de `dreamxist/balance` `00009_reconciliation.sql`).
+
+| Tabla | Por qué |
+|---|---|
+| `reconciliation_dimensions` | Registry: cada fila es una dimensión reconciliable (`backlog_sp`, `budget`, `capacity`, `knowledge_catalog_hash`, ...). Define `declared_query` + `computed_query` SQL strings + `amber_threshold` + `red_threshold`. Permite Enterprise tenants añadir dimensiones propias en runtime. |
+| `reconciliation_alerts` | Append-only log de transitions a amber/red. Auditable vía `attach_audit('reconciliation_alerts'::regclass)` (sinergia SPEC-SE-037). Indexed por `(tenant_id, dimension, alerted_at DESC)` para query reciente rápida. |
+
+### 2. Primitive — `tenant_reconciliation_status(tenant, dimension)`
+
+Función `STABLE` que devuelve JSONB:
+
+```json
+{
+  "tenant_id": "...",
+  "dimension": "budget",
+  "declared": 120000,
+  "computed": 117500,
+  "delta": 2500,
+  "abs_delta": 2500,
+  "tier": "amber",
+  "thresholds": {"amber": 1000, "red": 5000},
+  "checked_at": "2026-04-28T15:32:11Z"
+}
+```
+
+Tier cálculo idéntico al CLI `delta-tier.sh` (re-implementado en SQL para consistencia cross-language):
+
+```
+abs(declared - computed) >= red    → 'red'
+abs(declared - computed) >= amber  → 'amber'
+otherwise                          → 'green'
+```
+
+`STABLE` (no `IMMUTABLE`) porque las queries sub-yacentes leen tablas vivas. No `VOLATILE` para permitir cache dentro del mismo statement.
+
+### 3. CLI — `scripts/enterprise/reconciliation-status.sh`
+
+Wrapper bash que itera todas las dimensiones activas para un tenant y renderiza una tabla colored (verde/ámbar/rojo) o JSON estructurado.
+
+```
+$ reconciliation-status.sh --tenant <uuid>
+DIMENSION                      DECLARED        COMPUTED        DELTA           TIER
+---------                      --------        --------        -----           ----
+budget                         120000          117500          2500            ● amber
+backlog_sp                     320             318             2               ● green
+knowledge_catalog_hash         a7f9...         a7f9...         0               ● green
+capacity                       18              19              -1              ● green
+```
+
+Modo CI gate: `--fail-on red` retorna exit 7 si cualquier dimensión está en tier rojo (mismo pattern que hook-coverage ratchet, Slice 5 lo formaliza).
+
+```
+$ reconciliation-status.sh --tenant <uuid> --fail-on red
+[...] tabla [...]
+ALARM: 1 dimension(s) at tier 'red'
+exit code: 7
+```
+
+Decisiones de diseño:
+
+- **UUID validation antes de DSN/psql checks**: arg validation barata primero, fail-fast.
+- **`--fail-on` accepta solo `green|amber|red`** (no levels custom; mantiene API limpia).
+- **`--dimension` opcional** filtra a una sola dimensión (útil para CI gates específicos: e.g. solo `budget`).
+- **`--json` mode** emite `jsonb_agg` con todas las dimensiones para integración con dashboards externos.
+- **Color rendering inline** (no depende de `delta-tier.sh --color` para evitar fork overhead por fila).
+
+### 4. Helper — `delta-tier.sh` (numeric tiering reutilizable)
+
+`scripts/enterprise/delta-tier.sh` (pre-existente) computa tier desde dos numeric values en bash puro. Útil cuando un comando pm-workspace quiere renderizar drift sin tocar la DB (sprint-status, portfolio-overview con datos de Azure DevOps in-memory). El helper es **independiente** del SQL primitive — ambos usan los mismos thresholds por convención (1000 amber / 5000 red default).
+
+### 5. Recompute strategy
+
+| Estrategia | Cuándo | Coste | Implementado en |
+|---|---|---|---|
+| **On-demand** (CLI llama función) | Dashboard, CI gate, debug | O(query × N dimensiones) | Slice 1+3 (este) |
+| **Materialized view** + `REFRESH CONCURRENTLY` | Reads frecuentes desde varios consumidores | O(query × tenants × dimensiones) batched | Slice 3 follow-up |
+| **Trigger AFTER UPDATE** sobre tablas declarativas | Recompute tras cada write | O(N writes); riesgo recursivo | Slice 4 |
+
+### 6. Recursión + race conditions
+
+- **Triggers recursivos** (recompute → write → recompute) → `pg_advisory_lock` + flag `_in_reconciliation` en sesión (Slice 4).
+- **Falsos amber por timing** (write vs read race) → re-check en amber: solo alerta tras 2 lecturas consecutivas (Slice 4).
+- **Webhook abuse** → rate-limit per `(tenant, dimension)`: max 1 alerta / 15 min (Slice 4).
+
+---
+
+## Atribución
+
+Re-implementación clean-room de `dreamxist/balance` `supabase/migrations/00009_reconciliation.sql` (MIT). El patrón position-vs-accumulated y la función `get_reconciliation_status()` son la fuente; aquí se **generaliza** a una primitiva tenant-aware con dispatch por dimensión, no se copia código verbatim.
+
+---
+
+## Cross-refs
+
+- **SPEC-SE-002** — RLS multi-tenant para `reconciliation_dimensions` y `reconciliation_alerts`
+- **SPEC-SE-018** — project-billing: dimension `budget` consume este primitive
+- **SPEC-SE-022** — resource-bench: dimension `capacity` consume este primitive
+- **SPEC-SE-023** — knowledge-federation: dimension `knowledge_catalog_hash` consume este primitive
+- **SPEC-SE-024** — client-health: cross-tenant rollup de tiers
+- **SPEC-SE-037** — `reconciliation_alerts` debe estar wired vía `attach_audit('reconciliation_alerts'::regclass)`
+- **SPEC-SE-006** — governance-compliance auditará el log de alertas como evidencia
+
+---
+
+## Dimensiones seed (Slice 2 follow-up)
+
+Plan de seed inicial cuando se implemente Slice 2:
+
+| Dimension | declared_query (concept) | computed_query (concept) | Default thresholds |
+|---|---|---|---|
+| `backlog_sp` | `SELECT tenant_id, total_sp FROM tenant_backlog_header` | `SELECT tenant_id, sum(estimate_sp) FROM pbis WHERE active` | 5 / 20 (small numeric range) |
+| `budget` | `SELECT tenant_id, signed_amount FROM tenant_budget` | `SELECT tenant_id, sum(hours * rate) FROM hours_ledger` | 1000 / 5000 (EUR) |
+| `capacity` | `SELECT tenant_id, declared_headcount FROM tenant_contract` | `SELECT tenant_id, count(*) FROM active_assignments` | 0.5 / 2 (FTEs) |
+| `knowledge_catalog_hash` | `SELECT tenant_id, declared_hash FROM tenant_knowledge_catalog` | `SELECT tenant_id, encode(digest(string_agg(content, '|'), 'sha256'), 'hex') FROM knowledge_entries GROUP BY 1` | 0 / 1 (hash equality binary) |
+
+---
+
+## No hace (esta Slice)
+
+- NO implementa Slice 2 dispatch registry seed con dimensiones reales.
+- NO implementa Slice 4 webhook + alerting (trigger + rate-limit).
+- NO implementa Slice 5 ratchet baseline en CI.
+- NO añade dependencia Supabase ni servicio managed.
+- NO redefine RLS multi-tenant (asume SPEC-SE-002 estable).
+- NO inventa thresholds — son configurables per dimension; defaults conservadores 1000/5000 (override per Enterprise tenant).
+- NO escribe a sistemas externos (webhook explícito en Slice 4 con config gate).

--- a/scripts/enterprise/reconciliation-status.sh
+++ b/scripts/enterprise/reconciliation-status.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# reconciliation-status.sh — SPEC-SE-035 Slice 1+3: tenant reconciliation CLI.
+#
+# Renders the green/amber/red reconciliation status for a tenant across all
+# active dimensions registered in `reconciliation_dimensions`. Calls the
+# `tenant_reconciliation_status(tenant, dimension)` SQL primitive defined in
+# templates/reconciliation.sql for each active dimension and assembles a
+# single colored table.
+#
+# Defines tier alarm: --fail-on red|amber returns non-zero exit when any row
+# is at the requested tier. Useful for CI gates (e.g. red bloquea release).
+#
+# Requires:
+#   - SAVIA_ENTERPRISE_DSN     Postgres DSN
+#   - psql command available
+#   - delta-tier.sh sibling for color rendering
+#
+# Usage:
+#   reconciliation-status.sh --tenant <uuid>
+#   reconciliation-status.sh --tenant <uuid> --json
+#   reconciliation-status.sh --tenant <uuid> --fail-on red
+#   reconciliation-status.sh --tenant <uuid> --dimension budget
+#
+# Exit codes:
+#   0  ok (or no rows match alarm)
+#   2  usage / args invalid
+#   3  SAVIA_ENTERPRISE_DSN missing
+#   4  psql missing
+#   5  query failed
+#   7  alarm triggered (--fail-on tier matched ≥1 row)
+#
+# Reference: SPEC-SE-035 (docs/propuestas/savia-enterprise/SPEC-SE-035-reconciliation-delta-engine.md)
+# Pattern source: dreamxist/balance supabase/migrations/00009_reconciliation.sql (MIT, clean-room)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TENANT=""
+DIMENSION=""
+FAIL_ON=""
+JSON_OUT=0
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tenant)    TENANT="$2"; shift 2 ;;
+    --dimension) DIMENSION="$2"; shift 2 ;;
+    --fail-on)   FAIL_ON="$2"; shift 2 ;;
+    --json)      JSON_OUT=1; shift ;;
+    -h|--help)   usage ;;
+    *) echo "ERROR: unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+# ── Pre-flight ───────────────────────────────────────────────────────────────
+
+if [[ -z "$TENANT" ]]; then
+  echo "ERROR: --tenant <uuid> required" >&2
+  exit 2
+fi
+
+if ! [[ "$TENANT" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "ERROR: --tenant must be a UUID" >&2
+  exit 2
+fi
+
+case "$FAIL_ON" in
+  ""|"green"|"amber"|"red") ;;
+  *) echo "ERROR: --fail-on must be one of green|amber|red (got: $FAIL_ON)" >&2; exit 2 ;;
+esac
+
+if [[ -z "${SAVIA_ENTERPRISE_DSN:-}" ]]; then
+  echo "ERROR: SAVIA_ENTERPRISE_DSN env not set." >&2
+  exit 3
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "ERROR: psql not found." >&2
+  exit 4
+fi
+
+# ── Build query ──────────────────────────────────────────────────────────────
+
+TENANT_ESC="${TENANT//\'/\'\'}"
+
+if [[ -n "$DIMENSION" ]]; then
+  DIM_ESC="${DIMENSION//\'/\'\'}"
+  DIM_FILTER="AND d.dimension = '$DIM_ESC'"
+else
+  DIM_FILTER=""
+fi
+
+# Iterate every active dimension and call the SQL primitive
+SQL=$(cat <<SQL
+WITH dims AS (
+  SELECT dimension FROM reconciliation_dimensions d
+   WHERE active = true $DIM_FILTER
+)
+SELECT
+  d.dimension,
+  (tenant_reconciliation_status('$TENANT_ESC'::uuid, d.dimension))->>'declared' AS declared,
+  (tenant_reconciliation_status('$TENANT_ESC'::uuid, d.dimension))->>'computed' AS computed,
+  (tenant_reconciliation_status('$TENANT_ESC'::uuid, d.dimension))->>'delta'    AS delta,
+  (tenant_reconciliation_status('$TENANT_ESC'::uuid, d.dimension))->>'tier'     AS tier
+FROM dims d
+ORDER BY 5 DESC, 1
+SQL
+)
+
+# ── Render ───────────────────────────────────────────────────────────────────
+
+if [[ "$JSON_OUT" -eq 1 ]]; then
+  JSON_SQL="SELECT jsonb_agg(jsonb_build_object(
+              'tenant_id','$TENANT_ESC',
+              'dimension', d.dimension,
+              'status', tenant_reconciliation_status('$TENANT_ESC'::uuid, d.dimension)
+            ))
+            FROM reconciliation_dimensions d
+            WHERE active = true $DIM_FILTER"
+  out=$(psql "$SAVIA_ENTERPRISE_DSN" -At -c "$JSON_SQL" 2>&1) || {
+    echo "ERROR: query failed: $out" >&2
+    exit 5
+  }
+  printf '%s\n' "$out"
+else
+  rows=$(psql "$SAVIA_ENTERPRISE_DSN" -At -F '|' -c "$SQL" 2>&1) || {
+    echo "ERROR: query failed: $rows" >&2
+    exit 5
+  }
+
+  printf '%-30s %-15s %-15s %-15s %-8s\n' "DIMENSION" "DECLARED" "COMPUTED" "DELTA" "TIER"
+  printf '%-30s %-15s %-15s %-15s %-8s\n' "---------" "--------" "--------" "-----" "----"
+  while IFS='|' read -r dim declared computed delta tier; do
+    [[ -z "$dim" ]] && continue
+    case "$tier" in
+      green) symbol=$'\033[32m●\033[0m green' ;;
+      amber) symbol=$'\033[33m●\033[0m amber' ;;
+      red)   symbol=$'\033[31m●\033[0m red  ' ;;
+      *)     symbol="? $tier" ;;
+    esac
+    printf '%-30s %-15s %-15s %-15s %s\n' "$dim" "$declared" "$computed" "$delta" "$symbol"
+  done <<< "$rows"
+fi
+
+# ── Alarm enforcement (--fail-on) ───────────────────────────────────────────
+
+if [[ -n "$FAIL_ON" ]]; then
+  ALARM_SQL="SELECT count(*) FROM reconciliation_dimensions d
+             WHERE active = true $DIM_FILTER
+               AND (tenant_reconciliation_status('$TENANT_ESC'::uuid, d.dimension))->>'tier' = '$FAIL_ON'"
+  count=$(psql "$SAVIA_ENTERPRISE_DSN" -At -c "$ALARM_SQL" 2>&1) || {
+    echo "ERROR: alarm query failed: $count" >&2
+    exit 5
+  }
+  if [[ "$count" -gt 0 ]]; then
+    echo "ALARM: $count dimension(s) at tier '$FAIL_ON'" >&2
+    exit 7
+  fi
+fi

--- a/tests/structure/test-reconciliation-delta-engine.bats
+++ b/tests/structure/test-reconciliation-delta-engine.bats
@@ -1,0 +1,255 @@
+#!/usr/bin/env bats
+# Ref: SPEC-SE-035 — Reconciliation Delta Engine for Federated Knowledge
+# Spec: docs/propuestas/savia-enterprise/SPEC-SE-035-reconciliation-delta-engine.md
+# Slice 1+3: tenant_reconciliation_status() primitive (SQL template) +
+# reconciliation-status.sh CLI wrapper + delta-tier.sh helper.
+# Pattern source: dreamxist/balance MIT (clean-room re-implementation).
+
+setup() {
+  ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="scripts/enterprise/reconciliation-status.sh"
+  STATUS_ABS="$ROOT_DIR/$SCRIPT"
+  DELTA_ABS="$ROOT_DIR/scripts/enterprise/delta-tier.sh"
+  TEMPLATE_SQL="$ROOT_DIR/docs/propuestas/savia-enterprise/templates/reconciliation.sql"
+  RULE_DOC="$ROOT_DIR/docs/rules/domain/savia-enterprise/reconciliation-delta-engine.md"
+  TMPDIR_T=$(mktemp -d)
+  VALID_UUID="11111111-2222-3333-4444-555555555555"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_T"
+}
+
+# ── C1 — file-level safety + identity ───────────────────────────────────────
+
+@test "reconciliation-status.sh: file exists, has shebang, executable" {
+  [ -f "$STATUS_ABS" ]
+  head -1 "$STATUS_ABS" | grep -q '^#!'
+  [ -x "$STATUS_ABS" ]
+}
+
+@test "delta-tier.sh: file exists, has shebang, executable" {
+  [ -f "$DELTA_ABS" ]
+  head -1 "$DELTA_ABS" | grep -q '^#!'
+  [ -x "$DELTA_ABS" ]
+}
+
+@test "reconciliation-status.sh: declares 'set -uo pipefail'" {
+  grep -q "set -[uo]o pipefail" "$STATUS_ABS"
+}
+
+@test "delta-tier.sh: declares 'set -uo pipefail'" {
+  grep -q "set -[uo]o pipefail" "$DELTA_ABS"
+}
+
+@test "both CLIs pass bash -n syntax check" {
+  bash -n "$STATUS_ABS"
+  bash -n "$DELTA_ABS"
+}
+
+@test "spec ref: SPEC-SE-035 cited in CLI + helper + rule doc" {
+  grep -q "SPEC-SE-035" "$STATUS_ABS"
+  grep -q "SPEC-SE-035" "$DELTA_ABS"
+  grep -q "SPEC-SE-035" "$RULE_DOC"
+}
+
+@test "attribution: dreamxist/balance MIT pattern source cited everywhere" {
+  grep -qF "dreamxist/balance" "$STATUS_ABS"
+  grep -qF "dreamxist/balance" "$DELTA_ABS"
+  grep -qF "dreamxist/balance" "$TEMPLATE_SQL"
+  grep -qF "MIT" "$TEMPLATE_SQL"
+  grep -qiE "clean.room|re.implement" "$RULE_DOC"
+}
+
+# ── C2 — SQL template structure (positive) ──────────────────────────────────
+
+@test "template SQL: defines reconciliation_dimensions registry" {
+  [ -f "$TEMPLATE_SQL" ]
+  grep -qE "CREATE TABLE.*reconciliation_dimensions" "$TEMPLATE_SQL"
+  for col in dimension declared_query computed_query amber_threshold red_threshold active; do
+    grep -qE "^\\s+$col" "$TEMPLATE_SQL"
+  done
+}
+
+@test "template SQL: defines reconciliation_alerts append-only log" {
+  grep -qE "CREATE TABLE.*reconciliation_alerts" "$TEMPLATE_SQL"
+  grep -qE "tier\\s+text\\s+NOT NULL\\s+CHECK" "$TEMPLATE_SQL"
+  grep -qE "alerted_at" "$TEMPLATE_SQL"
+}
+
+@test "template SQL: tier CHECK constraint enforces green/amber/red only" {
+  grep -qE "CHECK\\s*\\(\\s*tier\\s+IN\\s*\\(\\s*'green'\\s*,\\s*'amber'\\s*,\\s*'red'\\s*\\)\\s*\\)" "$TEMPLATE_SQL"
+}
+
+@test "template SQL: tenant_reconciliation_status() function defined STABLE" {
+  grep -qE "FUNCTION tenant_reconciliation_status" "$TEMPLATE_SQL"
+  grep -qE "LANGUAGE plpgsql STABLE" "$TEMPLATE_SQL"
+}
+
+@test "template SQL: function returns jsonb (auditable + structured)" {
+  grep -qE "RETURNS jsonb" "$TEMPLATE_SQL"
+}
+
+# ── C3 — delta-tier.sh helper (positive + edge) ─────────────────────────────
+
+@test "delta-tier: declared==computed (delta=0) returns green tier" {
+  run bash "$DELTA_ABS" 100 100
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier=green"* ]]
+}
+
+@test "delta-tier: large delta returns red tier (overflow)" {
+  run bash "$DELTA_ABS" 10000 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier=red"* ]]
+}
+
+@test "delta-tier: medium delta returns amber tier (boundary)" {
+  run bash "$DELTA_ABS" 2000 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier=amber"* ]]
+}
+
+@test "delta-tier: negative delta uses absolute value (zero or below)" {
+  run bash "$DELTA_ABS" 0 5500
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier=red"* ]]
+}
+
+@test "delta-tier: float arithmetic precision (boundary numbers)" {
+  run bash "$DELTA_ABS" 1000.5 0.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"tier=amber"* ]]
+}
+
+@test "delta-tier: --json mode emits parseable JSON" {
+  run bash "$DELTA_ABS" --json 100 100
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"tier":"green"'* ]]
+  [[ "$output" == *'"declared":100'* ]]
+}
+
+@test "delta-tier: invalid number rejected (exit 3)" {
+  run bash "$DELTA_ABS" abc 100
+  [ "$status" -eq 3 ]
+}
+
+@test "delta-tier: missing args rejected (exit 2)" {
+  run bash "$DELTA_ABS" 100
+  [ "$status" -eq 2 ]
+}
+
+# ── C4 — reconciliation-status.sh negative paths ────────────────────────────
+
+@test "status: rejects unknown CLI argument (no-arg edge)" {
+  run bash "$STATUS_ABS" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown arg"* ]]
+}
+
+@test "status: zero-arg invocation exits 2 (boundary)" {
+  run bash "$STATUS_ABS"
+  [ "$status" -eq 2 ]
+}
+
+@test "status: missing --tenant exits 2" {
+  run bash "$STATUS_ABS" --json
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--tenant"* ]]
+}
+
+@test "status: rejects non-UUID --tenant (invalid input)" {
+  run bash "$STATUS_ABS" --tenant not-a-uuid
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"UUID"* ]]
+}
+
+@test "status: rejects invalid --fail-on value (boundary)" {
+  run bash "$STATUS_ABS" --tenant "$VALID_UUID" --fail-on yellow
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"green|amber|red"* ]]
+}
+
+@test "status: missing SAVIA_ENTERPRISE_DSN exits 3" {
+  run env -u SAVIA_ENTERPRISE_DSN bash "$STATUS_ABS" --tenant "$VALID_UUID"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"SAVIA_ENTERPRISE_DSN"* ]]
+}
+
+# ── C5 — Edge cases / structural assertions ─────────────────────────────────
+
+@test "edge: status accepts --fail-on red|amber|green (3 valid options)" {
+  for tier in red amber green; do
+    grep -qE "\"$tier\"" "$STATUS_ABS"
+  done
+}
+
+@test "edge: status calls SQL primitive tenant_reconciliation_status()" {
+  grep -qF "tenant_reconciliation_status(" "$STATUS_ABS"
+}
+
+@test "edge: status reads only active dimensions (where active=true)" {
+  grep -qF "active = true" "$STATUS_ABS"
+}
+
+@test "edge: status alarm exit code 7 documented + implemented" {
+  grep -qE "exit 7" "$STATUS_ABS"
+  grep -qF "ALARM:" "$STATUS_ABS"
+}
+
+@test "edge: status renders ANSI colors for terminal output" {
+  grep -qE "033\\[32m" "$STATUS_ABS"  # green
+  grep -qE "033\\[33m" "$STATUS_ABS"  # amber
+  grep -qE "033\\[31m" "$STATUS_ABS"  # red
+}
+
+# ── C6 — Rule canonical doc ─────────────────────────────────────────────────
+
+@test "rule doc: exists and references SPEC-SE-035" {
+  [ -f "$RULE_DOC" ]
+  grep -q "SPEC-SE-035" "$RULE_DOC"
+}
+
+@test "rule doc: explains green/amber/red tier semantics with thresholds" {
+  grep -qiE "green.*amber.*red|tier.*threshold" "$RULE_DOC"
+  grep -qF "1000" "$RULE_DOC"
+  grep -qF "5000" "$RULE_DOC"
+}
+
+@test "rule doc: documents seed dimensions plan (Slice 2 follow-up)" {
+  grep -qF "backlog_sp" "$RULE_DOC"
+  grep -qF "budget" "$RULE_DOC"
+  grep -qF "capacity" "$RULE_DOC"
+  grep -qF "knowledge_catalog_hash" "$RULE_DOC"
+}
+
+@test "rule doc: cross-references SPEC-SE-002 (RLS) + SPEC-SE-037 (audit) + SPEC-SE-018 (billing)" {
+  grep -qF "SPEC-SE-002" "$RULE_DOC"
+  grep -qF "SPEC-SE-037" "$RULE_DOC"
+  grep -qF "SPEC-SE-018" "$RULE_DOC"
+}
+
+@test "rule doc: documents recursion + race condition mitigations (deferred Slice 4)" {
+  grep -qiE "advisory_lock|recursi|race|rate.limit" "$RULE_DOC"
+}
+
+@test "rule doc: explains why STABLE (not IMMUTABLE, not VOLATILE)" {
+  grep -qiE "STABLE|tablas vivas|cache" "$RULE_DOC"
+}
+
+# ── C7 — Spec ref + exit code reinforcement ─────────────────────────────────
+
+@test "spec ref: docs/propuestas/savia-enterprise/SPEC-SE-035 referenced in this test file" {
+  grep -q "docs/propuestas/savia-enterprise/SPEC-SE-035" "$BATS_TEST_FILENAME"
+}
+
+@test "status: documents 6 distinct exit codes (0,2,3,4,5,7)" {
+  for code in 2 3 4 5 7; do
+    grep -qE "exit $code|^#.*\b$code\b" "$STATUS_ABS"
+  done
+}
+
+@test "status: --fail-on alarm triggers exit 7 (documented + implemented)" {
+  grep -qF -- "--fail-on" "$STATUS_ABS"
+  grep -qE "exit 7" "$STATUS_ABS"
+}


### PR DESCRIPTION
# Batch 81 — SPEC-SE-035 Slice 1+3 IMPLEMENTED (Reconciliation Delta Engine — primitive + CLI wrapper)

## Qué hace este PR (en lenguaje no técnico)

Esta PR cierra el último item pendiente de Era 232: SPEC-SE-035, el motor de reconciliación entre lo que una organización **declara que tiene** y lo que **realmente tiene**. Es el patrón que Balance (`dreamxist/balance`, MIT) aplica al dinero: el sistema se niega a mentir — si la posición real no cuadra con la suma de transacciones, bloquea. SPEC-SE-035 generaliza esa disciplina a portfolio health.

La idea: una organización Enterprise mantiene dos imágenes del mundo. Lo declarado (header del backlog SP, budget firmado, headcount declarado, KPIs publicados, hash del catálogo de conocimiento) y lo computado (suma de PBI estimates, hours ledger × tarifa, asignaciones activas, métricas en runtime, hash del estado actual). El silencio entre ambas es donde acumula el riesgo: cada unidad de drift sin detectar es credibilidad o margen erosionados, y normalmente sale a la luz en una review trimestral incómoda.

Este Slice 1+3 entrega la primitiva foundational + el wrapper CLI que la consume. La primitiva SQL `tenant_reconciliation_status(tenant, dimension)` ya estaba en el template `reconciliation.sql` desde batch 71 — devuelve JSONB con `declared`, `computed`, `delta`, y un tier `green / amber / red` según thresholds configurables (defaults 1000 / 5000). El CLI `reconciliation-status.sh` itera todas las dimensiones activas para un tenant y renderiza:

- **Tabla colored ANSI** por defecto (símbolo `●` verde/ámbar/rojo, fácil de leer en terminal y dashboards bash)
- **`--json` mode** con `jsonb_agg` para integración con dashboards externos
- **`--fail-on red|amber|green`** modo CI gate: exit 7 si ≥1 dimensión está en el tier solicitado. Es el precursor del Slice 5 (ratchet baseline) — ya hoy puedes meter `reconciliation-status.sh --tenant X --fail-on red` en cualquier CI y el merge se bloquea si algún cliente cae a rojo.
- **`--dimension <name>`** filtra a una sola dimensión (gates específicos: solo budget, solo capacity, etc.)

El rule doc canónico documenta las decisiones de diseño que pueden no ser obvias: por qué `STABLE` y no `IMMUTABLE` (las queries sub-yacentes leen tablas vivas) ni `VOLATILE` (se permite cache intra-statement); por qué validación UUID antes que DSN/psql checks (fail-fast en arg validation); por qué `--fail-on` solo acepta los 3 tiers literales (mantiene API limpia, no levels custom).

Lo que NO está aquí (deferred a Slices 2/4/5):

- **Slice 2 — dispatch registry seed**: el rule doc lista el plan conceptual para 4 dimensiones (backlog_sp, budget, capacity, knowledge_catalog_hash) pero NO inserta filas reales — esas requieren tablas que viven en el repo Savia Enterprise post-deploy.
- **Slice 4 — webhook + alerting**: el trigger AFTER UPDATE que recomputa on-write, el rate-limit por (tenant, dimension), el pg_advisory_lock contra recursión, y el webhook outbound a Slack/Teams/Nextcloud Talk son follow-up.
- **Slice 5 — ratchet baseline en `.ci-baseline/`**: la formalización del CI gate (precursor existe vía `--fail-on`, falta el comparador contra baseline.json).
- **pgTAP tests del primitive**: pm-workspace no tiene Postgres en CI; pgTAP del `tenant_reconciliation_status()` vive en repo Enterprise post-deploy.

Trabajo verificado: 40 tests BATS pasan certified.

## Spec refs

- SPEC-SE-035 — `docs/propuestas/savia-enterprise/SPEC-SE-035-reconciliation-delta-engine.md` (Slice 1+3 IMPLEMENTED, AC-02/AC-03/AC-05/AC-06/AC-07-pgTAP DEFERRED a Slices 2/3/4/5 y/o repo Enterprise)

## What's in scope

- `scripts/enterprise/reconciliation-status.sh` — wrapper CLI con tabla ANSI / JSON / CI gate `--fail-on`
- `docs/rules/domain/savia-enterprise/reconciliation-delta-engine.md` — regla canónica (tesis, decisiones de diseño, plan de seed, recompute strategies, recursion mitigation)
- `tests/structure/test-reconciliation-delta-engine.bats` — 40 tests certified
- `CHANGELOG.d/agent-batch81-spec-se-035-slice-1-reconciliation-20260428.md` — fragment

(El SQL template `docs/propuestas/savia-enterprise/templates/reconciliation.sql` y el helper `scripts/enterprise/delta-tier.sh` ya existían desde batch 71.)

## What's out of scope (intentionally)

- **AC-02 dispatch registry seed**: Slice 2 — requiere tablas reales del repo Enterprise (tenant_backlog_header, tenant_budget, etc.).
- **AC-03 vista materializada**: Slice 3 follow-up — Slice 1+3 entregan on-demand CLI; la vista materializada es optimización posterior cuando reads frecuentes lo justifiquen.
- **AC-05 trigger recompute on-write + webhook**: Slice 4 — incluye `pg_advisory_lock` + flag `_in_reconciliation` + rate-limit + webhook outbound. Riesgo de recursión + race conditions documentado en rule doc.
- **AC-06 baseline ratchet**: Slice 5 — precursor existe (`--fail-on` exit 7). Falta el comparador `.ci-baseline/reconciliation-tier-counts.json` formalizado.
- **AC-07 pgTAP tests**: pm-workspace no tiene Postgres en CI; viven en repo Enterprise post-deploy. BATS ≥8 ✅ cumplido (40 tests certified).
- **Cross-tenant rollup**: SPEC-SE-024 client-health consume este primitive pero el rollup queda fuera de SE-035.

## Safety boundaries

- `set -uo pipefail` en `reconciliation-status.sh` (y `delta-tier.sh` pre-existente).
- UUID validation antes de DSN/psql checks (fail-fast).
- `--fail-on` valida valor en {green, amber, red} antes de DB.
- Cero red, cero git operations.
- Cumple `docs/rules/domain/autonomous-safety.md`: rama `agent/spec-se-035-...`, sin push automático ni merge.
- Atribución MIT a `dreamxist/balance` explícita en CLI, helper, template SQL, rule doc (precedente: SE-035/036/037).
