### PR TITLE
fix: eliminate 'mid model not found' + complete OpenCode migration gaps

### DIFF
--- a/.claude/hooks/compress-agent-output.sh
+++ b/.claude/hooks/compress-agent-output.sh
@@ -3,6 +3,8 @@
 # PostToolUse hook for Task — compresses outputs >200 tokens in active dev sessions
 # async: true — never blocks main flow
 set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../../scripts/savia-env.sh"
+export CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$SAVIA_WORKSPACE_DIR}"
 
 # Only activate in multi-agent sessions (dev-session active or SDD_COMPRESS_AGENT_OUTPUT)
 SESSION_STATE_DIR="output/dev-sessions"
@@ -46,10 +48,11 @@ mkdir -p "$RAW_DIR"
 RAW_FILE="$RAW_DIR/${TS}.txt"
 echo "$TOOL_OUTPUT" > "$RAW_FILE"
 
-# Generate compressed bullets via Claude haiku (speed over quality)
+# Generate compressed bullets via fast-tier model (speed over quality)
+FAST_MODEL="$(savia_resolve_model fast 2>/dev/null || echo "fast")"
 BULLETS=$(echo "$TOOL_OUTPUT" | \
     claude -p "Compress this agent output to 5-8 structured bullet points. Include: action taken, files modified, key decisions/errors, state for next agent. Be concrete. Output ONLY the bullets, no preamble." \
-    --model claude-haiku-4-5-20251001 2>/dev/null || \
+    --model "$FAST_MODEL" 2>/dev/null || \
     echo "- Output compressed (raw saved to $RAW_FILE)")
 
 WORD_COUNT=$(echo "$BULLETS" | wc -w)

--- a/.claude/skills/pr-agent-judge/SKILL.md
+++ b/.claude/skills/pr-agent-judge/SKILL.md
@@ -52,7 +52,7 @@ Salida JSON compatible con formato Court:
 
 - [pr-agent](https://github.com/qodo-ai/pr-agent) instalado: `pip install pr-agent` o Docker
 - `GITHUB_TOKEN` env var (para acceder al PR)
-- Anthropic API key o compatible (`PR_AGENT_MODEL` en pm-config.md)
+- Anthropic API key o compatible (`PR_AGENT_MODEL` en pm-config.md). Por defecto resuelto via tier: `mid` → `~/.savia/preferences.yaml` model_mid.
 
 Si `pr-agent` no está instalado, el wrapper **falla gracefully** reportando `{"status":"SKIPPED","reason":"pr-agent not installed"}` sin bloquear al Court.
 
@@ -61,7 +61,7 @@ Si `pr-agent` no está instalado, el wrapper **falla gracefully** reportando `{"
 ```
 COURT_INCLUDE_PR_AGENT   = false        # default opt-in
 PR_AGENT_VERSION         = "0.27"       # pin
-PR_AGENT_MODEL           = "claude-sonnet-4-6"
+PR_AGENT_MODEL           = "mid"        # tier, resuelto via preferences.yaml
 PR_AGENT_MAX_LINES       = 1000         # evita token blowout
 ```
 

--- a/.claude/skills/spec-driven-development/references/agent-invocation.md
+++ b/.claude/skills/spec-driven-development/references/agent-invocation.md
@@ -14,8 +14,9 @@ El agente necesita acceso a:
 ## 3.2 Prompt de invocación para `agent-single`
 
 ```bash
-# Invocar Claude Code como subagente
-claude --model $CLAUDE_MODEL_AGENT \
+# Invocar Claude Code como subagente (modelo resuelto via tier)
+HEAVY_MODEL="$(savia_resolve_model heavy)"  # o: source scripts/savia-env.sh primero
+claude --model "$HEAVY_MODEL" \
   --system-prompt "$(cat projects/{proyecto}/CLAUDE.md)" \
   --max-turns 30 \
   "Implementa la siguiente Spec exactamente como se describe.
@@ -41,13 +42,15 @@ Para tasks grandes, se lanza un equipo de agentes con roles distintos:
 
 ```bash
 # Agente 1: Implementador — escribe el código de producción
-claude --model $CLAUDE_MODEL_AGENT \
+HEAVY_MODEL="$(savia_resolve_model heavy)"
+claude --model "$HEAVY_MODEL" \
   --system-prompt "Eres un implementador senior .NET. Tu único rol es implementar el código de producción de la Spec, sin escribir tests." \
   "$(cat {spec_file})" &
 PID_IMPL=$!
 
 # Agente 2: Tester — escribe los tests (puede ejecutarse en paralelo)
-claude --model $CLAUDE_MODEL_FAST \
+FAST_MODEL="$(savia_resolve_model fast)"
+claude --model "$FAST_MODEL" \
   --system-prompt "Eres un QA engineer senior. Tu único rol es escribir los tests descritos en la Spec." \
   "$(cat {spec_file})" &
 PID_TEST=$!
@@ -55,7 +58,8 @@ PID_TEST=$!
 wait $PID_IMPL $PID_TEST
 
 # Agente 3: Reviewer — revisa el output de los dos anteriores (secuencial)
-claude --model $CLAUDE_MODEL_AGENT \
+HEAVY_MODEL="$(savia_resolve_model heavy)"
+claude --model "$HEAVY_MODEL" \
   --system-prompt "Eres un Tech Lead revisando código. Verifica que la implementación cumple la Spec. Reporta discrepancias sin modificar código." \
   "Revisa los ficheros creados por el implementador y el tester contra esta Spec: $(cat {spec_file})"
 ```
@@ -117,12 +121,13 @@ find projects/{proyecto}/agent-notes -name "{ticket}-*" | sort
 ## Selección del Modelo por Task
 
 ```
-Tamaño de Task | Modelo | Razonamiento
----|---|---
-< 2h (DTOs, validators, boilerplate) | Haiku 4.5 | Costo mínimo, suficiente precisión
-2-6h (handlers, servicios, components) | Sonnet 4.6 | Balance costo/capacidad
-> 6h (sistemas complejos, integraciones) | Opus 4.6 | Máxima capacidad de razonamiento
+Tamaño de Task | Tier | Razonamiento
+---|---|---|---
+< 2h (DTOs, validators, boilerplate) | fast | Costo mínimo, suficiente precisión
+2-6h (handlers, servicios, components) | mid | Balance costo/capacidad
+> 6h (sistemas complejos, integraciones) | heavy | Máxima capacidad de razonamiento
 ```
+(Tiers resueltos via `savia_resolve_model` contra `~/.savia/preferences.yaml` al runtime)
 
 ---
 

--- a/.claude/skills/spec-driven-development/references/agent-team-patterns.md
+++ b/.claude/skills/spec-driven-development/references/agent-team-patterns.md
@@ -33,7 +33,8 @@ BASE="projects/{proyecto}"
 SPEC_FILE="$BASE/specs/{sprint}/{spec_filename}.spec.md"
 LOG_FILE="output/agent-runs/$(date +%Y%m%d-%H%M%S)-{task_id}-single.log"
 
-claude --model claude-opus-4-7 \
+HEAVY_MODEL="$(savia_resolve_model heavy)"
+claude --model "$HEAVY_MODEL" \
   --system-prompt "$(cat $BASE/CLAUDE.md)" \
   --max-turns 40 \
   "Implementa la siguiente Spec exactamente como se describe.
@@ -79,7 +80,7 @@ SPEC_FILE="$BASE/specs/{sprint}/{spec_filename}.spec.md"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 # Agente 1: Implementador — solo código de producción, sin tests
-claude --model claude-opus-4-7 \
+claude --model $(savia_resolve_model heavy) \
   --system-prompt "Eres un desarrollador .NET 8 senior especializado en Clean Architecture y CQRS.
 Tu único rol es implementar el código de PRODUCCIÓN de la Spec:
 - Ficheros en src/ (NO tests/)
@@ -93,7 +94,7 @@ $(cat $BASE/CLAUDE.md)" \
 PID_IMPL=$!
 
 # Agente 2: Tester — solo tests, usando la interfaz definida en la Spec
-claude --model claude-haiku-4-5-20251001 \
+claude --model $(savia_resolve_model fast) \
   --system-prompt "Eres un QA engineer senior especializado en .NET y xUnit.
 Tu único rol es escribir los TESTS descritos en la Spec:
 - Ficheros en tests/ (NO src/)
@@ -155,7 +156,7 @@ wait $PID_IMPL $PID_TEST
 IMPL_LOG="output/agent-runs/${TIMESTAMP}-{task_id}-implementador.log"
 TEST_LOG="output/agent-runs/${TIMESTAMP}-{task_id}-tester.log"
 
-claude --model claude-opus-4-7 \
+claude --model $(savia_resolve_model heavy) \
   --system-prompt "Eres un Tech Lead .NET revisando código generado por agentes IA.
 Tu rol es SOLO revisar y reportar — NO modificar código.
 Busca específicamente:
@@ -240,7 +241,7 @@ for ROLE in "api" "application" "infrastructure" "tests"; do
       ;;
   esac
 
-  claude --model claude-opus-4-7 \
+  claude --model $(savia_resolve_model heavy) \
     --system-prompt "$SYSTEM_PROMPT. $ROLE_PROMPT" \
     "$(cat $SPEC_FILE)" \
     2>&1 | tee "output/agent-runs/${TIMESTAMP}-{task_id}-${ROLE}.log" &
@@ -281,7 +282,7 @@ for SPEC_FILE in $SPRINT_DIR/*.spec.md; do
   fi
 
   echo "🚀 Lanzando agente para: $SPEC_BASENAME"
-  claude --model claude-opus-4-7 \
+  claude --model $(savia_resolve_model heavy) \
     --system-prompt "$(cat $BASE/CLAUDE.md)" \
     --max-turns 30 \
     "Implementa esta Spec exactamente. No tomes decisiones fuera de la Spec.
@@ -311,7 +312,7 @@ Cuando dos agentes modifican el mismo fichero (ej: `DependencyInjection.cs`), pu
 **Opción B — Merge post-ejecución:**
 ```bash
 # Después de que todos los agentes terminen, un agente merger resuelve conflictos
-claude --model claude-haiku-4-5-20251001 \
+claude --model $(savia_resolve_model fast) \
   "Revisa los siguientes ficheros que han sido creados por múltiples agentes
    y fusiona los cambios en DependencyInjection.cs sin perder registros de ningún agente:
 
@@ -343,7 +344,7 @@ output/agent-runs/
 TIMESTAMP="20260404-143022"
 TASK_ID="AB1234"
 
-claude --model claude-haiku-4-5-20251001 \
+claude --model $(savia_resolve_model fast) \
   "Analiza los siguientes logs de ejecución de agentes y genera un resumen en formato markdown:
    - Estado de cada agente (completado/bloqueado/error)
    - Ficheros creados/modificados
@@ -369,8 +370,8 @@ cat "output/agent-runs/${TIMESTAMP}-${TASK_ID}-summary.md"
 | `full-stack` | 4 | 25-40 c/u | ~180K total | ~90K total | ~$1.80 |
 | `parallel-handlers` (5 specs) | 5 | 20-30 c/u | ~200K total | ~120K total | ~$2.50 |
 
-*Estimaciones con claude-opus-4-7 a $15/MTok input, $75/MTok output.
-El patrón `tester` usa claude-haiku que es ~20x más barato.*
+*Estimaciones con $(savia_resolve_model heavy) a $15/MTok input, $75/MTok output.
+El patrón `tester` usa fast-tier que es ~20x más barato.*
 
 ---
 

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2cbdf17443249c0bf36f5b59fa44af7b6e36561ad2a0dcd1f2674db2f7dce113
-timestamp=2026-05-04T07:04:07Z
-branch=feature/spec-127-tier-models
-head_commit=cc781f50
-signature=87fd37aee2b13e1e7611b2513f3e2bc232b602643cfd5a6b0ebd2987c7a4e56e
+diff_hash=05018c67a74ac00f21bb433834b35c93a747fed865b6170cdc6928cd5b802fc3
+timestamp=2026-05-04T10:37:17Z
+branch=main
+head_commit=e5ece620
+signature=61da2eb654f0e9f92ffc359b470ca44934d326179a05ce995982f900b550a0d2

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2d55f339f7ebe0d3d4e80badf6b7772932c4d42a7aaa52a68a2831eb6d1620a8
-timestamp=2026-05-04T10:47:37Z
+diff_hash=4643096bd8cd341d7aae26b89b181337ae19708b3a7ef201cc07bb371589a1dc
+timestamp=2026-05-04T11:18:24Z
 branch=fix/mid-model-not-found-opencode-migration
-head_commit=e345aa06
-signature=640d0ba4bd5a8182daf9fdf58446766a473fcaa0b2a9c266ef48e2ede8dbcd68
+head_commit=0b3858ef
+signature=21e770119ebd6fbaacba6cca242d7a14306cd98221e9994078e325d773bb9f46

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=05018c67a74ac00f21bb433834b35c93a747fed865b6170cdc6928cd5b802fc3
-timestamp=2026-05-04T10:37:17Z
-branch=main
-head_commit=e5ece620
-signature=61da2eb654f0e9f92ffc359b470ca44934d326179a05ce995982f900b550a0d2
+diff_hash=2d55f339f7ebe0d3d4e80badf6b7772932c4d42a7aaa52a68a2831eb6d1620a8
+timestamp=2026-05-04T10:47:37Z
+branch=fix/mid-model-not-found-opencode-migration
+head_commit=e345aa06
+signature=640d0ba4bd5a8182daf9fdf58446766a473fcaa0b2a9c266ef48e2ede8dbcd68

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+- fork-agents.sh: tier names (heavy/mid/fast) resolved to provider model ID before passing to Claude CLI, fixing "mid, model not found" error.
+- compress-agent-output.sh: vendor model replaced with `$(savia_resolve_model fast)` tier resolution.
+- agent-invocation.md, agent-team-patterns.md: vendor model names replaced with tier resolution calls.
+- pr-agent-judge/SKILL.md: PR_AGENT_MODEL default now 'mid' tier instead of hardcoded vendor model.
+
 ## [6.14.1] — 2026-05-02
 
 Era 64 — Provider-agnostic hardening: API endpoints, hooks audit, docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [Unreleased] — 2026-05-04
 
 ### Fixed
 - fork-agents.sh: tier names (heavy/mid/fast) resolved to provider model ID before passing to Claude CLI, fixing "mid, model not found" error.

--- a/scripts/fork-agents.sh
+++ b/scripts/fork-agents.sh
@@ -32,6 +32,20 @@ if [[ -f "${SCRIPT_DIR}/savia-env.sh" ]]; then
 fi
 readonly DEFAULT_MODEL="${SAVIA_MODEL_MID:-deepseek/deepseek-chat}"
 
+# Resolve tier names (heavy/mid/fast) or legacy short names (sonnet/opus/haiku)
+# to the user's provider model ID via ~/.savia/preferences.yaml.
+resolve_fork_model() {
+  local raw="$1"
+  case "$raw" in
+    heavy|mid|fast|opus|sonnet|haiku)
+      savia_resolve_model "$raw" 2>/dev/null || echo "$raw"
+      ;;
+    *)
+      echo "$raw"
+      ;;
+  esac
+}
+
 # Context windows por modelo (tokens). 80% = limite para prefijo.
 # Key convention: CTX_<model_with_underscores>. Falls back to 200000 token default.
 readonly CTX_claude_sonnet_4_6=200000
@@ -294,6 +308,8 @@ generate_summary() {
 # ── Main ──────────────────────────────────────────────────────────────────────
 main() {
   parse_args "$@"
+  # Resolve tier names (heavy/mid/fast) to provider model ID
+  MODEL="$(resolve_fork_model "$MODEL")"
 
   # --verify-cache: solo imprime hash y sale
   if [[ "${VERIFY_CACHE}" == "true" ]]; then


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR elimina el error "mid, model not found" que aparecía cuando scripts como `fork-agents.sh` recibían un tier name (heavy/mid/fast) sin resolverlo a un modelo real del proveedor. También completa la migración de la documentación de skills y referencias que todavía mencionaban modelos de un proveedor concreto.

Si usabas `fork-agents.sh --model mid` o cualquier script que pasara tier names al CLI de Claude, ahora funcionan correctamente: el tier se resuelve automáticamente contra tu fichero `~/.savia/preferences.yaml` antes de llegar al CLI.

Además, toda la documentación de SDD (agent-invocation, agent-team-patterns, pr-agent-judge) ya no menciona modelos de Anthropic como valores por defecto, sino que enseña a usar `savia_resolve_model()` para resolver tiers al runtime.

El riesgo es mínimo: los cambios son aditivos (nueva función `resolve_fork_model` en fork-agents) o documentales. Si tu `preferences.yaml` está mal configurado, el fallback devuelve el tier name tal cual (comportamiento anterior).

## Summary

fix: eliminate 'mid model not found' + vendor model refs in scripts/skills

### Changes
- fork-agents.sh: add resolve_fork_model() to resolve tier names to provider IDs
- compress-agent-output.sh: source savia-env.sh + tier resolution
- agent-invocation.md: replace legacy config constants with tier resolution
- agent-team-patterns.md: replace all vendor model names with tier resolution
- pr-agent-judge/SKILL.md: PR_AGENT_MODEL default now 'mid' tier

### Type of contribution
- [x] Bug fix ('mid, model not found' error)
- [x] Documentation improvement (vendor-neutral skill docs)

### How to test
1. `source scripts/savia-env.sh && savia_resolve_model mid` → returns provider model ID
2. `bash scripts/fork-agents.sh --help` → works, shows usage
3. `bash scripts/opencode-migration-smoke.sh` → 6/6 PASS
4. `bash scripts/hook-latency-bench.sh --iterations 1 --threshold 200 --strict` → 67 hooks, 0 slow

## Test plan
- [x] Hook latency: 67/67, 0 slow
- [x] Model resolution: heavy/mid/fast/sonnet/opus → deepseek-v4-pro
- [x] OpenCode migration smoke: 6/6 PASS (v1.14.33, 73 agents, 557 commands)
- [ ] BATS Hook Tests (CI)