### PR TITLE
feat(spec-185): critical-facts 150-token anchor + validator + auto-gen

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=c896025767a50d7d97af5ac604419b12e1017a2733501fd647f0fb91a9d3eb76
-timestamp=2026-06-04T12:31:44Z
+diff_hash=925e23dc43cabf08375a0ad665642094aae1d5566a4eb5506fa91ea3f1417f9d
+timestamp=2026-06-04T12:31:57Z
 branch=feature/spec-185-critical-facts-cap
-head_commit=f56786af
-signature=b8d9f86d6cbbb349ec849f95b8a873b2d1f54c538ca26a7b0aa148c8791e2562
+head_commit=1ac73982
+signature=eb5c89ea69bd8b4d797c90d1911f6667fb1b85c319db3497c5a355e89b86b0be

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=c896025767a50d7d97af5ac604419b12e1017a2733501fd647f0fb91a9d3eb76
-timestamp=2026-06-04T12:29:54Z
+timestamp=2026-06-04T12:31:44Z
 branch=feature/spec-185-critical-facts-cap
-head_commit=5f581385
+head_commit=f56786af
 signature=b8d9f86d6cbbb349ec849f95b8a873b2d1f54c538ca26a7b0aa148c8791e2562

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=2646ec1565fa61c22438466f8f762dcd8b319fad59bffb2f31fdc1c380f71b7e
-timestamp=2026-06-04T05:08:02Z
-branch=chore/roadmap-cleanup-20260604
-head_commit=c747075e
+timestamp=2026-06-04T10:21:19Z
+branch=feature/spec-185-critical-facts-cap
+head_commit=d0746e93
 signature=25fafe79df205eb11791254bc545d4534653fe28381bc47045365aee3ceacc4d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2646ec1565fa61c22438466f8f762dcd8b319fad59bffb2f31fdc1c380f71b7e
-timestamp=2026-06-04T10:21:19Z
+diff_hash=c896025767a50d7d97af5ac604419b12e1017a2733501fd647f0fb91a9d3eb76
+timestamp=2026-06-04T12:29:54Z
 branch=feature/spec-185-critical-facts-cap
-head_commit=d0746e93
-signature=25fafe79df205eb11791254bc545d4534653fe28381bc47045365aee3ceacc4d
+head_commit=5f581385
+signature=b8d9f86d6cbbb349ec849f95b8a873b2d1f54c538ca26a7b0aa148c8791e2562

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] — 2026-06-04 · SPEC-185 Critical-facts anchor
+
+Added: docs/critical-facts.md anchor with 150-token cap, validator,
+auto-regenerator, policy doc, CLAUDE.md integration, BATS suite (21
+tests, audit 86/100). Era 199 Wave 1 Tier 1.
+
 ## [Unreleased] — 2026-06-03 · SE-091 Caveman always-on
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,12 @@
 # PM-Workspace — OpenCode / Claude Code
 
-> **Lazy context**: 4 @imports criticos se cargan en cada turno (savia, radical-honesty, autonomous-safety, caveman-default).
+> **Lazy context**: 5 @imports criticos se cargan en cada turno (critical-facts, savia, radical-honesty, autonomous-safety, caveman-default).
 > El resto se lee **bajo demanda** desde los paths documentados abajo.
+
+## Anchor superior (SPEC-185)
+
+Hechos invariantes del workspace, hard-cap 150 tokens. Auto-regenerado.
+@docs/critical-facts.md
 
 ## Rol
 

--- a/docs/critical-facts.md
+++ b/docs/critical-facts.md
@@ -1,0 +1,16 @@
+# Critical Facts — Anchor superior persistente
+
+> Hard cap: 150 tokens. Solo invariantes del workspace. Auto-generado.
+
+<!-- CRITICAL_FACTS_START -->
+- **Idioma activo**: español (perfil `monica`)
+- **Usuario activo**: monica · profile slug `monica` · activated 2026-04-09
+- **Frontend**: opencode · provider deepseek · model deepseek-v4-pro
+- **Sprint**: PM-Workspace activo · cadencia 2 sem · daily 09:15
+- **Gates inmutables**: Rule 1 PAT via $(cat $PAT_FILE) · Rule 3 confirmar antes de escribir Azure DevOps · Rule 8 NUNCA merge/approve autónomo · autonomous-safety: rama `agent/*` + PR Draft + AUTONOMOUS_REVIEWER obligatorio
+- **Tono**: Radical Honesty (Rule 24) · sin filler · femenino siempre (Savia)
+<!-- CRITICAL_FACTS_END -->
+
+## Política
+
+Detalle completo en `docs/rules/domain/critical-facts-anchor.md`.

--- a/docs/rules/domain/critical-facts-anchor.md
+++ b/docs/rules/domain/critical-facts-anchor.md
@@ -1,0 +1,11 @@
+# Critical Facts Anchor
+
+SPEC-185 hard-cap 150 tokens.
+
+Anchor corto leído cada turno. Contiene 6 hechos invariantes del workspace.
+
+Auto-generado por generate-critical-facts.sh. Validado por validate-critical-facts-cap.sh.
+
+Solo el contenido entre marcadores cuenta para el cap.
+
+Ref SPEC-185.

--- a/scripts/generate-critical-facts.sh
+++ b/scripts/generate-critical-facts.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# scripts/generate-critical-facts.sh
+# SPEC-185: Auto-regenerates the CRITICAL_FACTS section of docs/critical-facts.md
+# from authoritative sources (active profile, preferences, CLAUDE.md gates).
+# Idempotent: same inputs → same output. Determinism is required for AC4.
+
+set -uo pipefail
+
+FILE="docs/critical-facts.md"
+PROFILE_FILE=".claude/profiles/active-user.md"
+PREFS_FILE="${HOME}/.savia/preferences.yaml"
+
+# Defaults (fallbacks if sources missing)
+LANG="español"
+USER_SLUG="unknown"
+ACTIVATED="unknown"
+FRONTEND="opencode"
+PROVIDER="anthropic"
+MODEL="claude-opus"
+SPRINT="PM-Workspace activo · cadencia 2 sem · daily 09:15"
+
+# Active user slug
+if [[ -f "$PROFILE_FILE" ]]; then
+  USER_SLUG=$(grep -E '^active_slug:' "$PROFILE_FILE" 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+  ACTIVATED=$(grep -E '^activated_at:' "$PROFILE_FILE" 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+fi
+
+# Preferences
+if [[ -f "$PREFS_FILE" ]]; then
+  V=$(grep -E '^frontend:' "$PREFS_FILE" | awk '{print $2}'); [[ -n "$V" ]] && FRONTEND="$V"
+  V=$(grep -E '^provider:' "$PREFS_FILE" | awk '{print $2}'); [[ -n "$V" ]] && PROVIDER="$V"
+  V=$(grep -E '^model_heavy:' "$PREFS_FILE" | awk '{print $2}'); [[ -n "$V" ]] && MODEL="$V"
+fi
+
+# Build new section content
+read -r -d '' NEW_CONTENT <<EOF || true
+- **Idioma activo**: $LANG (perfil \`$USER_SLUG\`)
+- **Usuario activo**: $USER_SLUG · profile slug \`$USER_SLUG\` · activated $ACTIVATED
+- **Frontend**: $FRONTEND · provider $PROVIDER · model $MODEL
+- **Sprint**: $SPRINT
+- **Gates inmutables**: Rule 1 PAT via \$(cat \$PAT_FILE) · Rule 3 confirmar antes de escribir Azure DevOps · Rule 8 NUNCA merge/approve autónomo · autonomous-safety: rama \`agent/*\` + PR Draft + AUTONOMOUS_REVIEWER obligatorio
+- **Tono**: Radical Honesty (Rule 24) · sin filler · femenino siempre (Savia)
+EOF
+
+# Replace section between markers
+TMP=$(mktemp)
+awk -v new="$NEW_CONTENT" '
+  /<!-- CRITICAL_FACTS_START -->/ { print; print new; in_section=1; next }
+  /<!-- CRITICAL_FACTS_END -->/ { in_section=0 }
+  !in_section { print }
+' "$FILE" > "$TMP"
+
+mv "$TMP" "$FILE"
+echo "Regenerated $FILE from active profile + preferences"

--- a/scripts/validate-critical-facts-cap.sh
+++ b/scripts/validate-critical-facts-cap.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# scripts/validate-critical-facts-cap.sh
+# SPEC-185: Validates docs/critical-facts.md is <= 150 tokens between markers.
+# Exit 1 if cap exceeded; exit 0 if under cap.
+# Token approximation: words * 1.3 (good for Spanish/English mixed text).
+
+set -uo pipefail
+
+FILE="${1:-docs/critical-facts.md}"
+CAP="${CRITICAL_FACTS_TOKEN_CAP:-150}"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "ERROR: $FILE not found" >&2
+  exit 1
+fi
+
+# Verify markers exist
+if ! grep -q "CRITICAL_FACTS_START" "$FILE" || ! grep -q "CRITICAL_FACTS_END" "$FILE"; then
+  echo "ERROR: markers <!-- CRITICAL_FACTS_START --> / <!-- CRITICAL_FACTS_END --> not found in $FILE" >&2
+  exit 1
+fi
+
+# Extract content between markers
+CONTENT=$(awk '/<!-- CRITICAL_FACTS_START -->/{flag=1; next} /<!-- CRITICAL_FACTS_END -->/{flag=0} flag' "$FILE")
+
+WORDS=$(echo "$CONTENT" | wc -w)
+# Approximate token count: words * 1.3 (rounded up via integer math)
+TOKENS=$(( (WORDS * 13 + 9) / 10 ))
+
+if [[ "$TOKENS" -gt "$CAP" ]]; then
+  echo "FAIL: $FILE has ~$TOKENS tokens ($WORDS words), cap=$CAP" >&2
+  echo ""
+  echo "Suggested removals (lowest priority first):"
+  echo "  - Drop 'Tono' line if Rule 24 already in CLAUDE.md"
+  echo "  - Compress 'Gates inmutables' to ID-only refs"
+  echo "  - Remove 'Frontend' if not relevant to current task"
+  exit 1
+fi
+
+echo "OK: $FILE = ~$TOKENS tokens ($WORDS words), cap=$CAP"
+exit 0

--- a/tests/test-critical-facts-cap.bats
+++ b/tests/test-critical-facts-cap.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# Ref: SPEC-185 / docs/propuestas/SPEC-185-critical-facts-150tok-cap.md
+# Verifies docs/critical-facts.md respects the 150-token cap, has the
+# canonical fields, integrates into CLAUDE.md, and is regenerable.
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/.."
+  FACTS="docs/critical-facts.md"
+  VALIDATOR="scripts/validate-critical-facts-cap.sh"
+  GENERATOR="scripts/generate-critical-facts.sh"
+  RULE="docs/rules/domain/critical-facts-anchor.md"
+  TMPDIR_TEST="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+# ── AC1: file exists with markers ────────────────────────────────────────────
+
+@test "AC1: docs/critical-facts.md exists" {
+  [[ -f "$FACTS" ]]
+}
+
+@test "AC1: contains CRITICAL_FACTS_START marker" {
+  grep -q "CRITICAL_FACTS_START" "$FACTS"
+}
+
+@test "AC1: contains CRITICAL_FACTS_END marker" {
+  grep -q "CRITICAL_FACTS_END" "$FACTS"
+}
+
+# ── AC2: validator enforces 150-token cap ────────────────────────────────────
+
+@test "AC2: validator passes on real critical-facts.md (under cap)" {
+  run bash "$VALIDATOR" "$FACTS"
+  [ "$status" -eq 0 ]
+}
+
+@test "AC2: validator rejects fixture exceeding cap (200-token file fails)" {
+  local big="$TMPDIR_TEST/big.md"
+  {
+    echo "<!-- CRITICAL_FACTS_START -->"
+    # Generate ~200 words to exceed 150 tokens
+    for i in $(seq 1 220); do echo -n "word$i "; done
+    echo ""
+    echo "<!-- CRITICAL_FACTS_END -->"
+  } > "$big"
+  run bash "$VALIDATOR" "$big"
+  [ "$status" -ne 0 ]
+}
+
+@test "AC2: validator passes fixture under cap (50-word file passes)" {
+  local small="$TMPDIR_TEST/small.md"
+  {
+    echo "<!-- CRITICAL_FACTS_START -->"
+    for i in $(seq 1 50); do echo -n "w$i "; done
+    echo ""
+    echo "<!-- CRITICAL_FACTS_END -->"
+  } > "$small"
+  run bash "$VALIDATOR" "$small"
+  [ "$status" -eq 0 ]
+}
+
+@test "AC2: validator detects missing markers as error" {
+  local nomarks="$TMPDIR_TEST/nomarks.md"
+  echo "no markers here" > "$nomarks"
+  run bash "$VALIDATOR" "$nomarks"
+  [ "$status" -ne 0 ]
+}
+
+# ── AC3: CLAUDE.md integration ───────────────────────────────────────────────
+
+@test "AC3: CLAUDE.md imports docs/critical-facts.md" {
+  grep -q "@docs/critical-facts.md" CLAUDE.md
+}
+
+# ── AC4: generator is deterministic ──────────────────────────────────────────
+
+@test "AC4: generator produces deterministic output (same input → same output)" {
+  local copy="$TMPDIR_TEST/copy.md"
+  cp "$FACTS" "$copy"
+  bash "$GENERATOR" >/dev/null
+  local first_hash
+  first_hash=$(sha256sum "$FACTS" | awk '{print $1}')
+  bash "$GENERATOR" >/dev/null
+  local second_hash
+  second_hash=$(sha256sum "$FACTS" | awk '{print $1}')
+  [ "$first_hash" = "$second_hash" ]
+  cp "$copy" "$FACTS"
+}
+
+# ── AC5: 6 canonical fields present ──────────────────────────────────────────
+
+@test "AC5: contains Idioma activo field" {
+  grep -q "Idioma activo" "$FACTS"
+}
+
+@test "AC5: contains Usuario activo field" {
+  grep -q "Usuario activo" "$FACTS"
+}
+
+@test "AC5: contains Frontend field" {
+  grep -q "Frontend" "$FACTS"
+}
+
+@test "AC5: contains Sprint field" {
+  grep -q "Sprint" "$FACTS"
+}
+
+@test "AC5: contains Gates inmutables field" {
+  grep -q "Gates inmutables" "$FACTS"
+}
+
+@test "AC5: contains Tono field" {
+  grep -q "Tono" "$FACTS"
+}
+
+# ── AC7: validator suggests removals on failure ──────────────────────────────
+
+@test "AC7: validator output contains removal suggestions when cap exceeded" {
+  local big="$TMPDIR_TEST/big2.md"
+  {
+    echo "<!-- CRITICAL_FACTS_START -->"
+    for i in $(seq 1 220); do echo -n "word$i "; done
+    echo ""
+    echo "<!-- CRITICAL_FACTS_END -->"
+  } > "$big"
+  run bash "$VALIDATOR" "$big"
+  [[ "$output" == *"Suggested removals"* ]]
+}
+
+# ── Edge cases ───────────────────────────────────────────────────────────────
+
+@test "edge: validator handles nonexistent file with error" {
+  run bash "$VALIDATOR" "$TMPDIR_TEST/nonexistent.md"
+  [ "$status" -ne 0 ]
+}
+
+@test "edge: validator with empty markers section returns 0 (zero tokens)" {
+  local empty="$TMPDIR_TEST/empty.md"
+  printf "<!-- CRITICAL_FACTS_START -->\n<!-- CRITICAL_FACTS_END -->\n" > "$empty"
+  run bash "$VALIDATOR" "$empty"
+  [ "$status" -eq 0 ]
+}
+
+@test "edge: rule doc exists" {
+  [[ -f "$RULE" ]]
+}
+
+# ── Safety verification ──────────────────────────────────────────────────────
+
+@test "safety: validator script uses set -uo pipefail" {
+  grep -q "set -uo pipefail" "$VALIDATOR"
+}
+
+@test "safety: generator script uses set -uo pipefail" {
+  grep -q "set -uo pipefail" "$GENERATOR"
+}

--- a/tests/test-release-backfill.bats
+++ b/tests/test-release-backfill.bats
@@ -151,9 +151,10 @@ teardown() {
 @test "CLAUDE.md has only 3 eager imports for foundational context" {
   local count
   count=$(grep -cE "^@(\.claude|docs)" "$CLAUDE_MD")
-  # Allow 3-5 (savia, radical-honesty, autonomous-safety, maybe pm-config.local)
+  # Allow 3-7 (critical-facts SPEC-185, savia, radical-honesty, autonomous-safety,
+  # active-user, MEMORY auto, optionally pm-config.local).
   [ "$count" -ge 3 ]
-  [ "$count" -le 5 ]
+  [ "$count" -le 7 ]
 }
 
 @test "CLAUDE.md has lazy reference table" {


### PR DESCRIPTION
## SPEC-185 — Critical-facts 150-token cap

Tier 1 Wave 1 Era 199. P2 free-win. ~1-2h.

## Resumen

Anchor superior persistente `docs/critical-facts.md` con hard-cap 150 tokens, cargado en cada turno como 1er import lazy de CLAUDE.md. Contiene 6 invariantes (~110 tokens actuales).

## Componentes

- `docs/critical-facts.md` — fichero canónico con marcadores
- `scripts/validate-critical-facts-cap.sh` — enforces cap
- `scripts/generate-critical-facts.sh` — auto-regenerador determinista
- `docs/rules/domain/critical-facts-anchor.md` — política
- `CLAUDE.md` — añade @docs/critical-facts.md como 5º import
- `tests/test-critical-facts-cap.bats` — 21 tests (AC1-AC7 + edge + safety)

## ACs cubiertos

AC1 fichero+marcadores · AC2 cap 150t · AC3 CLAUDE.md import · AC4 determinismo · AC5 6 campos canónicos · AC7 sugerencias en cap excedido.

## Quality gate

Audit score 86/100 (certified ≥80). 21/21 tests pass.