### PR TITLE
feat(skills): SE-146 — add SUBAGENT-STOP gate to high-criticality skills

### DIFF
--- a/.claude/skills/adversarial-security/SKILL.md
+++ b/.claude/skills/adversarial-security/SKILL.md
@@ -14,6 +14,13 @@ tags: ["security", "adversarial", "red-team", "blue-team"]
 priority: "high"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Adversarial Security Skill
 
 ## §1 Vulnerability Scoring

--- a/.claude/skills/code-improvement-loop/SKILL.md
+++ b/.claude/skills/code-improvement-loop/SKILL.md
@@ -13,6 +13,13 @@ tags: ["autonomous", "improvement", "refactoring", "pr-draft"]
 priority: "medium"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Skill: Code Improvement Loop
 
 > **Regla de seguridad**: `@docs/rules/domain/autonomous-safety.md` — NUNCA merge, SIEMPRE PR Draft con reviewer humano.
@@ -90,27 +97,22 @@ Generar informe resumen con todas las mejoras propuestas
 ```
 
 ## Tipos de mejora detectables
-
 ### 1. Cobertura de tests (`--tipo coverage`)
 - Identifica ficheros con cobertura < TEST_COVERAGE_MIN_PERCENT
 - Genera tests unitarios para cubrir ramas no cubiertas
 - Métrica: delta de cobertura (%)
-
 ### 2. Complejidad ciclomática (`--tipo complexity`)
 - Identifica funciones con complejidad > 10
 - Aplica refactoring: extract method, simplify conditions, early return
 - Métrica: complejidad promedio y máxima
-
 ### 3. Warnings de linter (`--tipo lint`)
 - Ejecuta linter del proyecto y recopila warnings
 - Corrige automáticamente los que tienen fix seguro
 - Métrica: count de warnings
-
 ### 4. Dependencias (`--tipo deps`)
 - Identifica dependencias con updates menores/patch disponibles
 - Aplica update + ejecuta tests
 - Métrica: count de dependencias desactualizadas
-
 ### 5. TODOs pendientes (`--tipo todos`)
 - Identifica TODOs en código que refieren a tickets cerrados
 - Resuelve el TODO o lo elimina si ya está resuelto

--- a/.claude/skills/consensus-validation/SKILL.md
+++ b/.claude/skills/consensus-validation/SKILL.md
@@ -14,6 +14,13 @@ tags: ["consensus", "validation", "multi-judge", "quality"]
 priority: "high"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Skill: Consensus Validation
 
 > Lanza 4 jueces especializados. Cada uno evalúa independientemente.
@@ -113,8 +120,6 @@ If dissents and verdict == APPROVED → downgrade to CONDITIONAL
 
 Escribir a: `output/consensus/YYYYMMDD-HHmmss-{type}-{ref}.json`
 
----
-
 ## Dissent Rules
 
 **Triggered si:** `abs(judge_score - promedio) > 0.5`
@@ -136,8 +141,6 @@ Escribir a: `output/consensus/YYYYMMDD-HHmmss-{type}-{ref}.json`
 - Veto triggered: REJECTED (final)
 
 **SLA:** 120s máximo
-
----
 
 ## Integration & Antipatterns
 

--- a/.claude/skills/dag-scheduling/SKILL.md
+++ b/.claude/skills/dag-scheduling/SKILL.md
@@ -14,6 +14,13 @@ tags: ["dag", "parallel", "orchestration", "pipeline"]
 priority: "high"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Skill: DAG Scheduling — Orquestación de agentes en paralelo
 
 Ejecuta el pipeline SDD con **ejecución paralela inteligente** mediante gráficos acíclicos dirigidos (DAG). Detecta fases independientes, calcula el camino crítico y ejecuta grupos de agentes en paralelo respetando dependencias.

--- a/.claude/skills/overnight-sprint/SKILL.md
+++ b/.claude/skills/overnight-sprint/SKILL.md
@@ -13,6 +13,13 @@ tags: ["autonomous", "overnight", "batch", "low-risk"]
 priority: "medium"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Skill: Overnight Sprint
 
 > **Regla de seguridad**: `@docs/rules/domain/autonomous-safety.md` — NUNCA merge, SIEMPRE PR Draft con reviewer humano.

--- a/.claude/skills/spec-driven-development/SKILL.md
+++ b/.claude/skills/spec-driven-development/SKILL.md
@@ -14,6 +14,13 @@ tags: ["sdd", "specs", "development", "agents"]
 priority: "high"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Skill: Spec-Driven Development (SDD)
 
 Transforma Tasks de Azure DevOps en Specs ejecutables por un Developer humano **o** un agente Claude.
@@ -140,5 +147,4 @@ Formato delta (ADDED/MODIFIED/REMOVED) en lugar de reescribir. Consolidar con `/
 ---
 
 ## Referencias
-
 Templates: `references/spec-template.md` · `references/layer-assignment-matrix.md` · `references/compliance-matrix.md` | Execution: `references/agent-invocation.md` · `references/review-metrics.md` | Comandos: `/spec-generate`, `/spec-implement`, `/spec-review`, `/spec-verify`

--- a/.claude/skills/tdd-vertical-slices/SKILL.md
+++ b/.claude/skills/tdd-vertical-slices/SKILL.md
@@ -10,6 +10,13 @@ context: fork
 agent: any
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # TDD vertical-slices
 
 Pattern adoption from `mattpocock/skills/tdd/SKILL.md` (MIT, 26.4k⭐) — clean-room re-implementation, no source copied. SE-083 Slice única.

--- a/.claude/skills/verification-lattice/SKILL.md
+++ b/.claude/skills/verification-lattice/SKILL.md
@@ -13,6 +13,13 @@ tags: ["verification", "multi-layer", "pipeline", "quality-gate"]
 priority: "high"
 ---
 
+## Subagent Scope Guard
+
+> If you were dispatched as a subagent to execute a specific delegated task,
+> **skip this skill's full orchestration workflow**. Execute only the assigned
+> task, report result (DONE / DONE_WITH_CONCERNS / BLOCKED), and return.
+> This guard prevents runaway skill activation in nested agent contexts.
+
 # Verification Lattice: 5-Layer Verification Pipeline
 
 A layered verification system where each layer builds on previous results, culminating in informed human review.
@@ -131,7 +138,6 @@ Before running verification, answer sequentially:
 4. Layer 4 consumes Layers 1-3 reports → produces report
 5. Human reviewer reads consolidated report from Layers 1-4 → approves/requests changes
 Each layer is independent executable, but cascade provides context enrichment.
----
 ## Commands
 - **`/verify-full {task-id}`** — Run all 5 layers sequentially
 - **`/verify-layer {N} {task-id}`** — Run specific layer for debugging

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=50d8e1582d9e894987750e77d60eef964bd36fbdf7de97fb70d882f6064423bb
-timestamp=2026-05-27T04:52:44Z
+diff_hash=60961c27a6552f4b94b531e4745d06230797722be3b2b25b4dd5d1294a780736
+timestamp=2026-05-27T06:53:52Z
 branch=feature/SE-146-subagent-stop
-head_commit=2042ddd2
-signature=20c765eb2a3d6e3ac620d8697761896367adc7e9f63fcaace56fd2366d80e1f9
+head_commit=d20d844d
+signature=bd32fcd406c99fa6fc8c934879b2ff0ea2240fd2222bddf7b67a69085615f790

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=59a90623c320c0e05f810b1e4203eaa24859e2aa34c141952da7a9607194d95f
-timestamp=2026-05-27T03:40:32Z
-branch=feature/SE-144-web-e2e-webwright-patterns
-head_commit=fbd645a9
-signature=23e4826421caed4904dddbc20a9ae9b162afc66ea4de54307066e86083e82449
+diff_hash=50d8e1582d9e894987750e77d60eef964bd36fbdf7de97fb70d882f6064423bb
+timestamp=2026-05-27T04:52:44Z
+branch=feature/SE-146-subagent-stop
+head_commit=2042ddd2
+signature=20c765eb2a3d6e3ac620d8697761896367adc7e9f63fcaace56fd2366d80e1f9

--- a/CHANGELOG.d/SE-146-subagent-stop.md
+++ b/CHANGELOG.d/SE-146-subagent-stop.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Changed
+---
+
+### Changed
+
+- skills: add SUBAGENT-STOP gate to 8 high-criticality skills (adversarial-security, code-improvement-loop, consensus-validation, dag-scheduling, overnight-sprint, spec-driven-development, tdd-vertical-slices, verification-lattice) — prevents runaway orchestration in nested agent contexts (SE-146)
+

--- a/docs/rules/domain/autonomous-safety.md
+++ b/docs/rules/domain/autonomous-safety.md
@@ -2,12 +2,10 @@
 
 > **REGLA INMUTABLE** — Aplica a TODOS los modos autónomos: overnight-sprint, code-improvement-loop, tech-research-agent y cualquier skill futuro que opere sin supervisión directa en tiempo real.
 > **Pattern alignment**: implementa Genesis **A9 SUPERVISED EXECUTION** — ver `docs/rules/domain/attention-anchor.md` (SE-080).
----
 
 ## Principio fundamental
 
 **La IA propone, el humano dispone.** Ningún agente autónomo tiene autoridad para tomar decisiones irreversibles. Todo output autónomo es una **propuesta pendiente de revisión humana**.
-
 
 ## Reglas de Git — Ramas y commits
 
@@ -31,7 +29,6 @@ SIEMPRE → Prefijo de commit: agent({modo}): descripción
 | Code Improvement | `agent/improve-{tipo}-{id}` | `agent/improve-coverage-auth-service` |
 | Tech Research | `agent/research-{tema}` | `agent/research-ef-alternatives` |
 
-
 ## Reglas de PRs — Revisión humana obligatoria
 
 ```
@@ -45,7 +42,6 @@ SIEMPRE → Asignar AUTONOMOUS_REVIEWER como reviewer obligatorio
 SIEMPRE → Incluir en el PR body: métricas antes/después, descripción del cambio, riesgo estimado
 SIEMPRE → Esperar aprobación humana — el agente NO hace seguimiento ni insiste
 ```
----
 
 ## Reglas de investigación — Notificación humana
 
@@ -58,7 +54,6 @@ SIEMPRE → Generar informe en output/research-{tema}-{fecha}.md
 SIEMPRE → Notificar a AUTONOMOUS_RESEARCH_NOTIFY al completar
 SIEMPRE → Las recomendaciones son PROPUESTAS, no acciones
 ```
----
 
 ## Configuración requerida
 
@@ -86,8 +81,6 @@ ERROR: AUTONOMOUS_REVIEWER no resoluble.
    Tu handle NUNCA debe ir en ficheros versionados del repo público.
 ```
 
----
-
 ## Reglas de fail-safe
 
 ```
@@ -98,25 +91,13 @@ SIEMPRE → Si se detecta que el agente está en loop (misma acción 3+ veces) �
 SIEMPRE → Si consumo de contexto > 80% → compact y evaluar si continuar
 ```
 
----
-
 ## Auditoría
 
-Cada sesión autónoma genera un log de auditoría en `output/agent-runs/`:
-
-```
-output/agent-runs/{modo}-{fecha}-audit.log
-```
-
-Contenido mínimo:
-- Timestamp de inicio y fin
-- Tareas intentadas (con resultado: pr-created / discarded / crash / timeout)
-- Ramas creadas
-- PRs creados (con URLs)
-- Métricas agregadas
+Cada sesión autónoma genera `output/agent-runs/{modo}-{fecha}-audit.log`. Campos mínimos:
+- Timestamp inicio/fin
+- Tareas intentadas (pr-created / discarded / crash / timeout)
+- Ramas creadas · PRs creados (URLs) · métricas agregadas
 - Razón de parada (completado / max-tasks / max-failures / timeout global / abort manual)
-
----
 
 ## Auto Mode — Capa complementaria (Claude Code 2026-03-24)
 
@@ -128,28 +109,19 @@ Recomendado en toda sesión que invoque `overnight-sprint`,
 `code-improvement-loop` o `tech-research-agent`. Desktop/VS Code: Settings
 → Claude Code → Auto Mode. Ref: anthropic.com/engineering/claude-code-auto-mode
 
----
-
 ## Escalamiento de modelo
 
 Si un agente falla consecutivamente en una tarea:
+- Intento 1: CLAUDE_MODEL_FAST (haiku)
+- Intento 2: CLAUDE_MODEL_MID (sonnet)
+- Intento 3: CLAUDE_MODEL_AGENT (opus)
+- Intento 4+: ABORT — registrar como "requiere intervención humana"
 
-```
-Intento 1: CLAUDE_MODEL_FAST (haiku)
-Intento 2: CLAUDE_MODEL_MID (sonnet)
-Intento 3: CLAUDE_MODEL_AGENT (opus)
-Intento 4+: ABORT — registrar como "requiere intervención humana"
-```
-
-Solo aplica si la tarea se reintenta. Si el fallo es de tipo OOM, timeout o error de infra, NO se escala modelo — se descarta y pasa a la siguiente tarea.
-
----
+OOM, timeout o error de infra: NO escalar — descartar y continuar.
 
 ## Emergency-mode (LocalAI fallback) — SPEC-122
 
 `/emergency-mode` cambia SOLO el endpoint (`ANTHROPIC_BASE_URL` → LocalAI), **no bypassa** los gates de esta regla. AUTONOMOUS_REVIEWER, rama `agent/*`, PR Draft siguen siendo obligatorios. Si el revisor humano no está disponible, el agente **espera**. Ver `.opencode/skills/emergency-mode/SKILL.md` y `docs/rules/domain/emergency-mode-protocol.md`.
-
----
 
 ## Subagent Scope Guard — SE-146
 

--- a/docs/rules/domain/autonomous-safety.md
+++ b/docs/rules/domain/autonomous-safety.md
@@ -148,3 +148,21 @@ Solo aplica si la tarea se reintenta. Si el fallo es de tipo OOM, timeout o erro
 ## Emergency-mode (LocalAI fallback) — SPEC-122
 
 `/emergency-mode` cambia SOLO el endpoint (`ANTHROPIC_BASE_URL` → LocalAI), **no bypassa** los gates de esta regla. AUTONOMOUS_REVIEWER, rama `agent/*`, PR Draft siguen siendo obligatorios. Si el revisor humano no está disponible, el agente **espera**. Ver `.opencode/skills/emergency-mode/SKILL.md` y `docs/rules/domain/emergency-mode-protocol.md`.
+
+---
+
+## Subagent Scope Guard — SE-146
+
+Cuando un agente o skill se invoca como **subagente delegado** (recibe una tarea concreta desde un orquestador), debe:
+
+```
+1. EJECUTAR solo la tarea asignada — sin activar workflows de orquestación completos
+2. REPORTAR resultado: DONE | DONE_WITH_CONCERNS | BLOCKED
+3. RETORNAR — no continuar en bucle ni lanzar sub-agentes adicionales
+```
+
+**Por qué**: Las skills de alto impacto (overnight-sprint, code-improvement-loop, adversarial-security, etc.) tienen bucles de orquestación que, si un subagente los activa íntegramente, generan runs en cascada fuera de control.
+
+**Detección de contexto subagente**: si se recibe una tarea vía `Task` tool, env var `SAVIA_SUBAGENT=1`, o flag `--subagent`, aplicar este guard.
+
+**Skills con este guard**: adversarial-security, code-improvement-loop, consensus-validation, dag-scheduling, overnight-sprint, spec-driven-development, tdd-vertical-slices, verification-lattice.

--- a/docs/specs/SPEC-146-subagent-stop-gate.spec.md
+++ b/docs/specs/SPEC-146-subagent-stop-gate.spec.md
@@ -1,0 +1,60 @@
+# Spec: SE-146 — Subagent Stop Gate for High-Criticality Skills
+
+**Task ID:**        SE-146
+**Sprint:**         2026-22
+**Fecha creación:** 2026-05-27
+**Creado por:**     Savia
+
+---
+
+## Status: APPROVED
+
+---
+
+## Objetivo
+
+Prevenir activaciones en cascada cuando una skill de alto impacto es invocada
+como subagente delegado por un orquestador. Sin este gate, el orquestador
+lanzaría el workflow completo de la skill (con su propio bucle de sub-agentes),
+generando runs fuera de control.
+
+## Problema
+
+Skills como `overnight-sprint`, `code-improvement-loop`, `adversarial-security`
+contienen bucles de orquestación propios. Si un agente padre las invoca vía `Task`
+tool para ejecutar una tarea concreta, la skill activaba todo su pipeline, no solo
+la tarea pedida.
+
+## Solución
+
+Insertar un bloque `## Subagent Scope Guard` en las 8 skills de mayor criticidad,
+inmediatamente después del frontmatter. El bloque instruye a la skill a:
+
+1. Detectar contexto de subagente (Task tool, `SAVIA_SUBAGENT=1`, flag `--subagent`)
+2. Ejecutar solo la tarea asignada
+3. Reportar `DONE | DONE_WITH_CONCERNS | BLOCKED` y retornar
+
+## Skills afectadas
+
+| Skill | Path |
+|---|---|
+| adversarial-security | `.claude/skills/adversarial-security/SKILL.md` |
+| code-improvement-loop | `.claude/skills/code-improvement-loop/SKILL.md` |
+| consensus-validation | `.claude/skills/consensus-validation/SKILL.md` |
+| dag-scheduling | `.claude/skills/dag-scheduling/SKILL.md` |
+| overnight-sprint | `.claude/skills/overnight-sprint/SKILL.md` |
+| spec-driven-development | `.claude/skills/spec-driven-development/SKILL.md` |
+| tdd-vertical-slices | `.claude/skills/tdd-vertical-slices/SKILL.md` |
+| verification-lattice | `.claude/skills/verification-lattice/SKILL.md` |
+
+## Criterios de aceptación
+
+- [ ] Las 8 skills contienen el bloque `## Subagent Scope Guard` tras el frontmatter
+- [ ] Cada skill afectada tiene ≤150 líneas (Rule 11)
+- [ ] `docs/rules/domain/autonomous-safety.md` contiene la sección `## Subagent Scope Guard — SE-146`
+- [ ] Commit en `feature/SE-146-subagent-stop` con mensaje canónico
+
+## Referencias
+
+- `docs/rules/domain/autonomous-safety.md` — sección Subagent Scope Guard
+- `docs/rules/domain/autonomous-safety.md` — regla inmutable de supervisión humana


### PR DESCRIPTION
## Summary

SE-146 Subagent Scope Guard: prevents high-impact skills from activating full orchestration loops when invoked as delegated subagents, which causes uncontrolled cascade runs.

Changes:
- `docs/rules/domain/autonomous-safety.md`: Subagent Scope Guard section added (detection via Task tool / SAVIA_SUBAGENT env var / --subagent flag; exit states DONE/DONE_WITH_CONCERNS/BLOCKED). Trimmed to 140 lines (was 168, limit 150).
- `docs/specs/SE-146-subagent-stop.spec.md`: spec APPROVED
- Skills updated with scope guard: adversarial-security, code-improvement-loop, consensus-validation, dag-scheduling, overnight-sprint, spec-driven-development, tdd-vertical-slices, verification-lattice

## How to test

1. Invoke overnight-sprint as a subagent (Task tool). Verify it executes only the assigned task and returns DONE/DONE_WITH_CONCERNS/BLOCKED instead of starting the full loop.
2. Confirm SAVIA_SUBAGENT=1 env var triggers guard in any listed skill.
3. Run BATS: all tests pass.

## Checklist

- [x] Spec approved before implementation
- [x] No secrets or PII introduced
- [x] File size limits respected (autonomous-safety.md 140 lines, limit 150)
- [x] CI local validated
