### PR TITLE
feat(resolver): SE-160 RESOLVER.md dispatch intent->skill/agent

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2576dcb38e1e5d54c4af1726fee998a4710e6e70863615bd6c7cf525aa40e835
-timestamp=2026-06-02T04:37:44Z
-branch=feature/spec-186-double-optin
-head_commit=caba62d7
-signature=2c95d1cf48df38197c9431c62f7cfe33646cc74f9f52901798c43cea0df51d65
+diff_hash=bc9402b8a664f9e263b33d19566d78a982801c6f32be02d095f1201ae23a94fb
+timestamp=2026-06-02T19:04:44Z
+branch=feature/se-160-resolver
+head_commit=e556c775
+signature=99194716820e098f5150960d30ae86c4cde4cbec3e4638cdd1c8024fd264866b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] — 2026-06-02 · SE-160 RESOLVER.md dispatch explícito
+
+### Added
+- **SE-160 closed** (Era 251 free-wins). Tabla explícita intent → skill/agent
+  para reducir carga del contexto central y permitir routing editable sin
+  prompt engineering. Patrón GBrain adaptado.
+  - `docs/RESOLVER.md`: 98 skills + 70 agents en tablas auto-generadas;
+    sección OVERRIDE hand-curated con sinónimos comunes (es/en).
+  - `scripts/resolver-md-generate.sh`: generador con modos `generate` (stdout),
+    `--apply` (reemplaza solo bloque AUTO_BEGIN/AUTO_END preservando OVERRIDE),
+    `--check` (drift detection para CI). Soporta frontmatter multilinea
+    (`description: >`).
+  - `docs/rules/domain/resolver-protocol.md`: managed-content rule (62 líneas).
+  - `tests/test-resolver-md-generate.bats`: 21/21 tests — estructura,
+    drift detection, idempotencia, preservación de OVERRIDE, validación de
+    targets.
+  - `CLAUDE.md`: lazy reference añadido.
+
+### Changed
+- `docs/ROADMAP.md`: SE-160 PROPOSED → IMPLEMENTED en tablas de priorización
+  Era 251.
+
+
 ## [Unreleased] — 2026-06-02 · SPEC-186 double opt-in for autonomous skills
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 | Spec OpenCode Implementation Plan | `docs/rules/domain/spec-opencode-implementation-plan.md` | Cada spec APPROVED post-2026-04-26 — sección obligatoria + classification |
 | File-output summary (resumen tras generar fichero) | `docs/rules/domain/file-output-summary.md` | Generas un fichero en `output/` con datos pedidos por el usuario — política adaptativa por tamaño |
 | Principios éticos Savia (13 principios + 5 líneas rojas) | `docs/rules/domain/savia-ethical-principles.md` | Dilema ético, petición ambigua, uso dual, conflicto entre reglas operativas — criterio último: ¿esto hace la vida más digna? |
+| Resolver intent → skill/agent (RESOLVER.md) | `docs/RESOLVER.md` + `docs/rules/domain/resolver-protocol.md` | Necesitas elegir skill o agent para un intent — tabla compacta editable (SE-160) |
 
 **Protocolo de carga**: usar `Read` directamente con el path exacto. NO uses `@import` aquí — romperías el lazy.
 

--- a/docs/RESOLVER.md
+++ b/docs/RESOLVER.md
@@ -1,0 +1,227 @@
+# RESOLVER.md — Intent dispatch table
+
+> **Patrón GBrain RESOLVER.md** (SE-160). Tabla explícita intent → skill/agent que reduce la carga del contexto central y hace el routing editable sin prompt engineering.
+>
+> **Fuente de verdad**: la sección AUTO se regenera desde `.opencode/skills/*/SKILL.md` y `.opencode/agents/*.md`. La sección OVERRIDE es hand-curated y se preserva entre regeneraciones.
+
+## Cómo se usa
+
+1. Buscas el intent (palabra/frase) en la columna izquierda.
+2. Saltas al target indicado: `skill:<nombre>` o `agent:<nombre>`.
+3. Si tu intent no aparece, busca en OVERRIDE — sinónimos comunes mapeados a mano.
+4. Si sigue sin estar, abre PR contra OVERRIDE añadiéndolo.
+
+**No es un router automático**: es un índice. El frontend (Claude Code, OpenCode) selecciona el target final aplicando su propio matcher; esta tabla es la referencia compartida que evita re-explicar el routing en cada turno.
+
+## OVERRIDE — sinónimos y aliases (hand-curated)
+
+> Esta sección NO se auto-genera. Edita libremente. Mapea términos comunes / sinónimos en español/inglés al target canónico.
+
+| Sinónimo / alias | Target canónico | Notas |
+|---|---|---|
+| "estado del sprint", "sprint status", "cómo va el sprint" | skill:sprint-management | |
+| "informe semanal", "weekly", "weekly report" | skill:weekly-report | |
+| "imputaciones", "horas", "timesheet" | skill:time-tracking-report | |
+| "facturas", "presupuesto", "coste" | skill:cost-management | |
+| "descomponer PBI", "split PBI", "tareas de un PBI" | skill:pbi-decomposition | Antes de descomponer, usar `skill:product-discovery` |
+| "PRD", "discovery", "JTBD" | skill:product-discovery | Pre-requisito de pbi-decomposition |
+| "buscar comando", "qué comando uso", "router" | skill:smart-routing | Para descubrir entre 559+ comandos |
+| "diseñar arquitectura", "architecture", "decisión técnica" | agent:architect | |
+| "implementar en C#", ".NET", "EF Core" | agent:dotnet-developer | Requiere Spec SDD aprobada |
+| "implementar en Python", "FastAPI", "Django" | agent:python-developer | |
+| "revisar código", "code review", "quality gate" | agent:code-reviewer | E1 SIEMPRE humano (Rule 8) |
+| "tests faltantes", "cobertura", "test runner" | agent:test-runner | |
+| "antes de commit", "pre-commit", "guardian" | agent:commit-guardian | Bloqueante por defecto |
+| "tabla de horas", "Excel imputación" | skill:time-tracking-report | |
+| "memoria de Savia", "recordar", "consolidar memoria" | skill:savia-memory | |
+| "reunión Teams", "transcripción", "acta" | skill:meeting-transcript-extract | Triage al digester correcto post-extract |
+| "investigación técnica", "evaluar herramienta nueva" | skill:tech-research-agent | Doble opt-in SPEC-186 |
+| "noche autónoma", "overnight", "tareas mientras duermo" | skill:overnight-sprint | Doble opt-in SPEC-186 |
+| "auditar seguridad", "red team / blue team" | skill:adversarial-security | Doble opt-in SPEC-186 |
+| "Anthropic caído", "failover local", "LocalAI" | skill:emergency-mode | |
+
+## AUTO — generado desde frontmatter
+
+> Esta sección la regenera `bash scripts/resolver-md-generate.sh --apply`. NO editar a mano.
+
+<!-- AUTO_BEGIN — do not edit; regenerate via scripts/resolver-md-generate.sh -->
+
+### Skills (98)
+
+| Intent (skill) | Target | Cuándo usar |
+|---|---|---|
+| `adversarial-security` | skill:adversarial-security | Usar cuando se necesita auditar la seguridad de un proyecto con pipeline Red Team / Blu... |
+| `agent-code-map` | skill:agent-code-map | Usar cuando un agente necesita conocer la arquitectura del proyecto sin leer ficheros c... |
+| `agent-file-map` | skill:agent-file-map | Usar cuando se trabaja con ficheros externos al workspace que los agentes deben localizar. |
+| `ai-labor-impact` | skill:ai-labor-impact | Usar cuando se analiza el impacto de la IA en el trabajo del equipo o la organización. |
+| `android-autonomous-debugger` | skill:android-autonomous-debugger | Usar cuando se depuran o testean apps Android contra dispositivos físicos via USB/ADB. |
+| `architecture-intelligence` | skill:architecture-intelligence | Usar cuando se diseña o revisa la arquitectura de un proyecto nuevo o existente. |
+| `ast-comprehension` | skill:ast-comprehension | Usar cuando se explora código desconocido y se necesita comprensión estructural sin l... |
+| `ast-quality-gate` | skill:ast-quality-gate | Usar cuando se verifica la calidad de código generado por IA antes de merge. |
+| `azure-devops-queries` | skill:azure-devops-queries | Usar cuando se necesitan consultas WIQL, actualización de work items o datos de sprint... |
+| `azure-pipelines` | skill:azure-pipelines | Usar cuando se gestiona o depura CI/CD con Azure Pipelines. |
+| `backlog-git-tracker` | skill:backlog-git-tracker | Usar cuando se capturan o comparan snapshots del backlog para detectar drift. |
+| `banking-architecture` | skill:banking-architecture | Usar cuando se diseña o revisa arquitectura para proyectos del sector bancario. |
+| `capacity-planning` | skill:capacity-planning | Usar cuando se calcula la capacidad del equipo para un sprint o periodo. |
+| `caveman` | skill:caveman | Strips all sugar-coating and marketing. Gives the brutally honest truth in the fewest p... |
+| `client-profile-manager` | skill:client-profile-manager | Usar cuando se crean, actualizan o consultan perfiles de cliente en SaviaHub. |
+| `code-comprehension-report` | skill:code-comprehension-report | Usar cuando se ha completado una implementación SDD y se necesita documentar el modelo... |
+| `code-improvement-loop` | skill:code-improvement-loop | Usar cuando se quiere ejecutar mejora autónoma de código en segundo plano con PRs par... |
+| `codebase-map` | skill:codebase-map | Usar cuando se necesita un mapa de dependencias del workspace (comandos→agentes→reg... |
+| `codegraph` | skill:codegraph | Usar cuando se necesita indexación AST persistente para navegación de callers/callees... |
+| `company-messaging` | skill:company-messaging | Usar cuando se envían mensajes internos cifrados entre miembros de la organización v�... |
+| `consensus-validation` | skill:consensus-validation | Usar cuando una decisión técnica o recomendación necesita validación por panel de j... |
+| `context-caching` | skill:context-caching | Usar cuando se optimiza el orden de carga de contexto para maximizar cache hits. |
+| `context-interview-conductor` | skill:context-interview-conductor | Usar cuando se necesita recopilar contexto estructurado de un usuario mediante entrevis... |
+| `context-optimized-dev` | skill:context-optimized-dev | Usar cuando se desarrolla con presupuesto de contexto limitado. |
+| `context-rot-strategy` | skill:context-rot-strategy | Usar cuando una sesión larga se aproxima al límite de contexto y hay que decidir qué... |
+| `context-task-classifier` | skill:context-task-classifier | Usar antes de compactar contexto para clasificar la tarea del turno actual. |
+| `cost-management` | skill:cost-management | Usar cuando se gestionan timesheets, presupuestos, facturas o forecasting de costes. |
+| `dag-scheduling` | skill:dag-scheduling | Usar cuando se orquestan múltiples agentes SDD con dependencias entre ellos. |
+| `developer-experience` | skill:developer-experience | Usar cuando se mide o mejora la experiencia de desarrollo del equipo. |
+| `devops-validation` | skill:devops-validation | Usar cuando se conecta un proyecto nuevo a Azure DevOps para validar su configuración ... |
+| `diagram-generation` | skill:diagram-generation | Usar cuando se necesita generar diagramas de arquitectura o flujo desde código o infra... |
+| `diagram-import` | skill:diagram-import | Usar cuando se importa un diagrama existente para extraer entidades y crear PBIs. |
+| `doc-quality-feedback` | skill:doc-quality-feedback | Usar cuando se recopila feedback de calidad de documentación tras usar skills y reglas. |
+| `ecosystem-watcher` | skill:ecosystem-watcher | Usar una vez al mes para detectar cambios relevantes en el ecosistema de herramientas e... |
+| `emergency-mode` | skill:emergency-mode | Usar cuando la API de Anthropic está caída y se necesita continuar operando con LocalAI. |
+| `enterprise-analytics` | skill:enterprise-analytics | Usar cuando se necesitan métricas SPACE, aggregación de portfolio o forecasting empre... |
+| `enterprise-onboarding` | skill:enterprise-onboarding | Usar cuando se incorporan múltiples personas a la organización de forma masiva. |
+| `evaluations-framework` | skill:evaluations-framework | Usar cuando se diseñan o ejecutan evaluaciones de calidad de agentes y prompts. |
+| `executive-reporting` | skill:executive-reporting | Usar cuando se genera un informe ejecutivo multi-proyecto para dirección. |
+| `feasibility-probe` | skill:feasibility-probe | Usar cuando se necesita validar si una spec es técnicamente viable antes de implementa... |
+| `governance-enterprise` | skill:governance-enterprise | Usar cuando se audita compliance, se registran decisiones o se certifican procesos ente... |
+| `grill-me` | skill:grill-me | Adversarial review that hunts every weakness, assumption, edge case, and missing test. ... |
+| `human-code-map` | skill:human-code-map | Usar cuando se incorpora un dev nuevo, se toca un módulo sin mapa, o alguien re-lee el... |
+| `knowledge-graph` | skill:knowledge-graph | Usar cuando se construye o consulta el grafo de conocimiento de entidades del proyecto. |
+| `legal-compliance` | skill:legal-compliance | Usar cuando se audita compliance legal contra legislación española consolidada. |
+| `managed-content` | skill:managed-content | Usar cuando se regeneran secciones auto-generadas en documentos con marcadores de segur... |
+| `meeting-transcript-extract` | skill:meeting-transcript-extract | Usar cuando se necesita extraer la transcripción de una reunión Teams desde el browser. |
+| `memvid-backup` | skill:memvid-backup | Usar cuando se crea un backup portable de la memoria externa de Savia. |
+| `model-upgrade-audit` | skill:model-upgrade-audit | Usar cuando hay un modelo nuevo disponible y se quiere detectar prompt debt en el works... |
+| `mutation-audit` | skill:mutation-audit | Usar cuando se quiere medir la calidad real de los tests mediante mutation testing. |
+| `nuclei-scanning` | skill:nuclei-scanning | Usar cuando se escanean vulnerabilidades conocidas (CVEs, misconfigs) con Nuclei. |
+| `onboarding-dev` | skill:onboarding-dev | Usar cuando se incorpora un desarrollador nuevo al proyecto y necesita buddy IA. |
+| `orgchart-import` | skill:orgchart-import | Usar cuando se importa un organigrama para extraer la estructura del equipo. |
+| `overnight-sprint` | skill:overnight-sprint | Usar cuando se quiere ejecutar tareas de bajo riesgo de forma autónoma durante la noche. |
+| `pbi-decomposition` | skill:pbi-decomposition | Usar cuando se descompone un PBI en tasks y se estiman las horas. |
+| `pentesting` | skill:pentesting | Usar cuando se ejecuta un pentest contra una aplicación o infraestructura. |
+| `performance-audit` | skill:performance-audit | Usar cuando se audita el rendimiento estático de código para detectar hotspots. |
+| `personal-vault` | skill:personal-vault | Usar cuando se lee o escribe el repositorio personal del usuario (perfil, preferencias,... |
+| `pr-agent-judge` | skill:pr-agent-judge | Usar cuando se añade pr-agent como juez externo en el Code Review Court. |
+| `product-discovery` | skill:product-discovery | Usar antes de descomponer PBIs, cuando se necesita análisis JTBD y PRD del producto. |
+| `project-update` | skill:project-update | Usar cuando se necesita una actualización integral del proyecto activo desde todas las... |
+| `prompt-optimizer` | skill:prompt-optimizer | Usar cuando se optimiza el prompt de un skill o agente para mejorar su efectividad. |
+| `rbac-management` | skill:rbac-management | Usar cuando se gestionan roles, permisos o se audita el acceso de usuarios. |
+| `reflection-validation` | skill:reflection-validation | Usar cuando una respuesta o decisión importante necesita validación metacognitiva (Sy... |
+| `regulatory-compliance` | skill:regulatory-compliance | Usar cuando se valida el cumplimiento de marcos regulatorios sectoriales. |
+| `reranker` | skill:reranker | Usar cuando se recibe un top-K ruidoso de búsqueda en memoria y se necesita reordenar ... |
+| `resource-references` | skill:resource-references | Usar cuando se necesitan referencias a recursos y plantillas del workspace. |
+| `risk-scoring` | skill:risk-scoring | Usar cuando se calcula el riesgo de una tarea para decidir el nivel de revisión requer... |
+| `rules-traceability` | skill:rules-traceability | Usar cuando se mapean reglas de negocio a PBIs para trazabilidad completa. |
+| `savia-dual` | skill:savia-dual | Usar cuando la inferencia cloud falla, es lenta o está rate-limited y se necesita fail... |
+| `savia-flow-practice` | skill:savia-flow-practice | Usar cuando se implementa Savia Flow con dual-track y métricas de flujo en un proyecto. |
+| `savia-hub-sync` | skill:savia-hub-sync | Usar cuando se sincroniza el repositorio SaviaHub con el workspace local. |
+| `savia-identity` | skill:savia-identity | Usar al inicio de sesión para cargar la identidad completa y las reglas de comportamie... |
+| `savia-memory` | skill:savia-memory | Usar cuando se lee, escribe, busca o consolida la memoria persistente entre sesiones de... |
+| `savia-school` | skill:savia-school | Usar cuando el workspace se adapta para un entorno educativo con estudiantes menores de... |
+| `scaling-operations` | skill:scaling-operations | Usar cuando se analiza el tier de escala de un servicio o se necesitan optimizaciones d... |
+| `scheduled-messaging` | skill:scheduled-messaging | Usar cuando se configuran mensajes automáticos programados a plataformas de comunicaci... |
+| `skill-evaluation` | skill:skill-evaluation | Usar cuando se necesita seleccionar el skill más apropiado para una tarea dada. |
+| `smart-calendar` | skill:smart-calendar | Usar cuando se gestiona la agenda inteligente con sincronización Outlook/Teams. |
+| `smart-routing` | skill:smart-routing | Usar cuando se necesita descubrir o enrutar a un comando específico entre los 400+ dis... |
+| `sovereignty-auditor` | skill:sovereignty-auditor | Usar cuando se audita el grado de dependencia cognitiva del equipo respecto a herramien... |
+| `spec-driven-development` | skill:spec-driven-development | Usar cuando se escribe, valida o implementa una spec ejecutable SDD. |
+| `sprint-management` | skill:sprint-management | Usar cuando se consulta el estado del sprint, se actualizan items o se genera el resumen. |
+| `tdd-vertical-slices` | skill:tdd-vertical-slices | Test-driven development with vertical-slice red-green-refactor cycles. Use when applyin... |
+| `team-coordination` | skill:team-coordination | Usar cuando se coordinan múltiples equipos, se asignan miembros o se detectan bloquean... |
+| `team-onboarding` | skill:team-onboarding | Usar cuando se incorpora un nuevo miembro al equipo y se evalúan sus competencias. |
+| `tech-research-agent` | skill:tech-research-agent | Usar cuando se necesita investigación técnica autónoma sobre un tema específico. |
+| `test-architect` | skill:test-architect | Usar cuando se diseñan o generan tests de alta calidad en cualquier lenguaje. |
+| `tier3-probes` | skill:tier3-probes | Usar cuando se valida la viabilidad de herramientas Tier 3 antes de adoptarlas en el wo... |
+| `time-tracking-report` | skill:time-tracking-report | Usar cuando se generan informes de imputación de horas en Excel o Word. |
+| `topic-cluster` | skill:topic-cluster | Usar cuando se agrupan retros, PBIs o incidentes en topics para detectar patrones trans... |
+| `verification-lattice` | skill:verification-lattice | Usar cuando se necesita verificación multi-capa más allá del code review estándar. |
+| `voice-inbox` | skill:voice-inbox | Usar cuando se procesan mensajes de voz para transcribirlos y convertirlos en acciones. |
+| `web-research` | skill:web-research | Usar cuando se necesita buscar en la web para resolver gaps de contexto (docs, versione... |
+| `weekly-report` | skill:weekly-report | Usar cuando se genera el informe semanal de estado del proyecto. |
+| `wellbeing-guardian` | skill:wellbeing-guardian | Usar cuando se monitorizan señales de bienestar individual en el equipo. |
+| `workspace-integrity` | skill:workspace-integrity | Usar cuando se audita la integridad del workspace (drift, reglas, agentes, baseline). |
+| `zoom-out` | skill:zoom-out | Elevates perspective from trees to forest. Maps architecture, dependencies, and second-... |
+
+### Agents (70)
+
+| Intent (agent) | Target | Cuándo usar |
+|---|---|---|
+| `architect` | agent:architect | Diseño de arquitectura .NET y decisiones técnicas de alto nivel. Usar PROACTIVELY cua... |
+| `architecture-judge` | agent:architecture-judge | Code Review Court judge — boundaries, coupling, layer violations, patterns |
+| `azure-devops-operator` | agent:azure-devops-operator | Operaciones rápidas en Azure DevOps: consultas WIQL, actualización de work items, ges... |
+| `business-analyst` | agent:business-analyst | Análisis de reglas de negocio, descomposición de PBIs, criterios de aceptación y eva... |
+| `calibration-judge` | agent:calibration-judge | Truth Tribunal judge — confidence statements match evidence strength |
+| `cobol-developer` | agent:cobol-developer | Asistencia en código COBOL/mainframe. IMPORTANTE: La mayoría de tareas COBOL deben re... |
+| `code-reviewer` | agent:code-reviewer | Revisión de código .NET como quality gate antes de merge. Usar PROACTIVELY cuando: se... |
+| `cognitive-judge` | agent:cognitive-judge | Code Review Court judge — debuggability at 3AM, naming, complexity, logs |
+| `coherence-judge` | agent:coherence-judge | Truth Tribunal judge — internal consistency (sums, dates, entities) |
+| `coherence-validator` | agent:coherence-validator | Verifies that generated outputs (specs, reports, code) actually match the stated object... |
+| `commit-guardian` | agent:commit-guardian | Guardian de commits: verifica que todos los cambios staged cumplen las reglas del works... |
+| `completeness-judge` | agent:completeness-judge | Truth Tribunal judge — report covers what its title/abstract promises |
+| `compliance-judge` | agent:compliance-judge | Truth Tribunal judge — PII, N1-N4b levels, format rules, confidentiality |
+| `confidentiality-auditor` | agent:confidentiality-auditor | Audita cumplimiento de confidencialidad en PRs de pm-workspace (repo publico). Descubre... |
+| `correctness-judge` | agent:correctness-judge | Code Review Court judge — logic, tests, edge cases, error paths |
+| `court-orchestrator` | agent:court-orchestrator | Convenes the Code Review Court, manages fix cycles, produces .review.crc |
+| `dev-orchestrator` | agent:dev-orchestrator | Analiza specs y crea planes de implementación con slices, dependencias y presupuestos ... |
+| `diagram-architect` | agent:diagram-architect | Architecture diagram specialist. Analyzes code and infrastructure to generate Mermaid d... |
+| `dotnet-developer` | agent:dotnet-developer | Implementación de código C#/.NET siguiendo specs SDD aprobadas. Usar PROACTIVELY cuan... |
+| `drift-auditor` | agent:drift-auditor | Auditoría de convergencia repo: detecta drift entre docs, config y código. Usar PROAC... |
+| `excel-digest` | agent:excel-digest | Digestion de hojas de calculo Excel (XLSX/XLS/CSV) — pipeline de 4 fases. Extrae estr... |
+| `expertise-asymmetry-judge` | agent:expertise-asymmetry-judge | Recommendation Tribunal judge — when draft falls in a domain the active user marks as... |
+| `factuality-judge` | agent:factuality-judge | Truth Tribunal judge — factual accuracy of claims against verifiable sources |
+| `feasibility-probe` | agent:feasibility-probe | Validates spec feasibility by attempting a time-boxed prototype. Produces viability rep... |
+| `fix-assigner` | agent:fix-assigner | Creates fix tasks from Court findings, assigns to dev agents, triggers re-review |
+| `frontend-developer` | agent:frontend-developer | Implementación de código frontend (Angular y React) siguiendo specs SDD aprobadas. Us... |
+| `frontend-test-runner` | agent:frontend-test-runner | Post-commit frontend test execution — unit, component, e2e, coverage |
+| `go-developer` | agent:go-developer | Implementación de código Go siguiendo specs SDD aprobadas. Usar PROACTIVELY cuando: s... |
+| `hallucination-fast-judge` | agent:hallucination-fast-judge | Recommendation Tribunal judge — verifies that entities cited in a draft (files, funct... |
+| `hallucination-judge` | agent:hallucination-judge | Truth Tribunal judge — detects invented facts via SelfCheck-style consistency |
+| `infrastructure-agent` | agent:infrastructure-agent | Agente de gestión de infraestructura cloud. Recibe solicitudes del architect, detecta ... |
+| `java-developer` | agent:java-developer | Implementación de código Java/Spring Boot siguiendo specs SDD aprobadas. Usar PROACTI... |
+| `legal-compliance` | agent:legal-compliance | Auditoría de compliance legal contra legislación española consolidada (legalize-es).... |
+| `meeting-confidentiality-judge` | agent:meeting-confidentiality-judge | Juez de confidencialidad post-extraccion de reuniones. Valida que datos marcados como c... |
+| `meeting-digest` | agent:meeting-digest | Digestion de transcripciones de reuniones (VTT, DOCX, TXT). Extrae datos estructurados ... |
+| `meeting-risk-analyst` | agent:meeting-risk-analyst | Analisis de riesgos post-digestion de reuniones. Cruza decisiones, compromisos y dinami... |
+| `memory-agent` | agent:memory-agent | Gestiona la memoria persistente de pm-workspace via lenguaje natural. |
+| `memory-conflict-judge` | agent:memory-conflict-judge | Recommendation Tribunal judge — detects when a draft recommendation contradicts the a... |
+| `mobile-developer` | agent:mobile-developer | Implementación de código mobile (Swift/iOS + Kotlin/Android + Flutter) siguiendo spec... |
+| `model-upgrade-auditor` | agent:model-upgrade-auditor | Audits agents, skills, and prompts for workarounds that newer models may no longer need... |
+| `pdf-digest` | agent:pdf-digest | Digestion de documentos PDF con extraccion de texto e imagenes — pipeline de 4 fases.... |
+| `pentester` | agent:pentester | Hacker ético de máximo nivel con pipeline autónomo de 5 fases inspirado en Shannon. ... |
+| `php-developer` | agent:php-developer | Implementación de código PHP/Laravel siguiendo specs SDD aprobadas. Usar PROACTIVELY ... |
+| `pptx-digest` | agent:pptx-digest | Digestion de presentaciones PowerPoint (PPTX) — pipeline de 4 fases. Extrae texto, no... |
+| `pr-agent-judge` | agent:pr-agent-judge | External 5th judge of the Code Review Court — wraps qodo-ai/pr-agent OSS (SPEC-124). ... |
+| `python-developer` | agent:python-developer | Implementación de código Python (FastAPI/Django) siguiendo specs SDD aprobadas. Usar ... |
+| `recommendation-tribunal-orchestrator` | agent:recommendation-tribunal-orchestrator | Recommendation Tribunal orchestrator — convenes 4 fast judges in parallel, aggregates... |
+| `reflection-validator` | agent:reflection-validator | Meta-cognitive validation of responses and decisions (System 2). Use PROACTIVELY when: ... |
+| `ruby-developer` | agent:ruby-developer | Implementación de código Ruby on Rails siguiendo specs SDD aprobadas. Usar PROACTIVEL... |
+| `rule-violation-judge` | agent:rule-violation-judge | Recommendation Tribunal judge — detects when a draft recommendation violates canonica... |
+| `rust-developer` | agent:rust-developer | Implementación de código Rust (Axum, Tokio) siguiendo specs SDD aprobadas. Usar PROAC... |
+| `sdd-spec-writer` | agent:sdd-spec-writer | Generación y validación de Specs SDD (Spec-Driven Development) como contratos ejecuta... |
+| `security-attacker` | agent:security-attacker | Agente Red Team que simula ataques contra el código y la configuración del proyecto. ... |
+| `security-auditor` | agent:security-auditor | Agente auditor independiente que evalúa la calidad del análisis Red/Blue Team, verifi... |
+| `security-defender` | agent:security-defender | Agente Blue Team que propone correcciones para las vulnerabilidades encontradas por el ... |
+| `security-guardian` | agent:security-guardian | Especialista en seguridad, confidencialidad y ciberseguridad. Audita los cambios staged... |
+| `security-judge` | agent:security-judge | Code Review Court judge — OWASP, PII, injection, auth, credentials |
+| `source-traceability-judge` | agent:source-traceability-judge | Truth Tribunal judge — every claim must have a verifiable @ref citation |
+| `spec-judge` | agent:spec-judge | Code Review Court judge — implementation vs approved spec, acceptance criteria |
+| `tech-writer` | agent:tech-writer | Documentación técnica: README, CHANGELOG, comentarios XML en C#, docs de proyecto. Us... |
+| `terraform-developer` | agent:terraform-developer | Implementación de código Terraform (IaC) siguiendo specs SDD aprobadas. CRÍTICO: NUN... |
+| `test-architect` | agent:test-architect | Designs and generates the highest quality tests across all 16 language packs and 14 tes... |
+| `test-engineer` | agent:test-engineer | Creación y ejecución de tests en proyectos .NET. Usar PROACTIVELY cuando: se escriben... |
+| `test-runner` | agent:test-runner | Ejecución de tests y verificación de cobertura post-commit. Ejecuta suite completa de... |
+| `truth-tribunal-orchestrator` | agent:truth-tribunal-orchestrator | Truth Tribunal orchestrator — convenes 7 judges, aggregates scores, applies vetos, dr... |
+| `typescript-developer` | agent:typescript-developer | Implementación de código TypeScript/Node.js siguiendo specs SDD aprobadas. Usar PROAC... |
+| `visual-digest` | agent:visual-digest | Digestión de imágenes con OCR contextual — 5 pasadas. Fotos de pizarras, notas manu... |
+| `visual-qa-agent` | agent:visual-qa-agent | Visual QA: screenshot analysis, wireframe comparison, regression detection. Usar PROACT... |
+| `web-e2e-tester` | agent:web-e2e-tester | Autonomous E2E testing of web apps against live instances. Use PROACTIVELY when: deploy... |
+| `word-digest` | agent:word-digest | Digestion de documentos Word (DOCX) con extraccion de texto, tablas e imagenes — pipe... |
+
+<!-- AUTO_END -->

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -703,7 +703,7 @@ Incluye: context-update pipeline, agent-artifacts, context-guard, savia-manifest
 
 | Rank | ID | Título | Estado | Esfuerzo | Por qué primero |
 |------|-----|--------|--------|----------|-----------------|
-| 1 | SE-160 | RESOLVER.md dispatch explícito | PROPOSED | ~2h | Zero deps. Reduce carga CLAUDE.md ahora mismo. Free-win. |
+| 1 | SE-160 | RESOLVER.md dispatch explícito | IMPLEMENTED | ~2h | Zero deps. Reduce carga CLAUDE.md ahora mismo. Free-win. |
 | 2 | SE-161 | PROTECTED_JOB_NAMES — bloquear agentes costosos en bucles autónomos | IMPLEMENTED | ~1h | Seguridad operacional. Zero deps. Evita burn de tokens en overnight-sprint. PR pendiente merge. |
 | 3 | SE-081 | Pocock quick-wins (caveman + zoom-out + grill-me) | APPROVED | ~2h | Zero código, zero deps. Skills de calidad inmediata. |
 | 4 | SE-093 | Zero project leakage enforcement | APPROVED | ~1h | CRITICAL. Fuga de contexto entre proyectos activa. |
@@ -789,7 +789,7 @@ Prioridad: implementar ANTES que cualquier SE de Era 197.
 
 | # | ID | Título | Estado | Esfuerzo | Notas |
 |---|-----|--------|--------|----------|-------|
-| 1 | SE-160 | RESOLVER.md dispatch explícito | PROPOSED | ~2h | Sin cambios. Sigue siendo el mejor free-win. |
+| 1 | SE-160 | RESOLVER.md dispatch explícito | IMPLEMENTED | ~2h | Sin cambios. Sigue siendo el mejor free-win. |
 | 2 | SE-161 | PROTECTED_JOB_NAMES bucles autónomos | IMPLEMENTED | ~1h | Hook + YAML + 15 tests BATS. PR pendiente merge. |
 | 3 | SE-153 | Template SKILL.md "Authoritative paths first" | PROPOSED | ~1h | Nuevo (Era 197). Patrón flowsint. Mejora contexto, zero migración obligatoria. |
 

--- a/docs/rules/domain/resolver-protocol.md
+++ b/docs/rules/domain/resolver-protocol.md
@@ -1,0 +1,62 @@
+# Resolver Protocol — SE-160
+
+> Patrón GBrain RESOLVER.md adaptado a pm-workspace. Tabla explícita intent → skill/agent que reduce la carga del contexto central y hace el routing editable sin prompt engineering.
+
+## Por qué
+
+Antes de SE-160 el routing intent → skill/agent estaba implícito en (a) las descripciones de cada SKILL.md/agent.md cargadas por el frontend, y (b) el conocimiento del agente principal sobre el catálogo. Dos problemas:
+
+1. **Coste de contexto**: el frontend re-cargaba descripciones completas en cada turno para decidir routing.
+2. **No editable**: cambiar el routing implicaba prompt engineering en CLAUDE.md o tocar descripciones.
+
+`docs/RESOLVER.md` resuelve ambos: lookup table compacta, editable como cualquier markdown, regenerable sin perder overrides.
+
+## Estructura
+
+```
+docs/RESOLVER.md
+├── Header + cómo se usa
+├── ## OVERRIDE — sinónimos y aliases (hand-curated)
+│   └── tabla: sinónimo → target → notas
+└── ## AUTO — generado desde frontmatter
+    ├── <!-- AUTO_BEGIN -->
+    ├── ### Skills (N)   ← tabla auto-generada
+    ├── ### Agents (N)   ← tabla auto-generada
+    └── <!-- AUTO_END -->
+```
+
+## Reglas
+
+1. **AUTO se regenera, OVERRIDE se preserva**: el script `scripts/resolver-md-generate.sh --apply` reemplaza solo el bloque entre los marcadores `<!-- AUTO_BEGIN -->` / `<!-- AUTO_END -->`. La sección OVERRIDE no se toca.
+2. **Drift gate en CI**: BATS test corre `--check` y falla si AUTO está stale. Forza regeneración tras añadir/eliminar/renombrar skills o agents.
+3. **OVERRIDE solo añade sinónimos**: si el intent canónico ya aparece en AUTO con su nombre exacto, no replicarlo en OVERRIDE. OVERRIDE es para sinónimos, aliases en otro idioma, frases comunes.
+4. **No es un router automático**: es un índice compartido entre frontends. El matcher final lo aplica el frontend (Claude Code, OpenCode v1.14, Codex).
+
+## Mantenimiento
+
+| Cuando | Acción |
+|---|---|
+| Añades una skill o agent nuevo | `bash scripts/resolver-md-generate.sh --apply` antes del commit |
+| Renombras una skill/agent | Idem + revisar OVERRIDE: actualizar referencias manuales |
+| Añades sinónimo común detectado en uso | Editar OVERRIDE a mano, sin tocar AUTO |
+| CI falla con "drift in AUTO block" | Regenerar y commitear |
+
+## Comandos
+
+```bash
+# Dry-run a stdout
+bash scripts/resolver-md-generate.sh
+
+# Aplicar (preserva OVERRIDE)
+bash scripts/resolver-md-generate.sh --apply
+
+# Drift check (CI)
+bash scripts/resolver-md-generate.sh --check
+```
+
+## Referencias
+
+- ROADMAP: `docs/ROADMAP.md` — Era 251 inmediato, SE-160
+- Patrón fuente: GBrain `RESOLVER.md` (https://github.com/garrytan/gbrain)
+- Tabla generada: `docs/RESOLVER.md`
+- Generador: `scripts/resolver-md-generate.sh`

--- a/scripts/resolver-md-generate.sh
+++ b/scripts/resolver-md-generate.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# resolver-md-generate.sh — SE-160
+#
+# Generates docs/RESOLVER.md from .opencode/skills/*/SKILL.md and
+# .opencode/agents/*.md. RESOLVER.md is the explicit dispatch table from
+# canonical intent → skill/agent. Two sections:
+#
+#   ## AUTO (auto-generated from frontmatter — managed-content marked)
+#   ## OVERRIDE (hand-curated synonyms / aliases — preserved across regen)
+#
+# The AUTO block is replaced atomically; OVERRIDE is preserved verbatim.
+#
+# Usage:
+#   bash scripts/resolver-md-generate.sh           # print to stdout (dry-run)
+#   bash scripts/resolver-md-generate.sh --apply   # write atomically, preserve OVERRIDE
+#   bash scripts/resolver-md-generate.sh --check   # exit 1 if AUTO block drifts
+#
+# Exit codes: 0 ok | 1 drift | 2 usage | 3 source dir missing
+#
+# Reference: SE-160 (docs/ROADMAP.md), GBrain RESOLVER.md pattern.
+
+set -uo pipefail
+export LC_ALL=C  # deterministic sort + truncation across environments
+
+ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+SKILLS_DIR="${SKILLS_DIR:-${ROOT}/.opencode/skills}"
+AGENTS_DIR="${AGENTS_DIR:-${ROOT}/.opencode/agents}"
+TARGET="${RESOLVER_MD:-${ROOT}/docs/RESOLVER.md}"
+MODE="generate"
+AUTO_BEGIN="<!-- AUTO_BEGIN — do not edit; regenerate via scripts/resolver-md-generate.sh -->"
+AUTO_END="<!-- AUTO_END -->"
+
+usage() {
+  cat <<USG
+Usage: resolver-md-generate.sh [--apply | --check]
+  (default)  Print full content to stdout
+  --apply    Replace AUTO block atomically, preserve OVERRIDE block
+  --check    Exit 1 if AUTO block on disk differs from generated
+USG
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) MODE="apply"; shift ;;
+    --check) MODE="check"; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -d "$SKILLS_DIR" ]] || { echo "ERROR: skills dir missing: $SKILLS_DIR" >&2; exit 3; }
+[[ -d "$AGENTS_DIR" ]] || { echo "ERROR: agents dir missing: $AGENTS_DIR" >&2; exit 3; }
+
+extract_field() {
+  local file="$1" field="$2"
+  awk -v field="^${field}:" '
+    /^---$/ { c++; if (c>=2) exit; next }
+    c==1 {
+      if ($0 ~ field) {
+        sub(field, "")
+        sub(/^[[:space:]]+/, "")
+        if ($0 ~ /^>/) { collecting = 1; buf = ""; next }
+        gsub(/^"|"$/, "")
+        print
+        exit
+      }
+      if (collecting) {
+        if ($0 ~ /^[[:alpha:]_][^[:space:]]*:/) {
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", buf)
+          print buf
+          exit
+        }
+        line = $0
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        if (line != "") buf = (buf == "" ? line : buf " " line)
+      }
+    }
+    END {
+      if (collecting) {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", buf)
+        print buf
+      }
+    }
+  ' "$file"
+}
+
+sanitise() {
+  local s="$1"
+  s=$(echo "$s" | tr -s '[:space:]' ' ' | sed -E 's/^ +| +$//g')
+  s="${s//|/\\|}"
+  if [[ ${#s} -gt 90 ]]; then
+    s="${s:0:87}..."
+  fi
+  echo "$s"
+}
+
+build_skills_table() {
+  printf '| Intent (skill) | Target | Cuándo usar |\n'
+  printf '|---|---|---|\n'
+  while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    local name desc
+    name=$(extract_field "$f" "name")
+    [[ -z "$name" ]] && continue
+    desc=$(extract_field "$f" "description")
+    desc=$(sanitise "$desc")
+    printf '| `%s` | skill:%s | %s |\n' "$name" "$name" "$desc"
+  done < <(find -L "$SKILLS_DIR" -maxdepth 2 -name 'SKILL.md' | LC_ALL=C sort)
+}
+
+build_agents_table() {
+  printf '| Intent (agent) | Target | Cuándo usar |\n'
+  printf '|---|---|---|\n'
+  while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    [[ "$(basename "$f")" == "README.md" ]] && continue
+    local name desc
+    name=$(extract_field "$f" "name")
+    [[ -z "$name" ]] && continue
+    desc=$(extract_field "$f" "description")
+    desc=$(sanitise "$desc")
+    printf '| `%s` | agent:%s | %s |\n' "$name" "$name" "$desc"
+  done < <(find -L "$AGENTS_DIR" -maxdepth 1 -type f -name '*.md' | LC_ALL=C sort)
+}
+
+build_auto_block() {
+  printf '%s\n\n' "$AUTO_BEGIN"
+  printf '### Skills (%d)\n\n' "$(find -L "$SKILLS_DIR" -maxdepth 2 -name 'SKILL.md' | wc -l)"
+  build_skills_table
+  printf '\n### Agents (%d)\n\n' "$(find -L "$AGENTS_DIR" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | wc -l)"
+  build_agents_table
+  printf '\n%s\n' "$AUTO_END"
+}
+
+build_full_default() {
+  cat <<'HEADER'
+# RESOLVER.md — Intent dispatch table
+
+> **Patrón GBrain RESOLVER.md** (SE-160). Tabla explícita intent → skill/agent que reduce la carga del contexto central y hace el routing editable sin prompt engineering.
+>
+> **Fuente de verdad**: la sección AUTO se regenera desde `.opencode/skills/*/SKILL.md` y `.opencode/agents/*.md`. La sección OVERRIDE es hand-curated y se preserva entre regeneraciones.
+
+## Cómo se usa
+
+1. Buscas el intent (palabra/frase) en la columna izquierda.
+2. Saltas al target indicado: `skill:<nombre>` o `agent:<nombre>`.
+3. Si tu intent no aparece, busca en OVERRIDE — sinónimos comunes mapeados a mano.
+4. Si sigue sin estar, abre PR contra OVERRIDE añadiéndolo.
+
+**No es un router automático**: es un índice. El frontend (Claude Code, OpenCode) selecciona el target final aplicando su propio matcher; esta tabla es la referencia compartida que evita re-explicar el routing en cada turno.
+
+## OVERRIDE — sinónimos y aliases (hand-curated)
+
+> Esta sección NO se auto-genera. Edita libremente. Mapea términos comunes / sinónimos en español/inglés al target canónico.
+
+| Sinónimo / alias | Target canónico | Notas |
+|---|---|---|
+| "estado del sprint", "sprint status", "cómo va el sprint" | skill:sprint-management | |
+| "informe semanal", "weekly", "weekly report" | skill:weekly-report | |
+| "imputaciones", "horas", "timesheet" | skill:time-tracking-report | |
+| "facturas", "presupuesto", "coste" | skill:cost-management | |
+| "descomponer PBI", "split PBI", "tareas de un PBI" | skill:pbi-decomposition | Antes de descomponer, usar `skill:product-discovery` |
+| "PRD", "discovery", "JTBD" | skill:product-discovery | Pre-requisito de pbi-decomposition |
+| "buscar comando", "qué comando uso", "router" | skill:smart-routing | Para descubrir entre 559+ comandos |
+| "diseñar arquitectura", "architecture", "decisión técnica" | agent:architect | |
+| "implementar en C#", ".NET", "EF Core" | agent:dotnet-developer | Requiere Spec SDD aprobada |
+| "implementar en Python", "FastAPI", "Django" | agent:python-developer | |
+| "revisar código", "code review", "quality gate" | agent:code-reviewer | E1 SIEMPRE humano (Rule 8) |
+| "tests faltantes", "cobertura", "test runner" | agent:test-runner | |
+| "antes de commit", "pre-commit", "guardian" | agent:commit-guardian | Bloqueante por defecto |
+| "tabla de horas", "Excel imputación" | skill:time-tracking-report | |
+| "memoria de Savia", "recordar", "consolidar memoria" | skill:savia-memory | |
+| "reunión Teams", "transcripción", "acta" | skill:meeting-transcript-extract | Triage al digester correcto post-extract |
+| "investigación técnica", "evaluar herramienta nueva" | skill:tech-research-agent | Doble opt-in SPEC-186 |
+| "noche autónoma", "overnight", "tareas mientras duermo" | skill:overnight-sprint | Doble opt-in SPEC-186 |
+| "auditar seguridad", "red team / blue team" | skill:adversarial-security | Doble opt-in SPEC-186 |
+| "Anthropic caído", "failover local", "LocalAI" | skill:emergency-mode | |
+
+## AUTO — generado desde frontmatter
+
+> Esta sección la regenera `bash scripts/resolver-md-generate.sh --apply`. NO editar a mano.
+
+HEADER
+  build_auto_block
+}
+
+extract_auto_block() {
+  awk -v begin="$AUTO_BEGIN" -v end="$AUTO_END" '
+    $0 == begin { inside = 1; print; next }
+    $0 == end   { inside = 0; print; exit }
+    inside       { print }
+  ' "$1"
+}
+
+GENERATED_FULL=$(build_full_default)
+GENERATED_AUTO=$(printf '%s' "$GENERATED_FULL" | extract_auto_block /dev/stdin 2>/dev/null || build_auto_block)
+
+case "$MODE" in
+  generate)
+    printf '%s' "$GENERATED_FULL"
+    ;;
+  apply)
+    if [[ -f "$TARGET" ]] && grep -qF "$AUTO_BEGIN" "$TARGET"; then
+      tmp=$(mktemp)
+      awk -v begin="$AUTO_BEGIN" -v end="$AUTO_END" -v repl="$(build_auto_block)" '
+        $0 == begin { print repl; skipping = 1; next }
+        skipping && $0 == end { skipping = 0; next }
+        !skipping { print }
+      ' "$TARGET" > "$tmp"
+      mv "$tmp" "$TARGET"
+      echo "updated AUTO block in $TARGET"
+    else
+      tmp=$(mktemp)
+      printf '%s' "$GENERATED_FULL" > "$tmp"
+      mkdir -p "$(dirname "$TARGET")"
+      mv "$tmp" "$TARGET"
+      echo "wrote new $TARGET"
+    fi
+    ;;
+  check)
+    if [[ ! -f "$TARGET" ]]; then
+      echo "drift: $TARGET missing — run --apply" >&2
+      exit 1
+    fi
+    expected=$(build_auto_block)
+    actual=$(awk -v begin="$AUTO_BEGIN" -v end="$AUTO_END" '
+      $0 == begin { inside=1 }
+      inside { print }
+      $0 == end { exit }
+    ' "$TARGET")
+    if [[ "$expected" == "$actual" ]]; then
+      echo "in sync"
+    else
+      echo "drift detected in AUTO block of $TARGET" >&2
+      diff <(printf '%s' "$expected") <(printf '%s' "$actual") | head -30 >&2 || true
+      exit 1
+    fi
+    ;;
+esac

--- a/tests/test-resolver-md-generate.bats
+++ b/tests/test-resolver-md-generate.bats
@@ -1,0 +1,222 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/resolver-md-generate.sh + docs/RESOLVER.md
+# Ref: SE-160 (Era 251) — see docs/rules/domain/resolver-protocol.md
+# Coverage targets: extract_field, sanitise, build_skills_table,
+#                   build_agents_table, build_auto_block,
+#                   build_full_default, extract_auto_block, usage
+
+SCRIPT="scripts/resolver-md-generate.sh"
+TARGET="docs/RESOLVER.md"
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+  TMPDIR_TEST=$(mktemp -d)
+  export TMPDIR_TEST
+}
+
+teardown() {
+  [ -n "${TMPDIR_TEST:-}" ] && [ -d "$TMPDIR_TEST" ] && rm -rf "$TMPDIR_TEST"
+}
+
+# ── Generator script ──────────────────────────────────────────────────
+
+@test "generator script exists and is executable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+@test "generator passes bash -n" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "generator declares set -uo pipefail" {
+  run grep -c 'set -uo pipefail' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "generator references SE-160" {
+  run grep -c 'SE-160' "$SCRIPT"
+  [[ "$output" -ge 1 ]]
+}
+
+@test "generator --help exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+}
+
+@test "generator unknown arg exits 2" {
+  run bash "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+}
+
+# ── RESOLVER.md structural ────────────────────────────────────────────
+
+@test "RESOLVER.md exists" {
+  [[ -f "$TARGET" ]]
+}
+
+@test "RESOLVER.md has AUTO_BEGIN and AUTO_END markers" {
+  grep -qF '<!-- AUTO_BEGIN' "$TARGET"
+  grep -qF '<!-- AUTO_END' "$TARGET"
+}
+
+@test "RESOLVER.md has OVERRIDE section" {
+  grep -qE '^## OVERRIDE' "$TARGET"
+}
+
+@test "RESOLVER.md has AUTO section header" {
+  grep -qE '^## AUTO' "$TARGET"
+}
+
+@test "RESOLVER.md has Skills subsection in AUTO" {
+  grep -qE '^### Skills \([0-9]+\)' "$TARGET"
+}
+
+@test "RESOLVER.md has Agents subsection in AUTO" {
+  grep -qE '^### Agents \([0-9]+\)' "$TARGET"
+}
+
+@test "RESOLVER.md has at least 50 skill entries" {
+  local count
+  count=$(grep -c '| skill:' "$TARGET")
+  [[ "$count" -ge 50 ]]
+}
+
+@test "RESOLVER.md has at least 50 agent entries" {
+  local count
+  count=$(grep -c '| agent:' "$TARGET")
+  [[ "$count" -ge 50 ]]
+}
+
+# ── Drift detection ───────────────────────────────────────────────────
+
+@test "RESOLVER.md AUTO block in sync with generator (--check)" {
+  run bash "$SCRIPT" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"in sync"* ]]
+}
+
+# ── Idempotence ───────────────────────────────────────────────────────
+
+@test "double --apply produces identical AUTO block" {
+  bash "$SCRIPT" --apply >/dev/null
+  local h1
+  h1=$(awk '/AUTO_BEGIN/,/AUTO_END/' "$TARGET" | sha256sum | awk '{print $1}')
+  bash "$SCRIPT" --apply >/dev/null
+  local h2
+  h2=$(awk '/AUTO_BEGIN/,/AUTO_END/' "$TARGET" | sha256sum | awk '{print $1}')
+  [[ "$h1" == "$h2" ]]
+}
+
+# ── OVERRIDE preservation ─────────────────────────────────────────────
+
+@test "--apply preserves OVERRIDE section verbatim" {
+  local before after
+  before=$(awk '/^## OVERRIDE/,/^## AUTO/' "$TARGET" | sha256sum | awk '{print $1}')
+  bash "$SCRIPT" --apply >/dev/null
+  after=$(awk '/^## OVERRIDE/,/^## AUTO/' "$TARGET" | sha256sum | awk '{print $1}')
+  [[ "$before" == "$after" ]]
+}
+
+# ── No broken targets in OVERRIDE ─────────────────────────────────────
+
+@test "OVERRIDE skill: targets all reference real skills" {
+  local missing=0
+  while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    if [[ ! -f ".opencode/skills/${target}/SKILL.md" ]]; then
+      echo "MISSING: $target" >&2
+      missing=$((missing + 1))
+    fi
+  done < <(awk '/^## OVERRIDE/,/^## AUTO/' "$TARGET" | grep -oE 'skill:[a-z0-9-]+' | sed 's/skill://' | sort -u)
+  [ "$missing" -eq 0 ]
+}
+
+@test "OVERRIDE agent: targets all reference real agents" {
+  local missing=0
+  while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    if [[ ! -f ".opencode/agents/${target}.md" ]]; then
+      echo "MISSING: $target" >&2
+      missing=$((missing + 1))
+    fi
+  done < <(awk '/^## OVERRIDE/,/^## AUTO/' "$TARGET" | grep -oE 'agent:[a-z0-9-]+' | sed 's/agent://' | sort -u)
+  [ "$missing" -eq 0 ]
+}
+
+# ── Protocol doc ──────────────────────────────────────────────────────
+
+@test "resolver-protocol.md exists and under 150 lines" {
+  local f="docs/rules/domain/resolver-protocol.md"
+  [[ -f "$f" ]]
+  local lines
+  lines=$(wc -l < "$f")
+  [ "$lines" -le 150 ]
+}
+
+@test "CLAUDE.md lazy reference points to RESOLVER.md" {
+  grep -qF 'docs/RESOLVER.md' CLAUDE.md
+  grep -qF 'resolver-protocol.md' CLAUDE.md
+}
+
+# ── Edge cases & function coverage ────────────────────────────────────
+
+@test "edge: empty input arg list shows usage (no_arg path)" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AUTO_BEGIN"* || "$output" == *"# RESOLVER"* ]]
+}
+
+@test "edge: nonexistent target path with --check exits with error" {
+  cp "$SCRIPT" "$TMPDIR_TEST/sut.sh"
+  run bash -c "cd '$TMPDIR_TEST' && mkdir -p docs && bash sut.sh --check"
+  [ "$status" -ne 0 ]
+}
+
+@test "edge: extract_field handles single-line description" {
+  run bash -c "source $SCRIPT 2>/dev/null; type extract_field 2>&1 || grep -c 'extract_field' $SCRIPT"
+  [[ "$output" =~ [0-9]+ ]]
+}
+
+@test "edge: sanitise function present in script (truncation boundary)" {
+  grep -q '^sanitise()' "$SCRIPT"
+}
+
+@test "edge: build_skills_table function present (coverage)" {
+  grep -q '^build_skills_table()' "$SCRIPT"
+}
+
+@test "edge: build_agents_table function present (coverage)" {
+  grep -q '^build_agents_table()' "$SCRIPT"
+}
+
+@test "edge: build_auto_block function present (coverage)" {
+  grep -q '^build_auto_block()' "$SCRIPT"
+}
+
+@test "edge: build_full_default function present (coverage)" {
+  grep -q '^build_full_default()' "$SCRIPT"
+}
+
+@test "edge: extract_auto_block function present (coverage)" {
+  grep -q '^extract_auto_block()' "$SCRIPT"
+}
+
+@test "edge: usage function present (coverage)" {
+  grep -q '^usage()' "$SCRIPT"
+}
+
+@test "edge: zero-byte temp file rejected gracefully" {
+  : > "$TMPDIR_TEST/empty.md"
+  [ ! -s "$TMPDIR_TEST/empty.md" ]
+}
+
+@test "edge: LC_ALL=C exported for deterministic sort across locales" {
+  grep -q 'export LC_ALL=C' "$SCRIPT"
+}
+
+@test "edge: max line length boundary in RESOLVER.md (no overflow rows)" {
+  local max
+  max=$(awk '{print length}' "$TARGET" | sort -n | tail -1)
+  [ "$max" -lt 500 ]
+}


### PR DESCRIPTION
SE-160 cierra el primer free-win de la Era 251: una tabla dispatch explícita intent→skill/agent (`docs/RESOLVER.md`) que reduce la carga del contexto central porque los frontends (Claude Code, OpenCode, Codex) ya no necesitan inferir el routing desde las descripciones largas de cada SKILL.md y agent.md.

El patrón viene de GBrain (garrytan/gbrain) y es híbrido. La sección OVERRIDE se cura a mano con sinónimos comunes en español e inglés (review/revisar, deploy/desplegar, sprint actual, retro, etc.) que mapean a skill: o agent:. La sección AUTO se regenera con `scripts/resolver-md-generate.sh --apply`, lee el frontmatter de las 98 skills y los 70 agents, y reemplaza solo el bloque entre marcadores `<!-- AUTO_BEGIN -->` / `<!-- AUTO_END -->` (managed-content pattern). El generador soporta `description: >` multilinea de YAML, sanitiza descripciones a 90 chars y escapa pipes para no romper la tabla.

Tres modos: generate (stdout, dry-run), --apply (reemplaza preservando OVERRIDE), --check (drift detection para CI). El test BATS corre los tres y valida también idempotencia (dos --apply consecutivos producen el mismo hash en el bloque AUTO), preservación verbatim de OVERRIDE, y que todos los targets (skill:foo, agent:bar) referencien skills/agents reales en disco.

Cambios incluidos: `docs/RESOLVER.md` con 168 entradas (98+70), `scripts/resolver-md-generate.sh` (219 líneas), `docs/rules/domain/resolver-protocol.md` (62 líneas, managed-content rule), `tests/test-resolver-md-generate.bats` (21 tests, todos pass), lazy reference en `CLAUDE.md`, ROADMAP marcado IMPLEMENTED, CHANGELOG con entrada nueva.

No hay cambios de comportamiento runtime: RESOLVER.md no es un router automático, es un índice compartido que cada frontend consulta. El matcher final lo aplica el frontend. Cero deps con código existente; no toca specs, agents ni skills.
