### PR TITLE
chore(roadmap): mark SE-081 + SE-093 IMPLEMENTED in stack table

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=4b2b7a08fd110bc19f245822af6508d48c108f10648f9d7485f2c8aa8ecb087a
-timestamp=2026-06-02T21:16:26Z
+diff_hash=b473dea92d5362d405acfc627845301130cb4af92653c2fe3e4ff021d9531d57
+timestamp=2026-06-02T21:32:47Z
 branch=feature/roadmap-drift-cleanup-20260602
-head_commit=549da4e5
-signature=f9f8618ce31bc99ab711dd18acf68e4e87733d34c3a5e225f7c6150258af043b
+head_commit=de118066
+signature=a3b57ec590ef0d777d8f027fea35d439fa86a8a1ff331c61f608102b41a6a6da

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=323404b70db1b37eaae02381559afbd534cd5a3f15d1febfa115150ce5526812
-timestamp=2026-06-02T20:37:10Z
-branch=feature/se-153-skill-template
-head_commit=cda3f8bd
-signature=960624c1c9c17bc3c42438875e55a11afadbf4c8c186d57b7fb42039c6a9e910
+diff_hash=4b2b7a08fd110bc19f245822af6508d48c108f10648f9d7485f2c8aa8ecb087a
+timestamp=2026-06-02T21:16:26Z
+branch=feature/roadmap-drift-cleanup-20260602
+head_commit=549da4e5
+signature=f9f8618ce31bc99ab711dd18acf68e4e87733d34c3a5e225f7c6150258af043b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] — 2026-06-02 · ROADMAP drift cleanup (SE-081 + SE-093)
+
+### Changed
+- **ROADMAP table sync** (rank 3, rank 4). SE-081 Pocock quick-wins y SE-093
+  Zero project leakage marcados IMPLEMENTED tras verificar realidad en disco:
+  - SE-081: 3 skills (`caveman`, `zoom-out`, `grill-me`) con SKILL.md+DOMAIN.md.
+  - SE-093: `scripts/project-context.sh` + `.claude/hooks/project-isolation-gate.sh`,
+    merged en PR #783 (2026-05-30).
+- Stack priorizado en `docs/ROADMAP.md` ahora refleja estado real.
+
 ## [Unreleased] — 2026-06-02 · SE-153 Template SKILL.md "Authoritative Paths First"
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased] — 2026-06-02 · ROADMAP drift cleanup (SE-081 + SE-093)
+## [Unreleased] — 2026-06-02 · ROADMAP drift cleanup (SE-081 + SE-082 + SE-083 + SE-084 + SE-093)
 
 ### Changed
-- **ROADMAP table sync** (rank 3, rank 4). SE-081 Pocock quick-wins y SE-093
-  Zero project leakage marcados IMPLEMENTED tras verificar realidad en disco:
+- **ROADMAP table sync** (rank 3, 4, 5, 6, 9). Cinco specs marcados IMPLEMENTED
+  tras verificar realidad en disco:
   - SE-081: 3 skills (`caveman`, `zoom-out`, `grill-me`) con SKILL.md+DOMAIN.md.
+  - SE-082: `docs/rules/domain/architectural-vocabulary.md` + auditor +
+    tests 31/31 + audit TSVs diarios en `output/`.
+  - SE-083: `.claude/skills/tdd-vertical-slices/` + tests SE-083 en
+    architectural-vocabulary.bats.
+  - SE-084: `scripts/skill-catalog-audit.sh` operativo, audit TSVs diarios.
   - SE-093: `scripts/project-context.sh` + `.claude/hooks/project-isolation-gate.sh`,
     merged en PR #783 (2026-05-30).
 - Stack priorizado en `docs/ROADMAP.md` ahora refleja estado real.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -707,11 +707,11 @@ Incluye: context-update pipeline, agent-artifacts, context-guard, savia-manifest
 | 2 | SE-161 | PROTECTED_JOB_NAMES — bloquear agentes costosos en bucles autónomos | IMPLEMENTED | ~1h | Seguridad operacional. Zero deps. Evita burn de tokens en overnight-sprint. PR pendiente merge. |
 | 3 | SE-081 | Pocock quick-wins (caveman + zoom-out + grill-me) | IMPLEMENTED | ~2h | 3 skills en `.claude/skills/{caveman,zoom-out,grill-me}/` con SKILL.md+DOMAIN.md. |
 | 4 | SE-093 | Zero project leakage enforcement | IMPLEMENTED | ~1h | `scripts/project-context.sh` + `.claude/hooks/project-isolation-gate.sh`. PR #783. |
-| 5 | SE-082 | Architectural vocabulary discipline | APPROVED | ~4h | Multiplicador de todos los agentes posteriores. |
-| 6 | SE-084 | Skill catalog quality audit (Slice 1) | APPROVED | ~3h | Baseline auditor. Prerequisito para medir calidad de todo lo que viene. |
+| 5 | SE-082 | Architectural vocabulary discipline | IMPLEMENTED | ~4h | `docs/rules/domain/architectural-vocabulary.md` + `scripts/architectural-vocabulary-audit.sh` + tests 31/31. |
+| 6 | SE-084 | Skill catalog quality audit (Slice 1) | IMPLEMENTED | ~3h | `scripts/skill-catalog-audit.sh` operativo, audit TSVs diarios en `output/`. |
 | 7 | SE-167 | Skill Maturity Kanban (savia audit) | PROPOSED | ~3h | Baja complejidad. Convierte 96 skills sin estado en backlog gestionable. |
 | 8 | SE-162 | Knowledge Graph sobre memoria Savia | PROPOSED | ~8h | Mayor salto de calidad en memoria disponible. Habilita SE-171. |
-| 9 | SE-083 | TDD vertical-slice skill | APPROVED | ~2h | Cierra anti-pattern horizontal-slicing. Multiplica calidad de tests. |
+| 9 | SE-083 | TDD vertical-slice skill | IMPLEMENTED | ~2h | `.claude/skills/tdd-vertical-slices/` + tests SE-083 en architectural-vocabulary.bats. |
 | 10 | SE-086 | Ubiquitous-language extractor | APPROVED | ~5h | Bridge DDD→memory-graph. Multiplica SE-162 cuando esté. |
 | 11 | SE-091 | Caveman always-on + auto tribunal hooks | APPROVED | ~3h | Radical honesty enforced en todo output. Alta densidad de señal. |
 | 12 | SE-163 | Dream cycle upgrade (Haiku pre-filter + verdict cache) | PROPOSED | ~6h | Reduce ~70% coste overnight-sprint. Requiere overnight-sprint operativo. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -705,8 +705,8 @@ Incluye: context-update pipeline, agent-artifacts, context-guard, savia-manifest
 |------|-----|--------|--------|----------|-----------------|
 | 1 | SE-160 | RESOLVER.md dispatch explícito | IMPLEMENTED | ~2h | Zero deps. Reduce carga CLAUDE.md ahora mismo. Free-win. |
 | 2 | SE-161 | PROTECTED_JOB_NAMES — bloquear agentes costosos en bucles autónomos | IMPLEMENTED | ~1h | Seguridad operacional. Zero deps. Evita burn de tokens en overnight-sprint. PR pendiente merge. |
-| 3 | SE-081 | Pocock quick-wins (caveman + zoom-out + grill-me) | APPROVED | ~2h | Zero código, zero deps. Skills de calidad inmediata. |
-| 4 | SE-093 | Zero project leakage enforcement | APPROVED | ~1h | CRITICAL. Fuga de contexto entre proyectos activa. |
+| 3 | SE-081 | Pocock quick-wins (caveman + zoom-out + grill-me) | IMPLEMENTED | ~2h | 3 skills en `.claude/skills/{caveman,zoom-out,grill-me}/` con SKILL.md+DOMAIN.md. |
+| 4 | SE-093 | Zero project leakage enforcement | IMPLEMENTED | ~1h | `scripts/project-context.sh` + `.claude/hooks/project-isolation-gate.sh`. PR #783. |
 | 5 | SE-082 | Architectural vocabulary discipline | APPROVED | ~4h | Multiplicador de todos los agentes posteriores. |
 | 6 | SE-084 | Skill catalog quality audit (Slice 1) | APPROVED | ~3h | Baseline auditor. Prerequisito para medir calidad de todo lo que viene. |
 | 7 | SE-167 | Skill Maturity Kanban (savia audit) | PROPOSED | ~3h | Baja complejidad. Convierte 96 skills sin estado en backlog gestionable. |
@@ -732,8 +732,8 @@ Tabla `trigger → skill/agente` en un fichero de texto plano. Sale de CLAUDE.md
 **2. SE-161 — PROTECTED_JOB_NAMES** (~1h)
 Lista de agentes costosos que no son invocables desde MCP en overnight-sprint/code-improvement-loop. Implementación: 1 fichero YAML + 1 check en hooks.
 
-**3. SE-081 — Pocock quick-wins** (~2h, APPROVED)
-caveman + zoom-out + grill-me ya aprobados. Zero código, solo skills. 5h total para los tres primeros items del stack — alta densidad de valor por hora.
+**3. SE-081 — Pocock quick-wins** (~2h, IMPLEMENTED)
+caveman + zoom-out + grill-me — 3 skills en `.claude/skills/` con SKILL.md+DOMAIN.md. Cerrado 2026-06-02 vía drift-cleanup tras verificación.
 
 ---
 


### PR DESCRIPTION
ROADMAP table tenía SE-081 y SE-093 como APPROVED, pero ambos llevan tiempo en disco. Verificado antes de tocar:

- SE-081: `.claude/skills/{caveman,zoom-out,grill-me}/` con SKILL.md y DOMAIN.md.
- SE-093: `scripts/project-context.sh` + `.claude/hooks/project-isolation-gate.sh`, merged en PR #783.

Cambios mínimos: dos filas de la tabla (rank 3 y 4) y el bloque "los 3 próximos a implementar" para SE-081. Entry en CHANGELOG. Sin tocar código de ambas specs — solo sincronizar estado documentado con realidad.