### PR TITLE
feat(scripts): batch 82 SPEC-103 Slice 1 IMPLEMENTED — image-relevance-filter primitive (deterministic-first triage)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=86057e302c618485e581f9b3aa47fcd96b0e11e8c41da155ff189b9ef001b3fe
-timestamp=2026-04-28T21:29:20Z
-branch=agent/spec-se-035-reconciliation-slice-1-20260428
-head_commit=0ab977dd
+timestamp=2026-04-28T22:48:47Z
+branch=agent/spec-103-image-relevance-filter-primitive-20260429
+head_commit=14c9922a
 signature=c81856c7e23c3d59d7cfb3df8fd0bd60031b77d223a192ad4c1d14ad2f6c5f85

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=86057e302c618485e581f9b3aa47fcd96b0e11e8c41da155ff189b9ef001b3fe
+diff_hash=e29e92a2bc795b00897fbc8cd8e26cc22f4d681ac2e997105077ca8df3b259f2
 timestamp=2026-04-28T22:48:47Z
 branch=agent/spec-103-image-relevance-filter-primitive-20260429
-head_commit=14c9922a
-signature=c81856c7e23c3d59d7cfb3df8fd0bd60031b77d223a192ad4c1d14ad2f6c5f85
+head_commit=82b29518
+signature=76e0c927154250eb2ae7ed5def1167b639b179940e3696bbf25df428957227aa

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: e1f8f8f978d6 | resources: 1106
-> 530 commands · 90 skills · 65 agents · 421 scripts
+> hash: bb76a2636a1d | resources: 1107
+> 530 commands · 90 skills · 65 agents · 422 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Search — across,buscar,filtrar,language,multiple — cmd:.claude/commands/trace-search.md
@@ -187,6 +187,7 @@
 [development] graph-build — conocimiento,construye,grafo,proyecto — cmd:.claude/commands/graph-build.md
 [development] graph-temporal-ops — graph,spec,temporal — script:scripts/graph-temporal-ops.sh
 [development] human-code-map — activamente,alguien,cognitiva,componentes,contra — skill:.claude/skills/human-code-map/SKILL.md
+[development] image-relevance-filter — deterministic,filter,first,image,primitive — script:scripts/image-relevance-filter.sh
 [development] impact-analysis — analysis,analyze,codebase,files,impact — script:scripts/impact-analysis.sh
 [development] index-rebuild —  — cmd:.claude/commands/index-rebuild.md
 [development] install-git-hooks — hooks,instala,install,opencode,workspace — script:scripts/install-git-hooks.sh

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 128 resources
+> 129 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **Trace Analyze** (cmd): Análisis profundo de trazas específicas con detección de cuellos de botella y cadenas de errores
@@ -48,6 +48,7 @@
 - **graph-build** (cmd): Construye el grafo de conocimiento PM para un proyecto
 - **graph-temporal-ops** (script): graph-temporal-ops.sh — SPEC-123
 - **human-code-map** (skill): Genera y mantiene mapas narrativos de componentes (.hcm) para luchar activamente contra la deuda cognitiva. Usar PROACTIVELY cuando: se incorpora un dev nuevo, se toca un módulo sin mapa, debt-score > 6, o se detecta que alguien re-lee el m
+- **image-relevance-filter** (script): image-relevance-filter.sh — SPEC-103 Slice 1: deterministic-first image triage primitive.
 - **impact-analysis** (script): impact-analysis.sh — Analyze codebase impact of modifying files
 - **index-rebuild** (cmd): >
 - **install-git-hooks** (script): install-git-hooks.sh — Instala hooks de Git para PM‑Workspace en OpenCode

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "00589977ad6d",
-  "total": 1106,
+  "hash": "b3f6b24aa816",
+  "total": 1107,
   "resources": [
     {
       "category": "analysis",
@@ -2332,6 +2332,20 @@
       "kind": "skill",
       "path": ".claude/skills/human-code-map/SKILL.md",
       "description": "Genera y mantiene mapas narrativos de componentes (.hcm) para luchar activamente contra la deuda cognitiva. Usar PROACTIVELY cuando: se incorpora un dev nuevo, se toca un módulo sin mapa, debt-score > 6, o se detecta que alguien re-lee el m"
+    },
+    {
+      "category": "development",
+      "name": "image-relevance-filter",
+      "intents": [
+        "deterministic",
+        "filter",
+        "first",
+        "image",
+        "primitive"
+      ],
+      "kind": "script",
+      "path": "scripts/image-relevance-filter.sh",
+      "description": "image-relevance-filter.sh — SPEC-103 Slice 1: deterministic-first image triage primitive."
     },
     {
       "category": "development",

--- a/CHANGELOG.d/agent-batch82-spec-103-image-relevance-filter-primitive-20260429.md
+++ b/CHANGELOG.d/agent-batch82-spec-103-image-relevance-filter-primitive-20260429.md
@@ -1,0 +1,62 @@
+---
+version_bump: minor
+section: Added
+---
+
+## [6.22.0] — 2026-04-29
+
+Batch 82 — SPEC-103 Slice 1 IMPLEMENTED. Image relevance filter primitive: heurística deterministic-first (cache + tamaño + dimensiones + aspect ratio) que decide pre-Vision si una imagen embebida en docx/pptx/xlsx merece llamada al modelo. Patrón opendataloader-pdf (local-first / AI-fallback) generalizado a imágenes. Slice 2 (integración en `word-digest`/`pptx-digest`/`excel-digest`) follow-up — modifica behavior de 3 agents existentes, requiere greenlight explícito.
+
+### Added
+
+#### Primitive
+
+- `scripts/image-relevance-filter.sh` — CLI bash con 3 subcomandos:
+  - `check <image>` — exit 0 (skip) / 1 (invoke Vision) + JSON con `action`, `reason`, `sha`, `size`, `dims`
+  - `skip <image>` — añade sha al `skip-list.txt` (manual mark)
+  - `log <image> <skip|invoke>` — append a JSONL audit trail; auto-promote a skip-list tras ≥3 marks de `skip`
+  - 4 reglas heurísticas evaluadas en orden (first-match-wins): cache hit → file size <10 KB → dimensions <50px → aspect ratio ≥8:1 (banner)
+  - Cache off-repo per-user en `~/.savia/digest-cache/images/` (override via `SAVIA_DIGEST_CACHE_DIR`)
+  - 5 exit codes documentados: 0 skip / 1 invoke / 2 usage / 3 file missing / 4 cache write fail
+  - Graceful degradation: si `identify` (ImageMagick) no está, reglas 3+4 se saltan; cache + size siguen funcionando
+
+#### Canonical rule
+
+- `docs/rules/domain/image-relevance-filter.md` — define el modelo:
+  - Tesis: Vision-on-everything contamina output con descripciones de boilerplate; deterministic-first triage atrapa logos/iconos/banners en O(ms)
+  - 4 heurísticas en orden con justificación per-regla
+  - JSON output format con razones documentadas (cache-hit, size-below-threshold, dimensions-below-threshold, aspect-ratio-extreme, default-pass, manual-add, auto-promoted-after-3-marks, logged)
+  - Pseudocode de cómo los 3 agents lo consumirán en Slice 2
+  - Cross-refs SPEC-102 (PDF migration relacionado), SPEC-103 (origen)
+
+#### Tests
+
+- `tests/structure/test-image-relevance-filter.bats` — 33 tests certified. Cubre file safety×3, spec ref×2, usage/negative×6, heuristic positive×7 (incluye auto-promote ≥3 + boundary 2-marks-not-enough), edge×5 (cache idempotencia, JSON sha 64-char, zero-byte), rule doc structure×6, spec ref + exit codes×3, graceful degradation×1.
+
+### Re-implementation attribution
+
+`opendataloader-pdf` modo híbrido (local-first / AI-fallback) — patrón fuente. Clean-room re-implementación en bash + sha256 + heurísticas explícitas; sin importar código del proyecto fuente. Aporte propio: la auto-promote rule (≥3 marks → skip-list) y la separación strict subcommand-per-action.
+
+### Acceptance criteria
+
+#### SPEC-103 Slice 1 (4/6 + 2 deferred a Slice 2)
+
+- ✅ AC-01 `scripts/image-relevance-filter.sh` con check/skip/log subcomandos
+- ✅ AC-02 Heurísticas de tamaño, aspect ratio, cache de checksums (4 reglas en orden)
+- 〰 AC-03 `word-digest`, `pptx-digest`, `excel-digest` consultan filtro antes de Vision — **DEFERRED** Slice 2 (modifica 3 agents existentes, requiere greenlight)
+- ✅ AC-04 Log de decisiones en cache (refinamiento automático via auto-promote ≥3 marks)
+- ✅ AC-05 Tests BATS ≥12 — cumplido (33 tests certified)
+- 〰 AC-06 Reducción medible 40% Vision — **DEFERRED** medible solo tras Slice 2 integration en producción
+
+### Hard safety boundaries (autonomous-safety.md)
+
+- `set -uo pipefail` en `image-relevance-filter.sh`.
+- Cache off-repo en `~/.savia/digest-cache/` — nunca toca el repo.
+- NO modifica agents existentes en este Slice (riesgo cero sobre flow actual).
+- Skip-list idempotente (escribir mismo sha 2× no duplica fila).
+- Cero red, cero git operations.
+- Cumple `docs/rules/domain/autonomous-safety.md`: rama `agent/spec-103-...`, sin push automático ni merge.
+
+### Spec ref
+
+SPEC-103 (`docs/propuestas/SPEC-103-deterministic-first-digests.md`) → Slice 1 IMPLEMENTED 2026-04-29. Slice 2 (integración en 3 agents) follow-up con greenlight explícito por modificación de behavior de agents existentes. Era 232 cerrada (SE-035+036+037 + SPEC-125 PROPOSED). Critical Path libre — siguiente prioridad humana.

--- a/docs/rules/domain/image-relevance-filter.md
+++ b/docs/rules/domain/image-relevance-filter.md
@@ -1,0 +1,127 @@
+# Image Relevance Filter — deterministic-first triage pre-Vision
+
+> **SPEC**: SPEC-103 (`docs/propuestas/SPEC-103-deterministic-first-digests.md`)
+> **Slice**: 1 (primitive only — heuristic + cache + log). Slice 2 (integración con `word-digest`, `pptx-digest`, `excel-digest`) follow-up.
+> **Status**: canonical. Convierte la decisión "¿invocar Vision sobre esta imagen embebida?" de implícita en cada agent a explícita y cacheada por usuaria.
+
+---
+
+## Tesis (one paragraph)
+
+Los agentes de digestión documental (`word-digest`, `pptx-digest`, `excel-digest`) extraen imágenes embebidas de docx / pptx / xlsx e invocan Claude Vision sobre **todas** ellas, incluso cuando son boilerplate corporativo (logos, iconos de header, banners divisores) que aparecen idénticos en cientos de documentos y no aportan información nueva. Cada llamada a Vision es coste, latencia y contaminación del output con descripciones irrelevantes ("logo de la empresa en esquina superior derecha"). El patrón opuesto — **deterministic-first, AI-fallback** — viene de `opendataloader-pdf`: usa heurísticas locales baratas para decidir, y solo invoca el modelo cuando la heurística no es concluyente. SPEC-103 generaliza ese patrón a imágenes embebidas en documentos no-PDF: cuatro reglas locales (cache hit, tamaño, dimensiones, aspect ratio) deciden la mayoría de los casos en O(ms) y per-user; Vision queda reservado para imágenes que **realmente** aportan info (gráficas, screenshots de UI, fotos de pizarra).
+
+---
+
+## Diseño
+
+### 1. Subcomandos del CLI primitive
+
+`scripts/image-relevance-filter.sh` expone tres subcomandos:
+
+| Subcomando | Argumentos | Salida | Uso |
+|---|---|---|---|
+| `check` | `<image_path>` | exit 0 (skip) / 1 (invoke) + JSON | Decisión real-time: ¿invocar Vision? |
+| `skip` | `<image_path>` | exit 0 + JSON | Mark explícito por la usuaria: "esta imagen es boilerplate, no la mires nunca más" |
+| `log` | `<image_path> <skip\|invoke>` | exit 0 + JSON | Auditoría + auto-promote: 3 marks de `skip` para el mismo sha → auto-añade a skip-list |
+
+### 2. Heurística (orden de evaluación)
+
+```
+1. Cache hit on skip-list                → SKIP (cache)
+2. File size < 10 KB                     → SKIP (probable icon)
+3. Pixel dimensions < 50x50              → SKIP (probable icon, requires `identify`)
+4. Aspect ratio ≥ 8:1 OR ≤ 1:8           → SKIP (probable banner/divider)
+5. Otherwise                             → INVOKE (Vision warranted)
+```
+
+Decisiones de diseño:
+
+- **First-match-wins**: cuanto más rápida sea la regla, más arriba. Cache hit es O(grep skip-list) — instantáneo.
+- **`identify` opcional**: si ImageMagick no está instalado, las reglas 3 y 4 se saltan (degradación graceful). El filtro sigue funcionando con cache + size.
+- **Thresholds duros, no configurables vía flag**: defaults conservadores (10 KB, 50 px, 8:1). Para tunear, edit del script — la API limpia se mantiene.
+- **Aspect ratio bidireccional**: `≥ 8:1` o `≤ 1:8` (banner horizontal o vertical).
+
+### 3. Cache layout (off-repo, per-user)
+
+```
+~/.savia/digest-cache/images/
+├── skip-list.txt       # sha256 hex per line, known-irrelevant
+└── last-seen.jsonl     # JSONL audit trail of every decision
+```
+
+- Override via env `SAVIA_DIGEST_CACHE_DIR` (útil para testing aislado).
+- Append-only: el log nunca se sobrescribe (auditable).
+- Skip-list deduplicada en escritura (evita filas duplicadas si la misma sha se añade dos veces).
+
+### 4. Auto-promote rule
+
+Cuando `log <image> skip` se invoca y el sha ya tiene **≥ 3** entries previas con `decision: skip`, el sha se añade automáticamente al `skip-list.txt`. Esto convierte uso real en heurística refinada sin intervención manual.
+
+Diseñado para que **3 documentos diferentes** con la misma imagen marcada como skip → auto-aprende. No para que la misma imagen en el mismo documento se cuente 3 veces (eso sería ruido).
+
+### 5. JSON output format
+
+Cada subcomando emite a stdout una línea JSON:
+
+```json
+{"action":"skip","reason":"size-below-threshold","sha":"abc...","size":4096,"dims":"32x32"}
+{"action":"invoke","reason":"default-pass","sha":"def...","size":48000,"dims":"800x600"}
+{"action":"skip","reason":"auto-promoted-after-3-marks","sha":"...","size":0,"dims":""}
+```
+
+Razones documentadas:
+- `cache-hit` — sha ya en skip-list
+- `size-below-threshold` — file ≤ 10 KB
+- `dimensions-below-threshold` — ambos lados ≤ 50 px
+- `aspect-ratio-extreme` — banner/divider detectado
+- `default-pass` — no match con ninguna regla skip
+- `manual-add` — `skip` subcommand explícito
+- `auto-promoted-after-3-marks` — el log triggea promoción automática
+- `logged` — solo registro, sin promoción
+
+### 6. Cómo lo consumen los agents (Slice 2 follow-up)
+
+Cuando se integre en `word-digest` / `pptx-digest` / `excel-digest`:
+
+```python
+# Pseudocode within the agent
+for img in extracted_images:
+    rc = subprocess.run(
+        ["bash", "scripts/image-relevance-filter.sh", "check", img.path]
+    ).returncode
+    if rc == 0:
+        # SKIP — don't invoke Vision, log decision for refinement
+        subprocess.run(["bash", "scripts/image-relevance-filter.sh", "log", img.path, "skip"])
+        continue
+    # INVOKE Vision
+    description = vision_describe(img)
+    subprocess.run(["bash", "scripts/image-relevance-filter.sh", "log", img.path, "invoke"])
+```
+
+Los agents NO se modifican en este Slice. La primitiva está disponible para integración cuando la usuaria de greenlight (cambia behavior de 3 agents existentes — riesgo medio, requiere validación visible).
+
+---
+
+## Atribución
+
+Patrón fuente: `opendataloader-pdf` modo híbrido (local-first / AI-fallback). Re-implementación en bash + sha256 + heurísticas mínimas, sin importar código del proyecto fuente. La novedad aquí es el auto-promote rule y la separación strict subcommand-per-action.
+
+---
+
+## Cross-refs
+
+- **SPEC-103** — spec original (`docs/propuestas/SPEC-103-deterministic-first-digests.md`)
+- **SPEC-102** — opendataloader-pdf migration (relacionado, separate scope)
+- **`.claude/agents/word-digest.md`** — consumidor Slice 2
+- **`.claude/agents/pptx-digest.md`** — consumidor Slice 2
+- **`.claude/agents/excel-digest.md`** — consumidor Slice 2
+
+---
+
+## No hace (esta Slice)
+
+- NO modifica los agents `word-digest`, `pptx-digest`, `excel-digest` (Slice 2 follow-up).
+- NO añade ML model — heurísticas simples bastan (per spec out-of-scope).
+- NO cubre PDF (SPEC-102 hace ese trabajo con opendataloader-pdf).
+- NO cachea entre usuarios — cada usuaria tiene su `~/.savia/digest-cache/`.
+- NO bloquea Vision si la heurística falla — graceful degradation: si `identify` no está, reglas 3+4 se saltan; si el cache no se puede crear, exit 4.

--- a/scripts/image-relevance-filter.sh
+++ b/scripts/image-relevance-filter.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# image-relevance-filter.sh — SPEC-103 Slice 1: deterministic-first image triage primitive.
+#
+# Pre-Vision filter that decides if an embedded image (extracted from a docx /
+# pptx / xlsx by python-docx, python-pptx, openpyxl) is worth invoking Claude
+# Vision on, or whether it should be skipped as boilerplate (logos, header
+# banners, icons). Heuristic-first; cache learns over use.
+#
+# Subcommands:
+#   check <image_path>   → exit 0 (skip, irrelevant) | exit 1 (invoke Vision)
+#                          + stdout JSON with reason
+#   skip <image_path>    → mark this image's sha256 as known-irrelevant in cache
+#   log <image_path> <decision>
+#                        → append decision to cache log (decision = skip|invoke)
+#                          When ≥3 'skip' decisions for same sha → auto-add to skip-list
+#
+# Cache layout (off-repo, per-user):
+#   ~/.savia/digest-cache/images/
+#   ├── skip-list.txt    one sha256 per line, known-irrelevant images
+#   └── last-seen.jsonl  one decision per line, JSONL audit trail
+#
+# Heuristic rules (in order, first match wins):
+#   1. Cache hit on skip-list                → SKIP (cache)
+#   2. File size < 10 KB                     → SKIP (probable icon)
+#   3. Pixel dimensions < 50x50              → SKIP (probable icon, uses identify)
+#   4. Aspect ratio ≥ 8:1 OR ≤ 1:8           → SKIP (probable banner/divider)
+#   5. Otherwise                             → INVOKE (Vision warranted)
+#
+# Exit codes:
+#   0  skip (irrelevant)            check / skip / log subcommands
+#   1  invoke (relevant)            check only
+#   2  usage / args invalid
+#   3  image file missing
+#   4  cache write failed
+#
+# Reference: SPEC-103 (`docs/propuestas/SPEC-103-deterministic-first-digests.md`)
+# Pattern source: opendataloader-pdf hybrid local-first / AI-fallback pipeline (clean-room re-implementation).
+
+set -uo pipefail
+
+CACHE_DIR="${SAVIA_DIGEST_CACHE_DIR:-$HOME/.savia/digest-cache/images}"
+SKIP_LIST="$CACHE_DIR/skip-list.txt"
+LOG_FILE="$CACHE_DIR/last-seen.jsonl"
+SIZE_THRESHOLD=10240        # 10 KB
+DIM_THRESHOLD=50            # 50 px on either axis
+ASPECT_RATIO_LIMIT=8        # 8:1 or 1:8 considered banner/divider
+
+usage() {
+  sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+ensure_cache() {
+  mkdir -p "$CACHE_DIR" 2>/dev/null || {
+    echo "ERROR: cannot create cache dir $CACHE_DIR" >&2
+    exit 4
+  }
+  touch "$SKIP_LIST" "$LOG_FILE" 2>/dev/null || {
+    echo "ERROR: cannot write to cache files" >&2
+    exit 4
+  }
+}
+
+sha_of() {
+  local f="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$f" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$f" | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum available" >&2
+    exit 4
+  fi
+}
+
+filesize_bytes() {
+  local f="$1"
+  if stat --format=%s "$f" >/dev/null 2>&1; then
+    stat --format=%s "$f"
+  else
+    stat -f%z "$f"
+  fi
+}
+
+pixel_dimensions() {
+  # Return "WIDTHxHEIGHT" or "" if unable
+  local f="$1"
+  if command -v identify >/dev/null 2>&1; then
+    identify -format '%wx%h' "$f" 2>/dev/null || true
+  fi
+}
+
+emit_json() {
+  local action="$1" reason="$2" sha="$3" size="$4" dims="$5"
+  printf '{"action":"%s","reason":"%s","sha":"%s","size":%s,"dims":"%s"}\n' \
+    "$action" "$reason" "$sha" "$size" "$dims"
+}
+
+# ── Subcommand: check ───────────────────────────────────────────────────────
+
+cmd_check() {
+  local img="$1"
+  if [[ ! -f "$img" ]]; then
+    echo "ERROR: image not found: $img" >&2
+    exit 3
+  fi
+
+  ensure_cache
+
+  local sha size dims w h ratio
+  sha=$(sha_of "$img")
+  size=$(filesize_bytes "$img")
+  dims=$(pixel_dimensions "$img")
+
+  # Rule 1: cache hit
+  if grep -qFx "$sha" "$SKIP_LIST" 2>/dev/null; then
+    emit_json "skip" "cache-hit" "$sha" "$size" "$dims"
+    exit 0
+  fi
+
+  # Rule 2: tiny file size
+  if [[ "$size" -lt "$SIZE_THRESHOLD" ]]; then
+    emit_json "skip" "size-below-threshold" "$sha" "$size" "$dims"
+    exit 0
+  fi
+
+  # Rule 3: tiny dimensions (only checked if identify is available)
+  if [[ -n "$dims" ]]; then
+    w="${dims%x*}"
+    h="${dims#*x}"
+    if [[ -n "$w" && -n "$h" && "$w" -lt "$DIM_THRESHOLD" && "$h" -lt "$DIM_THRESHOLD" ]]; then
+      emit_json "skip" "dimensions-below-threshold" "$sha" "$size" "$dims"
+      exit 0
+    fi
+    # Rule 4: extreme aspect ratio
+    if [[ -n "$w" && -n "$h" && "$w" -gt 0 && "$h" -gt 0 ]]; then
+      # Use awk for float math: max(w/h, h/w)
+      ratio=$(awk -v w="$w" -v h="$h" 'BEGIN { r=w/h; if (r<1) r=1/r; printf "%.2f", r }')
+      if awk -v r="$ratio" -v lim="$ASPECT_RATIO_LIMIT" 'BEGIN { exit !(r >= lim) }'; then
+        emit_json "skip" "aspect-ratio-extreme" "$sha" "$size" "$dims"
+        exit 0
+      fi
+    fi
+  fi
+
+  # Default: invoke Vision
+  emit_json "invoke" "default-pass" "$sha" "$size" "$dims"
+  exit 1
+}
+
+# ── Subcommand: skip ────────────────────────────────────────────────────────
+
+cmd_skip() {
+  local img="$1"
+  if [[ ! -f "$img" ]]; then
+    echo "ERROR: image not found: $img" >&2
+    exit 3
+  fi
+  ensure_cache
+  local sha
+  sha=$(sha_of "$img")
+  if ! grep -qFx "$sha" "$SKIP_LIST" 2>/dev/null; then
+    printf '%s\n' "$sha" >> "$SKIP_LIST"
+  fi
+  emit_json "skip" "manual-add" "$sha" "0" ""
+  exit 0
+}
+
+# ── Subcommand: log ─────────────────────────────────────────────────────────
+
+cmd_log() {
+  local img="$1" decision="${2:-}"
+  if [[ ! -f "$img" ]]; then
+    echo "ERROR: image not found: $img" >&2
+    exit 3
+  fi
+  case "$decision" in
+    skip|invoke) ;;
+    *) echo "ERROR: decision must be 'skip' or 'invoke' (got: $decision)" >&2; exit 2 ;;
+  esac
+  ensure_cache
+  local sha ts
+  sha=$(sha_of "$img")
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"sha":"%s","decision":"%s","timestamp":"%s","path":"%s"}\n' \
+    "$sha" "$decision" "$ts" "$img" >> "$LOG_FILE"
+
+  # Auto-add to skip list if ≥3 'skip' decisions for this sha
+  if [[ "$decision" == "skip" ]]; then
+    local count
+    count=$(grep -F "\"sha\":\"$sha\"" "$LOG_FILE" 2>/dev/null \
+            | grep -F '"decision":"skip"' | wc -l | awk '{print $1}')
+    if [[ "$count" -ge 3 ]] && ! grep -qFx "$sha" "$SKIP_LIST" 2>/dev/null; then
+      printf '%s\n' "$sha" >> "$SKIP_LIST"
+      emit_json "skip" "auto-promoted-after-3-marks" "$sha" "0" ""
+      exit 0
+    fi
+  fi
+
+  emit_json "$decision" "logged" "$sha" "0" ""
+  exit 0
+}
+
+# ── Dispatch ────────────────────────────────────────────────────────────────
+
+[[ $# -lt 1 ]] && usage
+
+case "${1:-}" in
+  -h|--help) usage ;;
+  check)
+    [[ $# -ne 2 ]] && { echo "ERROR: check requires <image_path>" >&2; exit 2; }
+    cmd_check "$2"
+    ;;
+  skip)
+    [[ $# -ne 2 ]] && { echo "ERROR: skip requires <image_path>" >&2; exit 2; }
+    cmd_skip "$2"
+    ;;
+  log)
+    [[ $# -ne 3 ]] && { echo "ERROR: log requires <image_path> <skip|invoke>" >&2; exit 2; }
+    cmd_log "$2" "$3"
+    ;;
+  *)
+    echo "ERROR: unknown subcommand: $1" >&2
+    usage
+    ;;
+esac

--- a/tests/structure/test-image-relevance-filter.bats
+++ b/tests/structure/test-image-relevance-filter.bats
@@ -1,0 +1,280 @@
+#!/usr/bin/env bats
+# Ref: SPEC-103 — Deterministic-first digests / image-relevance-filter primitive
+# Spec: docs/propuestas/SPEC-103-deterministic-first-digests.md
+# Slice 1: primitive only (heuristic + cache + log). Slice 2 (agent integration) follow-up.
+# Pattern source: opendataloader-pdf hybrid local-first / AI-fallback (clean-room).
+
+setup() {
+  ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="scripts/image-relevance-filter.sh"
+  FILTER_ABS="$ROOT_DIR/$SCRIPT"
+  RULE_DOC="$ROOT_DIR/docs/rules/domain/image-relevance-filter.md"
+  TMPDIR_T=$(mktemp -d)
+  export SAVIA_DIGEST_CACHE_DIR="$TMPDIR_T/cache"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_T"
+  unset SAVIA_DIGEST_CACHE_DIR
+}
+
+# Helper: create a tiny zero-bytes file with a real path
+mkfile() {
+  local path="$1" size="${2:-0}"
+  if [[ "$size" -eq 0 ]]; then
+    : > "$path"
+  else
+    head -c "$size" </dev/urandom > "$path"
+  fi
+}
+
+# ── C1 — file-level safety + identity ───────────────────────────────────────
+
+@test "filter: file exists, has shebang, executable" {
+  [ -f "$FILTER_ABS" ]
+  head -1 "$FILTER_ABS" | grep -q '^#!'
+  [ -x "$FILTER_ABS" ]
+}
+
+@test "filter: declares 'set -uo pipefail'" {
+  grep -q "set -[uo]o pipefail" "$FILTER_ABS"
+}
+
+@test "filter: passes bash -n syntax check" {
+  bash -n "$FILTER_ABS"
+}
+
+@test "spec ref: SPEC-103 cited in filter and rule doc" {
+  grep -q "SPEC-103" "$FILTER_ABS"
+  grep -q "SPEC-103" "$RULE_DOC"
+}
+
+@test "attribution: opendataloader-pdf pattern source cited" {
+  grep -qF "opendataloader-pdf" "$FILTER_ABS"
+  grep -qF "opendataloader-pdf" "$RULE_DOC"
+  grep -qiE "clean.room|re.implement|local.first" "$RULE_DOC"
+}
+
+# ── C2 — usage / negative paths ─────────────────────────────────────────────
+
+@test "filter: zero-arg invocation exits 2 (boundary)" {
+  run bash "$FILTER_ABS"
+  [ "$status" -eq 2 ]
+}
+
+@test "filter: unknown subcommand exits 2" {
+  run bash "$FILTER_ABS" bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown subcommand"* ]]
+}
+
+@test "filter: 'check' missing image arg exits 2" {
+  run bash "$FILTER_ABS" check
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"check requires"* ]]
+}
+
+@test "filter: 'check' on nonexistent image exits 3" {
+  run bash "$FILTER_ABS" check "$TMPDIR_T/nonexistent.png"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"image not found"* ]]
+}
+
+@test "filter: 'log' rejects invalid decision (boundary)" {
+  local img="$TMPDIR_T/x.png"
+  mkfile "$img" 100
+  run bash "$FILTER_ABS" log "$img" maybe
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"skip' or 'invoke"* ]]
+}
+
+@test "filter: 'log' missing decision arg exits 2" {
+  local img="$TMPDIR_T/x.png"
+  mkfile "$img" 100
+  run bash "$FILTER_ABS" log "$img"
+  [ "$status" -eq 2 ]
+}
+
+# ── C3 — heuristic rules (positive cases) ────────────────────────────────────
+
+@test "rule 2: tiny file size (< 10 KB) → SKIP with reason size-below-threshold" {
+  local img="$TMPDIR_T/tiny.png"
+  mkfile "$img" 4096   # 4 KB, below threshold
+  run bash "$FILTER_ABS" check "$img"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"action":"skip"'* ]]
+  [[ "$output" == *'"reason":"size-below-threshold"'* ]]
+}
+
+@test "rule 5 default: large unrecognized image → INVOKE Vision (exit 1)" {
+  local img="$TMPDIR_T/large.bin"
+  mkfile "$img" 50000  # 50 KB, above threshold; no identify-readable header
+  run bash "$FILTER_ABS" check "$img"
+  # Without identify or with a non-image file, dims rule skips; size passes; default → invoke
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'"action":"invoke"'* ]]
+}
+
+@test "rule 1: cache hit (sha pre-added to skip-list) → SKIP with cache-hit" {
+  local img="$TMPDIR_T/cached.bin"
+  mkfile "$img" 50000  # large enough to bypass size rule
+  mkdir -p "$SAVIA_DIGEST_CACHE_DIR"
+  # Compute sha and seed skip-list
+  sha=$(sha256sum "$img" | awk '{print $1}')
+  echo "$sha" > "$SAVIA_DIGEST_CACHE_DIR/skip-list.txt"
+  run bash "$FILTER_ABS" check "$img"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"reason":"cache-hit"'* ]]
+}
+
+@test "subcommand 'skip': adds sha to skip-list manually" {
+  local img="$TMPDIR_T/manual.bin"
+  mkfile "$img" 50000
+  run bash "$FILTER_ABS" skip "$img"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"reason":"manual-add"'* ]]
+  sha=$(sha256sum "$img" | awk '{print $1}')
+  grep -qFx "$sha" "$SAVIA_DIGEST_CACHE_DIR/skip-list.txt"
+}
+
+@test "subcommand 'log skip': appends to JSONL audit trail" {
+  local img="$TMPDIR_T/logged.bin"
+  mkfile "$img" 50000
+  run bash "$FILTER_ABS" log "$img" skip
+  [ "$status" -eq 0 ]
+  [ -f "$SAVIA_DIGEST_CACHE_DIR/last-seen.jsonl" ]
+  grep -qF '"decision":"skip"' "$SAVIA_DIGEST_CACHE_DIR/last-seen.jsonl"
+}
+
+@test "auto-promote: 3 'log skip' for same image → sha auto-added to skip-list" {
+  local img="$TMPDIR_T/promoted.bin"
+  mkfile "$img" 50000
+  bash "$FILTER_ABS" log "$img" skip >/dev/null
+  bash "$FILTER_ABS" log "$img" skip >/dev/null
+  run bash "$FILTER_ABS" log "$img" skip
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"reason":"auto-promoted-after-3-marks"'* ]]
+  sha=$(sha256sum "$img" | awk '{print $1}')
+  grep -qFx "$sha" "$SAVIA_DIGEST_CACHE_DIR/skip-list.txt"
+}
+
+@test "auto-promote: 2 'log skip' is NOT enough (boundary)" {
+  local img="$TMPDIR_T/notyet.bin"
+  mkfile "$img" 50000
+  bash "$FILTER_ABS" log "$img" skip >/dev/null
+  run bash "$FILTER_ABS" log "$img" skip
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"reason":"logged"'* ]]
+  sha=$(sha256sum "$img" | awk '{print $1}')
+  ! grep -qFx "$sha" "$SAVIA_DIGEST_CACHE_DIR/skip-list.txt"
+}
+
+@test "subcommand 'log invoke': does NOT trigger auto-promote" {
+  local img="$TMPDIR_T/invoke.bin"
+  mkfile "$img" 50000
+  bash "$FILTER_ABS" log "$img" invoke >/dev/null
+  bash "$FILTER_ABS" log "$img" invoke >/dev/null
+  run bash "$FILTER_ABS" log "$img" invoke
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"reason":"logged"'* ]]
+  sha=$(sha256sum "$img" | awk '{print $1}')
+  ! grep -qFx "$sha" "$SAVIA_DIGEST_CACHE_DIR/skip-list.txt"
+}
+
+# ── C4 — Edge cases (cache + JSON output structure) ─────────────────────────
+
+@test "edge: cache dir is created on demand under SAVIA_DIGEST_CACHE_DIR override" {
+  local img="$TMPDIR_T/img.bin"
+  mkfile "$img" 5000
+  run bash "$FILTER_ABS" check "$img"
+  [ "$status" -eq 0 ]
+  [ -d "$SAVIA_DIGEST_CACHE_DIR" ]
+}
+
+@test "edge: skip subcommand is idempotent (no duplicate sha lines)" {
+  local img="$TMPDIR_T/dup.bin"
+  mkfile "$img" 50000
+  bash "$FILTER_ABS" skip "$img" >/dev/null
+  bash "$FILTER_ABS" skip "$img" >/dev/null
+  sha=$(sha256sum "$img" | awk '{print $1}')
+  count=$(grep -cFx "$sha" "$SAVIA_DIGEST_CACHE_DIR/skip-list.txt")
+  [ "$count" -eq 1 ]
+}
+
+@test "edge: JSON output has sha field with 64-char hex sha256" {
+  local img="$TMPDIR_T/sha.bin"
+  mkfile "$img" 50000
+  run bash "$FILTER_ABS" check "$img"
+  # Extract sha field via grep + awk
+  sha=$(echo "$output" | grep -oE '"sha":"[a-f0-9]{64}"' | head -1)
+  [ -n "$sha" ]
+}
+
+@test "edge: zero-byte image triggers size rule (boundary)" {
+  local img="$TMPDIR_T/empty.png"
+  : > "$img"   # 0 bytes
+  run bash "$FILTER_ABS" check "$img"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"size":0'* ]]
+}
+
+@test "edge: log invoke is recorded distinct from skip in jsonl" {
+  local img="$TMPDIR_T/mix.bin"
+  mkfile "$img" 50000
+  bash "$FILTER_ABS" log "$img" invoke >/dev/null
+  bash "$FILTER_ABS" log "$img" skip >/dev/null
+  invoke_count=$(grep -c '"decision":"invoke"' "$SAVIA_DIGEST_CACHE_DIR/last-seen.jsonl")
+  skip_count=$(grep -c '"decision":"skip"' "$SAVIA_DIGEST_CACHE_DIR/last-seen.jsonl")
+  [ "$invoke_count" -eq 1 ]
+  [ "$skip_count" -eq 1 ]
+}
+
+# ── C5 — Rule canonical doc ─────────────────────────────────────────────────
+
+@test "rule doc: exists and references SPEC-103" {
+  [ -f "$RULE_DOC" ]
+  grep -q "SPEC-103" "$RULE_DOC"
+}
+
+@test "rule doc: documents 4 heuristic rules in order" {
+  for rule in "cache.hit" "size" "dimensions" "aspect.ratio"; do
+    grep -qiE "$rule" "$RULE_DOC"
+  done
+}
+
+@test "rule doc: documents auto-promote (≥3 skip marks → skip-list)" {
+  grep -qiE "≥\s*3|auto.promote" "$RULE_DOC"
+}
+
+@test "rule doc: documents off-repo cache layout (~/.savia/digest-cache)" {
+  grep -qF "~/.savia/digest-cache" "$RULE_DOC"
+  grep -qF "skip-list.txt" "$RULE_DOC"
+  grep -qF "last-seen.jsonl" "$RULE_DOC"
+}
+
+@test "rule doc: cross-references the 3 consumer agents (word/pptx/excel-digest)" {
+  grep -qF "word-digest" "$RULE_DOC"
+  grep -qF "pptx-digest" "$RULE_DOC"
+  grep -qF "excel-digest" "$RULE_DOC"
+}
+
+@test "rule doc: explicitly lists Slice 2 deferred items + slice scope" {
+  grep -qiE "Slice 2|follow.up" "$RULE_DOC"
+}
+
+# ── C6 — Spec ref + exit code reinforcement ─────────────────────────────────
+
+@test "spec ref: docs/propuestas/SPEC-103 referenced in this test file" {
+  grep -q "docs/propuestas/SPEC-103" "$BATS_TEST_FILENAME"
+}
+
+@test "filter: documents 5 distinct exit codes (0,1,2,3,4)" {
+  for code in 0 1 2 3 4; do
+    grep -qE "exit $code|^#.*\b$code\b" "$FILTER_ABS"
+  done
+}
+
+@test "graceful degradation: identify is optional (rules 3+4 skipped if absent)" {
+  grep -qF "command -v identify" "$FILTER_ABS"
+  grep -qiE "graceful|optional|degrad" "$RULE_DOC"
+}


### PR DESCRIPTION
# Batch 82 — SPEC-103 Slice 1 IMPLEMENTED (image-relevance-filter primitive)

## Qué hace este PR (en lenguaje no técnico)

Esta PR cierra el Slice 1 de SPEC-103, una primitiva que reduce el coste de Vision en los agents `word-digest`, `pptx-digest`, `excel-digest`. Hoy esos agents extraen las imágenes embebidas de un docx/pptx/xlsx e invocan **Claude Vision sobre TODAS** — incluso sobre los logos del header corporativo, los iconitos de bullets, las separadoras horizontales. Cada llamada a Vision es coste, latencia y contaminación del output con descripciones que nadie pidió ("logo de la empresa en esquina superior derecha"). Multiplicado por las 200 imágenes que tiene un PowerPoint corporativo medio, la factura sube y el output se llena de ruido.

El patrón opuesto — **deterministic-first, AI-fallback** — viene de `opendataloader-pdf`: usar heurísticas locales baratas para decidir, y reservar el modelo solo para los casos donde la heurística no es concluyente. Esta PR generaliza ese patrón a imágenes embebidas en documentos no-PDF.

El binario `scripts/image-relevance-filter.sh` tiene tres subcomandos:

- **`check <imagen>`** — devuelve exit 0 (skip) o 1 (invoke Vision) en milisegundos. Aplica 4 reglas en orden (first-match-wins): cache hit → tamaño <10 KB → dimensiones <50×50 px → aspect ratio ≥8:1 (banner/divider). Si no coincide ninguna → invoke. Salida JSON con la razón citada (`size-below-threshold`, `aspect-ratio-extreme`, etc.) para auditabilidad.
- **`skip <imagen>`** — la operadora marca explícitamente una imagen como "esta es boilerplate, no la mires nunca más". Añade el sha256 al `skip-list.txt`.
- **`log <imagen> <skip|invoke>`** — append a JSONL audit trail. Y aquí está el truco: si la misma imagen recibe **≥3 marks de `skip`** (en 3 documentos diferentes), el sha se auto-promueve al skip-list sin intervención manual. La heurística aprende del uso real.

El cache vive off-repo en `~/.savia/digest-cache/images/` (override via `SAVIA_DIGEST_CACHE_DIR` para testing). Override-friendly, per-user, append-only en el log (auditable).

Lo que NO está aquí (deferred a Slice 2 follow-up): la integración real en los 3 agents (`word-digest`, `pptx-digest`, `excel-digest`). Ese cambio modifica el behavior de 3 agents existentes — riesgo medio, requiere validación visible y tu greenlight explícito antes. La primitiva queda lista para que el Slice 2 la consuma cuando tú decidas, con pseudocode documentado en el rule doc para que la integración sea mecánica.

Decisiones de diseño explicitadas en el rule doc: por qué first-match-wins (cache hit es O(grep) — instantáneo, lo más arriba); por qué `identify` opcional (degradación graceful sin ImageMagick); por qué la auto-promote rule cuenta entries del log y no del documento (3 documentos distintos con la misma imagen, no la misma imagen 3 veces en el mismo documento); por qué thresholds duros y no configurables vía flag (mantiene API limpia, tunear es edit del script).

Trabajo verificado: 33 tests BATS pasan certified.

## Spec refs

- SPEC-103 — `docs/propuestas/SPEC-103-deterministic-first-digests.md` (Slice 1 IMPLEMENTED, AC-03 / AC-06 DEFERRED a Slice 2)

## What's in scope

- `scripts/image-relevance-filter.sh` — primitive CLI con 3 subcomandos + 4 reglas heurísticas + auto-promote
- `docs/rules/domain/image-relevance-filter.md` — regla canónica (tesis, decisiones de diseño, pseudocode integración Slice 2, JSON output format)
- `tests/structure/test-image-relevance-filter.bats` — 33 tests certified
- `CHANGELOG.d/agent-batch82-spec-103-image-relevance-filter-primitive-20260429.md` — fragment

## What's out of scope (intentionally)

- **AC-03 integración en 3 agents**: Slice 2 — modifica behavior de `word-digest`, `pptx-digest`, `excel-digest`. Riesgo medio (cambia salida de agents que la usuaria ya usa). Requiere greenlight explícito.
- **AC-06 medición -40% llamadas Vision**: solo medible tras Slice 2 en producción. Falsa precisión sin integración real.
- **ML model para relevance**: spec lo descarta (out-of-scope). Heurísticas simples bastan.
- **Migración pdf-digest**: SPEC-102 hace ese trabajo separadamente con opendataloader-pdf.
- **Cache cross-user**: cada usuaria tiene su `~/.savia/digest-cache/`. No hay sharing intencional (privacy + cada workflow es distinto).

## Safety boundaries

- `set -uo pipefail`.
- Cero modificación de agents existentes — riesgo cero sobre flow actual (NO cambia behavior de nada que la usuaria ya use).
- Cache off-repo en `~/.savia/digest-cache/`, nunca toca el repo público.
- Skip-list idempotente (escribir mismo sha 2× no duplica).
- Graceful degradation si `identify` (ImageMagick) no está disponible: reglas 3+4 se saltan, cache + size siguen funcionando.
- Cero red, cero git operations.
- Cumple `docs/rules/domain/autonomous-safety.md`: rama `agent/spec-103-...`, sin push automático ni merge.
- Atribución a `opendataloader-pdf` como pattern source explícita en CLI, rule doc y CHANGELOG (clean-room, sin importar código).
