### PR TITLE
fix: reorganize .opencode/plugins/ so loader only sees Plugin-shaped files at top level

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=f67469e5574fec96692a171476823359f81ea303bba8e3ef0c4922a41ee8e4f1
-timestamp=2026-05-01T07:20:10Z
-branch=agent/spec-127-opencode-migration-final-20260501
-head_commit=66b8d77b
+timestamp=2026-05-01T11:54:38Z
+branch=fix/opencode-plugin-loader-skips-tests
+head_commit=51fe6b9f
 signature=4508f1b7604ee3d56a7ed856df1e1b3c117f8cb58c6b6e1bf16408c57d34a2a8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d752561f92546f696481ff40dc1d3667973aad5cfd149b753585ca23baf589ad
-timestamp=2026-05-01T11:54:38Z
+diff_hash=ca489aa2e1ec453f475a2885f5fa4714456c0c23170779647b555c6e40864b55
+timestamp=2026-05-01T12:37:51Z
 branch=fix/opencode-plugin-loader-skips-tests
-head_commit=bd38d619
-signature=ce6958a3ceda8bee37d0094e12332d321d58cdc1145518a561e8f49a7a46acad
+head_commit=62455823
+signature=ca5497ad6e55fe3bd97aac480dc7b62e986481f3c7e13b9efd5a876328734941

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f67469e5574fec96692a171476823359f81ea303bba8e3ef0c4922a41ee8e4f1
+diff_hash=d752561f92546f696481ff40dc1d3667973aad5cfd149b753585ca23baf589ad
 timestamp=2026-05-01T11:54:38Z
 branch=fix/opencode-plugin-loader-skips-tests
-head_commit=51fe6b9f
-signature=4508f1b7604ee3d56a7ed856df1e1b3c117f8cb58c6b6e1bf16408c57d34a2a8
+head_commit=bd38d619
+signature=ce6958a3ceda8bee37d0094e12332d321d58cdc1145518a561e8f49a7a46acad

--- a/.opencode/plugins/README.md
+++ b/.opencode/plugins/README.md
@@ -27,16 +27,36 @@ and establishes the typed contract that Slice 2b-ii ports build on.
 ## Porting roadmap (Slice 2b-ii)
 
 These 5 hooks are TIER-1 in the classifier. Each gets its own port file
-in this folder, with a matching `.test.ts` (Bun test runner):
+in `guards/`, with a matching `.test.ts` in `__tests__/` (Bun test runner):
 
-1. `validate-bash-global.sh` → `validate-bash-global.ts` (matcher: bash)
-2. `block-credential-leak.sh` → `block-credential-leak.ts` (bash, edit)
-3. `block-gitignored-references.sh` → `block-gitignored-references.ts` (edit, write)
-4. `prompt-injection-guard.sh` → `prompt-injection-guard.ts` (edit, write)
-5. `tdd-gate.sh` → `tdd-gate.ts` (edit)
+1. `validate-bash-global.sh` → `guards/validate-bash-global.ts` (matcher: bash)
+2. `block-credential-leak.sh` → `guards/block-credential-leak.ts` (bash, edit)
+3. `block-gitignored-references.sh` → `guards/block-gitignored-references.ts` (edit, write)
+4. `prompt-injection-guard.sh` → `guards/prompt-injection-guard.ts` (edit, write)
+5. `tdd-gate.sh` → `guards/tdd-gate.ts` (edit)
 
 Each port preserves the bash hook's intent. They are *additive* under
 OpenCode; Claude Code keeps using the original `.sh` hooks. PV-01.
+
+## Folder layout
+
+OpenCode v1.14 loads every top-level `.ts` in this folder as a plugin and
+expects each to export the `Plugin` shape (`{ auth, ...event handlers }`).
+Files that do NOT export that shape (guards, library helpers, tests) live
+in subfolders so the plugin loader does not pick them up:
+
+```
+plugins/
+  savia-foundation.ts          ← only top-level plugin
+  guards/                      ← guard functions imported by the plugin
+  lib/                         ← shared helpers (regex tables, type guards)
+  __tests__/                   ← bun:test suites for guards + foundation
+```
+
+If you add a new guard, put it in `guards/` and wire it into
+`savia-foundation.ts`. Never place plain functions or test files at the
+top level — the loader will crash with `J.auth is undefined` and break
+even non-tool commands like `opencode auth login`.
 
 ## What this folder does NOT do
 

--- a/.opencode/plugins/__tests__/block-credential-leak.test.ts
+++ b/.opencode/plugins/__tests__/block-credential-leak.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { blockCredentialLeak } from "./block-credential-leak.ts";
+import { blockCredentialLeak } from "../guards/block-credential-leak.ts";
 
 test("blockCredentialLeak: throws on AWS key in bash command", async () => {
   const input = { tool: "bash", args: { command: "export X=AKIAIOSFODNN7EXAMPLE" } };

--- a/.opencode/plugins/__tests__/block-gitignored-references.test.ts
+++ b/.opencode/plugins/__tests__/block-gitignored-references.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { blockGitignoredReferences } from "./block-gitignored-references.ts";
+import { blockGitignoredReferences } from "../guards/block-gitignored-references.ts";
 
 const F = {
   outputDated: "out" + "put/" + "20260501" + "-r.md",

--- a/.opencode/plugins/__tests__/prompt-injection-guard.test.ts
+++ b/.opencode/plugins/__tests__/prompt-injection-guard.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { promptInjectionGuard } from "./prompt-injection-guard.ts";
+import { promptInjectionGuard } from "../guards/prompt-injection-guard.ts";
 
 test("promptInjectionGuard: throws on override attempt in context-md content", async () => {
   const input = {

--- a/.opencode/plugins/__tests__/savia-foundation.test.ts
+++ b/.opencode/plugins/__tests__/savia-foundation.test.ts
@@ -5,7 +5,7 @@
 // by their individual *.test.ts files.
 
 import { test, expect } from "bun:test";
-import { SaviaFoundationPlugin } from "./savia-foundation.ts";
+import { SaviaFoundationPlugin } from "../savia-foundation.ts";
 
 const ctx = {
   project: { name: "test" } as any,

--- a/.opencode/plugins/__tests__/tdd-gate.test.ts
+++ b/.opencode/plugins/__tests__/tdd-gate.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { tddGateForPath, tddGate } from "./tdd-gate.ts";
+import { tddGateForPath, tddGate } from "../guards/tdd-gate.ts";
 
 // Static helper tests — exercise the path classification logic without
 // requiring filesystem access to find tests.

--- a/.opencode/plugins/__tests__/validate-bash-global.test.ts
+++ b/.opencode/plugins/__tests__/validate-bash-global.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { validateBashGlobal } from "./validate-bash-global.ts";
+import { validateBashGlobal } from "../guards/validate-bash-global.ts";
 
 test("validateBashGlobal: blocks rm -rf /", async () => {
   const input = { tool: "bash", args: { command: "rm -rf /" } };

--- a/.opencode/plugins/guards/block-credential-leak.ts
+++ b/.opencode/plugins/guards/block-credential-leak.ts
@@ -9,8 +9,8 @@
 //
 // Reference: SPEC-127 Slice 2b-ii AC-2.2
 
-import { extractToolName, extractCommand, type ToolInput } from "./lib/hook-input.ts";
-import { detectCredentialLeak } from "./lib/credential-patterns.ts";
+import { extractToolName, extractCommand, type ToolInput } from "../lib/hook-input.ts";
+import { detectCredentialLeak } from "../lib/credential-patterns.ts";
 
 export async function blockCredentialLeak(input: ToolInput, _output: unknown): Promise<void> {
   if (extractToolName(input) !== "bash") return;

--- a/.opencode/plugins/guards/block-gitignored-references.ts
+++ b/.opencode/plugins/guards/block-gitignored-references.ts
@@ -13,8 +13,8 @@ import {
   extractFilePath,
   extractContent,
   type ToolInput,
-} from "./lib/hook-input.ts";
-import { detectLeakage } from "./lib/leakage-patterns.ts";
+} from "../lib/hook-input.ts";
+import { detectLeakage } from "../lib/leakage-patterns.ts";
 
 const PRIVATE_DESTINATIONS = [
   /\/projects\//,

--- a/.opencode/plugins/guards/prompt-injection-guard.ts
+++ b/.opencode/plugins/guards/prompt-injection-guard.ts
@@ -13,8 +13,8 @@ import {
   extractFilePath,
   extractContent,
   type ToolInput,
-} from "./lib/hook-input.ts";
-import { detectInjection } from "./lib/injection-patterns.ts";
+} from "../lib/hook-input.ts";
+import { detectInjection } from "../lib/injection-patterns.ts";
 
 const SKIP_EXTENSIONS = new Set([
   "sh", "py", "ts", "js", "cs", "java", "go", "rs", "rb", "php",

--- a/.opencode/plugins/guards/tdd-gate.ts
+++ b/.opencode/plugins/guards/tdd-gate.ts
@@ -9,7 +9,7 @@
 // filesystem to look for matching test files; that runtime probe is
 // integration-tested via the bash hook fixture under Claude Code.
 
-import { extractToolName, extractFilePath, type ToolInput } from "./lib/hook-input.ts";
+import { extractToolName, extractFilePath, type ToolInput } from "../lib/hook-input.ts";
 
 const PRODUCTION_EXT = new Set([
   "cs", "py", "ts", "tsx", "js", "jsx", "go", "rs", "rb", "php",

--- a/.opencode/plugins/guards/validate-bash-global.ts
+++ b/.opencode/plugins/guards/validate-bash-global.ts
@@ -13,7 +13,7 @@
 //
 // Reference: SPEC-127 Slice 2b-ii AC-2.2
 
-import { extractToolName, extractCommand, type ToolInput } from "./lib/hook-input.ts";
+import { extractToolName, extractCommand, type ToolInput } from "../lib/hook-input.ts";
 
 const RULES: Array<{ rx: RegExp; msg: string }> = [
   {

--- a/.opencode/plugins/savia-foundation.ts
+++ b/.opencode/plugins/savia-foundation.ts
@@ -20,11 +20,11 @@
 
 import type { Plugin } from "@opencode-ai/plugin";
 
-import { validateBashGlobal } from "./validate-bash-global.ts";
-import { blockCredentialLeak } from "./block-credential-leak.ts";
-import { blockGitignoredReferences } from "./block-gitignored-references.ts";
-import { promptInjectionGuard } from "./prompt-injection-guard.ts";
-import { tddGate } from "./tdd-gate.ts";
+import { validateBashGlobal } from "./guards/validate-bash-global.ts";
+import { blockCredentialLeak } from "./guards/block-credential-leak.ts";
+import { blockGitignoredReferences } from "./guards/block-gitignored-references.ts";
+import { promptInjectionGuard } from "./guards/prompt-injection-guard.ts";
+import { tddGate } from "./guards/tdd-gate.ts";
 
 const GUARDS = [
   validateBashGlobal,

--- a/CHANGELOG.d/fix-opencode-plugin-loader-skips-tests-20260501.md
+++ b/CHANGELOG.d/fix-opencode-plugin-loader-skips-tests-20260501.md
@@ -1,0 +1,7 @@
+---
+version_bump: patch
+section: Fixed
+---
+- **`.opencode/plugins/`**: reorganized so OpenCode v1.14 plugin loader only sees `Plugin`-shaped files at top level. Guards moved to `guards/`, tests to `__tests__/`. Top level now contains only `savia-foundation.ts`. Without this, any OpenCode CLI command (including `opencode auth login`) crashed with `undefined is not an object (evaluating 'J.auth')` because the loader wraps every top-level `.ts` as a plugin and the guard/test modules don't export the plugin shape.
+- **`scripts/opencode-migration-smoke.sh`**: updated foundation file paths to point at `guards/` subfolder.
+- **`.opencode/plugins/README.md`**: documented the layout invariant ("only plugin-shaped files at top level") so future ports don't reintroduce the regression.

--- a/scripts/opencode-migration-smoke.sh
+++ b/scripts/opencode-migration-smoke.sh
@@ -113,9 +113,9 @@ for f in \
   ".opencode/plugins/savia-foundation.ts" \
   ".opencode/plugins/lib/hook-input.ts" \
   ".opencode/plugins/lib/credential-patterns.ts" \
-  ".opencode/plugins/block-credential-leak.ts" \
-  ".opencode/plugins/validate-bash-global.ts" \
-  ".opencode/plugins/tdd-gate.ts"
+  ".opencode/plugins/guards/block-credential-leak.ts" \
+  ".opencode/plugins/guards/validate-bash-global.ts" \
+  ".opencode/plugins/guards/tdd-gate.ts"
 do
   if [[ ! -f "$ROOT/$f" ]]; then
     fail "$f missing"

--- a/tests/structure/test-spec-127-migration-final.bats
+++ b/tests/structure/test-spec-127-migration-final.bats
@@ -25,20 +25,20 @@ teardown() {
 
 @test "AC-2.2: 5 TIER-1 hook TS files exist with their .test.ts" {
   for h in block-credential-leak block-gitignored-references prompt-injection-guard validate-bash-global tdd-gate; do
-    [ -f "$PLUGINS_DIR/${h}.ts" ]
-    [ -f "$PLUGINS_DIR/${h}.test.ts" ]
+    [ -f "$PLUGINS_DIR/guards/${h}.ts" ]
+    [ -f "$PLUGINS_DIR/__tests__/${h}.test.ts" ]
   done
 }
 
 @test "AC-2.2: each hook port imports from lib/hook-input" {
   for h in block-credential-leak block-gitignored-references prompt-injection-guard validate-bash-global tdd-gate; do
-    grep -qE 'from "\./lib/hook-input' "$PLUGINS_DIR/${h}.ts"
+    grep -qE 'from "\.\./lib/hook-input' "$PLUGINS_DIR/guards/${h}.ts"
   done
 }
 
 @test "AC-2.2: each hook test imports its handler" {
   for h in block-credential-leak block-gitignored-references prompt-injection-guard validate-bash-global tdd-gate; do
-    grep -qE "from \"\\./${h}\\.ts\"" "$PLUGINS_DIR/${h}.test.ts"
+    grep -qE "from \"\\.\\./guards/${h}\\.ts\"" "$PLUGINS_DIR/__tests__/${h}.test.ts"
   done
 }
 
@@ -50,18 +50,18 @@ teardown() {
 }
 
 @test "AC-2.3: block-credential-leak port (PV-02 safety-critical)" {
-  [ -f "$PLUGINS_DIR/block-credential-leak.ts" ]
-  grep -q "blockCredentialLeak" "$PLUGINS_DIR/block-credential-leak.ts"
+  [ -f "$PLUGINS_DIR/guards/block-credential-leak.ts" ]
+  grep -q "blockCredentialLeak" "$PLUGINS_DIR/guards/block-credential-leak.ts"
 }
 
 @test "AC-2.3: block-gitignored-references port (PV-02 safety-critical)" {
-  [ -f "$PLUGINS_DIR/block-gitignored-references.ts" ]
-  grep -q "blockGitignoredReferences" "$PLUGINS_DIR/block-gitignored-references.ts"
+  [ -f "$PLUGINS_DIR/guards/block-gitignored-references.ts" ]
+  grep -q "blockGitignoredReferences" "$PLUGINS_DIR/guards/block-gitignored-references.ts"
 }
 
 @test "AC-2.3: prompt-injection-guard port (PV-02 safety-critical)" {
-  [ -f "$PLUGINS_DIR/prompt-injection-guard.ts" ]
-  grep -q "promptInjectionGuard" "$PLUGINS_DIR/prompt-injection-guard.ts"
+  [ -f "$PLUGINS_DIR/guards/prompt-injection-guard.ts" ]
+  grep -q "promptInjectionGuard" "$PLUGINS_DIR/guards/prompt-injection-guard.ts"
 }
 
 @test "foundation plugin imports + chains all 5 guards" {
@@ -204,7 +204,7 @@ sys.exit(0 if found else 1)
 
 @test "PV-06: 5 TS hook ports never reference a hardcoded vendor" {
   for h in block-credential-leak block-gitignored-references prompt-injection-guard validate-bash-global tdd-gate; do
-    ! grep -qiE 'github\.copilot|copilot\.enterprise|openai\.com|anthropic\.com/v1|mistral\.|deepseek/' "$PLUGINS_DIR/${h}.ts"
+    ! grep -qiE 'github\.copilot|copilot\.enterprise|openai\.com|anthropic\.com/v1|mistral\.|deepseek/' "$PLUGINS_DIR/guards/${h}.ts"
   done
 }
 
@@ -257,12 +257,12 @@ sys.exit(0 if found else 1)
 
 @test "coverage: each TS port has Promise<void> annotation" {
   for h in block-credential-leak block-gitignored-references prompt-injection-guard validate-bash-global tdd-gate; do
-    grep -qE "Promise<void>" "$PLUGINS_DIR/${h}.ts"
+    grep -qE "Promise<void>" "$PLUGINS_DIR/guards/${h}.ts"
   done
 }
 
 @test "coverage: each TS port throws on block (block mechanism)" {
   for h in block-credential-leak block-gitignored-references prompt-injection-guard validate-bash-global; do
-    grep -qE 'throw new Error' "$PLUGINS_DIR/${h}.ts"
+    grep -qE 'throw new Error' "$PLUGINS_DIR/guards/${h}.ts"
   done
 }

--- a/tests/structure/test-spec-127-slice2b-i-ts-toolchain.bats
+++ b/tests/structure/test-spec-127-slice2b-i-ts-toolchain.bats
@@ -20,7 +20,7 @@ setup() {
   TSCONFIG="$REPO_ROOT/.opencode/tsconfig.json"
   PLUGINS_DIR="$REPO_ROOT/.opencode/plugins"
   FOUNDATION_TS="$REPO_ROOT/$SCRIPT"
-  FOUNDATION_TEST="$PLUGINS_DIR/savia-foundation.test.ts"
+  FOUNDATION_TEST="$PLUGINS_DIR/__tests__/savia-foundation.test.ts"
   PLUGINS_README="$PLUGINS_DIR/README.md"
   SPEC="$REPO_ROOT/docs/propuestas/SPEC-127-savia-opencode-provider-agnostic.md"
   CLASSIFIER_REPORT="$REPO_ROOT/output/hook-portability-classification.md"


### PR DESCRIPTION
## What this fixes

\`opencode auth login\` — and every other OpenCode command — was crashing with \`undefined is not an object (evaluating 'J.auth')\` because OpenCode v1.14 loads every top-level \`.ts\` in \`.opencode/plugins/\` as a plugin and expects each file to export the full \`Plugin\` shape (\`{ auth, ...event handlers }\`).

The 5 guard files and 6 test files that lived at the top level don't export that shape, so the loader blew up on the very first non-foundation file it hit — before any provider could be configured.

## The fix

Structural reorganisation — no logic changed:

- 5 guard files → \`guards/\` subfolder
- 6 test files → \`__tests__/\` subfolder  
- All internal imports updated to match new paths
- \`scripts/opencode-migration-smoke.sh\` paths corrected
- \`README.md\` documents the layout invariant: _"never place plain functions or test files at the top level — the loader will crash with \`J.auth is undefined\`"_

The plugin loader scans top-level only (non-recursive), so files in subdirs are invisible to it. Only \`savia-foundation.ts\` — which correctly exports \`Plugin\` — remains at top level.

After merge: \`opencode auth login\` shows the provider selection menu instead of crashing.

## Test plan

- [x] \`bash scripts/opencode-migration-smoke.sh\` → PASS=6 FAIL=0 WARN=0
- [x] \`opencode auth login\` shows provider selection (smoke-tested live)
- [x] \`bash scripts/pr-plan.sh\` → 17 PASS 0 FAIL 0 WARN
- [x] All BATS tests pass

## Changelog

\`CHANGELOG.d/fix-opencode-plugin-loader-skips-tests-20260501.md\` — patch, section Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)