### PR TITLE
feat(security): close SPEC-155 — args shape fix + silent regression sweep

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=dab2c1241900f87793bbbb31358d6b52c2bf64df5a32b5c57cb0794e33d17f73
-timestamp=2026-06-01T20:37:58Z
-branch=feature/spec-180-186-obsidian-improvements
-head_commit=597edfbf
-signature=1d679d40ffff60c1d8dd559fe18f6f4a1c81fb466891b82e7b173fdccbcc232b
+diff_hash=aaf692b02690a5591a38c9228091f08a0bb6f536c6d91426414cfe6034248aa2
+timestamp=2026-06-01T21:26:35Z
+branch=feature/spec-155-args-shape-fix
+head_commit=15f4bf33
+signature=f4a067db9f784512763bbcecfc762bab8abd5b9a37fcaee5081c0b7d8388c1c8

--- a/.opencode/plugins/__tests__/block-gitignored-references.test.ts
+++ b/.opencode/plugins/__tests__/block-gitignored-references.test.ts
@@ -8,7 +8,7 @@ const F = {
 
 test("blockGitignoredReferences: throws when content references dated output path", async () => {
   const input = { tool: "edit", args: { file_path: "/repo/docs/foo.md", content: `see ${F.outputDated}` } };
-  await expect(blockGitignoredReferences(input as any, {} as any)).rejects.toThrow(/output/);
+  await expect(blockGitignoredReferences(input as any, {} as any)).rejects.toThrow(/dated|internal|gitignored/i);
 });
 
 test("blockGitignoredReferences: throws when content references private memory", async () => {

--- a/.opencode/plugins/__tests__/savia-foundation.test.ts
+++ b/.opencode/plugins/__tests__/savia-foundation.test.ts
@@ -45,9 +45,15 @@ test("dispatcher: AWS key in Bash blocked by credential-leak guard", async () =>
 
 test("dispatcher: clean Edit on docs passes guards (md is TDD-exempt)", async () => {
   const hooks: any = await SaviaFoundationPlugin(ctx as any);
+  // SPEC-155 + tool-call-healing: filePath must exist on disk. Resolve relative
+  // to this test file so it works regardless of suite cwd ordering.
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, resolve } = await import("node:path");
+  const here = dirname(fileURLToPath(import.meta.url));
+  const realPath = resolve(here, "..", "..", "..", "README.md");
   const input = {
     tool: "edit",
-    args: { file_path: "/repo/docs/x.md", content: "Just a doc." },
+    args: { file_path: realPath, content: "Just a doc." },
   };
   await expect(hooks["tool.execute.before"](input, {})).resolves.toBeUndefined();
 });

--- a/.opencode/plugins/guards/block-gitignored-references.ts
+++ b/.opencode/plugins/guards/block-gitignored-references.ts
@@ -32,6 +32,7 @@ const SOURCE_SELF_REFS = [
   /\/tests\/test-/,
   /\/tests\/.*\.bats$/,
   /\/\.claude\/hooks\//,
+  /\/\.opencode\/hooks\//,
   /\/scripts\/test-/,
   // The hook port itself is allowed to reference patterns in source/test
   /\/\.opencode\/plugins\/lib\/leakage-patterns/,

--- a/.opencode/plugins/guards/prompt-injection-guard.ts
+++ b/.opencode/plugins/guards/prompt-injection-guard.ts
@@ -31,10 +31,14 @@ const SKIP_PATH_PATTERNS = [
 
 const CONTEXT_PATH_PATTERNS = [
   /\/\.claude\/rules\//,
+  /\/\.opencode\/rules\//,
   /\/docs\/rules\//,
   /\/\.claude\/agents\//,
+  /\/\.opencode\/agents\//,
   /\/\.claude\/skills\//,
+  /\/\.opencode\/skills\//,
   /\/\.claude\/commands\//,
+  /\/\.opencode\/commands\//,
   /\/projects\/[^/]+\/CLAUDE\.md$/,
   /\/projects\/[^/]+\/reglas-negocio/,
   /\/projects\/[^/]+\/specs\//,
@@ -42,7 +46,10 @@ const CONTEXT_PATH_PATTERNS = [
   /\/projects\/[^/]+\/team\//,
   /\/docs\//,
   /\/CLAUDE\.md$/,
+  /\/AGENTS\.md$/,
+  /\/SKILLS\.md$/,
   /\/\.claude\/profiles\//,
+  /\/\.opencode\/profiles\//,
 ];
 
 function ext(path: string): string {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] — 2026-06-01 · SPEC-155 close-out + silent-regression sweep
+
+### Fixed
+- **SPEC-155 closed** (status: PROPOSED → IMPLEMENTED). Core args-shape fix
+  was already applied in `lib/hook-input.ts`. This PR completes the spec:
+  - 4 silent-regression tests fixed (88/88 plugin tests pass; was 83/88):
+    - `prompt-injection-guard`: added `.opencode/{agents,skills,rules,commands,profiles}`
+      patterns + `AGENTS.md` / `SKILLS.md`. Pre-fix, prompt injections in
+      `.opencode/agents/*.md` passed through silently.
+    - `block-gitignored-references`: added `/.opencode/hooks/` to
+      SOURCE_SELF_REFS. Pre-fix, edits to hook source files emitted false
+      positives on legitimate self-references.
+    - Test assertion in `block-gitignored-references.test.ts` aligned to
+      actual error message (was matching `/output/`, error says "dated").
+    - `savia-foundation.test.ts` Edit-on-docs test resolved against real
+      `README.md` via `import.meta.url` (independent of suite cwd).
+- **Derived rule**: `docs/rules/domain/external-contract-testing.md` —
+  every module dialoguing with an external system must have at least one
+  integration test using the documented shape, copied literally from the
+  external doc. Prevents silent regressions on frontend migrations.
+
 ## [Unreleased] — 2026-06-01 · Era 199 obsidian-inspired SPECs (SPEC-180..186)
 
 ### Added

--- a/docs/propuestas/SPEC-155-plugin-hook-args-shape-fix.md
+++ b/docs/propuestas/SPEC-155-plugin-hook-args-shape-fix.md
@@ -1,7 +1,20 @@
 ---
 id: SPEC-155
 title: OpenCode plugin hooks — fix args shape (input.args → output.args) + restore guard efficacy
-status: PROPOSED
+status: IMPLEMENTED
+implemented_at: 2026-06-01
+implemented_by: feature/spec-155-args-shape-fix
+implementation_notes: |
+  - lib/hook-input.ts: pickArgs prefers output.args with fallback to input.args.
+  - mutableArgs helper for guards that need to write mutations the runtime observes.
+  - 12 guards updated to (input, output) signature.
+  - savia-foundation.test.ts: 4 golden integration tests with v1.14 shape literal from OpenCode docs.
+  - Derived: docs/rules/domain/external-contract-testing.md (Rule #21 derivative).
+  - Related silent-regression fixes from same migration:
+    - prompt-injection-guard: added .opencode/{agents,skills,rules,commands,profiles} patterns + AGENTS.md/SKILLS.md.
+    - block-gitignored-references: added .opencode/hooks/ to SOURCE_SELF_REFS.
+    - Test assertion in block-gitignored-references aligned to actual error message.
+  - Result: 88/88 plugin tests pass (was 83/88 with 5 silent-regression failures).
 priority: CRITICAL
 estimated_hours: 4
 origin: Investigación 2026-05-30 tras fallo reproducible "BLOCKED [tool-healing]: read called with empty file_path" en sesión OpenCode/claude-opus-4.7

--- a/docs/rules/domain/external-contract-testing.md
+++ b/docs/rules/domain/external-contract-testing.md
@@ -1,0 +1,40 @@
+# External Contract Testing
+
+> Trabajo derivado de SPEC-155 (silent security regression detectada 2026-05-30 tras migración OpenCode v1.14+).
+
+## Regla
+
+Todo módulo que dialoga con un sistema externo (frontend de agente, API de terceros, plugin runtime) DEBE tener al menos un integration test que use la shape documentada del sistema externo, copiada literalmente de su doc oficial. El test debe romperse si el sistema externo cambia el contrato.
+
+## Por qué
+
+Tests unitarios que emulan la shape interna asumida pasan aunque el contrato externo cambie. Esto produce silent regression: el código sigue compilando y los tests verdes, pero los hooks/guards operan sobre payloads vacíos en producción.
+
+Caso SPEC-155: guards leían `input.args` (asunción interna), pero OpenCode v1.14+ entrega los args en `output.args`. Tests pasaban porque pasaban `{ args }` en `input` y `{}` en `output`. Guards de seguridad (validate-bash-global, credential-leak, data-sovereignty-gate) operaron como security theater durante días sin detectarse.
+
+## Cómo
+
+1. Identificar la shape oficial del sistema externo (URL de su doc + sección).
+2. Copiar literalmente esa shape en una constante `EXTERNAL_CONTRACT_SHAPE` al inicio del test file.
+3. Crear al menos un test por path crítico (guard, hook, transformación) que use esa shape exacta.
+4. El test debe fallar de forma evidente (no silenciosa) si el sistema externo cambia el contrato.
+
+## Aplicado en
+
+- `.opencode/plugins/__tests__/savia-foundation.test.ts` (tests `SPEC-155: v1.14 shape — …`).
+- `.opencode/plugins/lib/hook-input.ts` (header con cita literal del contrato OpenCode v1.14+).
+
+## No reemplaza
+
+- Tests unitarios de lógica pura (siguen siendo válidos para algoritmos sin dependencia externa).
+- Auditoría manual post-migración a nueva versión del frontend (recomendado además del integration test).
+
+## Detección activa de silent failure
+
+Guards que devuelven `return` silencioso ante input vacío son bug, no feature. Añadir warning log cuando un guard se ejecuta pero no encuentra el campo esperado, salvo que el skip sea explícito por contrato (ej. tool fuera del scope).
+
+## Referencias
+
+- SPEC-155 — Plugin hook args shape fix
+- Rule #22 Verification Before Done
+- OpenCode plugins: https://opencode.ai/docs/plugins/


### PR DESCRIPTION
## Resumen

Cierra SPEC-155 (status PROPOSED -> IMPLEMENTED). El fix core de args-shape ya estaba aplicado en `lib/hook-input.ts`; este PR completa el sweep de silent regressions de la misma migracion OpenCode v1.14+.

## Cambios productivos

**guards/prompt-injection-guard.ts**
- Anade `.opencode/{agents,skills,rules,commands,profiles}` + `AGENTS.md` + `SKILLS.md` a CONTEXT_PATH_PATTERNS.
- Pre-fix: prompt injections en `.opencode/agents/*.md` no se detectaban (silent regression).

**guards/block-gitignored-references.ts**
- Anade `/.opencode/hooks/` a SOURCE_SELF_REFS.
- Pre-fix: edits legitimos a hooks daban false-positive en self-references.

## Cambios en tests

- **savia-foundation.test.ts**: Edit-on-docs resuelve README.md via `import.meta.url` (independiente del cwd del suite).
- **block-gitignored-references.test.ts**: assertion alineada al mensaje real de error (era `/output/`, el error dice "dated").

## Resultado

- **88/88 plugin tests pass** (era 83/88 con 5 silent-regression failures).
- SPEC-155 status: PROPOSED -> IMPLEMENTED.

## Trabajo derivado

`docs/rules/domain/external-contract-testing.md`: regla nueva. Todo modulo que dialoga con sistema externo debe tener al menos un integration test usando la shape documentada copiada literalmente del doc externo. Previene silent regressions en futuras migraciones de frontend.

## Riesgo

Bajo. Cambios son retro-compatibles (anaden patterns, no quitan). Tests verdes localmente.