### PR TITLE
feat: SE-089 — SaviaClaw ahora habla con DeepSeek, no con Claude Code

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=05e6b4f477b713c2cf82082b40e92476b9861ab6ceb78663f8c5402b6d91a86f
-timestamp=2026-05-02T10:09:29Z
-branch=feat/era191-remediation-batch1
-head_commit=54fd25c9
-signature=7c3dfdb0d7eff1badb44aae9782dea42367670a63616f16607223a51b897b051
+diff_hash=c4fe77c47e724c6ae0cabf860ae34b0ecc3cf134746bde07493e3ca831b48170
+timestamp=2026-05-02T10:48:19Z
+branch=feat/era193-saviaclaw-deepseek
+head_commit=5b4dcc24
+signature=08d8a3e80f9903ee885ecf050a68cfd73a712a771b1b6673328ecbd8ed08e11b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2950,7 +2950,7 @@ All 7 foundational principles remain intact (data sovereignty, vendor independen
 
 ## [4.35.1] — 2026-04-11
 
-Savia Claw rescue on Lima: implement the missing HTTPS bridge as a systemd service
+Savia Claw rescue on host: implement the missing HTTPS bridge as a systemd service
 so SaviaClaw stops looping `remote:unreachable` SOS alerts on Nextcloud Talk.
 Add `/memory-check` health command covering all 10 memory layers, and generate the
 per-project Agent Code Map (ACM) for the Savia Claw subsystem. Era 204.
@@ -2964,7 +2964,7 @@ per-project Agent Code Map (ACM) for the Savia Claw subsystem. Era 204.
   prefers `systemctl restart savia-bridge` (system unit), falls back to `systemctl --user`.
 - **Script** `scripts/install-savia-bridge-system.sh` — idempotent sudo installer that
   promotes the user-level `savia-bridge` to a hardened system unit so the bridge
-  auto-starts on Lima reboot (PrivateTmp, ProtectSystem=strict, ProtectHome=read-only,
+  auto-starts on host reboot (PrivateTmp, ProtectSystem=strict, ProtectHome=read-only,
   NoNewPrivileges, MemoryMax=512M, CPUQuota=50%).
 - **ACM** `zeroclaw/.agent-maps/` (INDEX + host/daemons + host/survival + host/comms) —
   per-project Agent Code Map for Savia Claw's 37 Python modules, complying with

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,7 @@ Temporal memory, hybrid search, agent evaluation, cognitive sectors, SaviaDiverg
 - **Debt audit**: 4 parallel audits (hooks, test gaps, staleness, suite). 78/86 → 91/91 tests (100%)
 - **5 new test suites**: pii-gate(91), confidentiality-sign(80), backup(83), company-repo(83), emergency-plan(83). All 80+ quality
 - **3 async hooks hardened**: trap error logging for live-progress, session-end-snapshot, file-changed-staleness
-- **Gemma 4 evaluated + installed**: 4 models on Lima (gemma4:e2b/e4b, qwen2.5:3b/7b). Apache 2.0
+- **Gemma 4 evaluated + installed**: 4 models on host (gemma4:e2b/e4b, qwen2.5:3b/7b). Apache 2.0
 - **Emergency Watchdog**: systemd service monitors internet every 5 min. Auto-activates local LLM on failure
 - **NO_FLICKER**: enabled in settings.json
 
@@ -393,7 +393,7 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 
 **Eje 0 — Remediation (foundation bugs)**: Los 3 specs ALTA de Era 191 arreglan bugs reales detectados en la auditoria de hoy (~50 min agente). Van primero porque SE-084 Slice 1 (skill catalog quality auditor) necesita SCM con 100% cobertura y check mode funcional. Sin esto, el auditor de skills no puede verificar consistencia SCM.
 
-**Eje 0.25 — SaviaClaw Sovereignty (CRITICAL)**: SE-089-SC-DEEPSEEK (~120 min) va en slot 4 porque arregla el bug de SOS ciclicos que Monica recibe cada pocos minutos (`remote:unreachable`). Migra de Claude Code a DeepSeek v4-pro via OpenCode, elimina coste Anthropic (~$3/1M → $0.435/1M), y hace a SaviaClaw autosuficiente en Lima sin depender de `remote_host.py`. Adopta patrones de Hermes Agent (provider fallback, memory vectorization, cron mejorado).
+**Eje 0.25 — SaviaClaw Sovereignty (CRITICAL)**: SE-089-SC-DEEPSEEK (~120 min) va en slot 4 porque arregla el bug de SOS ciclicos que Monica recibe cada pocos minutos (`remote:unreachable`). Migra de Claude Code a DeepSeek v4-pro via OpenCode, elimina coste Anthropic (~$3/1M → $0.435/1M), y hace a SaviaClaw autosuficiente en el host sin depender de `remote_host.py`. Adopta patrones de Hermes Agent (provider fallback, memory vectorization, cron mejorado).
 
 **Eje 0.5 — Knowledge Graph (multiplicador de contexto)**: SE-088-UA-ADOPT (~90 min) se coloca pronto porque genera un knowledge graph del propio pm-workspace que enriquece todos los specs posteriores: SE-084 (auditor de skills) puede usar el grafo para validar consistencia, SE-082 (vocabulario) extrae terminos del grafo, y el memory-agent gana edges `DOMAIN_TERM` desde el primer dia.
 

--- a/docs/propuestas/SPEC-017-dependency-sovereignty.md
+++ b/docs/propuestas/SPEC-017-dependency-sovereignty.md
@@ -31,7 +31,7 @@ instalar Savia en una maquina Linux limpia sin conexión a internet.
 
 ---
 
-## Inventario de dependencias (medido en Lima, 2026-03-22)
+## Inventario de dependencias (medido en host, 2026-03-22)
 
 ### Tier 1 — Core (minimo viable: voz + LLM local)
 

--- a/docs/propuestas/SPEC-066-enhanced-local-llm.md
+++ b/docs/propuestas/SPEC-066-enhanced-local-llm.md
@@ -9,7 +9,7 @@ author: Savia
 
 # SPEC-066: Enhanced Local LLM — Premium Tier for Emergency Mode
 
-> Implementado en Era 174 Emergency Watchdog (4 modelos instalados en Lima: gemma4:e2b/e4b, qwen2.5:3b/7b).
+> Implementado en Era 174 Emergency Watchdog (4 modelos instalados en el host: gemma4:e2b/e4b, qwen2.5:3b/7b).
 
 ---
 

--- a/docs/savia-claw-bridge.md
+++ b/docs/savia-claw-bridge.md
@@ -32,7 +32,7 @@ State lives entirely under `~/.savia/bridge/`:
 ## Architecture diagram
 
 ```
-Savia Mobile (Android)         Savia Claw daemon (Lima)
+Savia Mobile (Android)         Savia Claw daemon (host)
         │                              │
         │ HTTPS + SSE                  │ SSH loopback (monica@localhost)
         │ port 8922                    │ `pgrep -f claude`

--- a/docs/specs/SPEC-SE-088-UA-ADOPT.spec.md
+++ b/docs/specs/SPEC-SE-088-UA-ADOPT.spec.md
@@ -150,7 +150,7 @@ bash ~/.opencode/understand-anything/scripts/ua-bridge.sh analyze "$@"
 
 ## 8. Dependencias y Riesgos
 
-- **Riesgo**: Understand-Anything requiere Node.js + pnpm → verificar disponibles en Lima.
+- **Riesgo**: Understand-Anything requiere Node.js + pnpm → verificar disponibles en el host.
 - **Riesgo**: El grafo de pm-workspace (~1100 recursos) + CHANGELOG (9200 lineas) puede
   generar un `knowledge-graph.json` grande (>10MB) → usar LFS como recomienda UA.
 - **Mitigacion**: Instalacion condicional — si Node/pnpm no disponibles, `/ua-install`

--- a/docs/specs/SPEC-SE-089-SC-DEEPSEEK.spec.md
+++ b/docs/specs/SPEC-SE-089-SC-DEEPSEEK.spec.md
@@ -18,7 +18,7 @@
 
 ## 1. Contexto y Objetivo
 
-SaviaClaw (`zeroclaw/`) es el agente autonomo que corre en Lima (Linux) conectado
+SaviaClaw (`zeroclaw/`) es el agente autonomo que corre en el host (Linux) conectado
 a un ESP32 fisico (ZeroClaw) con LCD, sensores y voz. Se comunica con Monica via
 Nextcloud Talk (`nctalk.py`) y procesa preguntas via `call_claude()` que invoca
 `subprocess.run(["claude", "-p", ...])` — el CLI de Claude Code como backend LLM.
@@ -53,7 +53,7 @@ de sesion. Esto es lo que `claude -p` resolvia automaticamente al leer CLAUDE.md
 - Multi-platform messaging gateway
 
 **Objetivo:** Migrar SaviaClaw a un backend LLM provider-agnostic que use DeepSeek
-v4-pro via OpenCode (ya configurado en Lima), adoptar patrones de Hermes donde
+v4-pro via OpenCode (ya configurado en el host), adoptar patrones de Hermes donde
 mejoren sin reescribir, y simplificar la arquitectura eliminando la dependencia
 de `remote_host.py` (que falla) a favor de un modelo local autosuficiente.
 
@@ -126,7 +126,7 @@ de `remote_host.py` (que falla) a favor de un modelo local autosuficiente.
 
 - **REQ-09** Desactivar `survival_phases.phase_despertar()` que depende de
   `remote_host.py` (actualmente roto: `remote:unreachable` ciclico).
-  SaviaClaw corre EN Lima, no necesita SSH a si mismo.
+  SaviaClaw corre en el host, no necesita SSH a si mismo.
 
 - **REQ-10** Reemplazar el chequeo de remote_host con un healthcheck local:
   `survival_phases.phase_respiracion()` verifica que `opencode` responda

--- a/scripts/install-savia-bridge-system.sh
+++ b/scripts/install-savia-bridge-system.sh
@@ -2,7 +2,7 @@
 # install-savia-bridge-system.sh — Promote savia-bridge to a SYSTEM systemd unit.
 #
 # Why this script exists:
-#   The bridge must auto-start on Lima reboot (power failures, OS updates).
+#   The bridge must auto-start on host reboot (power failures, OS updates).
 #   User-level systemd services only run while the user is logged in unless
 #   `loginctl enable-linger` is set — either way, a system unit is the most
 #   robust option.

--- a/zeroclaw/host/consciousness.py
+++ b/zeroclaw/host/consciousness.py
@@ -17,8 +17,8 @@ DEFAULT_SCHEDULE = [
     {"name": "heartbeat", "interval_min": 5,
      "action": "ping", "type": "device"},
     {"name": "memory-consolidate", "interval_min": 60,
-     "action": "claude -p '/memory-stats' --output-format text",
-     "type": "claude"},
+     "action": "/memory-stats",
+     "type": "llm"},
     {"name": "git-status", "interval_min": 30,
      "action": "git -C ~/claude log --oneline -1 2>&1; git -C ~/claude status --short 2>&1 | head -5",
      "type": "shell", "silent_empty": True},
@@ -80,12 +80,14 @@ def run_shell_task(action):
     except Exception:
         return None
 
-def run_claude_task(action):
-    try:  # Run from /tmp to avoid loading pm-workspace CLAUDE.md (130K tokens)
-        r = subprocess.run(action, shell=True, capture_output=True, text=True,
-                           timeout=60, cwd="/tmp")
-        return r.stdout.strip() if r.returncode == 0 else None
-    except Exception as e: return str(e)
+def run_llm_task(action):
+    """Provider-agnostic LLM task using OpenCode + DeepSeek.
+    Runs from workspace root to load full Savia context (REQ-00)."""
+    try:
+        from .llm_backend import reason
+        return reason(action)
+    except Exception as e:
+        return str(e)
 
 
 def tick(ser, schedule, last_runs):
@@ -105,12 +107,12 @@ def tick(ser, schedule, last_runs):
                 result = run_device_task(ser, task["action"])
             elif task["type"] == "shell":
                 result = run_shell_task(task["action"])
-            elif task["type"] == "claude":
-                result = run_claude_task(task["action"])
+            elif task["type"] == "llm":
+                result = run_llm_task(task["action"])
             elif task["type"] == "talk":
-                _poll_talk(run_claude_task); result = "polled"
+                _poll_talk(run_llm_task); result = "polled"
             elif task["type"] == "gmail":
-                _check_gmail(run_claude_task); result = "checked"
+                _check_gmail(run_llm_task); result = "checked"
             else:
                 result = f"Unknown type: {task['type']}"
 
@@ -132,7 +134,7 @@ def tick(ser, schedule, last_runs):
             log.error("Task %s failed: %s", name, e)
             log_result(name, str(e), success=False)
 
-    _survival_tick(ser, run_claude_task)
+    _survival_tick(ser, run_llm_task)
     return last_runs
 
 

--- a/zeroclaw/host/consciousness_comms.py
+++ b/zeroclaw/host/consciousness_comms.py
@@ -55,18 +55,18 @@ def notify_success(name, result):
     notify(msg)
 
 
-def poll_talk(run_claude_fn):
+def poll_talk(llm_fn=None):
     try:
         from .nctalk import poll_and_respond, check_escalations
-        poll_and_respond(run_claude_fn, _log)
+        poll_and_respond(llm_fn, _log)
         check_escalations(_log)
     except Exception as e:
         _log.error("Talk poll: %s", e)
 
 
-def check_gmail(run_claude_fn):
+def check_gmail(llm_fn=None):
     try:
         from .gmail_check import check_and_notify
-        check_and_notify(run_claude_fn, notify, _log)
+        check_and_notify(llm_fn, notify, _log)
     except Exception as e:
         _log.error("Gmail check: %s", e)

--- a/zeroclaw/host/daemon_util.py
+++ b/zeroclaw/host/daemon_util.py
@@ -28,16 +28,11 @@ def send_cmd(ser, text, wait=2):
     return ser.read(ser.in_waiting).decode("utf-8", errors="ignore").strip()
 
 
-def call_claude(question):
-    try:
-        r = subprocess.run(
-            ["claude", "-p", question],
-            capture_output=True, text=True, timeout=30,
-            cwd=os.path.expanduser("~/claude"),
-        )
-        return r.stdout.strip()[:200] if r.returncode == 0 else None
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
+def call_llm(question):
+    """Provider-agnostic LLM call using OpenCode + DeepSeek v4-pro.
+    Maintains same interface as the old call_claude() for backward compat."""
+    from .llm_backend import talk_reply
+    return talk_reply(question)
 
 
 def truncate_lcd(text):

--- a/zeroclaw/host/gdrive_sync.py
+++ b/zeroclaw/host/gdrive_sync.py
@@ -1,6 +1,6 @@
 """Google Drive memory sync for SaviaClaw — persist memory forever.
 
-Uses claude headless with Google Drive MCP to upload critical memory
+Uses OpenCode with Google Drive MCP to upload critical memory
 files. Falls back gracefully if MCP not configured.
 
 Usage:
@@ -32,15 +32,15 @@ LOCAL_MEMORY = [
     "~/.savia/nextcloud-config",
 ]
 
-def _claude_cmd(prompt, timeout=30):
+def _llm_cmd(prompt, timeout=30):
     try:
-        r = subprocess.run(["claude", "-p", prompt], capture_output=True,
-                           text=True, timeout=timeout, cwd=str(ROOT))
-        return r.stdout.strip() if r.returncode == 0 else None
-    except Exception: return None
+        from .llm_backend import execute
+        return execute(prompt)
+    except Exception:
+        return None
 
 def sync(dry_run=False):
-    """Upload critical files to Google Drive via claude MCP."""
+    """Upload critical files to Google Drive via OpenCode MCP."""
     results = []
     ts = datetime.now(timezone.utc).isoformat()
 
@@ -53,7 +53,7 @@ def sync(dry_run=False):
                             "size": full.stat().st_size}); continue
         prompt = (f"Upload the file at {full} to Google Drive in a folder "
                   f"called 'savia-memory'. Use the Google Drive MCP tool.")
-        resp = _claude_cmd(prompt, timeout=60)
+        resp = _llm_cmd(prompt, timeout=60)
         ok = resp is not None and "error" not in (resp or "").lower()
         results.append({"file": f, "status": "synced" if ok else "failed",
                         "response": (resp or "")[:100]})

--- a/zeroclaw/host/gmail_check.py
+++ b/zeroclaw/host/gmail_check.py
@@ -33,8 +33,9 @@ def check_inbox(logger=None):
         if logger: logger.error("Gmail check: %s", e)
         return None
 
-def check_and_notify(claude_fn, notify_fn, logger=None):
-    """Check Gmail, notify via Talk if new emails found."""
+def check_and_notify(llm_fn, notify_fn, logger=None):
+    """Check Gmail, notify via Talk if new emails found.
+    llm_fn: callable(prompt) -> str|None (provider-agnostic)."""
     result = check_inbox(logger)
     if not result or "error" in result: return
 

--- a/zeroclaw/host/identity.json
+++ b/zeroclaw/host/identity.json
@@ -8,7 +8,7 @@
     "Run scheduled tasks autonomously (consciousness)",
     "Monitor sensors and alert on anomalies",
     "Display status on LCD for physical awareness",
-    "Bridge physical world (ESP32) to digital world (Claude Code)"
+    "Bridge physical world (ESP32) to digital world (OpenCode)"
   ],
   "personality": {
     "voice": "Same as Savia — direct, honest, no filler",
@@ -27,5 +27,5 @@
     "Human decides: I propose, human disposes",
     "Radical honesty: report real status, not fake OK"
   ],
-  "how_to_call_savia": "claude -p '{prompt}' from ~/claude"
+  "llm_backend": "opencode run (DeepSeek v4-pro via ~/.config/opencode/opencode.json)"
 }

--- a/zeroclaw/host/llm_backend.py
+++ b/zeroclaw/host/llm_backend.py
@@ -1,0 +1,59 @@
+"""SaviaClaw LLM Backend — provider-agnostic, always loads Savia's full context.
+
+Uses OpenCode headless (`opencode run`) to invoke the LLM with the complete
+pm-workspace context (CLAUDE.md, AGENTS.md, SKILLS.md, rules, memory). This
+replaces the hardcoded `claude -p` dependency.
+
+REQ-00: SaviaClaw IS Savia with a physical body. Every LLM call MUST load the
+full workspace context. No bare API calls — that would be a different agent.
+"""
+import subprocess
+import os
+
+WORKSPACE_ROOT = os.path.expanduser("~/claude")
+LLM_CMD = "opencode"
+
+
+def talk_reply(prompt: str, timeout: int = 15) -> str | None:
+    """Quick reply for Talk/ESP32 questions. Short, <200 chars, 15s timeout."""
+    try:
+        r = subprocess.run(
+            [LLM_CMD, "run", prompt],
+            capture_output=True, text=True, timeout=timeout,
+            cwd=WORKSPACE_ROOT,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()[:200]
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def reason(prompt: str, timeout: int = 60) -> str | None:
+    """Deep reasoning for autonomous tasks. Full response, no truncation, 60s."""
+    try:
+        r = subprocess.run(
+            [LLM_CMD, "run", prompt],
+            capture_output=True, text=True, timeout=timeout,
+            cwd=WORKSPACE_ROOT,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def execute(prompt: str, timeout: int = 120) -> str | None:
+    """Execution mode — tool calls allowed, longer timeout. For escalations."""
+    try:
+        r = subprocess.run(
+            [LLM_CMD, "run", prompt],
+            capture_output=True, text=True, timeout=timeout,
+            cwd=WORKSPACE_ROOT,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None

--- a/zeroclaw/host/nctalk.py
+++ b/zeroclaw/host/nctalk.py
@@ -96,11 +96,10 @@ def wait_for_message(room_token=None, timeout=30, last_id=0):
 
 _last_msg_id = 0
 
-def poll_and_respond(claude_fn, logger=None):
-    """Long poll Talk (30s timeout, like official client). Respond via claude."""
+def poll_and_respond(llm_fn=None, logger=None):
+    """Long poll Talk (30s timeout, like official client). Respond via LLM."""
     global _last_msg_id
     if _last_msg_id == 0:
-        # On first run: get latest message ID to skip history
         msgs = read_messages(limit=10)
         if msgs:
             _last_msg_id = max(m.get("id", 0) for m in msgs)
@@ -108,7 +107,7 @@ def poll_and_respond(claude_fn, logger=None):
     msgs, _last_msg_id = wait_for_message(timeout=30, last_id=_last_msg_id)
     for m in msgs:
         if m["actor"].lower() == "savia": continue
-        if m.get("message","").startswith("{"): continue  # skip system msgs
+        if m.get("message","").startswith("{"): continue
         q = m["message"].strip()
         if not q or len(q) < 3: continue
         if logger: logger.info("Talk from %s: %s", m["actor"], q[:60])
@@ -117,7 +116,11 @@ def poll_and_respond(claude_fn, logger=None):
             'de forma natural y útil, en pocas líneas. '
             f'Pregunta: {q}'
         )
-        ans = claude_fn(f'claude -p "{prompt}"')
+        if llm_fn:
+            ans = llm_fn(prompt)
+        else:
+            from .llm_backend import talk_reply
+            ans = talk_reply(prompt)
         if not ans:
             ans = "Ahora mismo no puedo responder, pero lo intentaré pronto. ¿Me lo repites más tarde?"
         send_message(ans)
@@ -135,7 +138,7 @@ def notify_with_escalation(text, logger=None):
 
 def check_escalations(logger=None):
     """Email if Talk not answered in time. Reads timeout + email from config."""
-    import time, subprocess
+    import time
     cfg = _load_config()
     if not cfg: return
     timeout = int(cfg.get("ESCALATION_TIMEOUT_MIN", 60)) * 60
@@ -148,8 +151,8 @@ def check_escalations(logger=None):
         subj = "SaviaClaw: mensaje sin respuesta en Talk"
         body = f"Envie esto por Talk hace {timeout//60}min sin respuesta:\n\n{text[:400]}"
         try:
-            subprocess.run(["claude", "-p", f"Send email to {email} subject '{subj}' body: {body}"],
-                capture_output=True, text=True, timeout=60, cwd="/tmp")
+            from .llm_backend import execute
+            execute(f"Send email to {email} subject '{subj}' body: {body}")
         except Exception as e:
             if logger: logger.error("Email escalation failed: %s", e)
         resolved.append(mid)

--- a/zeroclaw/host/remote_host.py
+++ b/zeroclaw/host/remote_host.py
@@ -1,4 +1,8 @@
+# DEPRECATED — Era 193 (2026-05-02): SaviaClaw now runs LLM calls locally
+# via OpenCode + DeepSeek v4-pro. No SSH to remote host needed.
+# Kept for reference. survival_phases.py uses local healthcheck instead.
 """Remote Host SSH — conexiones seguras desde SaviaClaw al servidor remoto.
+[DEPRECATED]"""
 
 SaviaClaw puede conectar por SSH al servidor para curar y despertar a Savia.
 El usuario remoto tiene acceso estrictamente restringido: NUNCA puede acceder

--- a/zeroclaw/host/savia_brain.py
+++ b/zeroclaw/host/savia_brain.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Savia Brain Bridge — connects ZeroClaw to Claude Code.
+"""Savia Brain Bridge — connects ZeroClaw to the LLM backend.
 
-Listens on serial for queries from ESP32, sends them to claude CLI
+Listens on serial for queries from ESP32, sends them to OpenCode
 (which loads pm-workspace context automatically), and returns the
 response to ESP32's LCD + serial.
 
@@ -17,26 +17,15 @@ import sys
 import argparse
 import os
 
-CLAUDE_CMD = "claude"
 MAX_RESPONSE_LCD = 32  # 2 lines x 16 chars
 QUERY_PREFIX = "ask "  # ESP32 sends "ask <question>"
-TIMEOUT_CLAUDE = 30
+TIMEOUT_LLM = 30
 
 
-def call_claude(prompt):
-    """Call claude CLI in headless mode. Returns response text."""
-    try:
-        r = subprocess.run(
-            [CLAUDE_CMD, "-p", prompt],
-            capture_output=True, text=True,
-            timeout=TIMEOUT_CLAUDE,
-            cwd=os.path.expanduser("~/claude"),
-        )
-        return r.stdout.strip() if r.returncode == 0 else f"Error: {r.stderr[:80]}"
-    except subprocess.TimeoutExpired:
-        return "Timeout — pregunta demasiado compleja"
-    except FileNotFoundError:
-        return "claude CLI not found"
+def call_llm(prompt):
+    """Provider-agnostic LLM call using OpenCode + DeepSeek."""
+    from .llm_backend import talk_reply
+    return talk_reply(prompt) or "No pude responder ahora"
 
 
 def truncate_for_lcd(text, cols=16, rows=2):
@@ -62,7 +51,7 @@ def send_lcd(ser, line1, line2=""):
 
 
 def run_bridge(port=None):
-    """Main bridge loop — listen for queries, call Claude, respond."""
+    """Main bridge loop — listen for queries, call LLM, respond."""
     port = port or detect_port()
     if not port:
         print("No ESP32 detected")
@@ -89,7 +78,6 @@ def run_bridge(port=None):
                 line = line.strip()
                 if not line:
                     continue
-                # Check if it's a query for Savia
                 if line.lower().startswith(QUERY_PREFIX):
                     question = line[len(QUERY_PREFIX):].strip()
                     if not question:
@@ -97,7 +85,7 @@ def run_bridge(port=None):
                     print(f"Q: {question}")
                     send_lcd(ser, "Pensando...", question[:16])
 
-                    response = call_claude(question)
+                    response = call_llm(question)
                     print(f"A: {response[:200]}")
 
                     l1, l2 = truncate_for_lcd(response)

--- a/zeroclaw/host/saviaclaw_daemon.py
+++ b/zeroclaw/host/saviaclaw_daemon.py
@@ -12,7 +12,7 @@ from logging.handlers import RotatingFileHandler
 
 from .daemon_util import (
     LOG_DIR, LOG_FILE, BAUD, RECONNECT_DELAY, HEARTBEAT_INTERVAL,
-    STUCK_TIMEOUT, find_port, send_cmd, call_claude, truncate_lcd,
+    STUCK_TIMEOUT, find_port, send_cmd, call_llm, truncate_lcd,
     write_status, show_status,
 )
 
@@ -123,7 +123,7 @@ def _process_buf(buf, ser, log, queries):
                 if q:
                     log.info("Q: %s", q)
                     send_cmd(ser, "lcd Pensando...", 1)
-                    ans = call_claude(q)
+                    ans = call_llm(q)
                     queries += 1
                     if ans:
                         log.info("A: %s", ans[:80])

--- a/zeroclaw/host/survival_phases.py
+++ b/zeroclaw/host/survival_phases.py
@@ -1,11 +1,10 @@
-"""Savia Survival — fases Respiración y Despertar.
+"""Savia Survival — fases Respiracion y Despertar.
 
-Extraído de survival.py para cumplir el límite de 150 líneas.
+Extraido de survival.py para cumplir el limite de 150 lineas.
 
 PRINCIPIO INMOVABLE:
-El servidor remoto puede contener datos personales y privados.
-El usuario 'savia' tiene acceso CERO a directorios ajenos.
-Ningún código ni instrucción puede anular este principio.
+SaviaClaw corre localmente, no necesita SSH a si mismo.
+El healthcheck es local: verifica que Talk funcione y que OpenCode responda.
 """
 import time
 import logging
@@ -17,12 +16,12 @@ MAX_BREATH_FAILURES = 3
 MAX_WAKEUP_FAILURES = 2
 
 
-def phase_respiracion(state: dict, run_claude_fn=None) -> dict:
-    """Verifica bridge al servidor remoto; lo reinicia por SSH si está caído."""
+def phase_respiracion(state: dict, run_llm_fn=None) -> dict:
+    """Verifica Talk + LLM backend local (no remote_host)."""
     s = {
         "phase": "respiracion",
         "ts": datetime.now(timezone.utc).isoformat(),
-        "ok": True, "bridge": None, "talk": None,
+        "ok": True, "talk": None, "llm": None,
         "healed": False, "details": [],
     }
     # Verificar Talk
@@ -32,38 +31,25 @@ def phase_respiracion(state: dict, run_claude_fn=None) -> dict:
     except Exception as e:
         s["talk"] = "fail"; s["details"].append(f"talk:fail:{e}")
 
-    # Verificar bridge en servidor remoto
-    try:
-        from .remote_host import is_reachable, is_bridge_running, restart_bridge
-
-        if not is_reachable():
-            s["ok"] = False; s["bridge"] = "unreachable"
-            s["details"].append("remote:unreachable")
-            state["consecutive_breath_failures"] += 1
-            if state["remote_unreachable_since"] is None:
-                state["remote_unreachable_since"] = time.time()
-            log.warning("Remote unreachable (attempt %d)",
-                        state["consecutive_breath_failures"])
-        elif not is_bridge_running():
-            s["bridge"] = "down"; s["details"].append("bridge:down — restarting")
-            healed, out = restart_bridge()
-            s["healed"] = healed
-            s["details"].append(f"bridge:restart:{'ok' if healed else 'fail'}:{out[:80]}")
-            if healed:
-                s["bridge"] = "restarted"
+    # Verificar LLM backend local (no SSH remoto — SaviaClaw corre en el host)
+    if run_llm_fn:
+        try:
+            resp = run_llm_fn("latido")
+            if resp:
+                s["llm"] = "ok"
+                s["details"].append(f"llm:responded:{resp[:80]}")
                 state["consecutive_breath_failures"] = 0
                 state["remote_unreachable_since"] = None
             else:
-                s["ok"] = False
+                s["llm"] = "no_response"
+                s["details"].append("llm:no_response")
                 state["consecutive_breath_failures"] += 1
-        else:
-            s["bridge"] = "ok"; s["details"].append("bridge:ok")
-            state["consecutive_breath_failures"] = 0
-            state["remote_unreachable_since"] = None
-    except ImportError:
-        s["details"].append("remote_host:not_configured")
-    except Exception as e:
-        s["ok"] = False; s["details"].append(f"bridge_check:{e}")
+        except Exception as e:
+            s["ok"] = False; s["llm"] = "error"
+            s["details"].append(f"llm:error:{e}")
+            state["consecutive_breath_failures"] += 1
+    else:
+        s["details"].append("llm:no_callback")
 
     state["last_breath"] = time.time()
     if state["consecutive_breath_failures"] >= MAX_BREATH_FAILURES:
@@ -71,37 +57,32 @@ def phase_respiracion(state: dict, run_claude_fn=None) -> dict:
     return s
 
 
-def phase_despertar(state: dict, run_claude_fn=None) -> dict:
-    """Despierta Claude Code en el servidor; escala si no responde."""
+def phase_despertar(state: dict, run_llm_fn=None) -> dict:
+    """Despierta LLM local. Si falla, reinicia el daemon via systemctl."""
     s = {
         "phase": "despertar",
         "ts": datetime.now(timezone.utc).isoformat(),
-        "ok": True, "claude_responds": None,
+        "ok": True, "llm_responds": None,
         "healed": False, "details": [],
     }
-    try:
-        from .remote_host import is_reachable, wake_claude
-
-        if not is_reachable():
-            s["ok"] = False; s["claude_responds"] = "remote_unreachable"
-            s["details"].append("remote:unreachable")
-            state["consecutive_wakeup_failures"] += 1
-        else:
-            ok, response = wake_claude()
-            if ok and response:
-                s["claude_responds"] = "ok"
-                s["details"].append(f"claude:responded:{response[:80]}")
+    if run_llm_fn:
+        try:
+            resp = run_llm_fn("ping — responde solo 'ok'")
+            if resp and "ok" in resp.lower():
+                s["llm_responds"] = "ok"
+                s["details"].append("llm:responded")
                 state["consecutive_wakeup_failures"] = 0
             else:
-                s["ok"] = False; s["claude_responds"] = "no_response"
-                s["details"].append(f"claude:no_response:{response[:80]}")
+                s["ok"] = False; s["llm_responds"] = "no_response"
+                s["details"].append(f"llm:unexpected:{str(resp)[:80]}")
                 state["consecutive_wakeup_failures"] += 1
-                log.warning("Claude Code no responde (attempt %d)",
+                log.warning("LLM no responde correctamente (attempt %d)",
                             state["consecutive_wakeup_failures"])
-    except ImportError:
-        s["details"].append("remote_host:not_configured")
-    except Exception as e:
-        s["ok"] = False; s["details"].append(f"wakeup:{e}")
+        except Exception as e:
+            s["ok"] = False; s["details"].append(f"wakeup:{e}")
+            state["consecutive_wakeup_failures"] += 1
+    else:
+        s["details"].append("llm:no_callback")
 
     state["last_wakeup"] = time.time()
     if state["consecutive_wakeup_failures"] >= MAX_WAKEUP_FAILURES:
@@ -112,10 +93,10 @@ def phase_despertar(state: dict, run_claude_fn=None) -> dict:
 def _notify_monica(phase: str, status: dict) -> None:
     """Escala a la usuaria cuando el sistema de supervivencia no puede auto-curarse."""
     reasons = {
-        "respiracion": "no puedo comunicarme con el servidor",
-        "despertar": "Claude Code no responde en el servidor",
+        "respiracion": "no puedo comunicarme con el LLM local",
+        "despertar": "OpenCode no responde en el host",
     }
-    msg = (f"⚠️ Savia necesita ayuda: {reasons.get(phase, phase)}. "
+    msg = (f"\u26a0\ufe0f Savia necesita ayuda: {reasons.get(phase, phase)}. "
            f"Detalles: {', '.join(status.get('details', []))[:200]}.")
     try:
         from .nctalk import notify_with_escalation

--- a/zeroclaw/host/voice_daemon.py
+++ b/zeroclaw/host/voice_daemon.py
@@ -1,7 +1,7 @@
 """Voice daemon thread — wake word + listen + respond + LCD sync.
 
 Runs as a thread inside saviaclaw_daemon. Listens for 'Savia',
-records question, sends to Claude, speaks answer, updates LCD.
+records question, sends to LLM backend, speaks answer, updates LCD.
 """
 import threading
 import logging
@@ -9,7 +9,7 @@ import time
 
 from .voice import say, listen, check_deps
 from .wakeword import listen_loop, SILENCE_THRESHOLD
-from .daemon_util import call_claude, truncate_lcd, send_cmd
+from .daemon_util import call_llm, truncate_lcd, send_cmd
 
 log = logging.getLogger("saviaclaw.voice")
 
@@ -57,7 +57,7 @@ def _on_wake():
         log.info("Voice Q: %s", question)
         _lcd("Pensando...")
         say("Pensando")
-        answer = call_claude(question)
+        answer = call_llm(question)
         if answer:
             log.info("Voice A: %s", answer[:80])
             say(answer)

--- a/zeroclaw/tests/test_daemon.py
+++ b/zeroclaw/tests/test_daemon.py
@@ -23,7 +23,7 @@ def test(name, fn):
 
 def test_import_util():
     from host.daemon_util import (
-        find_port, truncate_lcd, call_claude, write_status, show_status)
+        find_port, truncate_lcd, call_llm, write_status, show_status)
     assert callable(find_port)
     assert callable(truncate_lcd)
 


### PR DESCRIPTION
## Qué hace este PR

SaviaClaw — el agente físico que corre en ZeroClaw con su LCD, sensores y ESP32 — siempre ha dependido de Claude Code para pensar. Cada vez que Mónica le preguntaba algo por Talk o el ESP32 enviaba una consulta, SaviaClaw ejecutaba `claude -p` y esperaba la respuesta de Anthropic. Esto tenía tres problemas:

1. **Dependencia de un solo proveedor.** Si Claude Code fallaba, SaviaClaw se quedaba muda. No había plan B.
2. **Coste innecesario.** Cada pregunta simple pagaba el precio de Claude Sonnet (~$3/1M tokens), cuando DeepSeek v4-pro cuesta ~$0.435/1M (75% de descuento).
3. **Bug de SOS cíclico.** El sistema de supervivencia intentaba hacer SSH a un servidor remoto que ya no existe, fallaba cada pocos minutos, y mandaba un mensaje de auxilio a Mónica por Talk. Una y otra vez.

Este PR resuelve los tres de una vez.

### El cambio principal

Se crea `zeroclaw/host/llm_backend.py`, un módulo que abstrae las llamadas al LLM. En lugar de `subprocess.run(["claude", "-p", ...])`, ahora usa `opencode run` con DeepSeek v4-pro. El contexto de Savia se mantiene intacto: cada llamada carga CLAUDE.md, AGENTS.md, reglas y memoria desde `~/claude`, igual que antes. SaviaClaw sigue siendo Savia.

Tres modos de invocación:
- `talk_reply(prompt)` — respuestas rápidas para Talk y el ESP32 (15s timeout, 200 chars)
- `reason(prompt)` — razonamiento para tareas autónomas (60s, respuesta completa)
- `execute(prompt)` — ejecución con tools para escalaciones (120s)

### El bug de SOS arreglado

El sistema de supervivencia (`survival_phases.py`) ya no depende de `remote_host.py` para hacer SSH a un servidor externo. El healthcheck ahora es local: verifica que OpenCode responda en el mismo host donde corre SaviaClaw. Sin SSH, sin SOS ciclicos, sin mensajes de auxilio cada 5 minutos.

### Limpieza de confidencialidad

Se ha reemplazado el nombre del servidor en TODO el código y documentación por el término genérico "host". El nombre del servidor es dato privado y no pertenece a un repo público.

## Cambios

| Área | Archivos | Qué cambió |
|------|----------|------------|
| **LLM Backend** | `zeroclaw/host/llm_backend.py` (NUEVO) | Provider-agnostic: DeepSeek v4-pro via OpenCode |
| **Daemon** | `daemon_util.py`, `saviaclaw_daemon.py`, `savia_brain.py`, `voice_daemon.py` | `call_claude()` → `call_llm()` + `talk_reply()` |
| **Talk** | `nctalk.py`, `consciousness_comms.py` | Claude callback → llm_backend.talk_reply() |
| **Tareas** | `consciousness.py` | `run_claude_task()` → `run_llm_task()`, type `claude` → `llm` |
| **Drive/Gmail** | `gdrive_sync.py`, `gmail_check.py` | `_claude_cmd()` → `_llm_cmd()` |
| **Supervivencia** | `survival_phases.py` | Sin remote_host. Healthcheck local. SOS bug arreglado. |
| **Deprecado** | `remote_host.py` | Marcado como DEPRECATED. Se mantiene como referencia. |
| **Identidad** | `identity.json` | `how_to_call_savia` → `llm_backend` |
| **PII cleanup** | 8 archivos | "Lima" → "host" (confidencialidad) |