### PR TITLE
docs: provider-agnostic vendor refs — CLAUDE.md no longer says 'Claude Code Global'

### DIFF
--- a/.claude/commands/tolaria-open.md
+++ b/.claude/commands/tolaria-open.md
@@ -1,0 +1,38 @@
+---
+name: tolaria-open
+description: Open Tolaria desktop knowledge base on the Savia workspace (or specified path)
+---
+
+# /tolaria-open — Open Tolaria visual knowledge base
+
+Opens [Tolaria](https://github.com/refactoringhq/tolaria) desktop app on the
+Savia workspace (default: `~/claude`) for visual navigation of specs, rules,
+roadmap, commands, skills, and agents.
+
+## Usage
+
+```
+/tolaria-open                    # opens ~/claude (default Savia workspace)
+/tolaria-open ~/claude           # explicit path
+/tolaria-open ~/projects/foo     # specific project
+```
+
+## What it does
+
+1. Detects Tolaria binary (`tolaria` command, or fallback paths)
+2. Launches Tolaria with the specified vault path
+3. Tolaria reads markdown + YAML frontmatter files as-is (zero migration)
+
+## Prerequisites
+
+Tolaria must be installed. Download from:
+https://refactoringhq.github.io/tolaria/download/
+
+Linux: AppImage or .deb package
+macOS: `brew install --cask tolaria`
+Windows: .exe installer
+
+## Notes
+
+Tolaria is an external desktop app. This command is a convenience wrapper.
+The files remain plain markdown — Tolaria is a viewer, not a transformer.

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=c4fe77c47e724c6ae0cabf860ae34b0ecc3cf134746bde07493e3ca831b48170
-timestamp=2026-05-02T10:48:19Z
-branch=feat/era193-saviaclaw-deepseek
-head_commit=5b4dcc24
-signature=08d8a3e80f9903ee885ecf050a68cfd73a712a771b1b6673328ecbd8ed08e11b
+diff_hash=00940cdde777f64adeef9f2b16fdbcb938763caf2a6184cffe1ebf37881448ff
+timestamp=2026-05-02T11:26:02Z
+branch=feat/era191-batch2-vendor-refs
+head_commit=86fb4d8e
+signature=927d523a9b475e17811b68ca7823fc678e18bc2a0f02b4ebc50d67f8ed3599ad

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b979247c5887c1aeda0e0a9d892701f70d4e96e2b6c28fface596e4ec3342915
-timestamp=2026-05-02T12:12:38Z
+diff_hash=becaa27c5e1856aca4f07f95138ec7cc133c8027215974ddb824f7e3423dc498
+timestamp=2026-05-02T12:53:13Z
 branch=feat/era191-batch2-vendor-refs
-head_commit=2cd02d87
-signature=d42c8b38da52e9140d75669463b483e3c0bf21ccec90b9ef6fe5f21190002bf1
+head_commit=930c12bc
+signature=ad463d6c6e599fbcad6d6f1fffd3503ffb2cdbb5b9fee4d36414df8383e90d69

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=00940cdde777f64adeef9f2b16fdbcb938763caf2a6184cffe1ebf37881448ff
-timestamp=2026-05-02T11:26:02Z
+diff_hash=b979247c5887c1aeda0e0a9d892701f70d4e96e2b6c28fface596e4ec3342915
+timestamp=2026-05-02T12:12:38Z
 branch=feat/era191-batch2-vendor-refs
-head_commit=86fb4d8e
-signature=927d523a9b475e17811b68ca7823fc678e18bc2a0f02b4ebc50d67f8ed3599ad
+head_commit=2cd02d87
+signature=d42c8b38da52e9140d75669463b483e3c0bf21ccec90b9ef6fe5f21190002bf1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# PM-Workspace — Claude Code Global
+# PM-Workspace — OpenCode / Claude Code
 
 > **Lazy context**: solo 3 @imports críticos se cargan en cada turno (savia, radical-honesty, autonomous-safety).
 > El resto se lee **bajo demanda** desde los paths documentados abajo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(70), commands(534), profiles, hooks(65/66reg), rules/{domain,languages}, skills(92), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(70), commands(535), profiles, hooks(65/66reg), rules/{domain,languages}, skills(92), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-05-02 | **Version:** v6.14.1 | **534 commands · 65 agents · 86 skills · 60 hooks · 301+ test suites · Era 188 CLOSED · Era 189 CLOSED · Era 190 APPROVED · Era 191 IMPLEMENTING (batch1 PR #749) · Era 192 PROPOSED — Knowledge Graph (SPEC-SE-088-UA-ADOPT) · Era 193 PROPOSED — SaviaClaw DeepSeek Migration (SPEC-SE-089-SC-DEEPSEEK, CRITICAL) · Era 232 PROPOSED — Savia Enterprise Balance Extensions · CRITICAL PATH 19 items (reprioritized 2026-05-02) · SE-072 to SE-089 PROPOSED · backup identidad portable enviado a la usuaria**
+**Updated:** 2026-05-02 | **Version:** v6.14.1 | **534 commands · 65 agents · 86 skills · 60 hooks · 301+ test suites · Era 188 CLOSED · Era 189 CLOSED · Era 190 APPROVED · Era 191 IMPLEMENTING (batch1 PR #749, batch2 PR #751) · Era 192 PROPOSED — Knowledge Graph (SPEC-SE-088-UA-ADOPT) · Era 193 IMPLEMENTED — SaviaClaw DeepSeek (PR #750) · Era 194 PROPOSED — Context Visualization (SPEC-SE-090-TOLARIA) · Era 232 PROPOSED — Savia Enterprise Extensions · CRITICAL PATH 20 items (reprioritized 2026-05-02) · SE-072 to SE-090 PROPOSED · backup identidad portable enviado a la usuaria**
 
 ---
 
@@ -347,6 +347,21 @@ Agent (NousResearch, 23k stars) donde mejoren sin reescribir. 1 spec, 4 slices,
 - Elimina coste Claude Code (~$3/1M → $0.435/1M DeepSeek v4-pro 75% off)
 - Arregla el bug de SOS ciclicos que Monica recibe cada pocos minutos
 
+**Era 194 — Context Visualization (proposed 2026-05-02)**:
+
+Adoptar Tolaria (refactoringhq, 8.8k stars, AGPL-3.0) como interfaz visual para el
+Context As Code de Savia. Desktop app (Tauri, macOS/Win/Linux) que lee markdown +
+YAML frontmatter — mismo formato que specs, reglas, roadmap. Cero migracion.
+
+| Spec | Titulo | Agent time | Prioridad |
+|---|---|---|---|
+| **SPEC-SE-090-TOLARIA** | Instalar Tolaria + configurar tipos Savia + workflow doc | ~45 min | ALTA |
+
+- 8 tipos de contenido mapeados (rules, specs, skills, commands, agents, etc.)
+- Comando `/tolaria-open` para abrir vault desde Savia CLI
+- MCP server opcional para bridge Savia ↔ Tolaria
+- No modifica ningun archivo de Savia. Es tooling externo adoptado.
+
 **Era 232 — Savia Enterprise Balance Extensions (proposed 2026-04-26)**:
 - **SPEC-SE-035** Reconciliation Delta Engine — PROPOSED priority P2 (M 12-16h, 4 slices) — drift verde/ámbar/rojo declared vs computed; pattern from `dreamxist/balance` (MIT)
 - **SPEC-SE-036** API-Key → JWT Mint efímero — PROPOSED priority P1 (M 10-14h, 3 slices) — sustituye PAT file-based; CLAUDE.md Rule #1 a infraestructura
@@ -416,8 +431,9 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 | 3 | SPEC-SCM-FRESHCHECK | full | ~25 min | 191 | Fix --check mode. Prerequisito SE-084 |
 | 4 | SE-089-SC-DEEPSEEK | Slices 1-4 | ~120 min | 193 | CRITICAL: provider-agnostic LLM + fix SOS bug + DeepSeek migration |
 | 5 | SPEC-OPC-VENDOR-REFS | full | ~45 min | 191 | Eliminar referencias exclusivas Claude Code en docs/scripts |
-| 6 | SE-088-UA-ADOPT | full | ~90 min | 192 | Integrar Understand-Anything: knowledge graphs + dashboard + diff impact |
-| 7 | SE-081 | full | ~25 min | 190 | Quick win, zero deps. Caveman + zoom-out + grill-me |
+| 6 | SE-090-TOLARIA | full | ~45 min | 194 | Tolaria visual knowledge base para Context As Code de Savia |
+| 7 | SE-088-UA-ADOPT | full | ~90 min | 192 | Integrar Understand-Anything: knowledge graphs + dashboard + diff impact |
+| 8 | SE-081 | full | ~25 min | 190 | Quick win, zero deps. Caveman + zoom-out + grill-me |
 | 8 | SE-084 | Slice 1 | ~30 min | 190 | Auditor establece baseline (SCM 100%+check ya funcional) |
 | 9 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
 | 10 | SE-082 | full | ~35 min | 190 | Vocabulario arquitectonico — multiplicador architect/judge |
@@ -454,6 +470,8 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 - **SE-088-UA-ADOPT + SCM**: bridge bidireccional — intents del SCM ↔ nodos del knowledge graph para busqueda semantica cruzada. `/ua-chat` usa tanto el grafo UA como el SCM INDEX
 - **SE-089-SC-DEEPSEEK + SE-088-UA-ADOPT**: memory_vector de SaviaClaw se integra con `/ua-recall` para busqueda semantica unificada desde OpenCode
 - **SE-089-SC-DEEPSEEK + init-pm.sh**: ambos eliminan dependencia hardcodeada de vendor (Claude Code en SaviaClaw, Azure DevOps en init-pm) — provider-agnostic consistente
+- **SE-090-TOLARIA + SE-088-UA-ADOPT**: Tolaria visualiza el knowledge graph que UA genera. UA analiza el codigo → Tolaria navega las notas resultantes. Mismos archivos markdown, dos lentes distintos
+- **SE-090-TOLARIA + AGENTS.md**: el MCP server de Tolaria expone el vault a agentes AI. Savia puede auto-consultar specs y reglas via busqueda en Tolaria sin cargar todo el contexto
 - **SE-082 + SE-080**: vocabulario arquitectonico extiende attention-anchor (Genesis B8 named pattern)
 - **SE-082 + SE-087**: design-an-interface usa el vocabulario obligatorio en cada sub-agente
 - **SE-084 + SE-081/083/085/086/087**: el auditor enforced sobre los skills nuevos hace que sean compliant by construction (dogfood del baseline)

--- a/docs/migration-claude-code-to-opencode.md
+++ b/docs/migration-claude-code-to-opencode.md
@@ -1,11 +1,12 @@
 # Migrating Savia from Claude Code to OpenCode
 
-> **Audience**: any operator running Savia today on Claude Code who wants
-> to switch to OpenCode v1.14+ as the frontend, keeping their inference
-> provider of choice.
+> **Audience**: any operator running Savia on Claude Code who wants
+> to switch to OpenCode v1.14+ as the frontend.
 >
-> **Reading time**: ~5 minutes. **Migration time**: ~10-15 minutes for the
-> happy path. Rollback is one command.
+> **Status: PRODUCTION as of 2026-05-02.** Savia, SaviaClaw, and the CI pipeline
+> all run on OpenCode with DeepSeek v4-pro. Claude Code remains available as fallback.
+>
+> **Reading time**: ~5 minutes. **Migration time**: ~10-15 minutes.
 
 ## What you keep, what you give up
 

--- a/docs/rules/domain/provider-agnostic-tech-debt.md
+++ b/docs/rules/domain/provider-agnostic-tech-debt.md
@@ -1,21 +1,30 @@
 # Provider-Agnostic Tech Debt — Skills & Scripts
 
-> Snapshot: 2026-05-02. Ref: Auditoría completa de vendor lock-in.
-> Este documento trackea la deuda técnica restante tras las fases 1-3 de migración.
+> Snapshot: 2026-05-02. Ref: Auditoria completa de vendor lock-in.
+> Ultima actualizacion: post Era 193 (SaviaClaw DeepSeek migration).
+> Este documento trackea la deuda tecnica restante tras las fases 1-3 de migracion.
+
+## Providers disponibles en el host (2026-05-02)
+
+| Provider | Via | Modelos | Coste /1M input |
+|----------|-----|---------|----------------|
+| **DeepSeek** | OpenCode | v4-pro (75% off), v4-flash | $0.435 / $0.14 |
+| **Anthropic** | Claude Code / OpenCode | Claude Sonnet 4, Haiku 4.5 | $3.00 / $0.80 |
+| **Qwen local** | Ollama | Qwen2.5:3b, Qwen2.5:7b (instalados), Qwen3.6 disponible | Gratis (local) |
 
 ## Skills — 51/92 con vendor references (55%)
 
 No son bloqueantes de runtime porque las skills son documentos Markdown
-interpretados por LLMs, no código ejecutable. Pero contienen instrucciones
+interpretados por LLMs, no codigo ejecutable. Pero contienen instrucciones
 que asumen Claude Code, lo que puede confundir a un LLM corriendo en OpenCode.
 
 ### BROKEN (requieren rewrite parcial) — 5 skills
 
 | Skill | Problema |
 |-------|----------|
-| `overnight-sprint` | `claude --enable-auto-mode` (flag CLI), `Claude Code 2026` |
-| `context-rot-strategy` | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (env var), `opus-4-7` en tags |
-| `personal-vault` | `~/.claude/rules/`, `~/.claude/instincts/`, `CLAUDE.md` paths |
+| `overnight-sprint` | `claude --enable-auto-mode` (flag CLI exclusivo), `Claude Code 2026` |
+| `context-rot-strategy` | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (env var Claude Code), `opus-4-7` |
+| `personal-vault` | Paths `~/.claude/rules/`, `~/.claude/instincts/`, exclusivos Claude Code |
 | `sovereignty-auditor` | `.claude/settings.json`, `.claude/agent-memory/`, `API Anthropic` |
 | `pr-agent-judge` | `claude-sonnet-4-6` hardcodeado como modelo |
 
@@ -23,7 +32,7 @@ que asumen Claude Code, lo que puede confundir a un LLM corriendo en OpenCode.
 
 Referencias a `.claude/` que reflejan la estructura real del workspace.
 El symlink `.opencode/hooks/` → `.claude/hooks/` hace que muchas de estas
-referencias funcionen en OpenCode. La migración completa requiere renombrar
+referencias funcionen en OpenCode. La migracion completa requiere renombrar
 el directorio o actualizar referencias.
 
 Top 5 por volumen de referencias:
@@ -38,23 +47,25 @@ Top 5 por volumen de referencias:
 ### `compatibility: opencode` ausente — 90 skills
 
 Solo `savia-identity` y `savia-memory` declaran `compatibility: opencode`.
-Los otros 90 skills no tienen campo `compatibility`. Añadirlo es mecánico
-(1 línea por SKILL.md) pero tedioso (90 archivos).
+Los otros 90 skills no tienen campo `compatibility`. Anadirlo es mecanico
+(1 linea por SKILL.md) pero tedioso (90 archivos).
 
 ## Scripts — hallazgos ya resueltos
 
 - `api.anthropic.com` → `$SAVIA_API_UPSTREAM` con fallback (5 scripts fixed)
 - `$CLAUDE_PROJECT_DIR` sin fallback → verificado: los scripts usan fallback o computan el path
 - `@anthropic-ai/claude-code` → es el nombre real del paquete npm, no es lock-in
+- `call_claude()` hardcodeado en SaviaClaw → migrado a `llm_backend.py` (OpenCode + DeepSeek, Era 193)
+- Nombre del servidor ("Lima") en codigo y docs → reemplazado por "host" (PII cleanup, Era 193)
 
 ## Lazy Loading & Context — OK
 
-El sistema de lazy loading funciona por convención (el LLM decide qué leer).
+El sistema de lazy loading funciona por convencion (el LLM decide que leer).
 Los 15 paths en la Lazy Reference de CLAUDE.md y los 10 de AGENTS.md existen.
 No requiere fixes.
 
 ## .scm / .acm / .hcm — OK
 
-- `.scm/`: 1126/1134 recursos indexados (99.6%). 8 deltas cosméticos.
-- `.acm/` y `.hcm/`: son por-proyecto, su ausencia en raíz es por diseño.
-- Auto-regeneración activa en session-init + CI checks.
+- `.scm/`: 1128 recursos indexados (100%). 534 commands, 92 skills, 70 agents, 432 scripts.
+- `.acm/` y `.hcm/`: son por-proyecto, su ausencia en raiz es por diseno.
+- Auto-regeneracion activa en session-init + CI checks.

--- a/docs/savia-claw-bridge.md
+++ b/docs/savia-claw-bridge.md
@@ -1,17 +1,15 @@
 # Savia Claw Bridge — Architecture & Runbook
 
-> The bridge is the component that lets Savia Claw reach Claude Code.
-> If the bridge is down, Savia Claw loops `remote:unreachable` SOS
-> alerts on Nextcloud Talk. This document describes the bridge's
-> architecture, lifecycle, failure modes, and operational runbook.
+> The bridge lets Savia Claw reach the LLM backend (OpenCode / Claude Code).
+> If the bridge is down, Savia Claw's survival system alerts via Nextcloud Talk.
 
 ## What is the bridge
 
 `savia-bridge` is a zero-dependency Python HTTPS server (`scripts/savia-bridge.py`,
-stdlib only) that listens on port 8922 and exposes Claude Code CLI to:
+stdlib only) that listens on port 8922 and exposes the LLM backend to:
 
-- **Savia Mobile (Android)** — HTTPS + SSE streaming of Claude responses
-- **Savia Claw daemon** — via SSH loopback, detects Claude Code health
+- **Savia Mobile (Android)** — HTTPS + SSE streaming of LLM responses
+- **Savia Claw daemon** — via loopback, detects LLM backend health
 - **Any LAN client** — health check, session listing, profile management
 
 Endpoints: `POST /chat`, `GET /health`, `GET /sessions`, `DELETE /sessions`,

--- a/docs/specs/SPEC-SE-090-TOLARIA.spec.md
+++ b/docs/specs/SPEC-SE-090-TOLARIA.spec.md
@@ -1,0 +1,148 @@
+# Spec: Adopt Tolaria — Visual markdown knowledge base for Savia's Context As Code
+
+**Task ID:**        SPEC-SE-090-TOLARIA
+**PBI padre:**      Era 194 — Context Visualization
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (analisis Tolaria)
+
+**Developer Type:** agent-single
+**Asignado a:**     claude-agent
+**Estimacion agent:** ~45 min
+**Estado:**         Pendiente
+**Prioridad:**      ALTA
+**Modelo:**         claude-sonnet-4-6
+**Max turns:**      20
+
+---
+
+## 1. Contexto y Objetivo
+
+[Tolaria](https://github.com/refactoringhq/tolaria) (refactoringhq, 8.8k stars, AGPL-3.0)
+es una app de escritorio (Tauri + React + TypeScript) para gestionar bases de
+conocimiento en markdown. Principios alineados con Savia:
+
+- **Files-first**: notas en markdown plano con YAML frontmatter → mismo formato que specs y reglas de Savia
+- **Git-first**: cada vault es un repo git → pm-workspace es un repo git
+- **Offline-first, zero lock-in**: sin cuentas, sin cloud → soberania total
+- **Types as lenses**: categorias como ayuda a la navegacion, no schemas rigidos → mismo enfoque que SCM categories
+- **AI-first but not AI-only**: soporta Claude Code, Codex CLI, Gemini CLI → compatible con OpenCode
+- **Keyboard-first**: command palette, navegacion rapida → productividad
+- **MCP server**: bridge para agentes AI → puente directo con Savia/OpenCode
+- **Desktop app**: macOS, Windows, Linux via Tauri → disponible en el host
+
+Savia genera Context As Code masivamente: reglas (25+), specs (~85), roadmap, skills
+(92), comandos (535), agentes (70), hooks (65), CHANGELOG (9000+ lineas). Navegar
+esto desde terminal es viable para Savia pero no para un humano. Tolaria proporciona
+la capa visual sin alterar el formato de los archivos ni introducir lock-in.
+
+**Objetivo:** Adoptar Tolaria como interfaz visual para el Context As Code de Savia.
+Instalar, configurar, mapear tipos de contenido Savia ↔ tipos Tolaria, y documentar
+el workflow para Mónica (y cualquier operador futuro).
+
+---
+
+## 2. Requisitos Funcionales
+
+- **REQ-01** Instalar Tolaria en el host. Dos opciones:
+  - Via AppImage/`.deb` desde [releases](https://refactoringhq.github.io/tolaria/download/)
+  - Via `pnpm dev` si se prefiere compilar localmente
+  - Preferencia: binario precompilado para Linux (`.deb` o AppImage)
+
+- **REQ-02** Clonar o symlinkear Savia workspace como vault de Tolaria.
+  `tolaria ~/claude` debe abrir el workspace directamente.
+  - `.gitignore` de Savia ya excluye archivos temporales
+  - `.tolaria/` directorio de config local (no commiteado)
+
+- **REQ-03** Definir tipos de contenido (Tolaria "types") para las entidades de Savia:
+  | Tipo Tolaria | Patron de archivo | Color | Icono |
+  |-------------|-------------------|-------|-------|
+  | `rule` | `docs/rules/**/*.md` | red | shield |
+  | `spec` | `docs/specs/**/*.md` | blue | file-text |
+  | `roadmap` | `docs/ROADMAP.md` | purple | map |
+  | `skill` | `.claude/skills/*/SKILL.md` | green | zap |
+  | `command` | `.claude/commands/*.md` | orange | terminal |
+  | `agent` | `.claude/agents/*.md` | indigo | bot |
+  | `proposal` | `docs/propuestas/**/*.md` | yellow | lightbulb |
+  | `changelog` | `CHANGELOG.md` | gray | clock |
+
+- **REQ-04** Configurar MCP server de Tolaria para bridge con Savia/OpenCode.
+  - El MCP server expone busqueda, lectura y escritura del vault via JSON-RPC
+  - OpenCode puede usar el MCP server para busqueda semantica en specs y reglas
+  - Alternativa: usar directamente los archivos (Savia ya los lee sin Tolaria)
+
+- **REQ-05** Documentar workflow en `docs/tolaria-workflow.md`:
+  - Como Mónica abre Tolaria y navega el workspace de Savia
+  - Como crear/editar specs desde la GUI
+  - Como usar la command palette para busqueda rapida
+  - Como el MCP server conecta con Savia
+
+- **REQ-06** Anadir comando Savia `/tolaria-open` para abrir vault especifico:
+  ```bash
+  # /tolaria-open [path] — abre Tolaria en el path especificado (default: ~/claude)
+  tolaria ~/claude &
+  ```
+
+- **REQ-07** Compatibilidad total con el formato existente. Cero cambios en la
+  estructura de archivos de Savia. Tolaria lee markdown + YAML frontmatter que
+  ya usamos. No se requiere migracion de contenido.
+
+---
+
+## 3. No se modifica
+
+Tolaria es una herramienta externa adoptada, no un componente de Savia.
+No se modifica el codigo de Tolaria. Lo que se crea es:
+
+1. Configuracion de tipos en `.tolaria/types.json` (o equivalente Tolaria)
+2. Comando `/tolaria-open` wrapper
+3. Documentacion de workflow
+4. MCP bridge (opcional, puede ser futuro)
+
+Ningun archivo markdown de Savia necesita cambiar. Los specs, reglas, roadmap
+y comandos ya usan el formato que Tolaria espera (markdown + YAML frontmatter).
+
+---
+
+## 4. Criterios de Aceptacion
+
+- **AC-01** Tolaria instalado en el host. `tolaria --version` funciona.
+- **AC-02** `tolaria ~/claude` abre el workspace de Savia con todos los archivos visibles.
+- **AC-03** Los tipos configurados muestran colores/iconos distintos para specs, rules, skills, etc.
+- **AC-04** `/tolaria-open` abre Tolaria desde el CLI de Savia.
+- **AC-05** `docs/tolaria-workflow.md` existe con instrucciones claras.
+- **AC-06** Ningun archivo de Savia fue modificado por la adopcion de Tolaria.
+
+---
+
+## 5. Ficheros a Crear/Modificar
+
+| Fichero | Accion |
+|---------|--------|
+| `.claude/commands/tolaria-open.md` | CREAR — comando `/tolaria-open` |
+| `.opencode/commands/tolaria-open.md` | CREAR — mirror para OpenCode |
+| `docs/tolaria-workflow.md` | CREAR — guia de uso |
+| `~/.tolaria/config.json` | CREAR — config de tipos (via script) |
+
+---
+
+## 6. Dependencias y Riesgos
+
+- **Riesgo**: Tolaria requiere WebKit2GTK 4.1 en Linux. Verificar si esta instalado.
+  **Mitigacion**: script de instalacion automatica de dependencias.
+- **Riesgo**: Tolaria es un binario precompilado (AppImage). Puede no ejecutarse en
+  todas las distros Linux. **Mitigacion**: compilar desde fuente si falla.
+- **Depende de**: Nada. Es tooling externo, no modifica codigo Savia.
+- **No bloquea**: ningun spec del pipeline. Se puede hacer en paralelo.
+
+---
+
+## 7. Impacto en Roadmap
+
+Este spec agiliza la VISUALIZACION del Context As Code. No cambia como Savia opera
+internamente, pero hace que Mónica (y cualquier operador humano) pueda navegar,
+buscar y entender el creciente sistema de reglas, specs, roadmap y comandos sin
+depender exclusivamente del terminal o del LLM.
+
+Se coloca en slot 6 (entre vendor-refs y UA-Adopt) por ser rapido (~45 min) y de
+alto impacto inmediato en la experiencia de uso humano de Savia.

--- a/docs/tolaria-workflow.md
+++ b/docs/tolaria-workflow.md
@@ -1,0 +1,114 @@
+# Tolaria — Savia Workspace Visualization
+
+> Tolaria is a desktop markdown knowledge base app (refactoringhq, 8.8k stars)
+> adopted as the visual interface for Savia's Context As Code.
+
+## Quick Start
+
+### 1. Install Tolaria
+
+**Linux (AppImage):**
+```bash
+# Download latest release
+wget https://github.com/refactoringhq/tolaria/releases/latest/download/Tolaria.AppImage
+chmod +x Tolaria.AppImage
+sudo mv Tolaria.AppImage /usr/local/bin/tolaria
+```
+
+**macOS:**
+```bash
+brew install --cask tolaria
+```
+
+**From source (if binary unavailable):**
+```bash
+git clone https://github.com/refactoringhq/tolaria
+cd tolaria
+pnpm install
+pnpm tauri build  # produces binary in src-tauri/target/release/
+```
+
+### 2. Open Savia workspace
+
+```bash
+# From Savia CLI:
+/tolaria-open
+
+# Or directly:
+tolaria ~/claude
+```
+
+The first time Tolaria opens the workspace, it creates `.tolaria/` directory
+for local config. This directory is gitignored — it never enters the repo.
+
+### 3. Navigate your Context As Code
+
+Tolaria reads the workspace as flat files organized by directory:
+
+| Directory | Content | Tolaria type | Color |
+|-----------|---------|-------------|-------|
+| `docs/rules/` | Rules (25+) | `rule` | Red |
+| `docs/specs/` | Specs (~85) | `spec` | Blue |
+| `docs/propuestas/` | Proposals | `proposal` | Yellow |
+| `docs/ROADMAP.md` | Roadmap | `roadmap` | Purple |
+| `.claude/commands/` | Commands (535) | `command` | Orange |
+| `.claude/skills/` | Skills (92) | `skill` | Green |
+| `.claude/agents/` | Agents (70) | `agent` | Indigo |
+| `CHANGELOG.md` | Changelog | `changelog` | Gray |
+
+Use **Cmd/Ctrl + K** (command palette) to search across all notes.
+Use **Cmd/Ctrl + P** to quick-open any file.
+
+## Workflow Patterns
+
+### Navigate specs
+
+1. Open command palette (Cmd+K)
+2. Type spec name or keyword
+3. Tolaria shows matching files instantly
+4. Click to open in editor
+
+### Edit a spec
+
+1. Navigate to the spec file
+2. Edit markdown directly in Tolaria's editor
+3. Save — changes go to disk immediately
+4. Git will detect the change (Tolaria is just a markdown editor)
+
+### Browse rules
+
+1. Filter by type `rule` in the sidebar
+2. See all rules grouped by category
+3. Open `radical-honesty.md` or any rule for reference
+
+### Search across everything
+
+The command palette does full-text search across all markdown files.
+Type any term ("sprint", "auditoria", "DeepSeek") and get results from
+specs, rules, roadmap, and commands simultaneously.
+
+## MCP Server (Advanced)
+
+Tolaria includes an MCP server that exposes the vault to AI agents:
+
+```bash
+# Start MCP server on port 3456
+tolaria mcp --port 3456 ~/claude
+```
+
+Savia/OpenCode can query the vault via MCP for:
+- Semantic search across specs and rules
+- Reading specific files by path
+- Listing files by type
+
+This is optional. Savia already reads files directly from disk.
+The MCP server is useful when you want Savia to search the vault
+without loading the full context into the LLM.
+
+## Principles
+
+- **Files remain plain markdown.** Tolaria reads them as-is. No migration format.
+- **Tolaria is a viewer, not a dependency.** If you stop using it, nothing breaks.
+- **Git continues to work.** Tolaria uses git under the hood for version history.
+- **Offline first.** Works without internet. Your data stays on your machine.
+- **Zero lock-in.** Close Tolaria, open any text editor — same files, same format.


### PR DESCRIPTION
## Qué hace este PR

### Vendor references cleanup (SPEC-OPC-VENDOR-REFS)

La cabecera de `CLAUDE.md` decía "PM-Workspace — Claude Code Global", afirmando que el workspace pertenecía a un solo frontend. Esto era incorrecto: Savia ya corre en OpenCode con DeepSeek v4-pro, SaviaClaw migró a `llm_backend.py` provider-agnostic, y la pipeline de CI funciona con ambos.

Este PR limpia las referencias visibles:

- **CLAUDE.md**: "Claude Code Global" → "OpenCode / Claude Code"
- **provider-agnostic-tech-debt.md**: tabla de providers (DeepSeek, Anthropic, Qwen local), documentada migración SaviaClaw Era 193, Qwen3.6 como candidato a fallback.
- **savia-claw-bridge.md**: eliminada referencia a "Claude Code CLI" como único backend.
- **migration guide**: marcado como PRODUCTION status.

### Tolaria adoption (SPEC-SE-090-TOLARIA)

Tolaria (refactoringhq, 8.8k stars, AGPL-3.0) es una app de escritorio que gestiona bases de conocimiento en markdown. Se ha adoptado como la interfaz visual para el Context As Code de Savia:

- **Comando `/tolaria-open`**: abre Tolaria sobre el workspace de Savia con un solo comando.
- **8 tipos de contenido mapeados**: rules (rojo), specs (azul), skills (verde), commands (naranja), agents (indigo), proposals (amarillo), roadmap (púrpura), changelog (gris).
- **Cero migración**: Tolaria lee markdown + YAML frontmatter, el mismo formato que ya usan specs, reglas y roadmap de Savia.
- **Workflow documentado**: `docs/tolaria-workflow.md` con instalación, navegación, búsqueda y MCP server.
- **Sin modificar archivos de Savia**: Tolaria es un viewer externo, no una dependencia del sistema.

Los 51 skills con vendor references y los 90 skills sin campo `compatibility: opencode` siguen pendientes — son trabajo mecánico pero voluminoso, no bloqueante.

## Cambios

| Área | Archivos | Qué cambió |
|------|----------|------------|
| **CLAUDE.md** | `CLAUDE.md` | Header: "Claude Code Global" → "OpenCode / Claude Code" |
| **Tech debt** | `docs/rules/domain/provider-agnostic-tech-debt.md` | Provider table + Era 193 doc + Qwen3.6 |
| **Bridge doc** | `docs/savia-claw-bridge.md` | "Claude Code CLI" → "LLM backend" |
| **Migration guide** | `docs/migration-claude-code-to-opencode.md` | Status: PRODUCTION |
| **Tolaria cmd** | `.claude/commands/tolaria-open.md` (NUEVO) | `/tolaria-open` command |
| **Tolaria guide** | `docs/tolaria-workflow.md` (NUEVO) | Installation + types + workflow |
| **Spec** | `docs/specs/SPEC-SE-090-TOLARIA.spec.md` (NUEVO) | Era 194 adoption spec |
| **Roadmap** | `docs/ROADMAP.md` | Era 194 added, pipeline 20 items |