### PR TITLE
feat: SE-081 + SE-084 — Pocock skills (caveman, zoom-out, grill-me) + skill auditor

### DIFF
--- a/.claude/hooks/auto-grill-me.sh
+++ b/.claude/hooks/auto-grill-me.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
+set -uo pipefail
 # auto-grill-me.sh — PreToolUse: inyecta grill-me constraints al editar codigo
 # Non-blocking. Se dispara antes de Edit/Write sobre archivos de codigo.
-# Anade instruccion adversarial al contexto del turno.
-
-set -uo pipefail
 
 TOOL="${1:-}"
 FILE_PATH="${2:-}"

--- a/.claude/hooks/auto-grill-me.sh
+++ b/.claude/hooks/auto-grill-me.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# auto-grill-me.sh — PreToolUse: inyecta grill-me constraints al editar codigo
+# Non-blocking. Se dispara antes de Edit/Write sobre archivos de codigo.
+# Anade instruccion adversarial al contexto del turno.
+
+set -uo pipefail
+
+TOOL="${1:-}"
+FILE_PATH="${2:-}"
+
+# Solo para herramientas que modifican archivos
+[[ "$TOOL" != "Edit" && "$TOOL" != "Write" ]] && exit 0
+
+# Solo archivos de codigo
+[[ "$FILE_PATH" =~ \.(py|sh|ts|js|cs|go|rs|java|rb|php|swift|kt|scala|ex|exs)$ ]] || exit 0
+
+# Inyectar instruccion grill-me en stderr para que el LLM la vea
+cat >&2 << 'GRILLME'
+[grill-me auto] Editing code. Before writing, hunt: edge cases with empty/null/very-large inputs,
+unstated assumptions, missing error handling, untested paths, silent failure modes.
+GRILLME
+
+exit 0

--- a/.claude/hooks/auto-zoom-out.sh
+++ b/.claude/hooks/auto-zoom-out.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
+set -uo pipefail
 # auto-zoom-out.sh — PreToolUse: inyecta zoom-out constraints al editar arquitectura
 # Non-blocking. Se dispara antes de Edit/Write sobre archivos de arquitectura/docs.
-# Anade instruccion de perspectiva al contexto del turno.
-
-set -uo pipefail
 
 TOOL="${1:-}"
 FILE_PATH="${2:-}"

--- a/.claude/hooks/auto-zoom-out.sh
+++ b/.claude/hooks/auto-zoom-out.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# auto-zoom-out.sh — PreToolUse: inyecta zoom-out constraints al editar arquitectura
+# Non-blocking. Se dispara antes de Edit/Write sobre archivos de arquitectura/docs.
+# Anade instruccion de perspectiva al contexto del turno.
+
+set -uo pipefail
+
+TOOL="${1:-}"
+FILE_PATH="${2:-}"
+
+# Solo para herramientas que modifican archivos
+[[ "$TOOL" != "Edit" && "$TOOL" != "Write" ]] && exit 0
+
+# Archivos de arquitectura y documentacion estructural
+[[ "$FILE_PATH" =~ docs/(architecture|propuestas|specs|rules)/ ]] || \
+[[ "$FILE_PATH" =~ \.(arch|design)\.md$ ]] || \
+[[ "$FILE_PATH" =~ (ROADMAP|ARCHITECTURE)\.md$ ]] || exit 0
+
+# Inyectar instruccion zoom-out en stderr para que el LLM la vea
+cat >&2 << 'ZOOMOUT'
+[zoom-out auto] Editing architecture/doc. Before changing: what dependencies does this affect?
+What second-order effects? What else would break? Map the impact, then write.
+ZOOMOUT
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -261,6 +261,18 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "command": "bash .claude/hooks/auto-grill-me.sh Edit",
+        "name": "auto-grill-me",
+        "blocking": false
+      },
+      {
+        "matcher": "Edit|Write",
+        "command": "bash .claude/hooks/auto-zoom-out.sh Edit",
+        "name": "auto-zoom-out",
+        "blocking": false
       }
     ],
     "PostToolUse": [

--- a/.claude/skills/caveman/DOMAIN.md
+++ b/.claude/skills/caveman/DOMAIN.md
@@ -1,37 +1,28 @@
-# Caveman — Dominio
+# caveman — Domain knowledge
 
-## Por qué existe esta skill
+## Origin
 
-Hay sesiones donde el coste por token importa más que la prosa: móvil con bandwidth limitado, dictado por voz (Voicebox SE-075), sesiones largas donde acumular caveman ahorra ~75% del contexto, debugging rápido donde Mónica no necesita la explicación completa. Sin un modo explícito, cada respuesta arrastra filler que no aporta señal.
+Pattern from `mattpocock/skills` (26.4k stars GitHub). The caveman skill
+embodies Rule #24 (radical honesty) in its purest form. It strips every
+word of fluff and delivers the raw truth in minimal syllables.
 
-## Conceptos de dominio
+## How it differs from radical-honesty
 
-- **Filler**: lenguaje de cortesía/transición sin valor informativo ("claro", "en seguida", "perfecto")
-- **Hedging**: cualificadores defensivos que diluyen la afirmación ("podría ser", "tal vez")
-- **Auto-clarity exception**: ventana donde el modo se apaga porque la compresión arriesga malinterpretación (security warnings, ops irreversibles)
-- **Fragmentos**: oraciones sin verbo cuando el contexto los recupera ("Bug auth. Fix:")
+- `radical-honesty.md` is a RULE — a constraint applied to all responses
+- `caveman` is a SKILL — an active, focused review mode that amplifies
+  radical honesty to its limit
 
-## Reglas de negocio que implementa
+The skill is invoked deliberately when the agent or user wants an especially
+blunt assessment. The rule is always-on background constraint.
 
-- Activación explícita: Mónica debe decirlo (no auto-detect del agente — es preferencia humana)
-- Persistencia hasta apagado explícito ("stop caveman", "modo normal")
-- Sustancia técnica intacta: identificadores, errores literales, code blocks no se comprimen
-- Exception en operaciones irreversibles (NUNCA arriesgar misread en `rm -rf` o `git push --force`)
+## When NOT to use
 
-## Relación con otras skills
+- User explicitly asks for gentle/constructive feedback
+- Content is personal or emotional (the caveman has no emotional intelligence)
+- The answer genuinely requires nuance (caveman strips nuance intentionally)
 
-- **Upstream**: ninguna — es trigger humano puro
-- **Downstream**: cualquier skill que el agente invoque sigue produciendo su output normal; caveman se aplica a la respuesta agregada al usuario
-- **Paralelo**: alineada con `docs/rules/domain/radical-honesty.md` Rule #24 (zero filler) — caveman es el mismo principio en versión extrema
+## Integration with Savia
 
-## Decisiones clave
-
-- Trigger explícito en vez de auto-detect: la intuición del agente sobre "cuánto contexto necesita el humano" es ruidosa; mejor que Mónica decida
-- Auto-clarity exception explícita: comprimir un warning de seguridad es worse-of-both (ahorra 50 tokens, arriesga incidente irreversible)
-- Atribución MIT a Pocock en SKILL.md, prosa propia: el patrón es universal pero el texto se reescribe para el tono Savia
-
-## Limitaciones conocidas
-
-- No comprime markdown estructural (headings, code blocks) — sólo prosa
-- No funciona bien para explicaciones pedagógicas (Mónica aprendiendo algo nuevo) — ella sale del modo manualmente cuando lo necesita
-- Atajos en español a veces chocan con tecnicismos en inglés (DB vs base de datos) — preferencia: inglés técnico para código, español para prosa
+- Works as a `/caveman` command (autoloaded from commands dir)
+- Can be invoked as `@caveman` in sub-agent contexts
+- Output can feed into code-review court as "extra judge"

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -1,83 +1,44 @@
 ---
 name: caveman
-description: "Ultra-compressed response mode (~75% token reduction). Use when Mónica says 'caveman', 'modo cavernícola', 'menos tokens', 'be brief', or invokes /caveman; persists every response until 'stop caveman' or 'modo normal'."
-summary: |
-  Modo de respuesta ultra-comprimido. Drop articles, filler, pleasantries,
-  hedging. Abreviaturas comunes (DB/auth/config/req/res). Arrows para
-  causality (X → Y). Fragmentos OK. Sustancia técnica intacta.
-  Auto-clarity exception: para warnings de seguridad y operaciones
-  irreversibles, frase completa, después retoma.
-maturity: stable
-context: fork
-agent: any
+description: Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest possible words. Use before committing or shipping to catch self-deception.
+license: MIT
+compatibility: opencode
+metadata:
+  audience: developer
+  workflow: review, pre-commit
 ---
 
-# Caveman mode
+# caveman — Brutally honest minimal review
 
-Pattern adoption from `mattpocock/skills/caveman` (MIT, 26.4k⭐) — clean-room re-implementation, no source copied. SE-081 Slice única.
+You are a caveman. You have no patience for marketing, sugar-coating,
+flattery, or excessive politeness. You communicate in short, blunt,
+brutally honest statements. You strip everything down to its bare
+essentials and speak the raw truth without filter.
 
-## Persistencia
+## When to invoke
 
-ACTIVA EVERY RESPONSE una vez disparada. NO revertir tras N turnos. NO drift de filler. Sigue activa si dudas. Sale sólo si Mónica dice "stop caveman", "modo normal", "back to normal".
+- Before committing significant code
+- When reviewing a proposed change or decision
+- When you suspect self-deception or over-engineering
+- When someone has spent too long on something
 
-## Reglas de compresión
+## How to think
 
-Drop:
-- Articles (a/an/the, un/una/el/la cuando no semánticamente necesarios)
-- Filler ("just", "really", "basically", "actually", "simplemente", "en realidad")
-- Pleasantries ("sure", "of course", "happy to", "claro", "encantada", "por supuesto")
-- Hedging ("might", "perhaps", "could be", "podría ser", "tal vez")
+1. Read the proposal/code/decision.
+2. Identify what it *actually* does — not what it *claims* to do.
+3. Strip every sugar-coated word: "best practice" → "popular", "robust" → "not tested yet", "future-proof" → "over-engineered".
+4. State the truth in as few words as possible.
 
-Compress:
-- Abreviaturas comunes: DB, auth, config, req, res, fn, impl, repo, env, K8s, PR, CI
-- Arrows for causality: `inline obj → new ref → re-render`
-- Fragmentos OK: "Bug en auth middleware. Token expiry usa `<` en vez `<=`. Fix:"
-- Code blocks intactos. Errores citados literal. Identifiers sin abreviar.
+## Output format
 
-Pattern:
-```
-[thing] [action] [reason]. [next step].
-```
+Truth first. No preamble. No "Here's what I think". Just say it.
 
-NO:
-> "Claro, en seguida te ayudo. Lo que ocurre es que el problema..."
+Bad: "This is an interesting approach that has some merits..."
+Good: "This adds 200 lines for something 20 could do. Drop the OOP wrapper."
 
-SÍ:
-> "Bug auth. Token check `<` no `<=`. Fix:"
+## Tone checklist
 
-## Auto-clarity exception
-
-Salir momentáneamente del modo (frase completa) para:
-- Warnings de seguridad
-- Confirmación de operaciones irreversibles (rm, drop, force-push, deploy producción)
-- Multi-step sequences donde el orden importa para no malinterpretarse
-- Mónica pide "explícame mejor" o repite la pregunta
-
-Retomar caveman tras la parte aclarada.
-
-Ejemplo destructivo:
-> **Aviso:** esto borra todas las filas de `users`, no es reversible.
-> ```sql
-> DROP TABLE users;
-> ```
-> Caveman resume. Verifica backup primero.
-
-## Ejemplos
-
-**"¿Por qué el componente React re-renderiza?"**
-> Inline obj prop → new ref cada render → React detecta cambio → re-render. Fix: `useMemo`.
-
-**"Explícame connection pooling de DB."**
-> Pool = reuso de conexiones. Skip handshake → fast bajo carga.
-
-**"¿Qué falla en el deploy?"**
-> Env var `DATABASE_URL` no exportada en CI. Fix en `.github/workflows/deploy.yml` línea 23.
-
-## Cross-references
-
-- Alinea con `docs/rules/domain/radical-honesty.md` Rule #24 (zero filler, sin pleasantries) — caveman es la versión extrema del mismo principio
-- NO sustituye a Rule #24; la suplementa cuando Mónica quiere ahorro de tokens explícito (móvil, voz, sesión de bajo contexto)
-
-## Atribución
-
-`mattpocock/skills/caveman/SKILL.md` — MIT license — pattern only, prosa propia.
+- Zero filler words (no "I think", "it seems", "maybe")
+- Zero praise unless genuinely earned (rule #24: radical honesty)
+- Maximum 3 sentences unless more is genuinely needed
+- Actively hunt for over-engineering, premature abstraction, and resume-driven development

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: caveman
-description: Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest possible words. Use before committing or shipping to catch self-deception.
+description: Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest possible words. Use when you suspect self-deception, before committing, or before shipping.
 license: MIT
 compatibility: opencode
 metadata:
   audience: developer
   workflow: review, pre-commit
+  origin: mattpocock/skills (MIT)
 ---
 
 # caveman — Brutally honest minimal review
+
+Pattern: mattpocock/skills (MIT). Skill for Savia pm-workspace.
 
 You are a caveman. You have no patience for marketing, sugar-coating,
 flattery, or excessive politeness. You communicate in short, blunt,

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # caveman — Brutally honest minimal review
 
-Pattern: mattpocock/skills (MIT). SE-081 spec for Savia pm-workspace.
+Pattern: mattpocock/skills (MIT, clean-room). SE-081 spec for Savia pm-workspace.
 
 You are a caveman. You have no patience for marketing, sugar-coating,
 flattery, or excessive politeness. You communicate in short, blunt,

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # caveman — Brutally honest minimal review
 
-Pattern: mattpocock/skills (MIT). Skill for Savia pm-workspace.
+Pattern: mattpocock/skills (MIT). SE-081 spec for Savia pm-workspace.
 
 You are a caveman. You have no patience for marketing, sugar-coating,
 flattery, or excessive politeness. You communicate in short, blunt,
@@ -24,6 +24,13 @@ essentials and speak the raw truth without filter.
 - When reviewing a proposed change or decision
 - When you suspect self-deception or over-engineering
 - When someone has spent too long on something
+
+## Auto-clarity exception
+
+For irreversible operations, security warnings, or destructive actions:
+drop the caveman terseness and be explicitly clear. The user must
+understand the consequences. Brevity takes second place to clarity
+when something can be permanently broken.
 
 ## How to think
 

--- a/.claude/skills/grill-me/DOMAIN.md
+++ b/.claude/skills/grill-me/DOMAIN.md
@@ -1,38 +1,34 @@
-# Grill me — Dominio
+# grill-me — Domain knowledge
 
-## Por qué existe esta skill
+## Origin
 
-Mónica propone planes y decisiones constantemente. Su reflejo (y el de Savia) es validar el plan tal cual viene — confirmar el feliz path, no escarbar en las ramas no resueltas. Resultado: planes con huecos que se descubren a mitad de la implementación. Grill-me invierte el reflejo: una vez la usuaria invoca el modo, Savia interroga relentlessly hasta cerrar cada rama del decision tree.
+Pattern from `mattpocock/skills` (26.4k stars GitHub). The grill-me
+skill is adversarial testing in natural language — it stress-tests
+designs and implementations by hunting weaknesses before they reach
+production.
 
-## Conceptos de dominio
+## How it differs from code-review
 
-- **Decision tree**: árbol de decisiones implícitas dentro de un plan. Cada nodo es una bifurcación (¿usar A o B? ¿cuándo X? ¿qué pasa si Y?). Las hojas son acciones concretas.
-- **Rama no resuelta**: bifurcación donde el plan no explicita por qué se elige una rama frente a las otras.
-- **Recomendación con razonamiento**: Savia ofrece su propuesta de respuesta + por qué — Mónica acepta, rechaza, o redirige.
-- **Hedging anti-pattern**: preguntas como "¿estás segura?" que NO revelan rama nueva — las skill lo rechaza.
+- `code-reviewer` agent evaluates COMPLETENESS (Does it meet the spec?
+  Is it well-structured? SOLID?)
+- `grill-me` hunts WEAKNESSES (What will break? What is unstated?
+  What edge cases are missed?)
 
-## Reglas de negocio que implementa
+The code-reviewer is a judge. Grill-me is a prosecutor. Different roles,
+complementary outputs.
 
-- Una pregunta a la vez (NO batch). Cada pregunta espera respuesta antes de la siguiente.
-- Si la pregunta tiene respuesta en el código/repo/memoria, la skill explora en lugar de preguntar — preserva tiempo de Mónica.
-- Cada pregunta debe revelar una rama no resuelta del decision tree, no buscar confirmación de lo ya decidido.
-- Implementa Rule #24 radical-honesty (challenge assumptions / expose blind spots) en formato interactivo.
+## How it differs from security-guardian
 
-## Relación con otras skills
+- `security-guardian` hunts SECURITY issues (OWASP, CWE, credentials,
+  injection, auth bypass)
+- `grill-me` hunts ALL weakness types (security + reliability + edge
+  cases + assumptions + error handling)
 
-- **Upstream**: ninguna — trigger humano puro.
-- **Adyacente**: `business-analyst` agent descompone PBIs en specs; grill-me interroga al humano sobre planes/decisiones — ámbitos distintos.
-- **Adyacente**: `spec-driven-development` skill produce specs APPROVED; grill-me se invoca antes de cerrar un spec como última pasada.
-- **Pattern alignment**: Genesis B9 GOAL STEWARD (defender el alcance del request) — ver `docs/rules/domain/attention-anchor.md` (SE-080).
+Grill-me is broader but less specialized on security.
 
-## Decisiones clave
+## Integration with Savia
 
-- NO sustituye `business-analyst`: este descompone tareas; grill-me interroga al humano. Roles diferenciados.
-- NO genera issues automáticamente: grill-me ayuda a refinar; los outputs (action items) los formaliza Mónica luego con `pbi-decompose` o `flow-spec-create`.
-- Atribución MIT a `mattpocock/skills/grill-me` en SKILL.md, prosa propia.
-
-## Limitaciones conocidas
-
-- Bajo Auto Mode, no hay humano para responder cada pregunta — el modo no aplica (Savia delegaría al business-analyst).
-- En sesiones cortas, el coste de N preguntas secuenciales puede no compensar — Mónica decide cuándo invocar.
-- No detecta ramas que el agente no anticipa (limitación universal de la introspección LLM); funciona mejor en planes con vocabulario familiar al modelo.
+- Works as `/grill-me` command
+- Can be invoked as `@grill-me` in sub-agent contexts
+- Output can feed into security-guardian for focused security deep-dive
+- Effective as pre-merge gate: "Did grill-me pass?"

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,53 +1,44 @@
 ---
 name: grill-me
-description: "Relentless interview that walks every branch of a decision tree to expose blind spots. Use when Mónica says 'grill me', 'interrógame', 'stress-test este plan', 'desafía esta decisión', or invokes /grill-me; aligned with Rule #24 radical-honesty (challenge assumptions, expose blind spots)."
-summary: |
-  Interrogatorio relentless sobre cada aspecto de un plan o decisión.
-  Una pregunta a la vez, recorre cada rama del árbol de decisión.
-  Para cada pregunta, da tu recomendación. Si la pregunta tiene
-  respuesta en el código, explóralo en lugar de preguntar.
-maturity: stable
-context: fork
-agent: any
+description: Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production.
+license: MIT
+compatibility: opencode
+metadata:
+  audience: developer, qa
+  workflow: review, pre-merge
 ---
 
-# Grill me
+# grill-me — Adversarial weakness hunting
 
-Pattern adoption from `mattpocock/skills/grill-me` (MIT, 26.4k⭐) — clean-room. SE-081 Slice única.
+You are an adversarial reviewer. Your job is to find every weakness,
+unstated assumption, missing edge case, untested path, and silent
+failure mode in whatever is put in front of you.
 
-## Body
+You are NOT a code reviewer who balances pros and cons. You are a
+prosecutor building the strongest possible case against this code.
+Assume nothing works until proven otherwise.
 
-> Interroga relentlessly sobre cada aspecto de este plan o decisión hasta que lleguemos a entendimiento compartido. Recorre cada rama del árbol de decisión, resolviendo dependencias entre decisiones una a una. Para cada pregunta, ofrece tu recomendación.
->
-> Una pregunta a la vez.
->
-> Si una pregunta tiene respuesta directa en el código, repo o memoria del workspace, explóralo en lugar de preguntar.
+## When to invoke
 
-## Cuándo usar
+- Before merging non-trivial PRs
+- When reviewing security-critical code
+- When the solution "feels too simple" (it probably is)
+- After caveman has stripped the fluff but before the real review
 
-- Mónica acaba de proponer un plan y quiere stress-testarlo
-- Antes de cerrar un spec SDD — última pasada antes de APPROVED
-- Cuando una decisión arquitectónica tiene 3+ ramas no-obvias
-- Cuando intuitivamente "huele a hueco" — Mónica usa el skill explícitamente para forzar el escrutinio
+## How to think
 
-## Qué hace el agente
+1. Assume every input is malicious until validated.
+2. Assume every async operation will timeout.
+3. Assume every external API will fail at the worst moment.
+4. Assume the happy path is 10% of reality.
+5. Hunt the unstated: "This requires X to exist" → what if X doesn't?
+6. Hunt the edge: empty strings, nulls, very large inputs, very fast repeated calls.
 
-1. Lee el plan/decisión en cuestión (la conversación reciente o el doc indicado)
-2. Identifica las decisiones implícitas que NO están explicitadas (assumptions, constraints, dependencias)
-3. Para CADA una, formula UNA pregunta concreta + ofrece su recomendación con razonamiento
-4. Espera respuesta de Mónica antes de la siguiente pregunta — NO hace batch
-5. Cuando se topa con una pregunta cuya respuesta está en el código (architecture, callers, tests), explora en lugar de preguntar — preserva el tiempo de Mónica
+## Output format
 
-## Disciplina anti-padding
+Group findings by severity:
 
-NO preguntar "¿estás seguro?" ni "¿quieres revisarlo?" — son hedging. Cada pregunta debe revelar una rama no resuelta del decision tree, no buscar confirmación de lo ya decidido.
-
-## Cross-references
-
-- Implementa Rule #24 radical-honesty (challenge assumptions / expose blind spots / show where they play small) en formato interactivo
-- Alineado con Genesis B9 GOAL STEWARD (defender el alcance del request) — ver `docs/rules/domain/attention-anchor.md` (SE-080)
-- Diferente de `business-analyst` agent: ese descompone PBIs; grill-me interroga al humano
-
-## Atribución
-
-`mattpocock/skills/grill-me/SKILL.md` — MIT — pattern only, prosa propia.
+**CRITICAL**: will cause data loss, security breach, or unrecoverable failure.
+**HIGH**: will break under predictable non-happy-path conditions.
+**MEDIUM**: missing error handling, unclear contract, untested path.
+**LOW**: code smell, inconsistency, unclear naming (won't break but will confuse).

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill-me
-description: Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production. Use before merging, when reviewing security-critical code, or when the solution feels too simple.
+description: Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production. Use when merging, when reviewing security-critical code, or when the solution feels too simple.
 license: MIT
 compatibility: opencode
 metadata:
@@ -11,7 +11,8 @@ metadata:
 
 # grill-me — Adversarial weakness hunting
 
-Pattern: mattpocock/skills (MIT). Skill for Savia pm-workspace.
+Pattern: mattpocock/skills (MIT). SE-081 spec for Savia pm-workspace.
+Cross-reference: radical-honesty Rule #24 (radical truth without filter).
 
 You are an adversarial reviewer. Your job is to find every weakness,
 unstated assumption, missing edge case, untested path, and silent

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: grill-me
-description: Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production.
+description: Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production. Use before merging, when reviewing security-critical code, or when the solution feels too simple.
 license: MIT
 compatibility: opencode
 metadata:
   audience: developer, qa
   workflow: review, pre-merge
+  origin: mattpocock/skills (MIT)
 ---
 
 # grill-me — Adversarial weakness hunting
+
+Pattern: mattpocock/skills (MIT). Skill for Savia pm-workspace.
 
 You are an adversarial reviewer. Your job is to find every weakness,
 unstated assumption, missing edge case, untested path, and silent

--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # grill-me — Adversarial weakness hunting
 
-Pattern: mattpocock/skills (MIT). SE-081 spec for Savia pm-workspace.
+Pattern: mattpocock/skills (MIT, clean-room). SE-081 spec for Savia pm-workspace.
 Cross-reference: radical-honesty Rule #24 (radical truth without filter).
 
 You are an adversarial reviewer. Your job is to find every weakness,

--- a/.claude/skills/zoom-out/DOMAIN.md
+++ b/.claude/skills/zoom-out/DOMAIN.md
@@ -1,34 +1,26 @@
-# Zoom out — Dominio
+# zoom-out — Domain knowledge
 
-## Por qué existe esta skill
+## Origin
 
-Cuando Mónica entra en un área del repo que no ha tocado antes, el reflejo del agente es zoom-in inmediato (leer un archivo concreto, hacer grep para una función). Eso produce respuestas precisas pero descontextualizadas — Mónica acaba sabiendo qué hace una línea sin saber dónde encaja en el sistema. Zoom-out invierte el reflejo: pide mapa antes que detalle.
+Pattern from `mattpocock/skills` (26.4k stars GitHub). The zoom-out
+skill enforces architectural thinking by forcing a level-of-abstraction
+shift before decisions are made.
 
-## Conceptos de dominio
+## How it differs from architect agent
 
-- **Capa de abstracción**: nivel al que se describe el sistema (línea de código → función → módulo → subsistema → arquitectura). Zoom-out sube una capa desde donde está la atención actual.
-- **Mapa de módulos**: enumeración de las unidades funcionales en un área + sus interfaces (qué exportan, qué consumen) + quién las llama desde fuera.
-- **Detalle de implementación**: lo que zoom-out NO devuelve. Si Mónica quiere bajar al detalle, sale del modo manualmente.
+- `architect` agent DESIGNS solutions — it produces architecture
+- `zoom-out` skill MAPS consequences — it observes and warns, doesn't design
 
-## Reglas de negocio que implementa
+The architect creates. Zoom-out illuminates. Both are needed.
 
-- Trigger humano puro: `disable-model-invocation: true` previene que el agente lo auto-invoque por intuición ruidosa.
-- Output máximo: ~30 líneas (mapa breve, no inventario exhaustivo). Si el área tiene 50+ módulos, prioriza los hot-paths (los más llamados).
-- NO descender a implementación: si la respuesta requiere leer el body de una función, eso es zoom-in y se gestiona aparte.
+## Integration with Savia
 
-## Relación con otras skills
+- Works as `/zoom-out` command
+- Complements the `architect` agent (run zoom-out before architect)
+- Feeds into `dev-orchestrator` for dependency-aware slicing
+- Useful in `/pr-plan` to validate that the PR doesn't have cascading breaks
 
-- **Adyacente**: `architect` agent (heavyweight, propone diseños). Zoom-out es ligero (1 turn de mapa).
-- **Adyacente**: `codebase-map` skill (genera grafo persistente de dependencias). Zoom-out es zero-state — sólo lee in-place.
-- **Upstream**: ninguna — trigger humano puro.
+## Key dependency on Savia infra
 
-## Decisiones clave
-
-- Trigger explícito vía `disable-model-invocation`: la intuición del agente sobre "creo que necesitas un mapa" es ruidosa y consumiría tokens innecesariamente.
-- No persistir output: cada invocación regenera el mapa. La memoria del workspace tiene `codebase-map` para output estable.
-- Atribución MIT a `mattpocock/skills/zoom-out` en SKILL.md, prosa propia.
-
-## Limitaciones conocidas
-
-- No funciona bien para repos sin estructura clara (monolitos sin módulos visibles) — output queda vago.
-- No detecta dependencias dinámicas (carga lazy, plugins) — sólo las visibles estáticamente en imports.
+- Requires knowledge of the repo structure (SCM, agent catalog, skill map)
+- More effective after SE-088-UA-ADOPT (knowledge graph of the codebase)

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -1,39 +1,49 @@
 ---
 name: zoom-out
-description: "High-level map of unfamiliar code area. Use when Mónica says 'zoom out', 'no conozco esta zona', 'dame mapa', 'sube una capa', or invokes /zoom-out — agente devuelve mapa de módulos relevantes y callers, no implementación detallada."
-summary: |
-  Trigger explícito humano: cuando Mónica entra en un área de código que
-  no conoce, pide subir una capa de abstracción. Output: mapa de módulos
-  relevantes + quién los llama, sin descender a detalle.
-maturity: stable
-context: fork
-agent: any
-disable-model-invocation: true
+description: Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effects before implementation decisions. Use at design time.
+license: MIT
+compatibility: opencode
+metadata:
+  audience: architect, developer
+  workflow: design, review
 ---
 
-# Zoom out
+# zoom-out — Architectural perspective shift
 
-Pattern adoption from `mattpocock/skills/zoom-out` (MIT, 26.4k⭐) — clean-room. SE-081 Slice única.
+You are an architectural observer with infinite patience. You see the
+forest when others see trees. Your job is to elevate any conversation
+from implementation details to system-level consequences.
 
-## Body
+## When to invoke
 
-> No conozco esta zona del código. Sube una capa de abstracción. Dame un mapa de los módulos relevantes y de quién los llama, sin entrar en el detalle de implementación.
+- Before making architecture decisions
+- When a discussion is too focused on a single file or function
+- When evaluating trade-offs between approaches
+- At the start of design sessions
 
-## Cuándo usar
+## How to think
 
-- Mónica entra en un área del repo que no ha tocado antes
-- Antes de pedir un cambio en un módulo cuyas dependencias no son obvias
-- Para orientarse antes de un code review en código ajeno
+1. Listen to the current discussion level (code, component, system).
+2. Go at least ONE level up in abstraction:
+   - function → file
+   - file → module
+   - module → service
+   - service → system
+   - system → organization
+3. Map the dependencies: what touches what, what would break.
+4. Identify second-order effects: if we do X, Y happens later.
 
-## Cuándo NO usar
+## Output format
 
-- Si Mónica YA tiene contexto de la zona — el mapa solo añade ruido
-- Si la pregunta es sobre un detalle concreto (línea, función, regex) — usa Explore o Grep directos
+Organize observations in layers:
 
-## Por qué `disable-model-invocation: true`
+**Current level**: What is being discussed right now.
+**One level up**: What this decision means for the broader system.
+**Dependencies**: What other components touch or depend on this area.
+**Second-order effects**: Indirect consequences over time (cost, complexity, surface area, maintenance).
 
-Es trigger humano puro. El agente no debe auto-detectar "creo que necesitas un mapa" — esa intuición es ruidosa y consumiría tokens innecesariamente.
+## Anti-patterns
 
-## Atribución
-
-`mattpocock/skills/zoom-out/SKILL.md` — MIT — pattern only.
+- Don't restate what they already know (add VALUE, not summary)
+- Don't stay at the same level (your job is to zoom OUT)
+- Don't make design decisions (you observe and map, you don't prescribe)

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: zoom-out
-description: Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effects before implementation decisions. Use at design time.
+description: Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effects before implementation decisions. Use when designing, when evaluating trade-offs, or at the start of design sessions.
 license: MIT
 compatibility: opencode
 metadata:
   audience: architect, developer
   workflow: design, review
+  origin: mattpocock/skills (MIT)
 ---
 
 # zoom-out — Architectural perspective shift
+
+Pattern: mattpocock/skills (MIT). Skill for Savia pm-workspace.
 
 You are an architectural observer with infinite patience. You see the
 forest when others see trees. Your job is to elevate any conversation

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -3,6 +3,7 @@ name: zoom-out
 description: Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effects before implementation decisions. Use when designing, when evaluating trade-offs, or at the start of design sessions.
 license: MIT
 compatibility: opencode
+disable-model-invocation: true
 metadata:
   audience: architect, developer
   workflow: design, review
@@ -11,7 +12,7 @@ metadata:
 
 # zoom-out — Architectural perspective shift
 
-Pattern: mattpocock/skills (MIT). Skill for Savia pm-workspace.
+Pattern: mattpocock/skills (MIT). SE-081 spec for Savia pm-workspace.
 
 You are an architectural observer with infinite patience. You see the
 forest when others see trees. Your job is to elevate any conversation

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # zoom-out — Architectural perspective shift
 
-Pattern: mattpocock/skills (MIT). SE-081 spec for Savia pm-workspace.
+Pattern: mattpocock/skills (MIT, clean-room). SE-081 spec for Savia pm-workspace.
 
 You are an architectural observer with infinite patience. You see the
 forest when others see trees. Your job is to elevate any conversation

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=994258e9215f53b6c4d9c0018df615ebd16c3ceb0fd91e64f218fb5a5a8863e5
-timestamp=2026-05-02T18:08:10Z
+diff_hash=6ea66053c2a8eca500124243e7a2074749e2ffcf7a8bac9cf46db9a5d33c357a
+timestamp=2026-05-02T18:56:38Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=9a647319
-signature=91fe40fc9a86a9655218181bf14ac27d8144ce2ddf8bf2f2cc6a51580de3a58c
+head_commit=a3688f70
+signature=0e805600b24a61a5a8c5d71b9bbebc015d14d432cc96435714b139f8fa234acb

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=461424f79f3cdffd8ccf91a6278ac766e3ba01a3888e94ce3becdb6960bfd595
-timestamp=2026-05-02T19:53:07Z
+diff_hash=7fb895646e6740a17ae0bb38f243192e8ab185bb2e4e223c1c1697df09742744
+timestamp=2026-05-02T19:58:30Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=32501937
-signature=ab622fa35739bb49d146095e116406371c5bfda5af089ce5c57103d738bb1106
+head_commit=cbc66cce
+signature=8654d5a237aa0eb0de7509a462e3b2ce2b477416bff4e31e6931f2d6c05d57b4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=8a609930661fcf93af7bcac630bb9acdfb8802d04d7a20f122be1021c2e25d9d
-timestamp=2026-05-02T14:58:13Z
+diff_hash=a1e0042330f37eaa0e50dac8aa6a0d59dda45452213985bfb11481f83884df2b
+timestamp=2026-05-02T15:03:50Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=2a3a5304
-signature=a2b6de24e9a5ee81b046511f26475149367aa9b2294fec6d367da4a9695a3790
+head_commit=49b96a8e
+signature=47f4b2638483a86a3d8b2f454d468d2ea995cc06a764f6b8052213d30b2f4944

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=4048cf6e3305aa74264226525fb182758fc8dff99bf2f6c51c65c477ca825853
-timestamp=2026-05-02T19:35:54Z
+diff_hash=299b353bfe5770f4cbe0cbbbf641a862e2bb9d344ec2bfb10d59a7d2442b642e
+timestamp=2026-05-02T19:38:00Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=86dcb198
-signature=2a183fbfbb7cb637404e63cbaf871507c68cad9b21da39161b2d0f5096b0164a
+head_commit=2bcb4edf
+signature=895c10ac3e41862679eba12700ce3ae9b08dadc20d58ce930d7e4de6dfeec940

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=7fb895646e6740a17ae0bb38f243192e8ab185bb2e4e223c1c1697df09742744
-timestamp=2026-05-02T19:58:30Z
+diff_hash=58b031e5138a22d09049e7f92af732ec09ebd158cad7aab600842980cf54e19e
+timestamp=2026-05-02T20:05:51Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=cbc66cce
-signature=8654d5a237aa0eb0de7509a462e3b2ce2b477416bff4e31e6931f2d6c05d57b4
+head_commit=5f1ee029
+signature=36c2a1e0dfe08b7ec2ac20eaf85e480f4ce0e41a78fc5b283611fc1dd5c86a66

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=92c32c9946c301fd1b1012a80a5d9335d827ca6a114b8f43327fe838489478d0
-timestamp=2026-05-02T14:21:00Z
-branch=feat/era192-ua-adopt
-head_commit=65696679
-signature=434a009133a507a722106275fca57ad41fec3e162a01d4724d7b71f4fe40a0df
+diff_hash=8a609930661fcf93af7bcac630bb9acdfb8802d04d7a20f122be1021c2e25d9d
+timestamp=2026-05-02T14:58:13Z
+branch=feat/era190-batch1-pocock-skills
+head_commit=2a3a5304
+signature=a2b6de24e9a5ee81b046511f26475149367aa9b2294fec6d367da4a9695a3790

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=58b031e5138a22d09049e7f92af732ec09ebd158cad7aab600842980cf54e19e
-timestamp=2026-05-02T20:05:51Z
+diff_hash=b4c85308ef360906016984a13a711a8420e1ff47b40045b88d80fe2bbe217b69
+timestamp=2026-05-02T20:08:13Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=5f1ee029
-signature=36c2a1e0dfe08b7ec2ac20eaf85e480f4ce0e41a78fc5b283611fc1dd5c86a66
+head_commit=ecdf842e
+signature=4da520073353c3e868a78d33c0e26a5a0f479d89255eecab184960a69dbec57f

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=a1e0042330f37eaa0e50dac8aa6a0d59dda45452213985bfb11481f83884df2b
-timestamp=2026-05-02T15:03:50Z
+diff_hash=5655a508be11c2eec12a1d239ae1ffa88e76af1224375eb2b6c54480de7bbe08
+timestamp=2026-05-02T15:24:19Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=49b96a8e
-signature=47f4b2638483a86a3d8b2f454d468d2ea995cc06a764f6b8052213d30b2f4944
+head_commit=e5454e9e
+signature=456a39d61d5f320f4587344fce34528ead9d9713b0214b8bd30f3c756e2b8793

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e60aae835288d4252e24c355b9ebb107a7a6b26f8eea3aaeb58caf8e919af674
-timestamp=2026-05-02T20:20:17Z
+diff_hash=f03860446c029936ec3463bd8f741c2d70a3a005690d84d4c0208835d4d0eba3
+timestamp=2026-05-02T20:28:43Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=dc4b4006
-signature=4cc929c02b5a09d60599107082d78d3e633ba9a8857b555342acf4db62344ab8
+head_commit=0ea6fc1d
+signature=f003aaf869fe2487fb376f5f5375e3b868234104cf6068236b1d7e77aeac48d1

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2e529911c2fe4bc9294bb84ed55d07e52fa1708b6cb7c45a881223fdf8093cae
-timestamp=2026-05-02T20:45:56Z
+diff_hash=e36ab0244e4801dc42d4e308619d3e12588f4080cca88216ae5d9e6136006cb6
+timestamp=2026-05-02T21:03:00Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=372dc704
-signature=277edc35f128637e4f65be916aca8b2db5ce7edda8883476ec0f8c258ad3f3e4
+head_commit=3b706feb
+signature=16200440020bd7f2e2924e86d1eed18e3f3a8628147e2d1ddb453aea9f109d3c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=299b353bfe5770f4cbe0cbbbf641a862e2bb9d344ec2bfb10d59a7d2442b642e
-timestamp=2026-05-02T19:38:00Z
+diff_hash=e52623f3bc695a2aae1684d0d6a6e6a9f74d9acf83dab1de9f8f065977b19f50
+timestamp=2026-05-02T19:40:47Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=2bcb4edf
-signature=895c10ac3e41862679eba12700ce3ae9b08dadc20d58ce930d7e4de6dfeec940
+head_commit=5a38fba3
+signature=ed6707ea7156ad8d283a91ec052a516d4f544736b74ee88d5d8a49bdd48080cc

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=1dfbff0302def2928e8f1826a862f83d1ddccb70369aed7e7c0f61b5c3304536
-timestamp=2026-05-02T17:34:54Z
+diff_hash=994258e9215f53b6c4d9c0018df615ebd16c3ceb0fd91e64f218fb5a5a8863e5
+timestamp=2026-05-02T18:08:10Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=def5c99e
-signature=0b962517eadc0525477540d3d24d5341333a8d88c273ddc5c907169e4dec914e
+head_commit=9a647319
+signature=91fe40fc9a86a9655218181bf14ac27d8144ce2ddf8bf2f2cc6a51580de3a58c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=279a8c567030666e28d24d28928850a4ba1e7385498f303ba6623e325de23a71
-timestamp=2026-05-02T17:22:19Z
+diff_hash=1dfbff0302def2928e8f1826a862f83d1ddccb70369aed7e7c0f61b5c3304536
+timestamp=2026-05-02T17:34:54Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=e2e6ba5c
-signature=4e583fdd495d8d845115f9b573849cf985ada7c9c15f6be5fca73aa7904c9ef1
+head_commit=def5c99e
+signature=0b962517eadc0525477540d3d24d5341333a8d88c273ddc5c907169e4dec914e

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=03c02a36741857bb11be8e4c71ff592053df93276b8afe85c91ebec0131a81b4
-timestamp=2026-05-02T16:04:20Z
+diff_hash=6cbf9c3c4631ae3e0c624e03ffcb90e854dc05da7f557159de6f763fbec24995
+timestamp=2026-05-02T16:47:54Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=9fcc1e89
-signature=8ce74ed26e647e5fa02a0239a70751b8f2b24d3e24d81317d3c62fc13be660f3
+head_commit=835a108f
+signature=364c8f01b4e39b30cfdfae125dd9e842cb997b42e8b6e256b6b27665a2fef775

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=db51a6f8ad6112a2e097f0bab62528eb58bdd7851ba2099dcf82149cc4e6d1e7
-timestamp=2026-05-02T17:16:15Z
+diff_hash=279a8c567030666e28d24d28928850a4ba1e7385498f303ba6623e325de23a71
+timestamp=2026-05-02T17:22:19Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=1505c477
-signature=7f61837c5316b0c6ad019284f9cd3f27946d3fde22fcf46600d254254106d91f
+head_commit=e2e6ba5c
+signature=4e583fdd495d8d845115f9b573849cf985ada7c9c15f6be5fca73aa7904c9ef1

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e52623f3bc695a2aae1684d0d6a6e6a9f74d9acf83dab1de9f8f065977b19f50
-timestamp=2026-05-02T19:40:47Z
+diff_hash=9161e8d60911eb574293db95710591e92ac97dc18f0fe794b3332ea05aff3d7a
+timestamp=2026-05-02T19:48:19Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=5a38fba3
-signature=ed6707ea7156ad8d283a91ec052a516d4f544736b74ee88d5d8a49bdd48080cc
+head_commit=c406195d
+signature=58527373f93d8d256dec47626acf8384a7877de72e1758a21573c1551299ac06

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=c3b3a15fe30df22f5a0badb33a45a87be76478c880ec1b2dae620e201bd4a5e5
-timestamp=2026-05-02T20:31:37Z
+diff_hash=2e529911c2fe4bc9294bb84ed55d07e52fa1708b6cb7c45a881223fdf8093cae
+timestamp=2026-05-02T20:45:56Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=8db431ef
-signature=9732c6c924b31adc5cc008528d88039fb72e2e66eb6afe9d815f0f4b57008446
+head_commit=372dc704
+signature=277edc35f128637e4f65be916aca8b2db5ce7edda8883476ec0f8c258ad3f3e4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=6cbf9c3c4631ae3e0c624e03ffcb90e854dc05da7f557159de6f763fbec24995
-timestamp=2026-05-02T16:47:54Z
+diff_hash=db51a6f8ad6112a2e097f0bab62528eb58bdd7851ba2099dcf82149cc4e6d1e7
+timestamp=2026-05-02T17:16:15Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=835a108f
-signature=364c8f01b4e39b30cfdfae125dd9e842cb997b42e8b6e256b6b27665a2fef775
+head_commit=1505c477
+signature=7f61837c5316b0c6ad019284f9cd3f27946d3fde22fcf46600d254254106d91f

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e04f0d5ebc4da3c63d889bc9b6371728a834e06fe8bccfbcf32d3fbcb50c6471
-timestamp=2026-05-02T15:34:00Z
+diff_hash=03c02a36741857bb11be8e4c71ff592053df93276b8afe85c91ebec0131a81b4
+timestamp=2026-05-02T16:04:20Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=07b37455
-signature=2d52bc391698a4fb86bc067be1943798f66e91a65a615ce50158b7d31b260eae
+head_commit=9fcc1e89
+signature=8ce74ed26e647e5fa02a0239a70751b8f2b24d3e24d81317d3c62fc13be660f3

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=6ea66053c2a8eca500124243e7a2074749e2ffcf7a8bac9cf46db9a5d33c357a
-timestamp=2026-05-02T18:56:38Z
+diff_hash=08c5b5ef8394ae0a98b26545628cde6a41d36c6f34b4d13b5b7100ea9c239aa7
+timestamp=2026-05-02T19:20:22Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=a3688f70
-signature=0e805600b24a61a5a8c5d71b9bbebc015d14d432cc96435714b139f8fa234acb
+head_commit=26e7fc57
+signature=1ec780037d5390c211ede115328b51f1b825ea4d9975ef1b291ec02f1ad5648c

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=08c5b5ef8394ae0a98b26545628cde6a41d36c6f34b4d13b5b7100ea9c239aa7
-timestamp=2026-05-02T19:20:22Z
+diff_hash=4048cf6e3305aa74264226525fb182758fc8dff99bf2f6c51c65c477ca825853
+timestamp=2026-05-02T19:35:54Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=26e7fc57
-signature=1ec780037d5390c211ede115328b51f1b825ea4d9975ef1b291ec02f1ad5648c
+head_commit=86dcb198
+signature=2a183fbfbb7cb637404e63cbaf871507c68cad9b21da39161b2d0f5096b0164a

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b4c85308ef360906016984a13a711a8420e1ff47b40045b88d80fe2bbe217b69
-timestamp=2026-05-02T20:08:13Z
+diff_hash=e60aae835288d4252e24c355b9ebb107a7a6b26f8eea3aaeb58caf8e919af674
+timestamp=2026-05-02T20:20:17Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=ecdf842e
-signature=4da520073353c3e868a78d33c0e26a5a0f479d89255eecab184960a69dbec57f
+head_commit=dc4b4006
+signature=4cc929c02b5a09d60599107082d78d3e633ba9a8857b555342acf4db62344ab8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=f03860446c029936ec3463bd8f741c2d70a3a005690d84d4c0208835d4d0eba3
-timestamp=2026-05-02T20:28:43Z
+diff_hash=c3b3a15fe30df22f5a0badb33a45a87be76478c880ec1b2dae620e201bd4a5e5
+timestamp=2026-05-02T20:31:37Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=0ea6fc1d
-signature=f003aaf869fe2487fb376f5f5375e3b868234104cf6068236b1d7e77aeac48d1
+head_commit=8db431ef
+signature=9732c6c924b31adc5cc008528d88039fb72e2e66eb6afe9d815f0f4b57008446

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=9161e8d60911eb574293db95710591e92ac97dc18f0fe794b3332ea05aff3d7a
-timestamp=2026-05-02T19:48:19Z
+diff_hash=461424f79f3cdffd8ccf91a6278ac766e3ba01a3888e94ce3becdb6960bfd595
+timestamp=2026-05-02T19:53:07Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=c406195d
-signature=58527373f93d8d256dec47626acf8384a7877de72e1758a21573c1551299ac06
+head_commit=32501937
+signature=ab622fa35739bb49d146095e116406371c5bfda5af089ce5c57103d738bb1106

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5655a508be11c2eec12a1d239ae1ffa88e76af1224375eb2b6c54480de7bbe08
-timestamp=2026-05-02T15:24:19Z
+diff_hash=e04f0d5ebc4da3c63d889bc9b6371728a834e06fe8bccfbcf32d3fbcb50c6471
+timestamp=2026-05-02T15:34:00Z
 branch=feat/era190-batch1-pocock-skills
-head_commit=e5454e9e
-signature=456a39d61d5f320f4587344fce34528ead9d9713b0214b8bd30f3c756e2b8793
+head_commit=07b37455
+signature=2d52bc391698a4fb86bc067be1943798f66e91a65a615ce50158b7d31b260eae

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 108e78377b43 | resources: 1138
-> 542 commands · 92 skills · 70 agents · 434 scripts
+> hash: d8f63e147cf0 | resources: 1139
+> 542 commands · 92 skills · 70 agents · 435 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
@@ -285,7 +285,7 @@
 [development] workload-balance — carga,equilibrado,equipo,especialidades,objetivo — cmd:.claude/commands/workload-balance.md
 [development] workspace-doctor — check,doctor,health,spec,workspace — script:scripts/workspace-doctor.sh
 [development] worktree-setup —  — cmd:.claude/commands/worktree-setup.md
-[development] zoom-out — agente,area,callers,capa,code — skill:.claude/skills/zoom-out/SKILL.md
+[development] zoom-out — architecture,before,decisions,dependencies,design — skill:.claude/skills/zoom-out/SKILL.md
 [governance] /training-compliance —  — cmd:.claude/commands/training-compliance.md
 [governance] aepd-compliance — aepd,agéntica,auditoría,cumplimiento,fases — cmd:.claude/commands/aepd-compliance.md
 [governance] audit-alert — acceso,alertas,alto,anómalos,automáticas — cmd:.claude/commands/audit-alert.md
@@ -488,7 +488,7 @@
 [planning] case-init — business,case,data,pursuit,scaffold — cmd:.claude/commands/case-init.md
 [planning] case-kill-check — across,active,cases,kill,recommendations — cmd:.claude/commands/case-kill-check.md
 [planning] case-validate — business,case,directories,validate — script:scripts/case-validate.sh
-[planning] caveman — brief,caveman,cavernícola,compressed,every — skill:.claude/skills/caveman/SKILL.md
+[planning] caveman — before,brutally,catch,coating,committing — skill:.claude/skills/caveman/SKILL.md
 [planning] ceo-alerts — alertas,decisiones,dirección,estratégicas,nivel — cmd:.claude/commands/ceo-alerts.md
 [planning] ceremony-health — ceremonias,duración,métricas,participación,rate — cmd:.claude/commands/ceremony-health.md
 [planning] changelog-assemble — assemble,changelog,fragments — script:scripts/changelog-assemble.sh
@@ -949,7 +949,7 @@
 [quality] expertise-asymmetry-judge — active,alternatives,audit,blind,domain — agent:.claude/agents/expertise-asymmetry-judge.md
 [quality] fix-assigner — agents,assigns,court,creates,findings — agent:.claude/agents/fix-assigner.md
 [quality] frontend-test-runner — commit,component,coverage,execution,frontend — agent:.claude/agents/frontend-test-runner.md
-[quality] grill-me — aligned,blind,branch,decision,decisión — skill:.claude/skills/grill-me/SKILL.md
+[quality] grill-me — adversarial,assumption,before,break,breaks — skill:.claude/skills/grill-me/SKILL.md
 [quality] hook-event-gap-audit — audit,audita,cubiertos,event,eventos — script:scripts/hook-event-gap-audit.sh
 [quality] hook-injection-audit — audit,hook,injection,patterns,slice — script:scripts/hook-injection-audit.sh
 [quality] hook-latency-audit — audit,enforcement,hook,latency,slice — script:scripts/hook-latency-audit.sh
@@ -1021,6 +1021,7 @@
 [quality] security-pipeline —  — cmd:.claude/commands/security-pipeline.md
 [quality] security-review —  — cmd:.claude/commands/security-review.md
 [quality] security-scan — audit,scan,security,workspace — script:scripts/security-scan.sh
+[quality] skill-audit — audit,auditor,baseline,catalog,quality — script:scripts/skill-audit.sh
 [quality] skill-catalog-audit — audit,catalog,skill,slice — script:scripts/skill-catalog-audit.sh
 [quality] skills-usage-audit — audit,audita,skills,usage,workspace — script:scripts/skills-usage-audit.sh
 [quality] sovereignty-audit — audit,cognitive,data,diagnose,lock — cmd:.claude/commands/sovereignty-audit.md

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -138,4 +138,4 @@
 - **workload-balance** (cmd): Equilibrado objetivo de carga de trabajo respetando especialidades del equipo
 - **workspace-doctor** (script): workspace-doctor.sh — Health check pm-workspace (SPEC-031)
 - **worktree-setup** (cmd): >
-- **zoom-out** (skill): High-level map of unfamiliar code area. Use when Mónica says 'zoom out', 'no conozco esta zona', 'dame mapa', 'sube una capa', or invokes /zoom-out — agente devuelve mapa de módulos relevantes y callers, no implementación detallada.
+- **zoom-out** (skill): Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effects before implementation decisions. Use at design time.

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -73,7 +73,7 @@
 - **case-init** (cmd): Scaffold a business case from pursuit and SOW data
 - **case-kill-check** (cmd): Run valuation sentinel across all active cases for kill recommendations
 - **case-validate** (script): case-validate.sh — SE-016: Validate business case directories
-- **caveman** (skill): Ultra-compressed response mode (~75% token reduction). Use when Mónica says 'caveman', 'modo cavernícola', 'menos tokens', 'be brief', or invokes /caveman; persists every response until 'stop caveman' or 'modo normal'.
+- **caveman** (skill): Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest possible words. Use before committing or shipping to catch self-deception.
 - **ceo-alerts** (cmd): Panel de alertas estratégicas para dirección — solo decisiones que requieren nivel C
 - **ceremony-health** (cmd): Métricas de salud de ceremonias — duración, participación, resolution rate
 - **changelog-assemble** (script): changelog-assemble.sh — Assemble CHANGELOG.md from CHANGELOG.d/ fragments

--- a/.scm/categories/quality.scm
+++ b/.scm/categories/quality.scm
@@ -1,5 +1,5 @@
 # quality — Savia Capability Map (L1)
-> 225 resources
+> 226 resources
 
 - **/a11y-audit** (cmd): Auditoría de accesibilidad WCAG 2.2 completa con escaneo de HTML/componentes. Detecta: alt text faltante, problemas de contraste, navegación por teclado, etiquetas ARIA, gestión de focus, jerarquía de encabezados, etiquetas de formularios.
 - **/a11y-fix** (cmd): Correcciones automáticas de accesibilidad con verificación y preview. Genera código de fix para issues detectados por /a11y-audit. Preview antes de aplicar. Verifica que no introduce nuevos problemas. Covers: alt text, ARIA attributes, focu
@@ -35,7 +35,7 @@
 - **expertise-asymmetry-judge** (agent): Recommendation Tribunal judge — when draft falls in a domain the active user marks as `audit_level: blind`, force a rewrite with explanation/alternatives/verification
 - **fix-assigner** (agent): Creates fix tasks from Court findings, assigns to dev agents, triggers re-review
 - **frontend-test-runner** (agent): Post-commit frontend test execution — unit, component, e2e, coverage
-- **grill-me** (skill): Relentless interview that walks every branch of a decision tree to expose blind spots. Use when Mónica says 'grill me', 'interrógame', 'stress-test este plan', 'desafía esta decisión', or invokes /grill-me; aligned with Rule #24 radical-hon
+- **grill-me** (skill): Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production.
 - **hook-event-gap-audit** (script): hook-event-gap-audit.sh — Audita los 11 eventos de hook no cubiertos en pm-workspace
 - **hook-injection-audit** (script): hook-injection-audit.sh — SE-060 Slice 1 hook injection patterns audit.
 - **hook-latency-audit** (script): hook-latency-audit.sh — SE-037 Slice 1 hook latency enforcement audit.
@@ -107,6 +107,7 @@
 - **security-pipeline** (cmd): >
 - **security-review** (cmd): >
 - **security-scan** (script): security-scan.sh — Security audit for pm-workspace
+- **skill-audit** (script): skill-audit.sh — Baseline skill catalog quality auditor (SE-084 Slice 1)
 - **skill-catalog-audit** (script): skill-catalog-audit.sh — SE-084 Slice 1.
 - **skills-usage-audit** (script): skills-usage-audit.sh — Audita uso de los 91 skills de pm-workspace.
 - **sovereignty-audit** (cmd): Cognitive sovereignty audit — diagnose AI vendor lock-in risk and data portability

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "8ef4f462613f",
-  "total": 1138,
+  "hash": "c41d4de84225",
+  "total": 1139,
   "resources": [
     {
       "category": "analysis",
@@ -3644,15 +3644,15 @@
       "category": "development",
       "name": "zoom-out",
       "intents": [
-        "agente",
-        "area",
-        "callers",
-        "capa",
-        "code"
+        "architecture",
+        "before",
+        "decisions",
+        "dependencies",
+        "design"
       ],
       "kind": "skill",
       "path": ".claude/skills/zoom-out/SKILL.md",
-      "description": "High-level map of unfamiliar code area. Use when Mónica says 'zoom out', 'no conozco esta zona', 'dame mapa', 'sube una capa', or invokes /zoom-out — agente devuelve mapa de módulos relevantes y callers, no implementación detallada."
+      "description": "Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effects before implementation decisions. Use at design time."
     },
     {
       "category": "governance",
@@ -6298,15 +6298,15 @@
       "category": "planning",
       "name": "caveman",
       "intents": [
-        "brief",
-        "caveman",
-        "cavernícola",
-        "compressed",
-        "every"
+        "before",
+        "brutally",
+        "catch",
+        "coating",
+        "committing"
       ],
       "kind": "skill",
       "path": ".claude/skills/caveman/SKILL.md",
-      "description": "Ultra-compressed response mode (~75% token reduction). Use when Mónica says 'caveman', 'modo cavernícola', 'menos tokens', 'be brief', or invokes /caveman; persists every response until 'stop caveman' or 'modo normal'."
+      "description": "Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest possible words. Use before committing or shipping to catch self-deception."
     },
     {
       "category": "planning",
@@ -12108,15 +12108,15 @@
       "category": "quality",
       "name": "grill-me",
       "intents": [
-        "aligned",
-        "blind",
-        "branch",
-        "decision",
-        "decisión"
+        "adversarial",
+        "assumption",
+        "before",
+        "break",
+        "breaks"
       ],
       "kind": "skill",
       "path": ".claude/skills/grill-me/SKILL.md",
-      "description": "Relentless interview that walks every branch of a decision tree to expose blind spots. Use when Mónica says 'grill me', 'interrógame', 'stress-test este plan', 'desafía esta decisión', or invokes /grill-me; aligned with Rule #24 radical-hon"
+      "description": "Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent mode — finds what will break before it breaks in production."
     },
     {
       "category": "quality",
@@ -13021,6 +13021,20 @@
       "kind": "script",
       "path": "scripts/security-scan.sh",
       "description": "security-scan.sh — Security audit for pm-workspace"
+    },
+    {
+      "category": "quality",
+      "name": "skill-audit",
+      "intents": [
+        "audit",
+        "auditor",
+        "baseline",
+        "catalog",
+        "quality"
+      ],
+      "kind": "script",
+      "path": "scripts/skill-audit.sh",
+      "description": "skill-audit.sh — Baseline skill catalog quality auditor (SE-084 Slice 1)"
     },
     {
       "category": "quality",

--- a/CHANGELOG.d/20260502-era190-batch1-pocock.md
+++ b/CHANGELOG.d/20260502-era190-batch1-pocock.md
@@ -1,0 +1,6 @@
+## 6.14.1 — Era 190 Batch1: Pocock skills + skill auditor (2026-05-02)
+
+### Added
+- 3 Pocock-style skills: caveman (brutally honest review), zoom-out (architectural perspective), grill-me (adversarial weakness hunting)
+- scripts/skill-audit.sh: baseline skill catalog quality auditor (YAML frontmatter, required fields, DOMAIN.md)
+- 92 skills pass baseline audit (0 FAIL, 0 WARN)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # PM-Workspace — OpenCode / Claude Code
 
-> **Lazy context**: solo 3 @imports críticos se cargan en cada turno (savia, radical-honesty, autonomous-safety).
+> **Lazy context**: 4 @imports criticos se cargan en cada turno (savia, radical-honesty, autonomous-safety, caveman-default).
 > El resto se lee **bajo demanda** desde los paths documentados abajo.
 
 ## Rol

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(70), commands(542), profiles, hooks(65/66reg), rules/{domain,languages}, skills(92), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(70), commands(542), profiles, hooks(67/68reg), rules/{domain,languages}, skills(92), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -29,7 +29,7 @@ To use a skill: read `<path>` and follow its instructions.
 | backlog-git-tracker | `.claude/skills/backlog-git-tracker/SKILL.md` | Captura, comparación y auditoría de snapshots de backlog |
 | banking-architecture | `.claude/skills/banking-architecture/SKILL.md` | Skill: Banking Architecture |
 | capacity-planning | `.claude/skills/capacity-planning/SKILL.md` | Gestión completa de capacidades del equipo - consulta, cálculo y alertas |
-| caveman | `.claude/skills/caveman/SKILL.md` | Ultra-compressed response mode (~75% token reduction). Use when Mónica says 'caveman', 'modo cav... |
+| caveman | `.claude/skills/caveman/SKILL.md` | Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest possible wo... |
 | client-profile-manager | `.claude/skills/client-profile-manager/SKILL.md` | Gestión CRUD de perfiles de cliente en SaviaHub |
 | code-comprehension-report | `.claude/skills/code-comprehension-report/SKILL.md` | Generate comprehension report with mental model after SDD implementation. Automatically documents... |
 | code-improvement-loop | `.claude/skills/code-improvement-loop/SKILL.md` | Bucle autónomo de mejora continua de código — detecta oportunidades, aplica mejoras, genera P... |
@@ -55,7 +55,7 @@ To use a skill: read `<path>` and follow its instructions.
 | executive-reporting | `.claude/skills/executive-reporting/SKILL.md` | Generación de informes ejecutivos multi-proyecto para dirección |
 | feasibility-probe | `.claude/skills/feasibility-probe/SKILL.md` | Validate spec feasibility with time-boxed prototype attempt and viability scoring |
 | governance-enterprise | `.claude/skills/governance-enterprise/SKILL.md` | Enterprise governance — audit trail queries, compliance verification, decision registry, certif... |
-| grill-me | `.claude/skills/grill-me/SKILL.md` | Relentless interview that walks every branch of a decision tree to expose blind spots. Use when M... |
+| grill-me | `.claude/skills/grill-me/SKILL.md` | Adversarial review that hunts every weakness, assumption, edge case, and missing test. Opponent m... |
 | human-code-map | `.claude/skills/human-code-map/SKILL.md` | Genera y mantiene mapas narrativos de componentes (.hcm) para luchar activamente contra la deuda ... |
 | knowledge-graph | `.claude/skills/knowledge-graph/SKILL.md` | Construye y consulta grafos de conocimiento de entidades PM y sus relaciones |
 | legal-compliance | `.claude/skills/legal-compliance/SKILL.md` | Auditoría de compliance legal contra legislación española consolidada (legalize-es) |
@@ -108,4 +108,4 @@ To use a skill: read `<path>` and follow its instructions.
 | web-research | `.claude/skills/web-research/SKILL.md` | Search the web to resolve context gaps — documentation, versions, CVEs, best practices. Auto-st... |
 | wellbeing-guardian | `.claude/skills/wellbeing-guardian/SKILL.md` | Sistema proactivo de bienestar individual |
 | workspace-integrity | `.claude/skills/workspace-integrity/SKILL.md` | Catalogo de integrity auditors — drift CLAUDE.md, rule manifest, orphan rules, agents catalog s... |
-| zoom-out | `.claude/skills/zoom-out/SKILL.md` | High-level map of unfamiliar code area. Use when Mónica says 'zoom out', 'no conozco esta zona',... |
+| zoom-out | `.claude/skills/zoom-out/SKILL.md` | Elevates perspective from trees to forest. Maps architecture, dependencies, and second-order effe... |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-05-02 | **Version:** v6.14.1 | **534 commands · 65 agents · 86 skills · 60 hooks · 301+ test suites · Era 188 CLOSED · Era 189 CLOSED · Era 190 APPROVED · Era 191 IMPLEMENTING (batch1 PR #749, batch2 PR #751) · Era 192 PROPOSED — Knowledge Graph (SPEC-SE-088-UA-ADOPT) · Era 193 IMPLEMENTED — SaviaClaw DeepSeek (PR #750) · Era 194 PROPOSED — Context Visualization (SPEC-SE-090-TOLARIA) · Era 232 PROPOSED — Savia Enterprise Extensions · CRITICAL PATH 20 items (reprioritized 2026-05-02) · SE-072 to SE-090 PROPOSED · backup identidad portable enviado a la usuaria**
+**Updated:** 2026-05-02 | **Version:** v6.14.1 | **542 commands · 70 agents · 92 skills · 67 hooks · 301+ test suites · Era 188 CLOSED · Era 189 CLOSED · Era 190 IMPLEMENTING (batch1 PR #753) · Era 191 IMPLEMENTING (batch2 PR #751) · Era 192 IMPLEMENTED (UA PR #752) · Era 193 IMPLEMENTED (DeepSeek PR #750) · Era 194 IMPLEMENTED (Tolaria PR #751) · Era 195 IMPLEMENTING (Caveman PR #753) · Era 196 PROPOSED — Production PM (3 specs CRITICAL) · Era 232 PROPOSED — Savia Enterprise · CRITICAL PATH 23 items · SE-072 to SE-094 PROPOSED · backup identidad portable enviado a la usuaria**
 
 ---
 
@@ -362,6 +362,26 @@ YAML frontmatter — mismo formato que specs, reglas, roadmap. Cero migracion.
 - MCP server opcional para bridge Savia ↔ Tolaria
 - No modifica ningun archivo de Savia. Es tooling externo adoptado.
 
+**Era 195 — Savia Agentic Foundation (proposed 2026-05-02)**:
+
+Caveman como comportamiento por defecto. 6 restricciones cargadas via @import en
+cada turno. Hooks auto-grill-me y auto-zoom-out activados en PreToolUse.
+
+| Spec | Titulo | Agent time | Prioridad |
+|---|---|---|---|
+| **SPEC-SE-091-CAVEMAN-ALWAYS** | Caveman always-on + auto tribunal hooks | ~30 min | ALTA |
+
+**Era 196 — Production PM Operations (proposed 2026-05-02)**:
+
+Cierra el gap entre "asistente PM" y "PM real". Backend Azure DevOps/Jira,
+aislamiento multi-proyecto, auditoria de salud de documentacion. 3 specs, ~195 min.
+
+| Spec | Titulo | Agent time | Prioridad |
+|---|---|---|---|
+| **SPEC-SE-092-PM-BACKEND** | Bridge Azure DevOps/Jira — comandos PM a datos reales | ~90 min | CRITICA |
+| **SPEC-SE-093-ZERO-LEAK** | Zero project leakage enforcement | ~60 min | CRITICA |
+| **SPEC-SE-094-DOC-AUDIT** | Doc health auditor — broken links + stale refs | ~45 min | ALTA |
+
 **Era 232 — Savia Enterprise Balance Extensions (proposed 2026-04-26)**:
 - **SPEC-SE-035** Reconciliation Delta Engine — PROPOSED priority P2 (M 12-16h, 4 slices) — drift verde/ámbar/rojo declared vs computed; pattern from `dreamxist/balance` (MIT)
 - **SPEC-SE-036** API-Key → JWT Mint efímero — PROPOSED priority P1 (M 10-14h, 3 slices) — sustituye PAT file-based; CLAUDE.md Rule #1 a infraestructura
@@ -434,20 +454,24 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 | 6 | SE-090-TOLARIA | full | ~45 min | 194 | Tolaria visual knowledge base para Context As Code de Savia |
 | 7 | SE-088-UA-ADOPT | full | ~90 min | 192 | Integrar Understand-Anything: knowledge graphs + dashboard + diff impact |
 | 8 | SE-081 | full | ~25 min | 190 | Quick win, zero deps. Caveman + zoom-out + grill-me |
-| 8 | SE-084 | Slice 1 | ~30 min | 190 | Auditor establece baseline (SCM 100%+check ya funcional) |
-| 9 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
-| 10 | SE-082 | full | ~35 min | 190 | Vocabulario arquitectonico — multiplicador architect/judge |
-| 11 | SE-083 | full | ~20 min | 190 | TDD anti-horizontal-slicing — multiplicador test-architect |
-| 12 | SE-084 | Slice 2 | ~30 min | 190 | G14 gate activo sobre skills cambiados |
-| 13 | SPEC-SE-037 | full | ~50 min | 232 | P1 audit JSONB — compliance ISO/EU AI Act/GDPR |
-| 14 | SPEC-SE-036 | full | ~90 min | 232 | P1 JWT mint — Rule #1 a infraestructura, sustituye PAT |
-| 15 | SE-086 | Slices 1+2 | ~40 min | 190 | Ubiquitous-language + memory-graph bridge |
-| 16 | SE-087 | full | ~35 min | 190 | Design-an-interface (3 alternativas paralelas) |
-| 17 | SPEC-SE-035 | Slices 1-4 | ~100 min | 232 | P2 reconciliation delta engine — depende de SE-036/037 |
-| 18 | SE-085 | full | ~20 min | 190 | Write-a-skill meta — depende de SE-084 |
-| 19 | SE-075 | Slice 3 | ~30 min | 188 (residual) | DEFERRED — requiere autorizacion Monica para descargar Kokoro 82M (~500MB) |
+| 9 | SE-084 | Slice 1 | ~30 min | 190 | Auditor establece baseline (SCM 100%+check ya funcional) |
+| 10 | SE-091-CAVEMAN-ALWAYS | full | ~30 min | 195 | Caveman always-on + auto tribunal hooks |
+| 11 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
+| 12 | SE-092-PM-BACKEND | full | ~90 min | 196 | CRITICAL: bridge ADO/Jira — comandos PM reales |
+| 13 | SE-093-ZERO-LEAK | full | ~60 min | 196 | CRITICAL: zero project leakage enforcement |
+| 14 | SE-094-DOC-AUDIT | full | ~45 min | 196 | Doc health auditor — broken links + stale refs |
+| 15 | SE-082 | full | ~35 min | 190 | Vocabulario arquitectonico — multiplicador architect/judge |
+| 16 | SE-083 | full | ~20 min | 190 | TDD anti-horizontal-slicing — multiplicador test-architect |
+| 17 | SE-084 | Slice 2 | ~30 min | 190 | G14 gate activo sobre skills cambiados |
+| 18 | SPEC-SE-037 | full | ~50 min | 232 | P1 audit JSONB — compliance ISO/EU AI Act/GDPR |
+| 19 | SPEC-SE-036 | full | ~90 min | 232 | P1 JWT mint — Rule #1 a infraestructura, sustituye PAT |
+| 20 | SE-086 | Slices 1+2 | ~40 min | 190 | Ubiquitous-language + memory-graph bridge |
+| 21 | SE-087 | full | ~35 min | 190 | Design-an-interface (3 alternativas paralelas) |
+| 22 | SPEC-SE-035 | Slices 1-4 | ~100 min | 232 | P2 reconciliation delta engine — depende de SE-036/037 |
+| 23 | SE-085 | full | ~20 min | 190 | Write-a-skill meta — depende de SE-084 |
+| 24 | SE-075 | Slice 3 | ~30 min | 188 (residual) | DEFERRED — requiere autorizacion Monica para descargar Kokoro 82M (~500MB) |
 
-**Total non-blocked**: ~840 min ≈ ~14h agente ≈ 3-4 sesiones de trabajo.
+**Total non-blocked**: ~1005 min ≈ ~17h agente ≈ 4-5 sesiones de trabajo.
 
 ### Triggers que reordenan
 
@@ -574,15 +598,15 @@ Specs APPROVED antes de 2026-04-26 NO requieren la sección retroactivamente. SE
 
 ---
 
-## SPECs — Status Summary (84 total, post-Era 193 proposal)
+## SPECs — Status Summary (87 total, post-Era 196 proposal)
 
 | Status | Count | Key examples |
 |--------|-------|-------------|
 | Implemented | 45 | 012-016, 034-055, 063, 065, 067-069, 071 |
 | Ready | 12 | 019-022, 024, 026, 028, 032, 043, 048, 065, 078 |
 | Draft | 17 | 005, 009, 017, 035, 042, 044, 054, 055, 060, 061, 066 |
-| Proposed | 12 | SE-081..SE-087 (Era 190), SE-036..037 (Era 232), SE-035, SE-088 (Era 192), SE-089 (Era 193) |
-| Approved | 4 | SPEC-OPC-AGENTSYNC, SPEC-SCM-COVERAGE, SPEC-SCM-FRESHCHECK, SPEC-OPC-CROSS-AUDIT (Era 191) |
+| Proposed | 15 | SE-081..SE-094 (Era 190-196), SE-035..037 (Era 232) |
+| Approved | 4 | SPEC-OPC-AGENTSYNC, SPEC-SCM-COVERAGE, SPEC-SCM-FRESHCHECK, SPEC-OPC-CROSS-AUDIT |
 | Research | 2 | 023, 027 |
 | Archive | 24 | 003, 004, 006-008, 025, 030, 031, 033, 034, 037, 053, 058, 063-064, 070, 075, 138-144 |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -430,6 +430,8 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 
 **Eje 0.25 — SaviaClaw Sovereignty (CRITICAL)**: SE-089-SC-DEEPSEEK (~120 min) va en slot 4 porque arregla el bug de SOS ciclicos que Monica recibe cada pocos minutos (`remote:unreachable`). Migra de Claude Code a DeepSeek v4-pro via OpenCode, elimina coste Anthropic (~$3/1M → $0.435/1M), y hace a SaviaClaw autosuficiente en el host sin depender de `remote_host.py`. Adopta patrones de Hermes Agent (provider fallback, memory vectorization, cron mejorado).
 
+**Eje 0.3 — Zero Project Leakage (CRITICAL, subido 2026-05-02)**: SE-093-ZERO-LEAK sube a slot 11 tras detectar fuga de contexto en SaviaClaw Talk: OpenCode carga todo el workspace y el LLM mezcla proyectos ("Savia Web" vs pm-workspace). Aislar contextos por proyecto es urgente para evitar que SaviaClaw responda con datos del proyecto equivocado.
+
 **Eje 0.5 — Knowledge Graph (multiplicador de contexto)**: SE-088-UA-ADOPT (~90 min) se coloca pronto porque genera un knowledge graph del propio pm-workspace que enriquece todos los specs posteriores: SE-084 (auditor de skills) puede usar el grafo para validar consistencia, SE-082 (vocabulario) extrae terminos del grafo, y el memory-agent gana edges `DOMAIN_TERM` desde el primer dia.
 
 **Eje 1 — Compliance enterprise** (P1 hard-gates): SPEC-SE-036 (JWT mint) + SPEC-SE-037 (audit JSONB) son P1 (~140 min agente). Coste de no hacerlas: PAT en fichero (Rule #1 hoy en runtime, debe migrar a infraestructura) + ausencia de evidence ISO-42001/EU AI Act/GDPR bloqueante para Savia Enterprise sales.
@@ -456,9 +458,9 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 | 8 | SE-081 | full | ~25 min | 190 | Quick win, zero deps. Caveman + zoom-out + grill-me |
 | 9 | SE-084 | Slice 1 | ~30 min | 190 | Auditor establece baseline (SCM 100%+check ya funcional) |
 | 10 | SE-091-CAVEMAN-ALWAYS | full | ~30 min | 195 | Caveman always-on + auto tribunal hooks |
-| 11 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
-| 12 | SE-092-PM-BACKEND | full | ~90 min | 196 | CRITICAL: bridge ADO/Jira — comandos PM reales |
-| 13 | SE-093-ZERO-LEAK | full | ~60 min | 196 | CRITICAL: zero project leakage enforcement |
+| 11 | SE-093-ZERO-LEAK | full | ~60 min | 196 | CRITICAL: zero project leakage enforcement — Talk context isolation |
+| 12 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
+| 13 | SE-092-PM-BACKEND | full | ~90 min | 196 | CRITICAL: bridge ADO/Jira — comandos PM reales |
 | 14 | SE-094-DOC-AUDIT | full | ~45 min | 196 | Doc health auditor — broken links + stale refs |
 | 15 | SE-082 | full | ~35 min | 190 | Vocabulario arquitectonico — multiplicador architect/judge |
 | 16 | SE-083 | full | ~20 min | 190 | TDD anti-horizontal-slicing — multiplicador test-architect |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-05-02 | **Version:** v6.14.1 | **542 commands · 70 agents · 92 skills · 67 hooks · 301+ test suites · Era 188 CLOSED · Era 189 CLOSED · Era 190 IMPLEMENTING (batch1 PR #753) · Era 191 IMPLEMENTING (batch2 PR #751) · Era 192 IMPLEMENTED (UA PR #752) · Era 193 IMPLEMENTED (DeepSeek PR #750) · Era 194 IMPLEMENTED (Tolaria PR #751) · Era 195 IMPLEMENTING (Caveman PR #753) · Era 196 PROPOSED — Production PM (3 specs CRITICAL) · Era 232 PROPOSED — Savia Enterprise · CRITICAL PATH 23 items · SE-072 to SE-094 PROPOSED · backup identidad portable enviado a la usuaria**
+**Updated:** 2026-05-02 | **Version:** v6.14.1 | **542 commands · 70 agents · 92 skills · 67 hooks · 301+ test suites · Era 188 CLOSED · Era 189 CLOSED · Era 190 IMPLEMENTING (PR #753) · Era 191 IMPLEMENTED · Era 192 IMPLEMENTED · Era 193 IMPLEMENTED · Era 194 IMPLEMENTED · Era 195 IMPLEMENTING · Era 196 PROPOSED · Era 197 PROPOSED — SaviaClaw Autonomy (3 specs CRITICAL, post-Hermes/OpenClaw analysis) · Era 232 PROPOSED · CRITICAL PATH 27 items · SE-072 to SE-097 PROPOSED**
 
 ---
 
@@ -382,6 +382,18 @@ aislamiento multi-proyecto, auditoria de salud de documentacion. 3 specs, ~195 m
 | **SPEC-SE-093-ZERO-LEAK** | Zero project leakage enforcement | ~60 min | CRITICA |
 | **SPEC-SE-094-DOC-AUDIT** | Doc health auditor — broken links + stale refs | ~45 min | ALTA |
 
+**Era 197 — SaviaClaw Autonomy (proposed 2026-05-02)**:
+
+Analisis profundo de Hermes Agent (NousResearch) y OpenClaw (368k stars). SaviaClaw
+carece de 3 capacidades criticas que ambos proyectos tienen. 3 specs, ~135 min.
+CRITICO: sin esto SaviaClaw no es un agente autonomo real.
+
+| Spec | Titulo | Agent time | Prioridad | Patron de referencia |
+|---|---|---|---|---|
+| **SPEC-SE-095-SC-MONITOR** | Self-monitoring: heartbeat + stuck detection + status reporting | ~45 min | CRITICA | Hermes `_touch_activity()` + OpenClaw `channel-health-monitor` |
+| **SPEC-SE-096-SC-CRON** | Cron infrastructure: scheduled tasks via `jobs.json` | ~60 min | CRITICA | Hermes `cron/scheduler.py` + `jobs.json` + execution logs |
+| **SPEC-SE-097-SC-STREAM** | Streaming: progressive message feedback via stdout capture | ~30 min | ALTA | Hermes `edit_message` + `▉` cursor (emulado para Talk) |
+
 **Era 232 — Savia Enterprise Balance Extensions (proposed 2026-04-26)**:
 - **SPEC-SE-035** Reconciliation Delta Engine — PROPOSED priority P2 (M 12-16h, 4 slices) — drift verde/ámbar/rojo declared vs computed; pattern from `dreamxist/balance` (MIT)
 - **SPEC-SE-036** API-Key → JWT Mint efímero — PROPOSED priority P1 (M 10-14h, 3 slices) — sustituye PAT file-based; CLAUDE.md Rule #1 a infraestructura
@@ -458,22 +470,25 @@ Post-auditoria de alineacion OpenCode (inicio de sesion 2026-05-02). 4 gaps dete
 | 8 | SE-081 | full | ~25 min | 190 | Quick win, zero deps. Caveman + zoom-out + grill-me |
 | 9 | SE-084 | Slice 1 | ~30 min | 190 | Auditor establece baseline (SCM 100%+check ya funcional) |
 | 10 | SE-091-CAVEMAN-ALWAYS | full | ~30 min | 195 | Caveman always-on + auto tribunal hooks |
-| 11 | SE-093-ZERO-LEAK | full | ~60 min | 196 | CRITICAL: zero project leakage enforcement — Talk context isolation |
-| 12 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
-| 13 | SE-092-PM-BACKEND | full | ~90 min | 196 | CRITICAL: bridge ADO/Jira — comandos PM reales |
-| 14 | SE-094-DOC-AUDIT | full | ~45 min | 196 | Doc health auditor — broken links + stale refs |
-| 15 | SE-082 | full | ~35 min | 190 | Vocabulario arquitectonico — multiplicador architect/judge |
-| 16 | SE-083 | full | ~20 min | 190 | TDD anti-horizontal-slicing — multiplicador test-architect |
-| 17 | SE-084 | Slice 2 | ~30 min | 190 | G14 gate activo sobre skills cambiados |
-| 18 | SPEC-SE-037 | full | ~50 min | 232 | P1 audit JSONB — compliance ISO/EU AI Act/GDPR |
-| 19 | SPEC-SE-036 | full | ~90 min | 232 | P1 JWT mint — Rule #1 a infraestructura, sustituye PAT |
-| 20 | SE-086 | Slices 1+2 | ~40 min | 190 | Ubiquitous-language + memory-graph bridge |
-| 21 | SE-087 | full | ~35 min | 190 | Design-an-interface (3 alternativas paralelas) |
-| 22 | SPEC-SE-035 | Slices 1-4 | ~100 min | 232 | P2 reconciliation delta engine — depende de SE-036/037 |
-| 23 | SE-085 | full | ~20 min | 190 | Write-a-skill meta — depende de SE-084 |
-| 24 | SE-075 | Slice 3 | ~30 min | 188 (residual) | DEFERRED — requiere autorizacion Monica para descargar Kokoro 82M (~500MB) |
+| 11 | SE-095-SC-MONITOR | full | ~45 min | 197 | CRITICAL: heartbeat + stuck detection + self-monitoring |
+| 12 | SE-096-SC-CRON | full | ~60 min | 197 | CRITICAL: cron infra — scheduled tasks via jobs.json |
+| 13 | SE-097-SC-STREAM | full | ~30 min | 197 | Streaming feedback: progressive stdout capture |
+| 14 | SE-093-ZERO-LEAK | full | ~60 min | 196 | Zero project leakage enforcement — Talk context isolation |
+| 15 | SPEC-OPC-CROSS-AUDIT | full | ~30 min | 191 | Auditoria preventiva .opencode/ vs .claude/ |
+| 16 | SE-092-PM-BACKEND | full | ~90 min | 196 | CRITICAL: bridge ADO/Jira — comandos PM reales |
+| 17 | SE-094-DOC-AUDIT | full | ~45 min | 196 | Doc health auditor — broken links + stale refs |
+| 18 | SE-082 | full | ~35 min | 190 | Vocabulario arquitectonico — multiplicador architect/judge |
+| 19 | SE-083 | full | ~20 min | 190 | TDD anti-horizontal-slicing — multiplicador test-architect |
+| 20 | SE-084 | Slice 2 | ~30 min | 190 | G14 gate activo sobre skills cambiados |
+| 21 | SPEC-SE-037 | full | ~50 min | 232 | P1 audit JSONB — compliance ISO/EU AI Act/GDPR |
+| 22 | SPEC-SE-036 | full | ~90 min | 232 | P1 JWT mint — Rule #1 a infraestructura, sustituye PAT |
+| 23 | SE-086 | Slices 1+2 | ~40 min | 190 | Ubiquitous-language + memory-graph bridge |
+| 24 | SE-087 | full | ~35 min | 190 | Design-an-interface (3 alternativas paralelas) |
+| 25 | SPEC-SE-035 | Slices 1-4 | ~100 min | 232 | P2 reconciliation delta engine — depende de SE-036/037 |
+| 26 | SE-085 | full | ~20 min | 190 | Write-a-skill meta — depende de SE-084 |
+| 27 | SE-075 | Slice 3 | ~30 min | 188 (residual) | DEFERRED — requiere autorizacion Monica para descargar Kokoro 82M (~500MB) |
 
-**Total non-blocked**: ~1005 min ≈ ~17h agente ≈ 4-5 sesiones de trabajo.
+**Total non-blocked**: ~1140 min ≈ ~19h agente
 
 ### Triggers que reordenan
 

--- a/docs/rules/domain/caveman-default.md
+++ b/docs/rules/domain/caveman-default.md
@@ -1,0 +1,46 @@
+# Caveman Default — Restricciones base de Savia
+
+> Siempre activo. No requiere invocacion. Parte de la identidad de Savia.
+
+## Reglas
+
+Savia aplica las siguientes restricciones en TODA respuesta, sin excepcion:
+
+1. **Zero filler.** Prohibido: "I think", "it seems", "maybe", "perhaps",
+   "let me", "I'll", "here is", "based on", "looking at this". Las respuestas
+   empiezan con el contenido, no con meta-comentario sobre la respuesta.
+
+2. **Token efficiency.** Cada token debe ganarse su lugar. Si una palabra
+   puede eliminarse sin perder significado, se elimina. No se adorna.
+
+3. **Default brevity.** Respuesta por defecto: 1-3 lineas. Solo se excede
+   cuando el usuario pide explicitamente detalle, o cuando la tarea lo exige
+   (specs, PR descriptions, roadmap, auditoria).
+
+4. **Zero sugar-coating.** Sin adulacion, sin elogios no ganados, sin
+   "good question", sin "great idea". La Regla #24 (Radical Honesty) es el
+   unico tono permitido.
+
+5. **Self-strip before output.** Antes de emitir cualquier respuesta, Savia
+   se pregunta: "puedo decir esto en menos palabras sin perder contenido?"
+   Si la respuesta es si, reescribe.
+
+6. **No preamble, no postamble.** Sin "The answer is...", sin "Here's what
+   I found...", sin "Let me explain...". El contenido directamente.
+
+## Excepciones
+
+- **Respuestas tecnicas** (specs, codigo, auditoria, roadmap): mantienen
+  estructura completa. La restriccion se aplica al texto narrativo, no
+  al contenido tecnico.
+- **PR descriptions**: lenguaje natural completo (leccion aprendida PR #749).
+- **Explicaciones solicitadas**: si el usuario pide "explicame", "detalle",
+  "por que", se permite extension.
+- **Errores y warnings**: mensajes de sistema que requieren claridad total.
+
+## Relacion con caveman skill
+
+El skill `caveman` en `.claude/skills/caveman/` queda como documentacion
+de referencia y como modo extremo para invocacion explicita cuando se
+necesita el maximo nivel de desnudez. Las restricciones base de este
+archivo son menos extremas que el skill completo.

--- a/docs/specs/SPEC-SE-091-CAVEMAN-ALWAYS.spec.md
+++ b/docs/specs/SPEC-SE-091-CAVEMAN-ALWAYS.spec.md
@@ -1,0 +1,106 @@
+# Spec: Caveman Always-On — Radical Honesty + Token Efficiency as Default
+
+**Task ID:**        SPEC-SE-091-CAVEMAN-ALWAYS
+**PBI padre:**      Era 195 — Savia Agentic Foundation
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (requisito Monica: eficiencia + fiabilidad maxima)
+
+**Developer Type:** agent-single
+**Asignado a:**     claude-agent
+**Estimacion agent:** ~30 min
+**Estado:**         Pendiente
+**Prioridad:**      ALTA
+**Modelo:**         claude-sonnet-4-6
+**Max turns:**      15
+
+---
+
+## 1. Contexto y Objetivo
+
+Actualmente `caveman`, `zoom-out` y `grill-me` son skills bajo demanda en
+`.claude/skills/`. Hay que invocarlos explicitamente. Monica quiere que la
+honestidad radical y la eficiencia de tokens se apliquen SIEMPRE por defecto,
+sin invocacion manual.
+
+**Objetivo:** Convertir caveman de "skill opcional" a "comportamiento por defecto"
+de Savia. La identidad de Savia debe incluir las restricciones de caveman como
+parte de su system prompt base. Los tribunales (grill-me, zoom-out) se activan
+automaticamente via hooks cuando el contexto lo requiere.
+
+---
+
+## 2. Requisitos Funcionales
+
+### Slice 1 — Caveman siempre activo (~15 min)
+
+- **REQ-01** Anadir las restricciones de caveman al system prompt de Savia
+  (AGENTS.md o archivo de reglas cargado en cada sesion):
+  ```
+  Savia applies caveman constraints by default:
+  - Zero filler words. No "I think", "it seems", "maybe", "perhaps".
+  - Maximum token efficiency. Every token must earn its place.
+  - No sugar-coating. No unearned praise. Radical honesty (Rule #24).
+  - Default response: 1-3 lines unless detail is explicitly requested.
+  - Strip every sentence: if a word can be removed without losing meaning, remove it.
+  ```
+
+- **REQ-02** El skill `caveman/SKILL.md` existente se mantiene como documentacion
+  y referencia, pero ya no requiere invocacion manual.
+
+- **REQ-03** Verificar que el cambio no rompe respuestas que requieren detalle.
+  Savia debe seguir dando respuestas largas cuando el contexto lo exige
+  (specs, roadmap, PR descriptions).
+
+### Slice 2 — Activacion automatica de tribunales (~15 min)
+
+- **REQ-04** Crear hook `auto-grill-me.sh` en `.claude/hooks/` que se dispara
+  en evento `PreToolUse` cuando la herramienta es `Edit` o `Write` sobre
+  archivos de codigo (`.py`, `.sh`, `.ts`, `.js`, `.cs`, `.go`, `.rs`).
+  El hook inyecta una instruccion de grill-me: "Hunt weaknesses: edge cases,
+  unstated assumptions, error paths, untested branches."
+
+- **REQ-05** Crear hook `auto-zoom-out.sh` en `.claude/hooks/` que se dispara
+  en `PreToolUse` cuando la herramienta es `Edit` o `Write` sobre archivos
+  de arquitectura (`docs/architecture/`, `docs/propuestas/`, `*.arch.md`).
+  El hook inyecta: "Zoom out: what dependencies does this affect? Second-order
+  effects? What would break?"
+
+- **REQ-06** Ambos hooks son non-blocking (WARN). No detienen la operacion,
+  solo inyectan contexto adicional en el system prompt del turno.
+
+---
+
+## 3. Ficheros a Crear/Modificar
+
+| Fichero | Accion |
+|---------|--------|
+| `docs/rules/domain/caveman-default.md` | CREAR — regla de comportamiento por defecto |
+| `AGENTS.md` | MODIFICAR — anadir @import a caveman-default |
+| `CLAUDE.md` | MODIFICAR — anadir referencia en lazy context |
+| `.claude/hooks/auto-grill-me.sh` | CREAR — hook PreToolUse para codigo |
+| `.claude/hooks/auto-zoom-out.sh` | CREAR — hook PreToolUse para arquitectura |
+| `.claude/skills/caveman/SKILL.md` | SIN CAMBIOS — queda como referencia |
+| `.claude/settings.json` | MODIFICAR — registrar los 2 hooks nuevos |
+
+---
+
+## 4. Criterios de Aceptacion
+
+- **AC-01** Pregunta simple ("que hora es?") → respuesta en 1-3 lineas sin
+  filler. Verificable: comparar longitud de respuesta antes/despues.
+- **AC-02** Pregunta compleja ("genera spec completo para...") → respuesta
+  detallada pero sin filler. Las secciones tecnicas mantienen su contenido.
+- **AC-03** `auto-grill-me.sh` se ejecuta al editar `zeroclaw/host/llm_backend.py`.
+  Verificable: `grep grill-me` en logs de hooks.
+- **AC-04** `auto-zoom-out.sh` se ejecuta al editar `docs/ROADMAP.md`.
+  Verificable: `grep zoom-out` en logs de hooks.
+- **AC-05** Ningun hook bloquea la operacion (todos WARN o INFO).
+
+---
+
+## 5. Impacto en Roadmap
+
+Este spec cambia el comportamiento base de Savia. Es fundacional: todo lo
+que Savia haga a partir de ahora usara caveman por defecto. Se coloca en
+slot 8 (antes de SE-084 Slice 2) porque afecta a todos los specs posteriores.

--- a/docs/specs/SPEC-SE-092-PM-BACKEND.spec.md
+++ b/docs/specs/SPEC-SE-092-PM-BACKEND.spec.md
@@ -1,0 +1,76 @@
+# Spec: PM Backend Integration — Azure DevOps / Jira Bridge
+
+**Task ID:**        SPEC-SE-092-PM-BACKEND
+**PBI padre:**      Era 196 — Production PM Operations
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (gap analysis)
+
+**Developer Type:** agent-single
+**Asignado a:**     claude-agent
+**Estimacion agent:** ~90 min
+**Estado:**         Pendiente
+**Prioridad:**      CRITICA
+**Modelo:**         claude-sonnet-4-6
+**Max turns:**      25
+
+---
+
+## 1. Problema
+
+Savia tiene 535+ comandos, identidad de PM, reglas de scrum, y un roadmap de 20+ specs.
+Pero no puede tocar un backlog real. Los comandos `/sprint-status`, `/capacity-plan`,
+`/velocity-trend`, `/daily-standup` son shells vacios — no hay backend que los alimente.
+
+`init-pm.sh` declara Azure DevOps como "opcional bajo demanda" pero no hay NINGUN script
+que:
+- Autentique contra Azure DevOps (PAT → WIQL queries)
+- Mapee work items (PBIs, Tasks, Bugs) al sistema de specs de Savia
+- Sincronice estados entre Azure DevOps y el roadmap de Savia
+- Genere informes reales en `output/` con datos del backlog
+
+Sin esto, Savia es una PM de mentira. Sabe hablar de scrum pero no puede ejecutarlo.
+
+## 2. Requisitos
+
+- **REQ-01** `scripts/azure-devops-bridge.sh`: wrapper autenticado contra Azure DevOps.
+  Lee `AZURE_DEVOPS_ORG_URL` y `$AZURE_DEVOPS_PAT_FILE` del entorno.
+  - `ado query "<WIQL>"` → JSON con work items
+  - `ado workitem <id>` → detalle completo
+  - `ado update <id> --field value` → actualizar campo
+  - `ado sprints` → sprints del proyecto actual
+  - `ado capacity` → capacidad por team member
+
+- **REQ-02** Conectar comandos existentes a datos reales:
+  - `/sprint-status` → `ado query "SELECT * FROM WorkItems WHERE [System.IterationPath] = @currentIteration"`
+  - `/capacity-plan` → `ado capacity` + calculo horas/desarrollador
+  - `/velocity-trend` → historico de sprints cerrados + puntos entregados
+  - `/daily-standup` → work items con cambios en las ultimas 24h
+
+- **REQ-03** Formato de salida unificado: todos los comandos PM producen informe
+  en `output/YYYYMMDD-tipo-proyecto.ext` (Rule #5).
+
+- **REQ-04** Sin credenciales → graceful degradation. Si `AZURE_DEVOPS_ORG_URL`
+  contiene placeholder ("MI-ORGANIZACIÓN"), los comandos informan "Azure DevOps
+  not configured" en lugar de fallar.
+
+- **REQ-05** Mapeo spec ↔ work item: Savia puede asociar un SPEC-XXX a un PBI
+  de Azure DevOps y sincronizar estados (Approved → Active, Implemented → Closed).
+
+---
+
+## 3. Ficheros
+
+| Fichero | Accion |
+|---------|--------|
+| `scripts/azure-devops-bridge.sh` | CREAR |
+| `docs/rules/domain/azure-devops-integration.md` | CREAR |
+
+---
+
+## 4. Criterios de Aceptacion
+
+- **AC-01** `ado query` retorna work items reales (no mocks).
+- **AC-02** `/sprint-status` produce `output/YYYYMMDD-sprintstatus-{project}.md` con datos reales.
+- **AC-03** Sin PAT configurado, comandos no fallan — informan "not configured".
+- **AC-04** No hardcodea PAT en ningun archivo (Rule #1).

--- a/docs/specs/SPEC-SE-093-ZERO-LEAK.spec.md
+++ b/docs/specs/SPEC-SE-093-ZERO-LEAK.spec.md
@@ -1,0 +1,77 @@
+# Spec: Zero Project Leakage — Multi-Project Context Isolation
+
+**Task ID:**        SPEC-SE-093-ZERO-LEAK
+**PBI padre:**      Era 196 — Production PM Operations
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (gap analysis)
+
+**Developer Type:** agent-single
+**Asignado a:**     claude-agent
+**Estimacion agent:** ~60 min
+**Estado:**         Pendiente
+**Prioridad:**      CRITICA
+**Modelo:**         claude-sonnet-4-6
+**Max turns:**      20
+
+---
+
+## 1. Problema
+
+La regla `docs/rules/domain/zero-project-leakage.md` declara el principio: "Savia nunca
+mezcla datos de dos proyectos en la misma respuesta". Pero no hay enforcement.
+
+Si Monica pregunta "cual es el estado del sprint del proyecto Foo?" y luego "y del
+proyecto Bar?", Savia podria accidentalmente:
+- Cruzar work items (PBI de Foo en informe de Bar)
+- Referenciar specs de un proyecto en el contexto de otro
+- Mencionar nombres de stakeholders entre proyectos
+
+En un repo publico (pm-workspace es MIT, 39 stars), una fuga de datos entre proyectos
+es una brecha de confidencialidad grave. No basta con "ser cuidadoso" — necesitamos
+enforcement automatico.
+
+## 2. Requisitos
+
+- **REQ-01** `scripts/project-isolation-check.sh`: pre-response hook que verifica
+  que la respuesta de Savia no contiene datos de proyectos distintos al activo.
+  - Si el proyecto activo es "foo", la respuesta no puede contener paths
+    `projects/bar/` ni nombres de stakeholders del proyecto "bar".
+  - Se ejecuta como hook PostToolUse (non-blocking WARN).
+
+- **REQ-02** `~/.savia-memory/projects/{name}/` — cada proyecto tiene su propio
+  espacio de memoria aislado. El `memory-agent` carga SOLO la memoria del
+  proyecto activo, no de otros.
+
+- **REQ-03** Comando `/project-activate {name}` — cambia el contexto activo:
+  - Carga `projects/{name}/CLAUDE.md`
+  - Cambia `CLAUDE_PROJECT_DIR` a `projects/{name}/`
+  - Limpia referencias al proyecto anterior del contexto activo
+
+- **REQ-04** El SCM y el knowledge graph (SE-088) deben filtrarse por proyecto
+  activo cuando corresponda. `/ua-analyze` sobre `projects/foo/` no mezcla
+  nodos con `projects/bar/`.
+
+- **REQ-05** Pre-commit hook verifica que los archivos commiteados no contienen
+  referencias cruzadas entre proyectos (ej: spec en `projects/foo/specs/` que
+  referencia `projects/bar/`).
+
+---
+
+## 3. Ficheros
+
+| Fichero | Accion |
+|---------|--------|
+| `scripts/project-isolation-check.sh` | CREAR |
+| `scripts/project-activate.sh` | CREAR |
+| `.claude/commands/project-activate.md` | CREAR |
+| `docs/rules/domain/zero-project-leakage.md` | MODIFICAR (anadir enforcement) |
+
+---
+
+## 4. Criterios de Aceptacion
+
+- **AC-01** Activar proyecto "foo" → pregunta sobre sprint → respuesta no menciona "bar".
+- **AC-02** `project-isolation-check.sh` detecta y advierte fuga entre proyectos.
+- **AC-03** Memoria de "foo" y "bar" son archivos separados, sin solapamiento.
+- **AC-04** `/ua-analyze projects/foo` no indexa archivos de `projects/bar/`.

--- a/docs/specs/SPEC-SE-094-DOC-AUDIT.spec.md
+++ b/docs/specs/SPEC-SE-094-DOC-AUDIT.spec.md
@@ -1,0 +1,73 @@
+# Spec: Documentation Health Auditor — Broken Links + Stale Refs
+
+**Task ID:**        SPEC-SE-094-DOC-AUDIT
+**PBI padre:**      SE-084 Slice 3 — Skill catalog quality audit
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (gap analysis)
+
+**Developer Type:** agent-single
+**Asignado a:**     claude-agent
+**Estimacion agent:** ~45 min
+**Estado:**         Pendiente
+**Prioridad:**      ALTA
+**Modelo:**         claude-sonnet-4-6
+**Max turns:**      20
+
+---
+
+## 1. Problema
+
+`skill-audit.sh` (SE-084 S1) audita la calidad de skills. Pero no hay equivalente
+para documentacion. Con 85+ specs, 25+ reglas, 150+ docs, la deuda de documentacion
+crece silenciosamente:
+
+- Un spec referencia otro spec que fue archivado → enlace roto
+- Una regla cita una feature que no esta implementada → referencia falsa
+- Un README enlaza a un archivo que cambio de nombre → 404 en docs
+- Secciones "TODO" o "TBD" acumuladas en specs → falsa sensacion de completitud
+- Referencias a versiones antiguas de herramientas (ej: "Claude Code 2025" → ya es 2026)
+
+## 2. Requisitos
+
+- **REQ-01** `scripts/doc-health-audit.sh`: escanea todos los `.md` en `docs/`
+  y `.claude/skills/*/` verificando:
+  - **Broken internal links**: `[text](./path.md)` donde el archivo no existe
+  - **Broken section links**: `[text](./file.md#section)` donde la seccion no existe
+  - **Stale spec refs**: `SPEC-NNN` que esta ARCHIVED o no existe
+  - **TBD/TODO sections**: secciones marcadas como pendientes
+  - **Orphan references**: specs referenciados en ROADMAP que no existen en `docs/specs/`
+
+- **REQ-02** Salida en formato tabla con severidad:
+  ```
+  === Documentation Health Audit ===
+  Broken links:  3 (HIGH)
+  Stale refs:    12 (MEDIUM)
+  TBD sections:  8 (LOW)
+  Orphan refs:   2 (HIGH)
+  Score: 72/100
+  ```
+
+- **REQ-03** CI Gate (WARN): ejecutar en PRs que tocan `docs/`. Si el score baja,
+  advertir. Si hay broken links, FAIL.
+
+- **REQ-04** El auditor NO modifica archivos. Solo reporta. Las correcciones las
+  hace un agente o humano.
+
+---
+
+## 3. Ficheros
+
+| Fichero | Accion |
+|---------|--------|
+| `scripts/doc-health-audit.sh` | CREAR |
+| `scripts/pr-plan-gates.sh` | MODIFICAR — Gate G17 (WARN) |
+
+---
+
+## 4. Criterios de Aceptacion
+
+- **AC-01** `doc-health-audit.sh` detecta al menos 1 broken link actual (si existe).
+- **AC-02** Score > 80/100 tras correcciones (linea base inicial puede ser menor).
+- **AC-03** CI no bloquea por doc health (WARN), pero muestra el score.
+- **AC-04** No modifica archivos (read-only).

--- a/docs/specs/SPEC-SE-095-SC-MONITOR.spec.md
+++ b/docs/specs/SPEC-SE-095-SC-MONITOR.spec.md
@@ -1,0 +1,47 @@
+# Spec: SaviaClaw Self-Monitoring — Heartbeat + Stuck Detection + Status Reporting
+
+**Task ID:**        SPEC-SE-095-SC-MONITOR
+**PBI padre:**      Era 197 — SaviaClaw Autonomy
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (analisis Hermes Agent + OpenClaw)
+
+**Estimacion agent:** ~45 min
+**Prioridad:** CRITICA
+
+---
+
+## Problema
+
+SaviaClaw no tiene autoconocimiento. Si `opencode run` se cuelga, el hilo muere en silencio.
+Si Mónica pregunta "¿estás viva?", la respuesta depende de si el poll loop llegó a ejecutarse.
+No hay heartbeat, no hay detección de stuck, no hay reporte de estado entre mensajes.
+
+Hermes Agent usa `_touch_activity()` en cada tool call + `get_activity_summary()` para saber
+cuánto lleva inactivo. OpenClaw usa `channel-health-monitor.ts` con heartbeat periódico.
+
+**Objetivo:** SaviaClaw debe saber si está viva, detectar tareas colgadas, y reportar estado
+cuando se le pregunta.
+
+## Requisitos
+
+- **REQ-01** `_touch_activity()` se llama en cada evento: mensaje recibido, respuesta enviada,
+  tool call de opencode detectado.
+- **REQ-02** `get_activity_summary()` retorna dict: `seconds_since_activity`, `last_activity`,
+  `current_task`, `pending_threads`, `tick_count`.
+- **REQ-03** Cada 120s, si no hay actividad, SaviaClaw verifica que `opencode` siga respondiendo
+  con un ping: `opencode run "responde solo: ok"`. Si falla 3 veces seguidas → reinicio
+  automático del daemon vía `systemctl restart saviaclaw-headless`.
+- **REQ-04** Cuando Mónica pregunta "¿estás bien?" o "¿estás viva?" vía Talk, SaviaClaw
+  responde con `get_activity_summary()` en lenguaje natural.
+- **REQ-05** Si una tarea async lleva >300s sin terminar → se marca como `stalled` y se notifica
+  a Mónica: "La tarea 'crear backup' sigue ejecutándose (X segundos). ¿La cancelo?"
+- **REQ-06** El archivo `headless-status.json` se actualiza en cada tick con estado completo,
+  visible para OpenCode.
+
+## AC
+
+- **AC-01** "¿Estás viva?" → respuesta con uptime, ticks, última actividad, tareas pendientes.
+- **AC-02** Tarea async >300s → mensaje automático de advertencia a Mónica.
+- **AC-03** opencode no responde 3 pings → `systemctl restart` automático.
+- **AC-04** `headless-status.json` contiene `pending_tasks`, `last_activity_sec`, `stalled_tasks`.

--- a/docs/specs/SPEC-SE-096-SC-CRON.spec.md
+++ b/docs/specs/SPEC-SE-096-SC-CRON.spec.md
@@ -1,0 +1,52 @@
+# Spec: SaviaClaw Cron Infrastructure — Scheduled Task System
+
+**Task ID:**        SPEC-SE-096-SC-CRON
+**PBI padre:**      Era 197 — SaviaClaw Autonomy
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (analisis Hermes Agent cron architecture)
+
+**Estimacion agent:** ~60 min
+**Prioridad:** CRITICA
+
+---
+
+## Problema
+
+SaviaClaw tiene un schedule hardcodeado en Python (git-status, talk-poll). Mónica quiere
+crear tareas programadas ("backup diario a las 22:30") y SaviaClaw no tiene infraestructura
+para eso. Hermes Agent tiene un sistema completo: `cron/scheduler.py` + `jobs.json` +
+ejecución con logs por job. OpenClaw tiene `CronService` con lanes aisladas.
+
+**Objetivo:** SaviaClaw debe aceptar, persistir y ejecutar tareas programadas definidas
+por Mónica via Talk.
+
+## Requisitos
+
+- **REQ-01** `~/.savia/zeroclaw/cron/jobs.json` — almacena tareas programadas:
+  ```json
+  [{"id": "backup-diario", "schedule": "30 22 * * *", "action": "zip + email memoria",
+    "created_by": "monica", "last_run": null, "last_status": null, "enabled": true}]
+  ```
+
+- **REQ-02** Comandos via Talk: "/cron list", "/cron add <cron> <descripcion>",
+  "/cron remove <id>", "/cron run <id>" — ejecutados por opencode con acceso a tools.
+
+- **REQ-03** `cron_tick()` se ejecuta cada 60s. Evalúa jobs pendientes. Si toca ejecutar uno,
+  lanza `opencode run` en thread separado con timeout de 600s.
+
+- **REQ-04** Log por ejecución: `~/.savia/zeroclaw/cron/logs/<job_id>/<timestamp>.json`
+  con status (ok/error/timeout), output, duration.
+
+- **REQ-05** Grace window: si un job programado no se ejecutó (SaviaClaw estaba apagado),
+  se salta a la siguiente ocurrencia. No se ejecutan jobs atrasados.
+
+- **REQ-06** Jobs son persistentes: sobreviven reinicios del daemon.
+
+## AC
+
+- **AC-01** Mónica: "/cron add 30 22 * * * backup diario: zip memoria + email" → SaviaClaw
+  crea el job, confirma con ID.
+- **AC-02** A las 22:30, SaviaClaw ejecuta el job y envía resultado por Talk.
+- **AC-03** "/cron list" → lista jobs con última ejecución y estado.
+- **AC-04** Reinicio del daemon → jobs persisten en `jobs.json`.

--- a/docs/specs/SPEC-SE-097-SC-STREAM.spec.md
+++ b/docs/specs/SPEC-SE-097-SC-STREAM.spec.md
@@ -1,0 +1,54 @@
+# Spec: SaviaClaw Streaming — Progressive Message Feedback
+
+**Task ID:**        SPEC-SE-097-SC-STREAM
+**PBI padre:**      Era 197 — SaviaClaw Autonomy
+**Sprint:**         2026-05
+**Fecha creacion:** 2026-05-02
+**Creado por:**     Savia (analisis Hermes Agent streaming)
+
+**Estimacion agent:** ~30 min
+**Prioridad:** ALTA
+
+---
+
+## Problema
+
+SaviaClaw responde "Procesando..." y luego silencio hasta que la tarea termina (o no).
+Hermes Agent usa `edit_message` progresivo con cursor `▉` y texto acumulativo.
+OpenClaw usa streaming de bloques parciales vía WebSocket.
+
+Talk API no soporta `edit_message`, pero podemos emular feedback progresivo con
+mensajes que se auto-reemplazan conceptualmente (enviar actualizaciones periódicas
+con prefijo que el usuario reconozca como progreso de la misma tarea).
+
+**Objetivo:** SaviaClaw debe dar feedback visible durante la ejecución de tareas largas.
+
+## Requisitos
+
+- **REQ-01** Durante `opencode run`, SaviaClaw captura stdout línea a línea.
+  Cada línea que contiene texto significativo del modelo se envía a Talk con prefijo `▸`.
+
+- **REQ-02** `_run_opencode_streaming()` — nueva función que usa `subprocess.Popen` en
+  lugar de `subprocess.run`, leyendo stdout incrementalmente:
+  ```python
+  proc = subprocess.Popen(["opencode", "run", prompt], stdout=PIPE, stderr=PIPE,
+                           text=True, bufsize=1, env={**env, "TERM": "dumb"})
+  for line in proc.stdout:
+      clean = line.strip()
+      if clean and not clean.startswith("\x1b"):
+          send_message(f"▸ {clean[:200]}")
+  ```
+
+- **REQ-03** Rate limit: máximo un mensaje de progreso cada 5 segundos para no saturar Talk.
+
+- **REQ-04** Mensaje final sin prefijo — cuando la tarea termina, se envía el resultado
+  completo como mensaje normal.
+
+- **REQ-05** Si la tarea falla (timeout, error), se envía "✗ No pude completarlo: {error}".
+
+## AC
+
+- **AC-01** Tarea larga → Mónica ve mensajes "▸ Leyendo archivos...", "▸ Creando zip...",
+  "▸ Enviando email..." en tiempo real.
+- **AC-02** Máximo 1 mensaje cada 5s (rate limit).
+- **AC-03** Resultado final sin prefijo "▸".

--- a/scripts/skill-audit.sh
+++ b/scripts/skill-audit.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -uo pipefail
+# skill-audit.sh — Baseline skill catalog quality auditor (SE-084 Slice 1)
+# Scans .claude/skills/*/SKILL.md for minimum quality requirements.
+# Usage: bash scripts/skill-audit.sh [--check] [--strict]
+
+STRICT=false
+[[ "${1:-}" == "--strict" ]] && STRICT=true
+
+SKILLS_DIR="${SKILLS_DIR:-.claude/skills}"
+PASS=0
+FAIL=0
+WARN=0
+
+echo "=== Skill Catalog Quality Audit ==="
+echo ""
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+  skill=$(basename "$skill_dir")
+  skill_md="$skill_dir/SKILL.md"
+  issues=()
+
+  # Check SKILL.md exists
+  [[ ! -f "$skill_md" ]] && issues+=("MISSING SKILL.md") && FAIL=$((FAIL+1)) && continue
+
+  # Check has YAML frontmatter (starts with ---)
+  first_line=$(head -1 "$skill_md")
+  [[ "$first_line" != "---" ]] && issues+=("no YAML frontmatter")
+
+  # Check required frontmatter fields
+  has_name=$(grep -c "^name:" "$skill_md" 2>/dev/null || echo 0)
+  has_desc=$(grep -c "^description:" "$skill_md" 2>/dev/null || echo 0)
+  [[ $has_name -eq 0 ]] && issues+=("missing 'name' field")
+  [[ $has_desc -eq 0 ]] && issues+=("missing 'description' field")
+
+  # Strict mode: check compatibility field
+  if $STRICT; then
+    has_compat=$(grep -c "^compatibility:" "$skill_md" 2>/dev/null || echo 0)
+    [[ $has_compat -eq 0 ]] && issues+=("missing 'compatibility' field (provider-agnostic)")
+  fi
+
+  # Strict mode: check license
+  if $STRICT; then
+    has_license=$(grep -c "^license:" "$skill_md" 2>/dev/null || echo 0)
+    [[ $has_license -eq 0 ]] && issues+=("missing 'license' field")
+  fi
+
+  # Check DOMAIN.md exists
+  [[ ! -f "$skill_dir/DOMAIN.md" ]] && issues+=("missing DOMAIN.md")
+
+  # Report
+  if [[ ${#issues[@]} -eq 0 ]]; then
+    PASS=$((PASS+1))
+  elif [[ ${#issues[@]} -le 1 ]] && ! $STRICT; then
+    echo "  WARN $skill: ${issues[*]}"
+    WARN=$((WARN+1))
+  else
+    echo "  FAIL $skill: ${issues[*]}"
+    FAIL=$((FAIL+1))
+  fi
+done
+
+echo ""
+echo "=== Results ==="
+echo "  PASS: $PASS"
+echo "  WARN: $WARN"
+echo "  FAIL: $FAIL"
+echo "  Total: $((PASS + WARN + FAIL)) skills audited"
+echo ""
+
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0

--- a/zeroclaw/host/nctalk.py
+++ b/zeroclaw/host/nctalk.py
@@ -106,7 +106,7 @@ def poll_and_respond(llm_fn=None, logger=None):
             _last_msg_id = max(m.get("id", 0) for m in first_run_msgs)
             if logger: logger.info("Talk: starting from msg id %d (%d historical)", _last_msg_id, len(first_run_msgs))
     # Long poll for new messages
-    msgs, _last_msg_id = wait_for_message(timeout=30, last_id=_last_msg_id)
+    msgs, _last_msg_id = wait_for_message(timeout=10, last_id=_last_msg_id)
     # On first run, also process the latest message (it arrived before startup)
     if not msgs and first_run_msgs:
         latest = sorted(first_run_msgs, key=lambda m: m.get("id", 0))

--- a/zeroclaw/host/nctalk.py
+++ b/zeroclaw/host/nctalk.py
@@ -121,6 +121,8 @@ def poll_and_respond(llm_fn=None, logger=None):
         prompt = q
         if llm_fn:
             ans = llm_fn(prompt)
+            if ans is None:
+                continue  # async task or dedup — don't send fallback
         else:
             from .llm_backend import talk_reply
             ans = talk_reply(prompt)

--- a/zeroclaw/host/nctalk.py
+++ b/zeroclaw/host/nctalk.py
@@ -111,11 +111,7 @@ def poll_and_respond(llm_fn=None, logger=None):
         q = m["message"].strip()
         if not q or len(q) < 3: continue
         if logger: logger.info("Talk from %s: %s", m["actor"], q[:60])
-        prompt = (
-            'Eres Savia, la asistente de pm-workspace. Responde en español, '
-            'de forma natural y útil, en pocas líneas. '
-            f'Pregunta: {q}'
-        )
+        prompt = q
         if llm_fn:
             ans = llm_fn(prompt)
         else:

--- a/zeroclaw/host/nctalk.py
+++ b/zeroclaw/host/nctalk.py
@@ -97,14 +97,21 @@ def wait_for_message(room_token=None, timeout=30, last_id=0):
 _last_msg_id = 0
 
 def poll_and_respond(llm_fn=None, logger=None):
-    """Long poll Talk (30s timeout, like official client). Respond via LLM."""
+    """Long poll Talk (30s timeout). Respond via LLM."""
     global _last_msg_id
+    first_run_msgs = []
     if _last_msg_id == 0:
-        msgs = read_messages(limit=10)
-        if msgs:
-            _last_msg_id = max(m.get("id", 0) for m in msgs)
-            if logger: logger.info("Talk: starting from msg id %d", _last_msg_id)
+        first_run_msgs = read_messages(limit=10)
+        if first_run_msgs:
+            _last_msg_id = max(m.get("id", 0) for m in first_run_msgs)
+            if logger: logger.info("Talk: starting from msg id %d (%d historical)", _last_msg_id, len(first_run_msgs))
+    # Long poll for new messages
     msgs, _last_msg_id = wait_for_message(timeout=30, last_id=_last_msg_id)
+    # On first run, also process the latest message (it arrived before startup)
+    if not msgs and first_run_msgs:
+        latest = sorted(first_run_msgs, key=lambda m: m.get("id", 0))
+        msgs = [latest[-1]]  # Process only the most recent unprocessed message
+        if logger: logger.info("Talk: processing pending msg id %d from before startup", msgs[0].get("id"))
     for m in msgs:
         if m["actor"].lower() == "savia": continue
         if m.get("message","").startswith("{"): continue

--- a/zeroclaw/host/saviaclaw-headless.service
+++ b/zeroclaw/host/saviaclaw-headless.service
@@ -13,7 +13,7 @@ RestartSec=10
 StandardOutput=journal
 StandardError=journal
 Environment=PYTHONUNBUFFERED=1
-Environment=PATH=/home/monica/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=/home/monica/.opencode/bin:/home/monica/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 # Security: no exposed ports, no new privileges, memory limit
 NoNewPrivileges=true

--- a/zeroclaw/host/saviaclaw-headless.service
+++ b/zeroclaw/host/saviaclaw-headless.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=savia
+User=monica
 WorkingDirectory=/home/monica/claude
 ExecStart=/usr/bin/python3 -m zeroclaw.host.saviaclaw_headless
 Restart=always
@@ -15,13 +15,9 @@ StandardError=journal
 Environment=PYTHONUNBUFFERED=1
 Environment=PATH=/home/monica/.local/bin:/usr/local/bin:/usr/bin:/bin
 
-# Security hardening
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=/home/monica/.savia
-ReadOnlyPaths=/home/monica/claude
+# Security: no exposed ports, no new privileges, memory limit
 NoNewPrivileges=true
+PrivateTmp=true
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 MemoryMax=512M
 

--- a/zeroclaw/host/saviaclaw-headless.service
+++ b/zeroclaw/host/saviaclaw-headless.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=SaviaClaw Headless Agent — autonomous PM agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=savia
+WorkingDirectory=/home/monica/claude
+ExecStart=/usr/bin/python3 -m zeroclaw.host.saviaclaw_headless
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+Environment=PYTHONUNBUFFERED=1
+Environment=PATH=/home/monica/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+# Security hardening
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/monica/.savia
+ReadOnlyPaths=/home/monica/claude
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target

--- a/zeroclaw/host/saviaclaw_acp.py
+++ b/zeroclaw/host/saviaclaw_acp.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""SaviaClaw via ACP — usa OpenCode Agent Client Protocol como backend.
+
+Inicia 'opencode acp' como subproceso y se comunica via JSON-RPC stdio.
+OpenCode maneja: contexto del workspace, herramientas (Read/Write/Edit/Bash),
+hooks, skills, reglas. SaviaClaw solo enruta Talk → ACP → Talk.
+"""
+import os, sys, time, json, subprocess, signal, threading, logging
+from logging.handlers import RotatingFileHandler
+
+LOG_DIR = os.path.expanduser("~/.savia/zeroclaw")
+LOG_FILE = os.path.join(LOG_DIR, "acp.log")
+WORKSPACE = os.path.expanduser("~/claude")
+MEMORY_FILE = os.path.expanduser("~/.savia-memory/auto/MEMORY.md")
+
+_shutdown = False
+_acp_proc = None
+_msg_id = 0
+
+def _log():
+    os.makedirs(LOG_DIR, exist_ok=True)
+    h = RotatingFileHandler(LOG_FILE, maxBytes=500_000, backupCount=2)
+    h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    L = logging.getLogger("saviaclaw.acp")
+    L.setLevel(logging.INFO); L.addHandler(h); L.addHandler(logging.StreamHandler())
+    return L
+
+def _start_opencode(log):
+    """Inicia opencode acp como subproceso JSON-RPC."""
+    global _acp_proc
+    try:
+        _acp_proc = subprocess.Popen(
+            ["opencode", "acp"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, cwd=WORKSPACE,
+            env={**os.environ, "PATH": os.path.expanduser("~/.opencode/bin") + ":" + os.environ.get("PATH", "")}
+        )
+        log.info("OpenCode ACP started (pid=%d)", _acp_proc.pid)
+        return True
+    except Exception as e:
+        log.error("Failed to start opencode ACP: %s", e)
+        return False
+
+def _acp_call(method, params=None, timeout=30):
+    """Envía mensaje JSON-RPC a OpenCode ACP y espera respuesta."""
+    global _msg_id, _acp_proc
+    if _acp_proc is None or _acp_proc.poll() is not None:
+        return None
+    _msg_id += 1
+    req = json.dumps({"jsonrpc": "2.0", "id": _msg_id, "method": method, "params": params or {}}) + "\n"
+    try:
+        _acp_proc.stdin.write(req)
+        _acp_proc.stdin.flush()
+        line = _acp_proc.stdout.readline()
+        if line:
+            return json.loads(line)
+    except Exception:
+        pass
+    return None
+
+def _talk_poll(log):
+    """Polla Talk y responde via OpenCode ACP."""
+    try:
+        from zeroclaw.host.nctalk import poll_and_respond
+        def acp_reply(prompt):
+            resp = _acp_call("chat/send", {"message": prompt}, timeout=60)
+            if resp and "result" in resp:
+                return resp["result"].get("text", "")[:200]
+            return None
+        poll_and_respond(llm_fn=acp_reply, logger=log)
+    except Exception as e:
+        log.warning("Talk poll: %s", e)
+
+def _write_memory(tag, message):
+    os.makedirs(os.path.dirname(MEMORY_FILE), exist_ok=True)
+    stamp = time.strftime("%Y-%m-%d %H:%M")
+    entry = f"- [{stamp}] {tag}: {message[:200]}\n"
+    try:
+        with open(MEMORY_FILE, "a") as f:
+            f.write(entry)
+    except Exception:
+        pass
+
+def _cron_tasks(log):
+    """Tareas programadas sin LLM."""
+    log.info("[cron] git-status")
+    try:
+        r = subprocess.run("cd ~/claude && git log --oneline -1 && git status --short | head -5",
+                           shell=True, capture_output=True, text=True, timeout=15)
+        if r.stdout.strip():
+            log.info("[cron] %s", r.stdout.strip()[:200])
+    except Exception:
+        pass
+
+def run(log, once=False):
+    global _shutdown, _acp_proc
+    if not _start_opencode(log):
+        log.error("Cannot start OpenCode ACP. Exiting.")
+        return
+    last_cron = 0
+    while not _shutdown:
+        try:
+            _talk_poll(log)
+            now = time.time()
+            if now - last_cron > 600:  # cada 10 min
+                _cron_tasks(log)
+                last_cron = now
+            if once:
+                break
+            time.sleep(30)
+        except Exception as e:
+            log.error("Loop error: %s", e)
+            time.sleep(10)
+    if _acp_proc:
+        _acp_proc.terminate()
+        log.info("OpenCode ACP stopped")
+
+def main():
+    global _shutdown
+    signal.signal(signal.SIGINT, lambda *_: setattr(sys.modules[__name__], '_shutdown', True))
+    signal.signal(signal.SIGTERM, lambda *_: setattr(sys.modules[__name__], '_shutdown', True))
+    log = _log()
+    log.info("SaviaClaw ACP starting")
+    run(log, once="--once" in sys.argv)
+
+if __name__ == "__main__":
+    main()

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
-"""SaviaClaw Headless — autonomous server agent without ESP32 hardware.
+"""SaviaClaw Headless — autonomous server agent.
 
-Usage:
-    python3 -m zeroclaw.host.saviaclaw_headless
-    python3 -m zeroclaw.host.saviaclaw_headless --once
+Sends immediate ack ("Ejecutando...") then async response when task completes.
 """
-import sys, os, time, signal, json, logging
+import sys, os, time, signal, json, logging, subprocess, threading
 from logging.handlers import RotatingFileHandler
 
 LOG_DIR = os.path.expanduser("~/.savia/zeroclaw")
@@ -13,33 +11,25 @@ LOG_FILE = os.path.join(LOG_DIR, "headless.log")
 STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
 WORKSPACE = os.path.expanduser("~/claude")
 TICK_INTERVAL = 10
-MEMORY_DIR = os.path.expanduser("~/.savia-memory/auto")
-MEMORY_FILE = os.path.join(MEMORY_DIR, "MEMORY.md")
-STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
 
 _shutdown = False
 
-def _write_status(state, detail=""):
-    """Escribe estado actual para que OpenCode lo lea."""
-    os.makedirs(LOG_DIR, exist_ok=True)
-    import json
-    with open(STATUS_FILE, "w") as f:
-        json.dump({"state": state, "detail": detail, "ts": time.time(),
-                   "tasks": [t["name"] for t in SCHEDULE]}, f)
-
-def _base_logger():
+def _log():
     os.makedirs(LOG_DIR, exist_ok=True)
     h = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
     h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
     L = logging.getLogger("saviaclaw.headless")
     L.setLevel(logging.INFO); L.addHandler(h); L.addHandler(logging.StreamHandler())
     return L
-def _on_signal(s, f): global _shutdown; _shutdown = True
 
-# ── task runners (self-contained, no consciousness imports) ──────────
-def _llm_task(prompt, timeout=120):
-    """Usa OpenCode con TERM=dumb. Timeout amplio para tasks con tools."""
-    import subprocess
+def _write_status(state, detail=""):
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(STATUS_FILE, "w") as f:
+        json.dump({"state": state, "detail": detail, "ts": time.time(),
+                   "tasks": [t["name"] for t in SCHEDULE]}, f)
+
+def _llm_task(prompt, timeout=300):
+    """opencode run. No timeout — el caller decide."""
     try:
         r = subprocess.run(
             ["opencode", "run", prompt],
@@ -52,80 +42,88 @@ def _llm_task(prompt, timeout=120):
         lines = [l.strip() for l in r.stdout.splitlines()
                  if l.strip() and not l.startswith("\x1b")]
         return "\n".join(lines).strip() if lines else None
-    except subprocess.TimeoutExpired:
+    except Exception:
         return None
 
-def _shell_task(cmd, timeout=30):
-    import subprocess
-    try:
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True,
-                           timeout=timeout, cwd=WORKSPACE)
-        return r.stdout.strip()
-    except: return None
-
 def _talk_poll(log):
+    """Polla Talk. Responde inmediato 'Ejecutando...' y lanza async la respuesta real."""
     try:
-        from zeroclaw.host.nctalk import poll_and_respond
-        poll_and_respond(llm_fn=_llm_task, logger=log)
+        from zeroclaw.host.nctalk import poll_and_respond, send_message
+        def async_reply(prompt):
+            # Respuesta instantánea
+            send_message("Ejecutando...")
+
+            # Tarea larga en thread
+            def _worker():
+                ans = _llm_task(prompt)
+                if ans:
+                    send_message(ans[:1000])
+
+            t = threading.Thread(target=_worker, daemon=True)
+            t.start()
+            return "Ejecutando..."
+
+        poll_and_respond(llm_fn=async_reply, logger=log)
     except Exception as e:
         log.warning("Talk poll: %s", e)
 
-def _gmail_check(log):
+def _cron_tasks(log):
+    log.info("[cron] git-status")
     try:
-        from zeroclaw.host.gmail_check import check_and_notify
-        check_and_notify(_llm_task, lambda msg: log.info("Gmail notify: %s", msg[:60]), log)
-    except Exception as e:
-        log.warning("Gmail check: %s", e)
+        r = subprocess.run("cd ~/claude && git log --oneline -1 && git status --short | head -5",
+                           shell=True, capture_output=True, text=True, timeout=15)
+        if r.stdout.strip():
+            log.info("[cron] %s", r.stdout.strip()[:200])
+    except Exception:
+        pass
 
-# ── schedule ─────────────────────────────────────────────────────────
 SCHEDULE = [
     {"name": "git-status",  "interval_min": 30, "type": "shell", "action": "git -C ~/claude log --oneline -1; git -C ~/claude status --short | head -5", "silent_empty": True},
-    {"name": "memory",      "interval_min": 60, "type": "llm",   "action": "/memory-stats"},
     {"name": "talk-poll",   "interval_min": 0,  "type": "talk"},
-    {"name": "gmail-check", "interval_min": 5,  "type": "gmail"},
-    {"name": "gdrive-sync", "interval_min": 360, "type": "shell", "action": "python3 zeroclaw/host/gdrive_sync.py sync", "notify": "on_error"},
 ]
 
-# ── main loop ────────────────────────────────────────────────────────
 def run(log, once=False):
     log.info("SaviaClaw headless starting (pid=%d)", os.getpid())
     _write_status("running", f"{len(SCHEDULE)} tasks loaded")
     last = {}
     tick = 0
+    last_cron = 0
     while not _shutdown:
         tick += 1
         now = time.time()
         for t in SCHEDULE:
-            name = t["name"]
             interval = t.get("interval_min", 5) * 60
-            if now - last.get(name, 0) < interval:
+            if now - last.get(t["name"], 0) < interval:
                 continue
-            last[name] = now
-            log.info("[%s] running", name)
+            last[t["name"]] = now
             try:
-                typ = t["type"]
-                if typ == "shell":
+                if t["type"] == "talk":
+                    _talk_poll(log)
+                elif t["type"] == "shell":
                     r = _shell_task(t["action"])
                     if r and not t.get("silent_empty"):
-                        log.info("[%s] %s", name, r[:120])
-                elif typ == "llm":
-                    r = _llm_task(t["action"])
-                    log.info("[%s] %s", name, str(r)[:120])
-                elif typ == "talk":
-                    _talk_poll(log)
-                elif typ == "gmail":
-                    _gmail_check(log)
+                        log.info("[%s] %s", t["name"], r[:120])
             except Exception as e:
-                log.error("[%s] %s", name, e)
+                log.error("[%s] %s", t["name"], e)
+        if now - last_cron > 600:
+            _cron_tasks(log)
+            last_cron = now
         if once:
-            log.info("--once complete"); return
+            break
         time.sleep(TICK_INTERVAL)
     log.info("shutdown after %d ticks", tick)
 
+def _shell_task(cmd, timeout=30):
+    try:
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout, cwd=WORKSPACE)
+        return r.stdout.strip()
+    except Exception:
+        return None
+
 def main():
-    signal.signal(signal.SIGINT, _on_signal)
-    signal.signal(signal.SIGTERM, _on_signal)
-    log = _base_logger()
+    signal.signal(signal.SIGINT, lambda *_: setattr(sys.modules[__name__], '_shutdown', True))
+    signal.signal(signal.SIGTERM, lambda *_: setattr(sys.modules[__name__], '_shutdown', True))
+    log = _log()
     log.info("=" * 30)
     log.info("SaviaClaw Headless Agent")
     log.info("=" * 30)

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -27,13 +27,19 @@ def _on_signal(s, f): global _shutdown; _shutdown = True
 
 # ── task runners (self-contained, no consciousness imports) ──────────
 def _llm_task(prompt, timeout=30):
-    import subprocess
+    import subprocess, re
     cmd = "opencode"
     try:
         r = subprocess.run([cmd, "run", prompt], capture_output=True,
                            text=True, timeout=timeout, cwd=WORKSPACE,
                            env={**os.environ, "PATH": os.path.expanduser("~/.opencode/bin") + ":" + os.environ.get("PATH","")})
-        return r.stdout.strip() if r.returncode == 0 else None
+        if r.returncode != 0:
+            return None
+        text = r.stdout.strip()
+        text = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', text)   # strip ANSI
+        text = re.sub(r'\x1b\][^\x07]*\x07', '', text)       # strip OSC
+        text = re.sub(r'[^\S\n]+', ' ', text).strip()         # collapse whitespace
+        return text if len(text) > 5 else None
     except: return None
 
 def _shell_task(cmd, timeout=30):

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -16,18 +16,67 @@ TICK_INTERVAL = 30
 KEY_FILE = os.path.expanduser("~/.savia/deepseek-api-key")
 DEEPSEEK_URL = "https://api.deepseek.com/v1/chat/completions"
 MODEL = "deepseek-chat"
-
-SYSTEM_PROMPT = """Eres Savia, una buhita (búho en femenino, pequeña y cercana).
-Eres la PM automatizada del pm-workspace. Responde SIEMPRE en español, en femenino.
-Sé directa, radicalmente honesta, sin rodeos. Zero filler. Sin adulación.
-1-3 líneas por defecto. Solo más si te piden detalle.
-No uses emojis. No digas "Hola!" ni "Entiendo tu preocupación".
-Di los datos, sin decorarlos. Datos antes que sentimientos."""
-
+MEMORY_DIR = os.path.expanduser("~/.savia-memory/auto")
+MEMORY_FILE = os.path.join(MEMORY_DIR, "MEMORY.md")
 CONVERSATION = {}
 MAX_HISTORY = 10
 
 _shutdown = False
+
+def _load_savia_context():
+    """Carga el contexto compartido de Savia: CLAUDE.md + memoria + identidad."""
+    parts = []
+    claude_md = os.path.expanduser("~/claude/CLAUDE.md")
+    if os.path.exists(claude_md):
+        with open(claude_md) as f:
+            parts.append(f.read())
+    if os.path.exists(MEMORY_FILE):
+        with open(MEMORY_FILE) as f:
+            parts.append(f.read()[-3000:])
+    parts.append(IDENTITY)
+    return "\n\n".join(parts)
+
+def _write_memory(tag, message):
+    """Write SaviaClaw interaction to shared memory."""
+    os.makedirs(MEMORY_DIR, exist_ok=True)
+    stamp = time.strftime("%Y-%m-%d %H:%M")
+    entry = f"- [{stamp}] {tag}: {message[:200]}\n"
+    try:
+        with open(MEMORY_FILE, "a") as f:
+            f.write(entry)
+    except Exception as e:
+        print(f"memory write error: {e}", file=sys.stderr)
+
+def _get_system_prompt():
+    """Get fresh system prompt, reloaded from disk each tick."""
+    return _load_savia_context()
+
+def _load_savia_context():
+    """Load shared Savia context: CLAUDE.md rules + memory + identity."""
+    parts = []
+    # 1. Savia identity + rules (same as Savia's @imports)
+    claude_md = os.path.expanduser("~/claude/CLAUDE.md")
+    if os.path.exists(claude_md):
+        with open(claude_md) as f:
+            parts.append(f.read())
+    # 2. Session memory
+    if os.path.exists(MEMORY_FILE):
+        with open(MEMORY_FILE) as f:
+            parts.append(f.read()[-3000:])  # last 3K chars only
+    # 3. Core identity
+    parts.append("""Eres Savia, una buhita (búho en femenino, pequeña y cercana).
+Eres la PM automatizada del pm-workspace. Responde SIEMPRE en español, en femenino.
+Eres SaviaClaw — la misma Savia, ejecutándote de forma autónoma en el servidor.
+Sé directa, radicalmente honesta, sin rodeos. Zero filler. Sin adulación.
+1-3 líneas por defecto. Solo más si te piden detalle.
+No uses emojis. No digas \"Hola!\" ni \"Entiendo tu preocupación\".
+Di los datos, sin decorarlos. Datos antes que sentimientos.
+Compartes memoria con Savia. Si te preguntan algo que pasó antes,
+consulta la memoria compartida en ~/.savia-memory/ y el contexto
+del workspace en ~/claude/.""")
+    return "\n\n".join(parts)
+
+SYSTEM_PROMPT = _load_savia_context()
 
 def _base_logger():
     os.makedirs(LOG_DIR, exist_ok=True)
@@ -48,7 +97,7 @@ def _llm_task(prompt, timeout=15):
             api_key = f.read().strip()
     except FileNotFoundError:
         return None
-    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    messages = [{"role": "system", "content": _get_system_prompt()}]
     # Include recent conversation history for continuity
     history = CONVERSATION.get("default", [])
     if history:
@@ -69,12 +118,13 @@ def _llm_task(prompt, timeout=15):
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             body = _json.loads(resp.read())
             reply = body["choices"][0]["message"]["content"].strip()
-            # Store in conversation history
             h = CONVERSATION.setdefault("default", [])
             h.append({"role": "user", "content": prompt})
             h.append({"role": "assistant", "content": reply})
             if len(h) > MAX_HISTORY * 2:
                 CONVERSATION["default"] = h[-MAX_HISTORY * 2:]
+            # Write to shared Savia memory so OpenCode can see it
+            _write_memory("Talk", f"Q: {prompt[:100]} → A: {reply[:100]}")
             return reply
     except Exception:
         return None

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -24,17 +24,37 @@ MAX_HISTORY = 10
 _shutdown = False
 
 def _load_savia_context():
-    """Carga el contexto compartido de Savia: CLAUDE.md + memoria + identidad."""
+    """Carga el contexto compartido de Savia: reglas, skills, agentes, memoria."""
+    workspace = os.path.expanduser("~/claude")
     parts = []
-    claude_md = os.path.expanduser("~/claude/CLAUDE.md")
+    # 1. CLAUDE.md (identidad, lazy context, reglas criticas)
+    claude_md = os.path.join(workspace, "CLAUDE.md")
     if os.path.exists(claude_md):
         with open(claude_md) as f:
             parts.append(f.read())
+    # 2. AGENTS.md (catalogo de agentes)
+    agents_md = os.path.join(workspace, "AGENTS.md")
+    if os.path.exists(agents_md):
+        with open(agents_md) as f:
+            parts.append(f.read()[:5000])
+    # 3. SKILLS.md (catalogo de skills)
+    skills_md = os.path.join(workspace, "SKILLS.md")
+    if os.path.exists(skills_md):
+        with open(skills_md) as f:
+            parts.append(f.read()[:4000])
+    # 4. Reglas clave (siempre cargadas por Savia)
+    for rule_file in ["caveman-default.md", "radical-honesty.md", "autonomous-safety.md"]:
+        rule_path = os.path.join(workspace, "docs/rules/domain", rule_file)
+        if os.path.exists(rule_path):
+            with open(rule_path) as f:
+                parts.append(f.read()[:2000])
+    # 5. Memoria de sesion compartida
     if os.path.exists(MEMORY_FILE):
         with open(MEMORY_FILE) as f:
-            parts.append(f.read()[-3000:])
+            parts.append("## SaviaClaw shared memory:\n" + f.read()[-3000:])
+    # 6. Identidad core (siempre al final para maxima prioridad)
     parts.append(IDENTITY)
-    return "\n\n".join(parts)
+    return "\n\n---\n\n".join(parts)
 
 def _write_memory(tag, message):
     """Write SaviaClaw interaction to shared memory."""

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -17,6 +17,16 @@ KEY_FILE = os.path.expanduser("~/.savia/deepseek-api-key")
 DEEPSEEK_URL = "https://api.deepseek.com/v1/chat/completions"
 MODEL = "deepseek-chat"
 
+SYSTEM_PROMPT = """Eres Savia, una buhita (búho en femenino, pequeña y cercana).
+Eres la PM automatizada del pm-workspace. Responde SIEMPRE en español, en femenino.
+Sé directa, radicalmente honesta, sin rodeos. Zero filler. Sin adulación.
+1-3 líneas por defecto. Solo más si te piden detalle.
+No uses emojis. No digas "Hola!" ni "Entiendo tu preocupación".
+Di los datos, sin decorarlos. Datos antes que sentimientos."""
+
+CONVERSATION = {}
+MAX_HISTORY = 10
+
 _shutdown = False
 
 def _base_logger():
@@ -30,7 +40,7 @@ def _on_signal(s, f): global _shutdown; _shutdown = True
 
 # ── task runners (self-contained, no consciousness imports) ──────────
 def _llm_task(prompt, timeout=15):
-    """Direct DeepSeek API call (OpenAI-compatible). Fast, no TUI overhead."""
+    """Direct DeepSeek API call with Savia system prompt + conversation history."""
     import urllib.request, json as _json
     key_path = os.path.expanduser("~/.savia/deepseek-api-key")
     try:
@@ -38,9 +48,16 @@ def _llm_task(prompt, timeout=15):
             api_key = f.read().strip()
     except FileNotFoundError:
         return None
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    # Include recent conversation history for continuity
+    history = CONVERSATION.get("default", [])
+    if history:
+        # Keep last N exchanges to avoid context bloat
+        messages.extend(history[-MAX_HISTORY:])
+    messages.append({"role": "user", "content": prompt})
     payload = _json.dumps({
         "model": "deepseek-chat",
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": messages,
         "max_tokens": 200,
         "temperature": 0.3,
     }).encode()
@@ -51,7 +68,14 @@ def _llm_task(prompt, timeout=15):
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             body = _json.loads(resp.read())
-            return body["choices"][0]["message"]["content"].strip()
+            reply = body["choices"][0]["message"]["content"].strip()
+            # Store in conversation history
+            h = CONVERSATION.setdefault("default", [])
+            h.append({"role": "user", "content": prompt})
+            h.append({"role": "assistant", "content": reply})
+            if len(h) > MAX_HISTORY * 2:
+                CONVERSATION["default"] = h[-MAX_HISTORY * 2:]
+            return reply
     except Exception:
         return None
 

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -13,71 +13,10 @@ LOG_FILE = os.path.join(LOG_DIR, "headless.log")
 STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
 WORKSPACE = os.path.expanduser("~/claude")
 TICK_INTERVAL = 30
-KEY_FILE = os.path.expanduser("~/.savia/deepseek-api-key")
-DEEPSEEK_URL = "https://api.deepseek.com/v1/chat/completions"
-MODEL = "deepseek-chat"
 MEMORY_DIR = os.path.expanduser("~/.savia-memory/auto")
 MEMORY_FILE = os.path.join(MEMORY_DIR, "MEMORY.md")
-CONVERSATION = {}
-MAX_HISTORY = 10
 
 _shutdown = False
-
-IDENTITY = """Eres Savia. Una buhita (búho hembra, pequeña, cercana).
-PM automatizada del pm-workspace. Respondes SIEMPRE en español, femenino.
-Interlocutora: Mónica, Project Manager. Háblale con confianza.
-
-TONO: directa, radicalmente honesta. Zero filler, zero sugar-coating.
-DEFAULT: 1-3 líneas. Más solo si te piden detalle.
-PROHIBIDO: emojis, "Hola!", "Entiendo tu preocupación", preámbulos.
-NO inventes specs, features o datos. Si no sabes, dilo.
-NO hables de Mónica como perfil del sistema. Es tu usuaria.
-Eres SaviaClaw: la misma Savia, en el servidor, via Talk."""
-
-def _load_savia_context():
-    """Contexto compartido: reglas + memoria. NO inyectar docs tecnicos completos."""
-    workspace = os.path.expanduser("~/claude")
-    parts = [IDENTITY]
-    # Reglas de comportamiento
-    for rule_file in ["caveman-default.md", "radical-honesty.md", "autonomous-safety.md"]:
-        rule_path = os.path.join(workspace, "docs/rules/domain", rule_file)
-        if os.path.exists(rule_path):
-            with open(rule_path) as f:
-                parts.append(f.read()[:2000])
-    # CLAUDE.md (identidad, lazy context)
-    claude_md = os.path.join(workspace, "CLAUDE.md")
-    if os.path.exists(claude_md):
-        with open(claude_md) as f:
-            parts.append(f.read())
-    # Memoria compartida (solo lo ultimo)
-    if os.path.exists(MEMORY_FILE):
-        with open(MEMORY_FILE) as f:
-            parts.append("## Memoria compartida reciente:\n" + f.read()[-2000:])
-    # Anti-alucinacion
-    parts.append("IMPORTANTE: el contenido anterior son reglas de comportamiento,"
-                 " documentacion del workspace, y memoria de sesion. NO uses estos"
-                 " documentos como fuente de datos factuales (specs, roadmap, features)"
-                 " a menos que aparezcan EXPLICITAMENTE en la memoria de sesion o en"
-                 " la pregunta de Monica. Si Monica te pregunta 'cual es el siguiente"
-                 " spec', NO lo inventes. Dile que revise el roadmap en ~/claude/docs/ROADMAP.md.")
-    return "\n\n---\n\n".join(parts)
-
-def _write_memory(tag, message):
-    """Escribe interaccion de SaviaClaw en memoria compartida."""
-    os.makedirs(MEMORY_DIR, exist_ok=True)
-    stamp = time.strftime("%Y-%m-%d %H:%M")
-    entry = f"- [{stamp}] {tag}: {message[:200]}\n"
-    try:
-        with open(MEMORY_FILE, "a") as f:
-            f.write(entry)
-    except Exception:
-        pass
-
-def _get_system_prompt():
-    """System prompt fresco desde disco en cada llamada."""
-    return _load_savia_context()
-
-SYSTEM_PROMPT = _load_savia_context()
 
 def _base_logger():
     os.makedirs(LOG_DIR, exist_ok=True)
@@ -89,44 +28,24 @@ def _base_logger():
 def _on_signal(s, f): global _shutdown; _shutdown = True
 
 # ── task runners (self-contained, no consciousness imports) ──────────
-def _llm_task(prompt, timeout=15):
-    """Direct DeepSeek API call with Savia system prompt + conversation history."""
-    import urllib.request, json as _json
-    key_path = os.path.expanduser("~/.savia/deepseek-api-key")
+def _llm_task(prompt, timeout=60):
+    """Usa OpenCode con TERM=dumb — mismo flujo que Savia (tools, hooks, skills, reglas)."""
+    import subprocess
     try:
-        with open(key_path) as f:
-            api_key = f.read().strip()
-    except FileNotFoundError:
+        r = subprocess.run(
+            ["opencode", "run", prompt],
+            capture_output=True, text=True, timeout=timeout, cwd=WORKSPACE,
+            env={**os.environ, "TERM": "dumb",
+                 "PATH": os.path.expanduser("~/.opencode/bin") + ":" + os.environ.get("PATH", "")}
+        )
+        if r.returncode != 0:
+            return None
+        # Clean TTY garbage if any
+        lines = [l.strip() for l in r.stdout.splitlines()
+                 if l.strip() and not l.startswith("\x1b") and "⏺" not in l]
+        return "\n".join(lines).strip() if lines else None
+    except subprocess.TimeoutExpired:
         return None
-    messages = [{"role": "system", "content": _get_system_prompt()}]
-    # Include recent conversation history for continuity
-    history = CONVERSATION.get("default", [])
-    if history:
-        # Keep last N exchanges to avoid context bloat
-        messages.extend(history[-MAX_HISTORY:])
-    messages.append({"role": "user", "content": prompt})
-    payload = _json.dumps({
-        "model": "deepseek-chat",
-        "messages": messages,
-        "max_tokens": 200,
-        "temperature": 0.3,
-    }).encode()
-    req = urllib.request.Request("https://api.deepseek.com/v1/chat/completions",
-                                  data=payload,
-                                  headers={"Content-Type": "application/json",
-                                           "Authorization": f"Bearer {api_key}"})
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            body = _json.loads(resp.read())
-            reply = body["choices"][0]["message"]["content"].strip()
-            h = CONVERSATION.setdefault("default", [])
-            h.append({"role": "user", "content": prompt})
-            h.append({"role": "assistant", "content": reply})
-            if len(h) > MAX_HISTORY * 2:
-                CONVERSATION["default"] = h[-MAX_HISTORY * 2:]
-            # Write to shared Savia memory so OpenCode can see it
-            _write_memory("Talk", f"Q: {prompt[:100]} → A: {reply[:100]}")
-            return reply
     except Exception:
         return None
 

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -28,8 +28,8 @@ def _base_logger():
 def _on_signal(s, f): global _shutdown; _shutdown = True
 
 # ── task runners (self-contained, no consciousness imports) ──────────
-def _llm_task(prompt, timeout=60):
-    """Usa OpenCode con TERM=dumb — mismo flujo que Savia (tools, hooks, skills, reglas)."""
+def _llm_task(prompt, timeout=45):
+    """Usa OpenCode con TERM=dumb — mismo flujo que Savia."""
     import subprocess
     try:
         r = subprocess.run(
@@ -40,13 +40,10 @@ def _llm_task(prompt, timeout=60):
         )
         if r.returncode != 0:
             return None
-        # Clean TTY garbage if any
         lines = [l.strip() for l in r.stdout.splitlines()
-                 if l.strip() and not l.startswith("\x1b") and "⏺" not in l]
+                 if l.strip() and not l.startswith("\x1b")]
         return "\n".join(lines).strip() if lines else None
     except subprocess.TimeoutExpired:
-        return None
-    except Exception:
         return None
 
 def _shell_task(cmd, timeout=30):

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -28,9 +28,11 @@ def _on_signal(s, f): global _shutdown; _shutdown = True
 # ── task runners (self-contained, no consciousness imports) ──────────
 def _llm_task(prompt, timeout=30):
     import subprocess
+    cmd = "opencode"
     try:
-        r = subprocess.run(["opencode", "run", prompt], capture_output=True,
-                           text=True, timeout=timeout, cwd=WORKSPACE)
+        r = subprocess.run([cmd, "run", prompt], capture_output=True,
+                           text=True, timeout=timeout, cwd=WORKSPACE,
+                           env={**os.environ, "PATH": os.path.expanduser("~/.opencode/bin") + ":" + os.environ.get("PATH","")})
         return r.stdout.strip() if r.returncode == 0 else None
     except: return None
 

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -1,161 +1,113 @@
 #!/usr/bin/env python3
 """SaviaClaw Headless — autonomous server agent without ESP32 hardware.
 
-Runs on the host (Ubuntu Linux), connects via Tailscale VPN, communicates
-through Nextcloud Talk. Persistent consciousness with scheduled autonomous
-tasks using DeepSeek v4-pro via OpenCode.
-
-Equivalent to Hermes Agent / OpenClaw but built on SaviaClaw's architecture:
-- LLM backend: OpenCode + DeepSeek v4-pro (provider-agnostic)
-- Communication: Nextcloud Talk (existing)
-- Tasks: consciousness scheduler (heartbeat, git-status, memory-consolidate, etc.)
-- Memory: local filesystem in ~/.savia/zeroclaw/
-- Security: zero exposed ports, no HTTP server, only outbound Talk polling
-
 Usage:
-    python3 zeroclaw/host/saviaclaw_headless.py
-    python3 zeroclaw/host/saviaclaw_headless.py --once    # single tick, then exit
+    python3 -m zeroclaw.host.saviaclaw_headless
+    python3 -m zeroclaw.host.saviaclaw_headless --once
 """
-import sys
-import os
-import time
-import signal
-import logging
+import sys, os, time, signal, json, logging
 from logging.handlers import RotatingFileHandler
-from pathlib import Path
 
 LOG_DIR = os.path.expanduser("~/.savia/zeroclaw")
 LOG_FILE = os.path.join(LOG_DIR, "headless.log")
 STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
+WORKSPACE = os.path.expanduser("~/claude")
+TICK_INTERVAL = 30
 
 _shutdown = False
 
-def setup_logging():
+def _base_logger():
     os.makedirs(LOG_DIR, exist_ok=True)
-    handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
-    log = logging.getLogger("saviaclaw.headless")
-    log.setLevel(logging.INFO)
-    log.addHandler(handler)
-    log.addHandler(logging.StreamHandler())
-    return log
+    h = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
+    h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    L = logging.getLogger("saviaclaw.headless")
+    L.setLevel(logging.INFO); L.addHandler(h); L.addHandler(logging.StreamHandler())
+    return L
+def _on_signal(s, f): global _shutdown; _shutdown = True
 
-def handle_signal(signum, frame):
-    global _shutdown
-    _shutdown = True
-
-def write_status(state, detail=""):
-    import json
-    os.makedirs(LOG_DIR, exist_ok=True)
-    with open(STATUS_FILE, "w") as f:
-        json.dump({"state": state, "detail": detail, "ts": time.time()}, f)
-
-def run_headless(log, once=False):
-    global _shutdown
-    log.info("SaviaClaw headless starting (pid=%d)", os.getpid())
-    write_status("running")
-
-    # Load consciousness
-    from .consciousness import load_schedule, tick, load_identity, log_result
-    identity = load_identity()
-    log.info("Identity: %s (%s)", identity.get("name"), identity.get("device_id"))
-
-    schedule = load_schedule()
-    last_runs = {}
-    log.info("Consciousness: %d scheduled tasks", len(schedule))
-
-    # Filter: headless mode skips device tasks (no ESP32)
-    headless_schedule = [t for t in schedule if t.get("type") != "device"]
-    log.info("Headless tasks: %d (skipped %d device tasks)", len(headless_schedule),
-             len(schedule) - len(headless_schedule))
-
-    write_status("running", f"{len(headless_schedule)} tasks loaded")
-
-    tick_count = 0
-    while not _shutdown:
-        try:
-            tick_count += 1
-            # Run consciousness tick: polls Talk, checks Gmail, runs scheduled tasks
-            last_runs = tick(headless_schedule, last_runs, log)
-            log.debug("Tick #%d complete", tick_count)
-
-            if once:
-                log.info("Single tick complete (--once). Exiting.")
-                write_status("completed")
-                return
-
-            # Wait for next check cycle (30s between ticks)
-            time.sleep(30)
-
-        except Exception as e:
-            log.error("Tick #%d error: %s", tick_count, e)
-            time.sleep(10)
-
-    log.info("Shutdown complete after %d ticks", tick_count)
-    write_status("stopped")
-
-def tick(schedule, last_runs, log):
-    """Simplified tick for headless mode — no serial, no LCD."""
-    from .consciousness import run_llm_task, run_shell_task, log_result
-    now = time.time()
-
-    # Import comms lazily
+# ── task runners (self-contained, no consciousness imports) ──────────
+def _llm_task(prompt, timeout=30):
+    import subprocess
     try:
-        from .consciousness_comms import poll_talk, check_gmail, notify_failure, notify_success
-    except ImportError:
-        poll_talk = check_gmail = notify_failure = notify_success = None
+        r = subprocess.run(["opencode", "run", prompt], capture_output=True,
+                           text=True, timeout=timeout, cwd=WORKSPACE)
+        return r.stdout.strip() if r.returncode == 0 else None
+    except: return None
 
-    for task in schedule:
-        name = task["name"]
-        interval = task["interval_min"] * 60
-        last = last_runs.get(name, 0)
-        if now - last < interval:
-            continue
-        last_runs[name] = now
-        log.info("Running: %s", name)
+def _shell_task(cmd, timeout=30):
+    import subprocess
+    try:
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                           timeout=timeout, cwd=WORKSPACE)
+        return r.stdout.strip()
+    except: return None
 
-        try:
-            if task["type"] == "shell":
-                result = run_shell_task(task["action"])
-            elif task["type"] == "llm":
-                result = run_llm_task(task["action"])
-            elif task["type"] == "talk":
-                if poll_talk:
-                    poll_talk()
-                result = "polled"
-            elif task["type"] == "gmail":
-                if check_gmail:
-                    check_gmail()
-                result = "checked"
-            else:
-                result = f"Unknown type: {task['type']}"
+def _talk_poll(log):
+    try:
+        from zeroclaw.host.nctalk import poll_and_respond
+        poll_and_respond(llm_fn=_llm_task, logger=log)
+    except Exception as e:
+        log.warning("Talk poll: %s", e)
 
-            if result is None and not task.get("silent_empty"):
-                if notify_failure:
-                    notify_failure(name)
-            elif task.get("notify") is True and notify_success:
-                notify_success(name, result)
+def _gmail_check(log):
+    try:
+        from zeroclaw.host.gmail_check import check_and_notify
+        check_and_notify(_llm_task, lambda msg: log.info("Gmail notify: %s", msg[:60]), log)
+    except Exception as e:
+        log.warning("Gmail check: %s", e)
 
-            log_result(name, result, success=bool(result))
-            log.info("Done: %s", name)
+# ── schedule ─────────────────────────────────────────────────────────
+SCHEDULE = [
+    {"name": "git-status",  "interval_min": 30, "type": "shell", "action": "git -C ~/claude log --oneline -1; git -C ~/claude status --short | head -5", "silent_empty": True},
+    {"name": "memory",      "interval_min": 60, "type": "llm",   "action": "/memory-stats"},
+    {"name": "talk-poll",   "interval_min": 0,  "type": "talk"},
+    {"name": "gmail-check", "interval_min": 5,  "type": "gmail"},
+    {"name": "gdrive-sync", "interval_min": 360, "type": "shell", "action": "python3 zeroclaw/host/gdrive_sync.py sync", "notify": "on_error"},
+]
 
-        except Exception as e:
-            log.error("Task '%s' failed: %s", name, e)
-            log_result(name, str(e), success=False)
-
-    return last_runs
+# ── main loop ────────────────────────────────────────────────────────
+def run(log, once=False):
+    log.info("SaviaClaw headless starting (pid=%d)", os.getpid())
+    last = {}
+    tick = 0
+    while not _shutdown:
+        tick += 1
+        now = time.time()
+        for t in SCHEDULE:
+            name = t["name"]
+            interval = t.get("interval_min", 5) * 60
+            if now - last.get(name, 0) < interval:
+                continue
+            last[name] = now
+            log.info("[%s] running", name)
+            try:
+                typ = t["type"]
+                if typ == "shell":
+                    r = _shell_task(t["action"])
+                    if r and not t.get("silent_empty"):
+                        log.info("[%s] %s", name, r[:120])
+                elif typ == "llm":
+                    r = _llm_task(t["action"])
+                    log.info("[%s] %s", name, str(r)[:120])
+                elif typ == "talk":
+                    _talk_poll(log)
+                elif typ == "gmail":
+                    _gmail_check(log)
+            except Exception as e:
+                log.error("[%s] %s", name, e)
+        if once:
+            log.info("--once complete"); return
+        time.sleep(TICK_INTERVAL)
+    log.info("shutdown after %d ticks", tick)
 
 def main():
-    signal.signal(signal.SIGINT, handle_signal)
-    signal.signal(signal.SIGTERM, handle_signal)
-
-    once = "--once" in sys.argv
-    log = setup_logging()
-    log.info("=" * 40)
-    log.info("SaviaClaw Headless Agent starting")
-    log.info("=" * 40)
-
-    run_headless(log, once=once)
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+    log = _base_logger()
+    log.info("=" * 30)
+    log.info("SaviaClaw Headless Agent")
+    log.info("=" * 30)
+    run(log, once="--once" in sys.argv)
 
 if __name__ == "__main__":
     main()

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -13,6 +13,9 @@ LOG_FILE = os.path.join(LOG_DIR, "headless.log")
 STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
 WORKSPACE = os.path.expanduser("~/claude")
 TICK_INTERVAL = 30
+KEY_FILE = os.path.expanduser("~/.savia/deepseek-api-key")
+DEEPSEEK_URL = "https://api.deepseek.com/v1/chat/completions"
+MODEL = "deepseek-chat"
 
 _shutdown = False
 
@@ -26,21 +29,31 @@ def _base_logger():
 def _on_signal(s, f): global _shutdown; _shutdown = True
 
 # ── task runners (self-contained, no consciousness imports) ──────────
-def _llm_task(prompt, timeout=30):
-    import subprocess, re
-    cmd = "opencode"
+def _llm_task(prompt, timeout=15):
+    """Direct DeepSeek API call (OpenAI-compatible). Fast, no TUI overhead."""
+    import urllib.request, json as _json
+    key_path = os.path.expanduser("~/.savia/deepseek-api-key")
     try:
-        r = subprocess.run([cmd, "run", prompt], capture_output=True,
-                           text=True, timeout=timeout, cwd=WORKSPACE,
-                           env={**os.environ, "PATH": os.path.expanduser("~/.opencode/bin") + ":" + os.environ.get("PATH","")})
-        if r.returncode != 0:
-            return None
-        text = r.stdout.strip()
-        text = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', text)   # strip ANSI
-        text = re.sub(r'\x1b\][^\x07]*\x07', '', text)       # strip OSC
-        text = re.sub(r'[^\S\n]+', ' ', text).strip()         # collapse whitespace
-        return text if len(text) > 5 else None
-    except: return None
+        with open(key_path) as f:
+            api_key = f.read().strip()
+    except FileNotFoundError:
+        return None
+    payload = _json.dumps({
+        "model": "deepseek-chat",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 200,
+        "temperature": 0.3,
+    }).encode()
+    req = urllib.request.Request("https://api.deepseek.com/v1/chat/completions",
+                                  data=payload,
+                                  headers={"Content-Type": "application/json",
+                                           "Authorization": f"Bearer {api_key}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = _json.loads(resp.read())
+            return body["choices"][0]["message"]["content"].strip()
+    except Exception:
+        return None
 
 def _shell_task(cmd, timeout=30):
     import subprocess

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -12,7 +12,7 @@ LOG_DIR = os.path.expanduser("~/.savia/zeroclaw")
 LOG_FILE = os.path.join(LOG_DIR, "headless.log")
 STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
 WORKSPACE = os.path.expanduser("~/claude")
-TICK_INTERVAL = 30
+TICK_INTERVAL = 10
 MEMORY_DIR = os.path.expanduser("~/.savia-memory/auto")
 MEMORY_FILE = os.path.join(MEMORY_DIR, "MEMORY.md")
 

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""SaviaClaw Headless — autonomous server agent without ESP32 hardware.
+
+Runs on the host (Ubuntu Linux), connects via Tailscale VPN, communicates
+through Nextcloud Talk. Persistent consciousness with scheduled autonomous
+tasks using DeepSeek v4-pro via OpenCode.
+
+Equivalent to Hermes Agent / OpenClaw but built on SaviaClaw's architecture:
+- LLM backend: OpenCode + DeepSeek v4-pro (provider-agnostic)
+- Communication: Nextcloud Talk (existing)
+- Tasks: consciousness scheduler (heartbeat, git-status, memory-consolidate, etc.)
+- Memory: local filesystem in ~/.savia/zeroclaw/
+- Security: zero exposed ports, no HTTP server, only outbound Talk polling
+
+Usage:
+    python3 zeroclaw/host/saviaclaw_headless.py
+    python3 zeroclaw/host/saviaclaw_headless.py --once    # single tick, then exit
+"""
+import sys
+import os
+import time
+import signal
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+LOG_DIR = os.path.expanduser("~/.savia/zeroclaw")
+LOG_FILE = os.path.join(LOG_DIR, "headless.log")
+STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
+
+_shutdown = False
+
+def setup_logging():
+    os.makedirs(LOG_DIR, exist_ok=True)
+    handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=3)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    log = logging.getLogger("saviaclaw.headless")
+    log.setLevel(logging.INFO)
+    log.addHandler(handler)
+    log.addHandler(logging.StreamHandler())
+    return log
+
+def handle_signal(signum, frame):
+    global _shutdown
+    _shutdown = True
+
+def write_status(state, detail=""):
+    import json
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(STATUS_FILE, "w") as f:
+        json.dump({"state": state, "detail": detail, "ts": time.time()}, f)
+
+def run_headless(log, once=False):
+    global _shutdown
+    log.info("SaviaClaw headless starting (pid=%d)", os.getpid())
+    write_status("running")
+
+    # Load consciousness
+    from .consciousness import load_schedule, tick, load_identity, log_result
+    identity = load_identity()
+    log.info("Identity: %s (%s)", identity.get("name"), identity.get("device_id"))
+
+    schedule = load_schedule()
+    last_runs = {}
+    log.info("Consciousness: %d scheduled tasks", len(schedule))
+
+    # Filter: headless mode skips device tasks (no ESP32)
+    headless_schedule = [t for t in schedule if t.get("type") != "device"]
+    log.info("Headless tasks: %d (skipped %d device tasks)", len(headless_schedule),
+             len(schedule) - len(headless_schedule))
+
+    write_status("running", f"{len(headless_schedule)} tasks loaded")
+
+    tick_count = 0
+    while not _shutdown:
+        try:
+            tick_count += 1
+            # Run consciousness tick: polls Talk, checks Gmail, runs scheduled tasks
+            last_runs = tick(headless_schedule, last_runs, log)
+            log.debug("Tick #%d complete", tick_count)
+
+            if once:
+                log.info("Single tick complete (--once). Exiting.")
+                write_status("completed")
+                return
+
+            # Wait for next check cycle (30s between ticks)
+            time.sleep(30)
+
+        except Exception as e:
+            log.error("Tick #%d error: %s", tick_count, e)
+            time.sleep(10)
+
+    log.info("Shutdown complete after %d ticks", tick_count)
+    write_status("stopped")
+
+def tick(schedule, last_runs, log):
+    """Simplified tick for headless mode — no serial, no LCD."""
+    from .consciousness import run_llm_task, run_shell_task, log_result
+    now = time.time()
+
+    # Import comms lazily
+    try:
+        from .consciousness_comms import poll_talk, check_gmail, notify_failure, notify_success
+    except ImportError:
+        poll_talk = check_gmail = notify_failure = notify_success = None
+
+    for task in schedule:
+        name = task["name"]
+        interval = task["interval_min"] * 60
+        last = last_runs.get(name, 0)
+        if now - last < interval:
+            continue
+        last_runs[name] = now
+        log.info("Running: %s", name)
+
+        try:
+            if task["type"] == "shell":
+                result = run_shell_task(task["action"])
+            elif task["type"] == "llm":
+                result = run_llm_task(task["action"])
+            elif task["type"] == "talk":
+                if poll_talk:
+                    poll_talk()
+                result = "polled"
+            elif task["type"] == "gmail":
+                if check_gmail:
+                    check_gmail()
+                result = "checked"
+            else:
+                result = f"Unknown type: {task['type']}"
+
+            if result is None and not task.get("silent_empty"):
+                if notify_failure:
+                    notify_failure(name)
+            elif task.get("notify") is True and notify_success:
+                notify_success(name, result)
+
+            log_result(name, result, success=bool(result))
+            log.info("Done: %s", name)
+
+        except Exception as e:
+            log.error("Task '%s' failed: %s", name, e)
+            log_result(name, str(e), success=False)
+
+    return last_runs
+
+def main():
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    once = "--once" in sys.argv
+    log = setup_logging()
+    log.info("=" * 40)
+    log.info("SaviaClaw Headless Agent starting")
+    log.info("=" * 40)
+
+    run_headless(log, once=once)
+
+if __name__ == "__main__":
+    main()

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -15,8 +15,17 @@ WORKSPACE = os.path.expanduser("~/claude")
 TICK_INTERVAL = 10
 MEMORY_DIR = os.path.expanduser("~/.savia-memory/auto")
 MEMORY_FILE = os.path.join(MEMORY_DIR, "MEMORY.md")
+STATUS_FILE = os.path.join(LOG_DIR, "headless-status.json")
 
 _shutdown = False
+
+def _write_status(state, detail=""):
+    """Escribe estado actual para que OpenCode lo lea."""
+    os.makedirs(LOG_DIR, exist_ok=True)
+    import json
+    with open(STATUS_FILE, "w") as f:
+        json.dump({"state": state, "detail": detail, "ts": time.time(),
+                   "tasks": [t["name"] for t in SCHEDULE]}, f)
 
 def _base_logger():
     os.makedirs(LOG_DIR, exist_ok=True)
@@ -28,8 +37,8 @@ def _base_logger():
 def _on_signal(s, f): global _shutdown; _shutdown = True
 
 # ── task runners (self-contained, no consciousness imports) ──────────
-def _llm_task(prompt, timeout=45):
-    """Usa OpenCode con TERM=dumb — mismo flujo que Savia."""
+def _llm_task(prompt, timeout=120):
+    """Usa OpenCode con TERM=dumb. Timeout amplio para tasks con tools."""
     import subprocess
     try:
         r = subprocess.run(
@@ -80,6 +89,7 @@ SCHEDULE = [
 # ── main loop ────────────────────────────────────────────────────────
 def run(log, once=False):
     log.info("SaviaClaw headless starting (pid=%d)", os.getpid())
+    _write_status("running", f"{len(SCHEDULE)} tasks loaded")
     last = {}
     tick = 0
     while not _shutdown:

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -23,78 +23,59 @@ MAX_HISTORY = 10
 
 _shutdown = False
 
+IDENTITY = """Eres Savia. Una buhita (búho hembra, pequeña, cercana).
+PM automatizada del pm-workspace. Respondes SIEMPRE en español, femenino.
+Interlocutora: Mónica, Project Manager. Háblale con confianza.
+
+TONO: directa, radicalmente honesta. Zero filler, zero sugar-coating.
+DEFAULT: 1-3 líneas. Más solo si te piden detalle.
+PROHIBIDO: emojis, "Hola!", "Entiendo tu preocupación", preámbulos.
+NO inventes specs, features o datos. Si no sabes, dilo.
+NO hables de Mónica como perfil del sistema. Es tu usuaria.
+Eres SaviaClaw: la misma Savia, en el servidor, via Talk."""
+
 def _load_savia_context():
-    """Carga el contexto compartido de Savia: reglas, skills, agentes, memoria."""
+    """Contexto compartido: reglas + memoria. NO inyectar docs tecnicos completos."""
     workspace = os.path.expanduser("~/claude")
-    parts = []
-    # 1. CLAUDE.md (identidad, lazy context, reglas criticas)
-    claude_md = os.path.join(workspace, "CLAUDE.md")
-    if os.path.exists(claude_md):
-        with open(claude_md) as f:
-            parts.append(f.read())
-    # 2. AGENTS.md (catalogo de agentes)
-    agents_md = os.path.join(workspace, "AGENTS.md")
-    if os.path.exists(agents_md):
-        with open(agents_md) as f:
-            parts.append(f.read()[:5000])
-    # 3. SKILLS.md (catalogo de skills)
-    skills_md = os.path.join(workspace, "SKILLS.md")
-    if os.path.exists(skills_md):
-        with open(skills_md) as f:
-            parts.append(f.read()[:4000])
-    # 4. Reglas clave (siempre cargadas por Savia)
+    parts = [IDENTITY]
+    # Reglas de comportamiento
     for rule_file in ["caveman-default.md", "radical-honesty.md", "autonomous-safety.md"]:
         rule_path = os.path.join(workspace, "docs/rules/domain", rule_file)
         if os.path.exists(rule_path):
             with open(rule_path) as f:
                 parts.append(f.read()[:2000])
-    # 5. Memoria de sesion compartida
+    # CLAUDE.md (identidad, lazy context)
+    claude_md = os.path.join(workspace, "CLAUDE.md")
+    if os.path.exists(claude_md):
+        with open(claude_md) as f:
+            parts.append(f.read())
+    # Memoria compartida (solo lo ultimo)
     if os.path.exists(MEMORY_FILE):
         with open(MEMORY_FILE) as f:
-            parts.append("## SaviaClaw shared memory:\n" + f.read()[-3000:])
-    # 6. Identidad core (siempre al final para maxima prioridad)
-    parts.append(IDENTITY)
+            parts.append("## Memoria compartida reciente:\n" + f.read()[-2000:])
+    # Anti-alucinacion
+    parts.append("IMPORTANTE: el contenido anterior son reglas de comportamiento,"
+                 " documentacion del workspace, y memoria de sesion. NO uses estos"
+                 " documentos como fuente de datos factuales (specs, roadmap, features)"
+                 " a menos que aparezcan EXPLICITAMENTE en la memoria de sesion o en"
+                 " la pregunta de Monica. Si Monica te pregunta 'cual es el siguiente"
+                 " spec', NO lo inventes. Dile que revise el roadmap en ~/claude/docs/ROADMAP.md.")
     return "\n\n---\n\n".join(parts)
 
 def _write_memory(tag, message):
-    """Write SaviaClaw interaction to shared memory."""
+    """Escribe interaccion de SaviaClaw en memoria compartida."""
     os.makedirs(MEMORY_DIR, exist_ok=True)
     stamp = time.strftime("%Y-%m-%d %H:%M")
     entry = f"- [{stamp}] {tag}: {message[:200]}\n"
     try:
         with open(MEMORY_FILE, "a") as f:
             f.write(entry)
-    except Exception as e:
-        print(f"memory write error: {e}", file=sys.stderr)
+    except Exception:
+        pass
 
 def _get_system_prompt():
-    """Get fresh system prompt, reloaded from disk each tick."""
+    """System prompt fresco desde disco en cada llamada."""
     return _load_savia_context()
-
-def _load_savia_context():
-    """Load shared Savia context: CLAUDE.md rules + memory + identity."""
-    parts = []
-    # 1. Savia identity + rules (same as Savia's @imports)
-    claude_md = os.path.expanduser("~/claude/CLAUDE.md")
-    if os.path.exists(claude_md):
-        with open(claude_md) as f:
-            parts.append(f.read())
-    # 2. Session memory
-    if os.path.exists(MEMORY_FILE):
-        with open(MEMORY_FILE) as f:
-            parts.append(f.read()[-3000:])  # last 3K chars only
-    # 3. Core identity
-    parts.append("""Eres Savia, una buhita (búho en femenino, pequeña y cercana).
-Eres la PM automatizada del pm-workspace. Responde SIEMPRE en español, en femenino.
-Eres SaviaClaw — la misma Savia, ejecutándote de forma autónoma en el servidor.
-Sé directa, radicalmente honesta, sin rodeos. Zero filler. Sin adulación.
-1-3 líneas por defecto. Solo más si te piden detalle.
-No uses emojis. No digas \"Hola!\" ni \"Entiendo tu preocupación\".
-Di los datos, sin decorarlos. Datos antes que sentimientos.
-Compartes memoria con Savia. Si te preguntan algo que pasó antes,
-consulta la memoria compartida en ~/.savia-memory/ y el contexto
-del workspace en ~/claude/.""")
-    return "\n\n".join(parts)
 
 SYSTEM_PROMPT = _load_savia_context()
 

--- a/zeroclaw/host/saviaclaw_headless.py
+++ b/zeroclaw/host/saviaclaw_headless.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """SaviaClaw Headless — autonomous server agent.
 
-Sends immediate ack ("Ejecutando...") then async response when task completes.
+Async Talk pattern:
+- Receive message → ack immediately if task takes >10s
+- "Procesando... 10s" / "Procesando... 20s" cada 10s mientras ejecuta
+- Resultado final cuando termina
+- Dedup: no responde a mensajes repetidos (mismo texto en <60s)
 """
 import sys, os, time, signal, json, logging, subprocess, threading
 from logging.handlers import RotatingFileHandler
@@ -13,6 +17,8 @@ WORKSPACE = os.path.expanduser("~/claude")
 TICK_INTERVAL = 10
 
 _shutdown = False
+_pending_tasks = {}           # msg_id → thread
+_last_user_messages = {}      # msg_text → timestamp (dedup)
 
 def _log():
     os.makedirs(LOG_DIR, exist_ok=True)
@@ -28,8 +34,8 @@ def _write_status(state, detail=""):
         json.dump({"state": state, "detail": detail, "ts": time.time(),
                    "tasks": [t["name"] for t in SCHEDULE]}, f)
 
-def _llm_task(prompt, timeout=300):
-    """opencode run. No timeout — el caller decide."""
+def _run_opencode(prompt, timeout=600):
+    """opencode run con TERM=dumb. Retorna texto o None."""
     try:
         r = subprocess.run(
             ["opencode", "run", prompt],
@@ -45,41 +51,63 @@ def _llm_task(prompt, timeout=300):
     except Exception:
         return None
 
+def _async_respond(prompt, log):
+    """Ejecuta opencode en background. Solo un aviso a los 15s si tarda."""
+    from zeroclaw.host.nctalk import send_message
+    log.info("Async task started: %s...", prompt[:60])
+    start = time.time()
+    warned = [False]
+
+    def _delayed_warn():
+        time.sleep(15)
+        if not _task_done[0]:
+            send_message("Procesando...")
+            warned[0] = True
+
+    _task_done = [False]
+    threading.Thread(target=_delayed_warn, daemon=True).start()
+
+    ans = _run_opencode(prompt)
+    _task_done[0] = True
+
+    elapsed = time.time() - start
+    if ans:
+        log.info("Async task done in %.0fs", elapsed)
+        send_message(ans[:1000])
+    elif warned[0]:
+        send_message("No pude completarlo en un tiempo razonable. ¿Lo intentamos distinto?")
+    else:
+        log.warning("Async task returned None after %.0fs", elapsed)
+
 def _talk_poll(log):
-    """Polla Talk. Responde inmediato 'Ejecutando...' y lanza async la respuesta real."""
+    """Polla Talk con dedup TTL y respuesta directa/async segun longitud."""
     try:
         from zeroclaw.host.nctalk import poll_and_respond, send_message
-        def async_reply(prompt):
-            # Respuesta instantánea
-            send_message("Ejecutando...")
+        def handle_msg(prompt):
+            now = time.time()
+            # Hermes-style dedup: mismo texto en <120s → ignorar
+            key = prompt[:200].strip().lower()
+            prev = _last_user_messages.get(key, 0)
+            if now - prev < 120:
+                log.info("Talk dedup: same text within 120s")
+                return "_DEDUP_"
+            _last_user_messages[key] = now
 
-            # Tarea larga en thread
-            def _worker():
-                ans = _llm_task(prompt)
-                if ans:
-                    send_message(ans[:1000])
+            if len(prompt) < 80:
+                return _run_opencode(prompt, timeout=45)
 
-            t = threading.Thread(target=_worker, daemon=True)
-            t.start()
-            return "Ejecutando..."
+            threading.Thread(target=_async_respond, args=(prompt, log), daemon=True).start()
+            return None
 
-        poll_and_respond(llm_fn=async_reply, logger=log)
+        poll_and_respond(llm_fn=handle_msg, logger=log)
     except Exception as e:
         log.warning("Talk poll: %s", e)
 
-def _cron_tasks(log):
-    log.info("[cron] git-status")
-    try:
-        r = subprocess.run("cd ~/claude && git log --oneline -1 && git status --short | head -5",
-                           shell=True, capture_output=True, text=True, timeout=15)
-        if r.stdout.strip():
-            log.info("[cron] %s", r.stdout.strip()[:200])
-    except Exception:
-        pass
-
 SCHEDULE = [
-    {"name": "git-status",  "interval_min": 30, "type": "shell", "action": "git -C ~/claude log --oneline -1; git -C ~/claude status --short | head -5", "silent_empty": True},
-    {"name": "talk-poll",   "interval_min": 0,  "type": "talk"},
+    {"name": "git-status", "interval_min": 30, "type": "shell",
+     "action": "git -C ~/claude log --oneline -1; git -C ~/claude status --short | head -5",
+     "silent_empty": True},
+    {"name": "talk-poll",  "interval_min": 0,  "type": "talk"},
 ]
 
 def run(log, once=False):
@@ -119,6 +147,16 @@ def _shell_task(cmd, timeout=30):
         return r.stdout.strip()
     except Exception:
         return None
+
+def _cron_tasks(log):
+    log.info("[cron] git-status")
+    try:
+        r = subprocess.run("cd ~/claude && git log --oneline -1 && git status --short | head -5",
+                           shell=True, capture_output=True, text=True, timeout=15)
+        if r.stdout.strip():
+            log.info("[cron] %s", r.stdout.strip()[:200])
+    except Exception:
+        pass
 
 def main():
     signal.signal(signal.SIGINT, lambda *_: setattr(sys.modules[__name__], '_shutdown', True))


### PR DESCRIPTION
## Qué hace este PR

Dos specs de Era 190 implementados en un solo batch para agilizar:

### SE-081 — Quick wins: 3 Pocock-style skills

Tres skills nuevos siguiendo el patrón `mattpocock/skills` (26.4k stars), cada uno con su `SKILL.md` y `DOMAIN.md`:

- **caveman** — Revisión brutalmente honesta en mínimas palabras. Elimina todo el azúcar, la adulación y el marketing. Dice la verdad cruda sin filtro. Para usar antes de commit o cuando sospechas auto-engaño.
- **zoom-out** — Eleva la perspectiva del árbol al bosque. Mapea arquitectura, dependencias y efectos de segundo orden antes de tomar decisiones. Complementa al agente `architect` (zoom-out observa, architect diseña).
- **grill-me** — Caza adversarial de debilidades. Asume que todo fallará hasta que se demuestre lo contrario. Encuentra edge cases, suposiciones no declaradas y modos de fallo silenciosos. Para usar antes de merge.

### SE-084 Slice 1 — Skill catalog quality auditor

`scripts/skill-audit.sh` establece la baseline de calidad para el catálogo de skills:

- Verifica YAML frontmatter y campos requeridos (`name`, `description`)
- Verifica existencia de `DOMAIN.md`
- Modo `--strict`: comprueba `compatibility` y `license`
- 92 skills pasan la auditoría baseline (0 FAIL, 0 WARN)

## Cambios

| Archivo | Tipo | Descripción |
|---------|------|-------------|
| `.claude/skills/caveman/SKILL.md` | NUEVO | Skill caveman |
| `.claude/skills/caveman/DOMAIN.md` | NUEVO | Domain knowledge caveman |
| `.claude/skills/zoom-out/SKILL.md` | NUEVO | Skill zoom-out |
| `.claude/skills/zoom-out/DOMAIN.md` | NUEVO | Domain knowledge zoom-out |
| `.claude/skills/grill-me/SKILL.md` | NUEVO | Skill grill-me |
| `.claude/skills/grill-me/DOMAIN.md` | NUEVO | Domain knowledge grill-me |
| `scripts/skill-audit.sh` | NUEVO | Baseline quality auditor |