### PR TITLE
docs: add Rule 20b — Operational Privacy (private data stays in ~/.savia/)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d78029dbed4d5d964731e63709899a3c957daabb0a9cee0cdf151d9580b69418
-timestamp=2026-05-02T21:32:59Z
-branch=feat/era197-saviaclaw-autonomy
-head_commit=cdf778e9
-signature=32d4969a215c540870c730119d98e4a6068e4d54122006be847ff75cda7aa756
+diff_hash=263141585b79494d014772bfb23fe51ecf138a5f55112335a10c1a1bfd2e61af
+timestamp=2026-05-03T06:11:56Z
+branch=fix/rule-20b
+head_commit=dcc7ec76
+signature=c9d771b6f265d70f671f157a608007923bf7c833b41ffffdc37d835a9bb161a0

--- a/docs/rules/domain/critical-rules-extended.md
+++ b/docs/rules/domain/critical-rules-extended.md
@@ -14,6 +14,7 @@
 18. **Serializacion**: scopes antes de Agent Teams. Solapan → serializar. Hook `scope-guard.sh`
 19. **Arranque seguro**: MCP/integraciones se cargan bajo demanda, NUNCA al inicio. Savia SIEMPRE arranca.
 20. **PII-Free repo**: NUNCA nombres reales, empresas, handles ni datos personales en codigo, docs, CHANGELOG, releases, commits ni PRs. Usar genericos (`test-org`, `alice`, `test company repo`). Detalle → `@docs/rules/domain/pii-sanitization.md`
+20b. **Operational Privacy**: El repo publico contiene software general reutilizable. NUNCA datos operacionales privados: backups personales, cron jobs, systemd units con paths/usuarios concretos, emails, tokens, URLs de infraestructura privada, configuraciones de despliegue personal. Este tipo de artefactos va en `~/.savia/` (privado, fuera del repo). Si un PR introduce datos operacionales, CIERRALO y mueve los ficheros a `~/.savia/`.
 21. **Self-Improvement Loop**: Tras correccion del usuario o bug descubierto → escribir leccion en `tasks/lessons.md`. Revisar al inicio de sesion. Detalle → `@docs/rules/domain/self-improvement.md`
 22. **Verification Before Done**: NUNCA marcar tarea como completada sin prueba demostrable. Preguntarse "¿lo aprobaria un senior?" Detalle → `@docs/rules/domain/verification-before-done.md`
 23. **Equality Shield**: Asignaciones, evaluaciones y comunicaciones INDEPENDIENTES de genero, raza u origen. Test contrafactual obligatorio. Detalle → `@docs/rules/domain/equality-shield.md`


### PR DESCRIPTION
## Qué hace este PR

Añade la regla 20b a las reglas críticas extendidas.

El repositorio pm-workspace es público (MIT) y debe contener solo software general reutilizable. Esta regla prohíbe explícitamente que datos operacionales privados (backups, cron jobs, systemd units, emails, tokens, paths personales) entren al repo.

Estos artefactos van en `~/.savia/` (privado, fuera del repo).

## Cambios

| Archivo | Cambio |
|---------|--------|
| `docs/rules/domain/critical-rules-extended.md` | Añadida Rule 20b — Operational Privacy |