### PR TITLE
docs(roadmap): SE-172 markitdown como capa 0 universal de digestión

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=9464a20bacfb6c65900ed717b441685f6a653e14b682477300ff21585dd5fc22
-timestamp=2026-06-03T20:01:38Z
-branch=feature/se-086-ubiquitous-language
-head_commit=64f8c9c3
-signature=5fa06807184976a15e19f2e8d691783a53ef1a461f1a8ee273ca90dc60887933
+diff_hash=5cecf71f365406b3cca0d2c152b3e8baff65c1471fe8a3dd0036297f5bd9dc8c
+timestamp=2026-06-03T20:55:18Z
+branch=feature/se-172-markitdown-roadmap
+head_commit=4bc53aac
+signature=b19b6bef94681e4eb76afbe253775145992ea0c2a0b28209165ef9b0ed4a9f99

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -723,6 +723,7 @@ Incluye: context-update pipeline, agent-artifacts, context-guard, savia-manifest
 | 18 | SE-170 | Transclusion macros en SKILL.md | PROPOSED | ~3h | Elimina drift PII/seguridad. Post SE-084 para medir impacto. |
 | 19 | SE-166 | Skill Calibration Pipeline (uplift harness) | PROPOSED | ~12h | Alta complejidad. Requiere corpus de evals. Era 254+. |
 | 20 | SE-171 | Contradiction detector sobre memoria | PROPOSED | ~8h | Requiere SE-162 como prerequisito. |
+| 21 | SE-172 | markitdown como capa 0 universal de digestión | PROPOSED | ~6h | Microsoft markitdown (MIT, 143k★) reemplaza parsing en pdf/word/excel/pptx/visual/meeting-digest. Cobertura nueva gratis: ZIP, EPub, YouTube, Outlook .msg. ~60% menos código en parsers, una superficie de seguridad en lugar de seis. Los digest agents conservan análisis de dominio (perfiles, contexto proyecto, riesgos). |
 
 ### Los 3 próximos a implementar (cuando bloque 0 cierre)
 
@@ -824,6 +825,7 @@ Prioridad: implementar ANTES que cualquier SE de Era 197.
 | 18 | SE-170 | Transclusion macros en SKILL.md | PROPOSED | ~3h | Sin cambios. |
 | 19 | SE-166 | Skill Calibration Pipeline | PROPOSED | ~12h | Sin cambios. |
 | 20 | SE-171 | Contradiction detector sobre memoria | PROPOSED | ~8h | Requiere SE-162 + SE-151. |
+| 21 | SE-172 | markitdown como capa 0 universal de digestión | PROPOSED | ~6h | Nuevo (Era 199). Reemplaza parsing en 6 digest-agents. Cobertura ZIP/EPub/YouTube/.msg gratis. MIT compatible. |
 
 ### Removidos del stack (ya hechos, verificado contra git/SKILLS.md)
 

--- a/docs/propuestas/SE-172-markitdown-universal-digest.md
+++ b/docs/propuestas/SE-172-markitdown-universal-digest.md
@@ -1,0 +1,93 @@
+---
+id: SE-172
+title: SE-172 — markitdown como capa 0 universal de digestión
+status: PROPOSED
+origin: microsoft/markitdown (MIT, 143k★, v0.1.6 2026-05-26) — análisis 2026-06-03
+author: Savia
+priority: media
+effort: M 6h
+related: SPEC pdf-digest, word-digest, excel-digest, pptx-digest, visual-digest, meeting-digest
+proposed_at: "2026-06-03"
+applied_at: null
+expires: "2026-09-03"
+era: 199
+---
+
+# SE-172 — markitdown como capa 0 universal de digestión
+
+## Why
+
+pm-workspace tiene 6 digest-agents (`pdf-digest`, `word-digest`, `excel-digest`, `pptx-digest`, `visual-digest`, `meeting-digest`). Cada uno reimplementa parsing+normalización (extracción de texto, tablas, imágenes, OCR, transcripción) **antes** de su pipeline de 4 fases de análisis de dominio. Resultado: ~6 superficies de seguridad I/O, código duplicado de extracción, formatos de entrada limitados a lo que cada agente sabe parsear.
+
+Microsoft markitdown (MIT, 143k★) es una utility Python que convierte ficheros heterogéneos a Markdown optimizado para LLMs. Cobertura: PDF, DOCX, PPTX, XLSX, imágenes (EXIF+OCR), audio (transcripción), HTML, CSV/JSON/XML, ZIP, YouTube, EPub, Outlook .msg. Token-efficient. API estable.
+
+Lección que pm-workspace puede importar: **separar extracción (commodity) de análisis de dominio (valor)**. Los digest-agents deberían recibir Markdown ya canónico y centrarse en cross-ref con perfiles, contexto de proyecto, riesgos y reglas — no en luchar con `python-pptx` o `openpyxl`.
+
+Coste de no adoptar: cada formato nuevo (Outlook .msg, EPub, ZIP, YouTube) requiere escribir un parser propio. Cada digest-agent mantiene código de extracción que duplica el de otros. Coste de adoptar: ~6h para wrappear markitdown como capa 0 + adaptar los 6 agentes a consumir Markdown canónico.
+
+## Scope (M 6h, 3 slices)
+
+### Slice 1 (S 1h) — Wrapper `scripts/digest-extract.sh`
+
+Script único que delega en markitdown:
+
+```bash
+bash scripts/digest-extract.sh <input-file> [--output <md-file>]
+# Auto-detecta formato. Salida: Markdown canónico + YAML front-matter
+# con metadatos (mime, páginas, idioma detectado, hash del original)
+```
+
+Instalación opt-in: `pip install 'markitdown[pdf,docx,pptx,xlsx]'` (solo extras necesarios, no `[all]`).
+
+### Slice 2 (S 3h) — Adaptar digest-agents
+
+Cada uno de los 6 agentes (`pdf-digest`, `word-digest`, `excel-digest`, `pptx-digest`, `visual-digest`, `meeting-digest`) modifica su Fase 1 (extracción) para invocar `digest-extract.sh` en lugar de su parser propio. Las Fases 2-4 (estructura, contexto, reglas) consumen el Markdown canónico sin cambios.
+
+Compatibilidad: si markitdown falla, fallback al parser histórico del agente (ya existente). Zero migración obligatoria.
+
+### Slice 3 (S 2h) — Cobertura nueva gratis
+
+Activar 4 nuevos formatos con un agente único `archive-digest` que delega todo en markitdown:
+
+- ZIP (itera contenidos)
+- EPub
+- YouTube URL (transcripción)
+- Outlook .msg
+
+Sin pipelines de 4 fases — solo extracción + indexación en memoria.
+
+## Acceptance Criteria
+
+- **AC-01**: `scripts/digest-extract.sh foo.pdf` produce Markdown válido con front-matter (mime, hash, timestamp).
+- **AC-02**: Los 6 digest-agents existentes pasan sus tests actuales sin cambios funcionales (mismo análisis de dominio sobre Markdown equivalente).
+- **AC-03**: ≥4 formatos nuevos cubiertos (ZIP, EPub, YouTube, .msg) sin escribir parser propio.
+- **AC-04**: Reducción ≥40% de LOC en parsers de los 6 digest-agents (medido sobre `scripts/*-digest-*.py`).
+- **AC-05**: Sanitización de inputs: usar `convert_local()` por defecto (no `convert()` permisivo). Rechazar URIs no-file en agentes locales.
+- **AC-06**: Cuando markitdown falla, fallback al parser histórico del agente con warning en log (zero data loss).
+- **AC-07**: Gate de seguridad — `digest-extract.sh` ejecuta con `umask 077` y rechaza paths fuera de `$WORKSPACE_ROOT` salvo flag explícito `--external`.
+- **AC-08**: Tests BATS ≥20 cubriendo: cada formato soportado, fallback, sanitización, front-matter, rechazo de paths externos.
+
+## Risks
+
+- **Deps Python**: `markitdown[all]` instala muchas libs (poppler, pandoc, ffmpeg). Mitigación: extras selectivos (`[pdf,docx,pptx,xlsx]` cubre el 90% de casos).
+- **Privilegios I/O**: markitdown opera con privilegios del proceso (igual que `open()`). Mitigación: AC-05 + AC-07 restringen superficie.
+- **Calidad subjetiva**: algunos formatos (PDF escaneados complejos) pueden dar Markdown peor que el parser histórico. Mitigación: fallback en AC-06 + opt-in por agente vía flag `MARKITDOWN_ENABLED=true`.
+- **Versioning**: markitdown v0.x.x — API puede cambiar. Mitigación: pin estricto en requirements.txt + test de regresión por release.
+
+## Out of Scope
+
+- Azure Document Intelligence / Content Understanding (cloud paid). Feature opt-in para fase 2 si surge necesidad real.
+- Plugin `markitdown-ocr` (LLM Vision OCR). Evaluar tras Slice 2 si se detecta gap real.
+- Refactor de `meeting-digest` para usar markitdown audio transcription en lugar de pipeline propio (alto riesgo, baja prioridad).
+
+## Dependencies
+
+- Python ≥3.10 (ya cubierto en pm-workspace).
+- Skills `*-digest` actuales operativos como baseline.
+- `confidentiality-gate` cubre el sandboxing de inputs.
+
+## References
+
+- https://github.com/microsoft/markitdown — repo upstream
+- https://pypi.org/project/markitdown/ — paquete PyPI
+- License: MIT — compatible con pm-workspace


### PR DESCRIPTION
## SE-172 — markitdown como capa 0 universal de digestión

Microsoft markitdown (MIT, 143k★, v0.1.6) reemplaza el parsing en los 6 digest-agents (pdf, word, excel, pptx, visual, meeting) y aporta cobertura nueva gratis para ZIP, EPub, YouTube, Outlook .msg.

### Beneficios
- ~60% menos código en parsers actuales
- Una superficie de seguridad I/O en lugar de seis
- 4 formatos nuevos cubiertos sin escribir parser propio
- MIT compatible

### Scope
- M 6h en 3 slices (wrapper, adaptación de 6 agents, archive-digest nuevo)
- Tests BATS ≥20
- Fallback al parser histórico si markitdown falla (zero data loss)

Spec completa en `docs/propuestas/SE-172-markitdown-universal-digest.md`.
Estado: PROPOSED. Era 199. Esfuerzo M (~6h).

Refs: análisis 2026-06-03 sobre microsoft/markitdown.