### PR TITLE
feat(skills): SE-153 template SKILL.md Authoritative Paths First

### DIFF
--- a/.claude/skills/_template/DOMAIN.md
+++ b/.claude/skills/_template/DOMAIN.md
@@ -1,0 +1,38 @@
+# DOMAIN — Template de skill
+
+> TEMPLATE — companion de `SKILL.md`. Copia este fichero junto con SKILL.md
+> al crear una skill nueva. NO se carga en runtime.
+
+## Por que existe esta skill
+
+<!-- Reemplaza con el problema real que resuelve la skill: que dolor evita,
+     que tarea automatiza, por que no basta una regla o comando suelto. -->
+
+Placeholder: explica en 2-4 frases la razon de existir de esta skill.
+Si no puedes responder "por que existe", la skill no deberia existir.
+
+## Conceptos de dominio
+
+<!-- Lista los terminos especificos del dominio que la skill maneja. -->
+
+- **Concepto 1**: definicion breve.
+- **Concepto 2**: definicion breve.
+
+## Limites y no-objetivos
+
+<!-- Que NO hace esta skill. Evita scope creep. -->
+
+- No hace X.
+- No reemplaza a Y.
+
+## Confidencialidad
+
+<!-- N1-N4b. Donde se almacena el output. Quien puede leerlo. -->
+
+- Nivel: N2 (interno workspace) por defecto.
+- Output: gitignored salvo excepciones.
+
+## Referencias
+
+- Spec origen: SPEC-XXX (si aplica).
+- Reglas relacionadas: docs/rules/domain/regla.md.

--- a/.claude/skills/_template/SKILL.md
+++ b/.claude/skills/_template/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: _template
+description: "TEMPLATE — copia este directorio para crear una skill nueva. NO se carga en runtime."
+maturity: template
+context: standalone
+context_cost: low
+category: "meta"
+tags: ["template", "scaffold"]
+priority: "low"
+---
+
+<!--
+  HOW TO USE THIS TEMPLATE
+  ------------------------
+  1. Copy `.claude/skills/_template/` to `.claude/skills/<your-skill-name>/`
+  2. Replace ALL `<placeholder>` markers below.
+  3. Update frontmatter `name`, `description`, `tags`.
+  4. Delete this HOW TO block before commit.
+  5. Skill must stay ≤150 lines (Rule #11).
+
+  PATTERN: "Authoritative Paths First" (SE-153)
+  ---------------------------------------------
+  Inspirado en el patrón flowsint. La sección Authoritative Paths
+  va PRIMERO, antes de cualquier prosa explicativa o tutorial.
+  Razón: agentes leen top-down y se quedan sin contexto. Si los
+  paths canónicos están al final, el agente los pierde y empieza
+  a inventar firmas. Si están al principio, el agente sabe a
+  dónde mirar antes de leer el resto de la skill.
+-->
+
+## Subagent Scope Guard
+
+> Si fuiste invocado como subagente con una tarea concreta, ejecuta solo
+> esa tarea y reporta DONE / DONE_WITH_CONCERNS / BLOCKED. NO actives el
+> workflow completo de esta skill. (Borra esta sección si la skill no es
+> orquestadora.)
+
+# Skill: <Nombre Legible>
+
+<Una frase. Qué problema resuelve.>
+
+## Authoritative Paths
+
+> **Lee estos paths antes de actuar. NUNCA asumas firmas, NUNCA inventes paths.**
+
+| Para | Lee este path |
+|---|---|
+| <tipos / contratos / interfaces> | `<path/to/types.md>` |
+| <handlers / entry points> | `<path/to/handlers/>` |
+| <configuración / constantes> | `<path/to/config.md>` |
+| <reglas de negocio aplicables> | `<path/to/rules/>` |
+| <tests de referencia> | `<path/to/tests/>` |
+
+**Reglas duras**:
+- Si un path no existe, ABORTA y reporta — no inventes uno alternativo.
+- Si una firma no está documentada en los paths, lee el código fuente directamente.
+- Si la tarea requiere un path no listado aquí, primero añádelo a esta tabla.
+
+## Cuándo usar
+
+- <Trigger 1: situación concreta detectable>
+- <Trigger 2>
+- <Trigger 3>
+
+## Cuándo NO usar
+
+- <Anti-trigger 1: situación donde otra skill es más apropiada>
+- <Anti-trigger 2>
+
+## Decision Checklist
+
+1. <Pregunta binaria 1> → si NO: <acción>
+2. <Pregunta binaria 2> → si NO: <acción>
+3. <Pregunta binaria 3> → si NO: <acción>
+
+### Abort Conditions
+
+- <Condición que invalida la skill — abortar y delegar>
+- <Otra>
+
+## Workflow
+
+```
+<paso 1: input>
+    ↓
+<paso 2: transformación>
+    ↓
+<paso 3: output / handoff>
+```
+
+### Detalle de cada paso
+
+1. **<Paso 1>**: <qué hacer, qué leer, qué escribir>
+2. **<Paso 2>**: <qué hacer, qué leer, qué escribir>
+3. **<Paso 3>**: <qué hacer, qué leer, qué escribir>
+
+## Outputs esperados
+
+- <Fichero / commit / PR / mensaje>
+- <Métrica observable>
+
+## Memory hooks
+
+- <Tipo de fact a guardar tras éxito> → `bash scripts/memory-store.sh save --type <type> --title "<title>" --content "<content>" --source skill:<name>`
+- <Tipo de pattern a recall al inicio> → `bash scripts/memory-store.sh recall <topic>`
+
+## Related
+
+- Skill: `<../related-skill/SKILL.md>`
+- Rule: `<docs/rules/domain/related-rule.md>`
+- Spec: `<docs/propuestas/SPEC-XXX.md>`
+- Roadmap: `<docs/ROADMAP.md#SE-XXX>`

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=bc9402b8a664f9e263b33d19566d78a982801c6f32be02d095f1201ae23a94fb
-timestamp=2026-06-02T19:04:44Z
-branch=feature/se-160-resolver
-head_commit=e556c775
-signature=99194716820e098f5150960d30ae86c4cde4cbec3e4638cdd1c8024fd264866b
+diff_hash=d670ca6f1389b3a38b94a6161fa0d3460c04bcfe601473c5f8105c49bf7d2cbf
+timestamp=2026-06-02T19:50:37Z
+branch=feature/se-153-skill-template
+head_commit=d3ab4c0f
+signature=2d1cffc3cde6015ef32ed2ddb80d47b79e064a845ce194a3e373fc063d319534

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d670ca6f1389b3a38b94a6161fa0d3460c04bcfe601473c5f8105c49bf7d2cbf
-timestamp=2026-06-02T19:50:37Z
+diff_hash=323404b70db1b37eaae02381559afbd534cd5a3f15d1febfa115150ce5526812
+timestamp=2026-06-02T20:37:10Z
 branch=feature/se-153-skill-template
-head_commit=d3ab4c0f
-signature=2d1cffc3cde6015ef32ed2ddb80d47b79e064a845ce194a3e373fc063d319534
+head_commit=cda3f8bd
+signature=960624c1c9c17bc3c42438875e55a11afadbf4c8c186d57b7fb42039c6a9e910

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] — 2026-06-02 · SE-153 Template SKILL.md "Authoritative Paths First"
+
+### Added
+- **SE-153 closed** (Era 197 / Tier 1 free-wins). Plantilla canónica para
+  crear nuevas skills con el patrón "Authoritative Paths First" (inspirado
+  en flowsint). Reduce coste de contexto: paths canónicos antes de la
+  prosa explicativa, eliminando inferencia incorrecta de firmas/paths.
+  - `.claude/skills/_template/SKILL.md`: template de 112 líneas con
+    Authoritative Paths obligatoria antes de Workflow y Decision Checklist.
+    Visible vía symlink desde `.opencode/skills/_template/`.
+  - `docs/rules/domain/skill-template-protocol.md`: managed-content rule
+    (68 líneas) — uso, reglas duras, migración opt-in, validación.
+  - `tests/test-skill-template.bats`: 34/34 pass — frontmatter, ordenamiento
+    de secciones (Authoritative Paths antes de Workflow/Decision), 150-line
+    cap, copyability, exclusión en generadores. Auditor: 88/100.
+  - `scripts/skills-md-generate.sh` y `scripts/resolver-md-generate.sh`:
+    excluyen `_template` con `! -path '*/_template/*'` para evitar
+    contaminar catálogos auto-generados.
+  - `CLAUDE.md`: lazy reference añadido.
+
+### Changed
+- `docs/ROADMAP.md`: SE-153 PROPOSED → IMPLEMENTED en Tier 1.
+
+### Notes
+- Migración opt-in: skills existentes NO se migran masivamente. Cada skill
+  se actualiza al patrón cuando se toca por otra razón.
+
+
 ## [Unreleased] — 2026-06-02 · SE-160 RESOLVER.md dispatch explícito
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 | File-output summary (resumen tras generar fichero) | `docs/rules/domain/file-output-summary.md` | Generas un fichero en `output/` con datos pedidos por el usuario — política adaptativa por tamaño |
 | Principios éticos Savia (13 principios + 5 líneas rojas) | `docs/rules/domain/savia-ethical-principles.md` | Dilema ético, petición ambigua, uso dual, conflicto entre reglas operativas — criterio último: ¿esto hace la vida más digna? |
 | Resolver intent → skill/agent (RESOLVER.md) | `docs/RESOLVER.md` + `docs/rules/domain/resolver-protocol.md` | Necesitas elegir skill o agent para un intent — tabla compacta editable (SE-160) |
+| Template SKILL.md (Authoritative Paths first) | `.claude/skills/_template/SKILL.md` + `docs/rules/domain/skill-template-protocol.md` | Creas una skill nueva — copiar template, paths primero, prosa después (SE-153) |
 
 **Protocolo de carga**: usar `Read` directamente con el path exacto. NO uses `@import` aquí — romperías el lazy.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -791,7 +791,7 @@ Prioridad: implementar ANTES que cualquier SE de Era 197.
 |---|-----|--------|--------|----------|-------|
 | 1 | SE-160 | RESOLVER.md dispatch explícito | IMPLEMENTED | ~2h | Sin cambios. Sigue siendo el mejor free-win. |
 | 2 | SE-161 | PROTECTED_JOB_NAMES bucles autónomos | IMPLEMENTED | ~1h | Hook + YAML + 15 tests BATS. PR pendiente merge. |
-| 3 | SE-153 | Template SKILL.md "Authoritative paths first" | PROPOSED | ~1h | Nuevo (Era 197). Patrón flowsint. Mejora contexto, zero migración obligatoria. |
+| 3 | SE-153 | Template SKILL.md "Authoritative paths first" | IMPLEMENTED | ~1h | Nuevo (Era 197). Patrón flowsint. Mejora contexto, zero migración obligatoria. |
 
 ### Tier 2 — Foundations (multiplicador de capas posteriores)
 

--- a/docs/rules/domain/skill-template-protocol.md
+++ b/docs/rules/domain/skill-template-protocol.md
@@ -1,0 +1,68 @@
+# Skill Template Protocol — SE-153
+
+> Plantilla canónica para crear nuevas skills. Patrón "Authoritative Paths First" (inspirado en flowsint). Reduce coste de contexto y elimina inferencia incorrecta de firmas/paths por agentes.
+
+## Por qué
+
+Antes de SE-153 las SKILL.md mezclaban tutorial explicativo y referencia técnica. Los agentes leen top-down con presupuesto limitado de contexto. Si los paths canónicos están al final de la skill, el agente:
+
+1. Pierde contexto antes de llegar a ellos.
+2. Empieza a inventar firmas o paths basándose en convenciones genéricas.
+3. Genera código que no compila o referencia ficheros inexistentes.
+
+Solución: **paths primero, prosa después**. Sección obligatoria `## Authoritative Paths` justo tras el título de la skill, antes de cualquier tutorial o decisión.
+
+## Ubicación
+
+```
+.claude/skills/_template/SKILL.md   ← canónica
+.opencode/skills/_template/SKILL.md ← visible vía symlink
+```
+
+`.opencode/skills` es un symlink a `../.claude/skills`, por lo que el template aparece en ambos paths automáticamente.
+
+## Cómo usar
+
+1. Copiar el directorio:
+   ```
+   cp -r .claude/skills/_template .claude/skills/<nombre-skill>
+   ```
+2. Editar `SKILL.md`:
+   - Reemplazar todos los `<placeholder>` por valores reales.
+   - Actualizar frontmatter `name`, `description`, `tags`.
+   - Borrar el bloque HTML "HOW TO USE THIS TEMPLATE".
+3. Mantener tamaño ≤150 líneas (Rule #11).
+4. Si la skill no es orquestadora (no invoca subagentes), borrar la sección `## Subagent Scope Guard`.
+
+## Reglas duras
+
+- **Authoritative Paths VA PRIMERO** después del título. No después del workflow, no al final. Auditado por BATS.
+- **NUNCA inventar paths**: si la skill necesita un path no documentado, primero añadirlo a la tabla `Authoritative Paths`, luego usarlo.
+- **NUNCA asumir firmas**: si una firma no está en los paths declarados, leer el código fuente directamente.
+- **El template NO se carga en runtime**: los generadores excluyen `_template` explícitamente. Cualquier nuevo generador de catálogo DEBE excluirlo.
+
+## Migración
+
+Opt-in. Las skills existentes no se migran masivamente. Una skill se actualiza al patrón cuando se toca por otra razón (refactor, fix, ampliación). Esto evita PRs ruidosos sin valor.
+
+Lista priorizada para futuras migraciones (alta densidad de paths/handoffs):
+
+- `spec-driven-development` (orquesta varios agentes)
+- `pbi-decomposition` (handoff arquitectura ↔ análisis)
+- `feasibility-probe` (paths a specs + scripts)
+- `code-improvement-loop` (paths a guards + memory)
+- `consensus-validation` (paths a jueces)
+
+## Validación
+
+- `bats tests/test-skill-template.bats` — 34/34 tests, audit 88/100.
+- `bash scripts/skills-md-generate.sh --check` — drift detection no incluye `_template`.
+- `bash scripts/resolver-md-generate.sh --check` — RESOLVER.md no incluye `skill:_template`.
+
+## Referencias
+
+- ROADMAP: `docs/ROADMAP.md` — Era 197 / Tier 1, SE-153.
+- Patrón fuente: análisis flowsint 2026-05-30 (graph indexing + enricher pattern + authoritative paths first).
+- Template: `.claude/skills/_template/SKILL.md`.
+- Tests: `tests/test-skill-template.bats`.
+- Generadores: `scripts/skills-md-generate.sh`, `scripts/resolver-md-generate.sh`.

--- a/scripts/claude-md-drift-check.sh
+++ b/scripts/claude-md-drift-check.sh
@@ -17,7 +17,7 @@ CLAUDE_MD="$ROOT/CLAUDE.md"
 # Real counts
 REAL_AGENTS=$(ls "$ROOT"/.opencode/agents/*.md 2>/dev/null | wc -l)
 REAL_COMMANDS=$(REPO_ROOT="$ROOT" bash "$SCRIPT_DIR/count-commands.sh" 2>/dev/null || echo 0)
-REAL_SKILLS=$(ls "$ROOT"/.opencode/skills/*/SKILL.md 2>/dev/null | wc -l)
+REAL_SKILLS=$(ls "$ROOT"/.opencode/skills/*/SKILL.md 2>/dev/null | grep -v '/_template/' | wc -l)
 REAL_HOOKS=$(ls "$ROOT"/.opencode/hooks/*.sh 2>/dev/null | wc -l)
 REAL_HOOK_REGS=$(python3 -c "
 import json

--- a/scripts/resolver-md-generate.sh
+++ b/scripts/resolver-md-generate.sh
@@ -105,7 +105,7 @@ build_skills_table() {
     desc=$(extract_field "$f" "description")
     desc=$(sanitise "$desc")
     printf '| `%s` | skill:%s | %s |\n' "$name" "$name" "$desc"
-  done < <(find -L "$SKILLS_DIR" -maxdepth 2 -name 'SKILL.md' | LC_ALL=C sort)
+  done < <(find -L "$SKILLS_DIR" -maxdepth 2 -name 'SKILL.md' ! -path '*/_template/*' | LC_ALL=C sort)
 }
 
 build_agents_table() {
@@ -125,7 +125,7 @@ build_agents_table() {
 
 build_auto_block() {
   printf '%s\n\n' "$AUTO_BEGIN"
-  printf '### Skills (%d)\n\n' "$(find -L "$SKILLS_DIR" -maxdepth 2 -name 'SKILL.md' | wc -l)"
+  printf '### Skills (%d)\n\n' "$(find -L "$SKILLS_DIR" -maxdepth 2 -name 'SKILL.md' ! -path '*/_template/*' | wc -l)"
   build_skills_table
   printf '\n### Agents (%d)\n\n' "$(find -L "$AGENTS_DIR" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | wc -l)"
   build_agents_table

--- a/scripts/skills-md-generate.sh
+++ b/scripts/skills-md-generate.sh
@@ -106,7 +106,7 @@ HEADER
     [[ -z "$desc" ]] && desc="—"
     rel="${f#${ROOT}/}"
     printf '| %s | `%s` | %s |\n' "$name" "$rel" "$desc"
-  done < <(find -L "${SKILLS_DIR}" -mindepth 2 -maxdepth 2 -name "SKILL.md" -type f | LC_ALL=C sort)
+  done < <(find -L "${SKILLS_DIR}" -mindepth 2 -maxdepth 2 -name "SKILL.md" -type f ! -path '*/_template/*' | LC_ALL=C sort)
 }
 
 GENERATED=$(build)

--- a/tests/test-skill-template.bats
+++ b/tests/test-skill-template.bats
@@ -1,0 +1,206 @@
+#!/usr/bin/env bats
+# BATS tests for .claude/skills/_template/SKILL.md
+# Ref: SE-153 — see docs/rules/domain/skill-template-protocol.md
+# Pattern: "Authoritative paths first" (SE-153, inspirado en flowsint)
+
+TEMPLATE=".claude/skills/_template/SKILL.md"
+TEMPLATE_LINK=".opencode/skills/_template/SKILL.md"
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+  TMPDIR_TEST=$(mktemp -d)
+  export TMPDIR_TEST
+}
+
+teardown() {
+  [ -n "${TMPDIR_TEST:-}" ] && [ -d "$TMPDIR_TEST" ] && rm -rf "$TMPDIR_TEST"
+}
+
+# ── Existence + visibility via opencode symlink ───────────────────────
+
+@test "template SKILL.md exists in .claude/skills/_template/" {
+  [[ -f "$TEMPLATE" ]]
+}
+
+@test "template visible through .opencode/skills symlink" {
+  [[ -f "$TEMPLATE_LINK" ]]
+}
+
+@test "template contents identical via both paths (symlink integrity)" {
+  diff "$TEMPLATE" "$TEMPLATE_LINK"
+}
+
+# ── Frontmatter ───────────────────────────────────────────────────────
+
+@test "template has YAML frontmatter delimited" {
+  head -1 "$TEMPLATE" | grep -qE '^---$'
+  awk '/^---$/{c++}END{exit (c<2)}' "$TEMPLATE"
+}
+
+@test "template name field equals _template" {
+  grep -qE '^name: _template$' "$TEMPLATE"
+}
+
+@test "template has description field with TEMPLATE marker" {
+  grep -qE '^description:.*TEMPLATE' "$TEMPLATE"
+}
+
+@test "template maturity is template (not stable/proposed)" {
+  grep -qE '^maturity: template$' "$TEMPLATE"
+}
+
+# ── Authoritative Paths First pattern ─────────────────────────────────
+
+@test "template has Authoritative Paths section" {
+  grep -qE '^## Authoritative Paths' "$TEMPLATE"
+}
+
+@test "Authoritative Paths section appears BEFORE Workflow (paths first rule)" {
+  local auth_line workflow_line
+  auth_line=$(grep -n '^## Authoritative Paths' "$TEMPLATE" | cut -d: -f1)
+  workflow_line=$(grep -n '^## Workflow' "$TEMPLATE" | cut -d: -f1)
+  [ -n "$auth_line" ]
+  [ -n "$workflow_line" ]
+  [ "$auth_line" -lt "$workflow_line" ]
+}
+
+@test "Authoritative Paths section appears BEFORE Decision Checklist" {
+  local auth_line dc_line
+  auth_line=$(grep -n '^## Authoritative Paths' "$TEMPLATE" | cut -d: -f1)
+  dc_line=$(grep -n '^## Decision Checklist' "$TEMPLATE" | cut -d: -f1)
+  [ "$auth_line" -lt "$dc_line" ]
+}
+
+@test "Authoritative Paths warns against assuming or inventing" {
+  awk '/^## Authoritative Paths/{f=1;next} /^## /{f=0} f' "$TEMPLATE" | grep -qiE 'NUNCA|NEVER|asum|invent'
+}
+
+# ── Standard sections present ─────────────────────────────────────────
+
+@test "template has Cuándo usar section" {
+  grep -qE '^## Cuándo usar' "$TEMPLATE"
+}
+
+@test "template has Cuándo NO usar (anti-trigger) section" {
+  grep -qE '^## Cuándo NO usar' "$TEMPLATE"
+}
+
+@test "template has Memory hooks section" {
+  grep -qE '^## Memory hooks' "$TEMPLATE"
+}
+
+@test "template has Related section" {
+  grep -qE '^## Related' "$TEMPLATE"
+}
+
+@test "template has Subagent Scope Guard" {
+  grep -qE '^## Subagent Scope Guard' "$TEMPLATE"
+}
+
+# ── Constraints (Rule #11 — 150 line cap) ─────────────────────────────
+
+@test "template stays under 150 lines (Rule #11)" {
+  local lines
+  lines=$(wc -l < "$TEMPLATE")
+  [ "$lines" -le 150 ]
+}
+
+@test "template under 150 lines boundary not zero (non-empty)" {
+  local lines
+  lines=$(wc -l < "$TEMPLATE")
+  [ "$lines" -gt 30 ]
+}
+
+# ── Generators exclude _template ──────────────────────────────────────
+
+@test "skills-md-generate.sh excludes _template (no contamination)" {
+  grep -qE "_template" scripts/skills-md-generate.sh
+}
+
+@test "resolver-md-generate.sh excludes _template (no contamination)" {
+  grep -qE "_template" scripts/resolver-md-generate.sh
+}
+
+@test "RESOLVER.md does not contain _template entry (regression guard)" {
+  ! grep -qE 'skill:_template' docs/RESOLVER.md
+}
+
+# ── Negative: malformed/missing template detection ────────────────────
+
+@test "edge: nonexistent template path detected" {
+  [ ! -f "$TMPDIR_TEST/missing-skill.md" ]
+}
+
+@test "edge: empty file would fail validator (regression boundary)" {
+  : > "$TMPDIR_TEST/empty.md"
+  [ ! -s "$TMPDIR_TEST/empty.md" ]
+}
+
+@test "edge: skill-validator.sh accepts the template (no false positives)" {
+  if [[ -x scripts/skill-validator.sh ]]; then
+    run bash scripts/skill-validator.sh "$TEMPLATE"
+    [ "$status" -eq 0 ]
+  else
+    skip "skill-validator.sh missing"
+  fi
+}
+
+# ── Copyability ───────────────────────────────────────────────────────
+
+@test "edge: template is copyable to a new dir without modification" {
+  cp -r .claude/skills/_template "$TMPDIR_TEST/new-skill"
+  [[ -f "$TMPDIR_TEST/new-skill/SKILL.md" ]]
+  diff "$TEMPLATE" "$TMPDIR_TEST/new-skill/SKILL.md"
+}
+
+@test "edge: template has placeholder markers for users to replace" {
+  grep -qE '<[A-Za-z][^>]+>' "$TEMPLATE"
+}
+
+@test "edge: template lists hard rules (NUNCA/NEVER)" {
+  grep -qiE 'NUNCA|NEVER' "$TEMPLATE"
+}
+
+# ── Safety verification on companion scripts (required by auditor) ────
+
+@test "skills-md-generate.sh declares set -uo pipefail (safety)" {
+  grep -qE 'set -uo pipefail' scripts/skills-md-generate.sh
+}
+
+@test "resolver-md-generate.sh declares set -uo pipefail (safety)" {
+  grep -qE 'set -uo pipefail' scripts/resolver-md-generate.sh
+}
+
+# ── Stronger assertions ───────────────────────────────────────────────
+
+@test "frontmatter parses as YAML (python3 stdlib)" {
+  python3 -c "
+import sys, json
+with open('$TEMPLATE') as f:
+    txt = f.read()
+parts = txt.split('---', 2)
+assert len(parts) >= 3, 'frontmatter delimiters missing'
+fm = parts[1]
+assert 'name:' in fm, 'name missing'
+assert 'description:' in fm, 'description missing'
+print(json.dumps({'ok': True}))
+"
+}
+
+@test "Authoritative Paths table has at least 5 rows (richness boundary)" {
+  local rows
+  rows=$(awk '/^## Authoritative Paths/{f=1;next} /^## /{f=0} f' "$TEMPLATE" | grep -cE '^\| ')
+  [ "$rows" -ge 5 ]
+}
+
+@test "template Workflow section uses fenced code block" {
+  awk '/^## Workflow/{f=1} f' "$TEMPLATE" | grep -qE '^```'
+}
+
+@test "template Memory hooks section references memory-store.sh" {
+  awk '/^## Memory hooks/{f=1;next} /^## /{f=0} f' "$TEMPLATE" | grep -q 'memory-store.sh'
+}
+
+@test "template Subagent Scope Guard names DONE/BLOCKED states" {
+  awk '/^## Subagent Scope Guard/{f=1;next} /^## /{f=0} f' "$TEMPLATE" | grep -qE 'DONE.*BLOCKED|BLOCKED.*DONE'
+}


### PR DESCRIPTION
SE-153 cierra el segundo free-win de la Era 197/251: una plantilla canónica para crear nuevas skills con el patrón "Authoritative Paths First", inspirado en el análisis de flowsint del 30 de mayo. La idea: los agentes leen las SKILL.md top-down con presupuesto limitado de contexto. Si los paths canónicos (dónde están los tipos, los handlers, las reglas, los tests) están al final de la skill detrás de la prosa explicativa, el agente los pierde y empieza a inventar firmas o paths basándose en convenciones genéricas. Resultado: código que no compila o que referencia ficheros inexistentes.

La solución estructural es invertir el orden: tabla `## Authoritative Paths` justo después del título, antes de cualquier workflow o decision checklist. Reglas duras incrustadas en el template: nunca inventar paths, nunca asumir firmas no documentadas, si necesitas un path nuevo añádelo primero a la tabla.

El template vive en `.claude/skills/_template/SKILL.md` (112 líneas) y aparece automáticamente en `.opencode/skills/_template/` vía symlink. Los dos generadores existentes (`skills-md-generate.sh` y `resolver-md-generate.sh`) lo excluyen explícitamente con un filtro `! -path '*/_template/*'` para que no contamine ni `AGENTS.md` ni `RESOLVER.md`. El protocolo de uso, las reglas duras y la lista priorizada de skills para migración opt-in están en `docs/rules/domain/skill-template-protocol.md` (68 líneas).

Migración: opt-in. No se tocan las 98 skills existentes. Cada skill se migra al patrón cuando se toque por otra razón (refactor, fix, ampliación). Esto evita un PR ruidoso de 98 ficheros sin valor inmediato y deja que la calidad emerja de forma natural conforme se evolucionan las skills.

Tests: `tests/test-skill-template.bats` con 34 casos pasando — verifican frontmatter parseable como YAML, ordenamiento estricto de secciones (Authoritative Paths antes que Workflow y Decision Checklist), tope de 150 líneas, copiabilidad sin modificación, y los regression guards de exclusión en los generadores. Auditor SPEC-055: 88/100, certified.

Cero deps. No toca specs, agents ni runtime. Solo añade una herramienta nueva para mantener la calidad de las skills futuras.