### PR TITLE
fix(savia-monitor): detect alive PIDs on macOS via libc::kill

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0847c8964de4433708ed0225b7970de31768bc9c0537e8a151728da7a7763a8f
-timestamp=2026-04-29T21:06:42Z
-branch=agent/fix-blocklist-generator-unicode-grep-20260429
-head_commit=82e13150
-signature=620d84be7bfd3e45c05d7c2bbc1f31e77d17ecb6ff9f6fb7f4197db07e0d94ee
+diff_hash=3b4189860838d3bfae8aae4ad46bee8738733ca53f5c41336fb1d1c99f12f7a3
+timestamp=2026-04-29T21:43:28Z
+branch=fix/savia-monitor-macos-pid-detection
+head_commit=5889fe76
+signature=4559bfe40ace6b285aacca5cebc553f47d2dfdadd9120f1e28d545786bcd892d

--- a/projects/savia-monitor/CHANGELOG.md
+++ b/projects/savia-monitor/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — Savia Monitor
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Savia Monitor: fix `is_pid_alive` on macOS — replace `/proc/{pid}` check with POSIX `libc::kill(pid, 0)`. Cross-Unix compatible without `/proc` dependency. Windows path unchanged.

--- a/projects/savia-monitor/src-tauri/Cargo.lock
+++ b/projects/savia-monitor/src-tauri/Cargo.lock
@@ -3417,6 +3417,7 @@ name = "savia-monitor"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "libc",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/projects/savia-monitor/src-tauri/Cargo.toml
+++ b/projects/savia-monitor/src-tauri/Cargo.toml
@@ -17,3 +17,6 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["blocking", "json", "native-tls-vendored"] }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/projects/savia-monitor/src-tauri/src/sessions.rs
+++ b/projects/savia-monitor/src-tauri/src/sessions.rs
@@ -38,9 +38,11 @@ fn is_pid_alive(pid: u32) -> bool {
             out.contains(&pid.to_string())
         }).unwrap_or(false)
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(unix)]
     {
-        std::path::Path::new(&format!("/proc/{}", pid)).exists()
+        // kill(pid, 0) checks process existence without sending a signal.
+        // Works on macOS, Linux, and other Unix variants (no /proc dependency).
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
     }
 }
 

--- a/tests/test-savia-monitor-linux.bats
+++ b/tests/test-savia-monitor-linux.bats
@@ -107,9 +107,9 @@ teardown() {
 
 # ── Rust source code cross-platform ─────────────────────────────────────────
 
-@test "sessions.rs has Linux PID detection via /proc" {
+@test "sessions.rs has Unix PID detection via libc::kill" {
   local sessions="$REPO_ROOT/projects/savia-monitor/src-tauri/src/sessions.rs"
-  grep -q "/proc/" "$sessions"
+  grep -q "libc::kill" "$sessions"
 }
 
 @test "config.rs handles HOME env var" {


### PR DESCRIPTION
`/proc/{pid}` no existe en macOS, así que `is_pid_alive` devolvía siempre false y la lista de sesiones quedaba vacía. Reemplaza la comprobación por `libc::kill(pid, 0)` (POSIX estándar), que funciona en macOS y Linux. Windows sigue usando `tasklist`.

## Resumen

- Bug: Savia Monitor no detectaba ninguna sesión activa en macOS porque `is_pid_alive` comprobaba `/proc/{pid}`, ruta que solo existe en Linux.
- Fix: sustituye la comprobación por `libc::kill(pid, 0)`, llamada POSIX estándar que verifica existencia de proceso sin enviar señal.
- Compatibilidad: funciona en macOS, Linux y otros Unix; Windows mantiene el camino existente con `tasklist`.
- Dependencia: añade `libc = "0.2"` bajo `[target.'cfg(unix)'.dependencies]` en `Cargo.toml`.
- Verificación: build limpio (warnings preexistentes no relacionados) y comprobación manual con 5 sesiones activas detectadas correctamente.

## What does this PR add or fix?

Fixes Savia Monitor session detection on macOS. The previous implementation relied on `/proc/{pid}` which is Linux-only, causing the macOS build to report zero active sessions even when Claude Code instances were running. Replaces the filesystem check with a POSIX `kill(pid, 0)` syscall via the `libc` crate, restoring cross-Unix compatibility without affecting Linux or Windows code paths.

## Type of contribution

- [ ] New slash command
- [ ] New agent
- [ ] New skill
- [ ] New hook
- [ ] New domain rule
- [x] Bug fix
- [ ] Documentation improvement
- [ ] Test suite addition
- [ ] Refactor (no behaviour change)
- [ ] Other: ___

## Context impact

- [x] This PR does NOT modify CLAUDE.md or files loaded at startup
- [ ] This PR modifies context files — estimated impact: ___ lines added/removed
- [x] CLAUDE.md stays within 120 lines limit

## Hook safety (if modifying hooks)

N/A — this PR does not modify any hooks.

Ficheros afectados (por si te lo pide):
- projects/savia-monitor/src-tauri/Cargo.toml (+3)
- projects/savia-monitor/src-tauri/Cargo.lock (+1)
- projects/savia-monitor/src-tauri/src/sessions.rs (+4 / −2)