### PR TITLE
feat(spec-125): Slice 2 - asymmetric expertise + audit-trail CLI

### DIFF
--- a/.claude/profiles/users/template/expertise.md
+++ b/.claude/profiles/users/template/expertise.md
@@ -1,0 +1,107 @@
+---
+schema_version: 1
+audit_level_default: medium
+last_updated: TEMPLATE
+---
+
+# expertise.md — Areas de auditoria asimetrica
+
+> **TEMPLATE** — copia este fichero a tu propio perfil bajo `.claude/profiles/users/<tu-slug>/expertise.md` y rellena con tus areas reales antes de activar el Recommendation Tribunal con modo asymmetric.
+
+## Para que sirve este fichero
+
+El **expertise-asymmetry-judge** (parte del Recommendation Tribunal SPEC-125) lee este fichero antes de validar cualquier recomendacion accionable que Savia de.
+
+Si la recomendacion cae en un area marcada como `blind` (no auditable tecnicamente), el sistema reescribe la respuesta anadiendo tres secciones obligatorias:
+
+1. **Por que creo esto** — razonamiento explicito (no apelacion a autoridad)
+2. **Alternativas que descarte** — comparativa explicita
+3. **Como verificar tu misma** — comandos o queries concretos para validar sin depender del criterio del modelo
+
+Esto preserva la **soberania epistemica** de la usuaria: no hace falta confiar a ciegas en areas donde no se puede evaluar la calidad del propio juicio del modelo.
+
+## Niveles de auditoria
+
+| Nivel | Significado | Comportamiento del tribunal |
+|---|---|---|
+| `blind` | No se puede evaluar la recomendacion en absoluto. | Rewrite obligatorio + banner `[CALIBRATION: blind-area]`. |
+| `low` | Distincion gruesa bueno/malo, sin detalles. | Banner suave + reasoning visible (sin alternativas obligatorias). |
+| `medium` | Auditable parcialmente. | Tribunal en modo normal con score reportado. |
+| `high` | Plenamente auditable. | Tribunal estandar; sin banner. |
+
+Default cuando un area no aparece listada: ver `audit_level_default` en el frontmatter.
+
+## Esquema esperado
+
+```yaml
+areas:
+  - domain: <slug-snake-or-kebab>
+    audit_level: blind | low | medium | high
+    notes: "(opcional) motivo o contexto que ayude al juez"
+default_audit_level: blind | low | medium | high
+```
+
+## Plantilla — reemplaza los placeholders con tus areas reales
+
+```yaml
+areas:
+  # Punto de partida orientativo. ANADE o QUITA segun tu realidad.
+  # Lo que no listes recibe `default_audit_level`.
+
+  - domain: postgres-tuning
+    audit_level: blind
+    notes: "Si configuras shared_buffers a ojo, este es blind."
+
+  - domain: kubernetes-internals
+    audit_level: blind
+
+  - domain: low-level-performance
+    audit_level: blind
+    notes: "cache lines, branch prediction, NUMA"
+
+  - domain: infrastructure-cost-modeling
+    audit_level: low
+
+  - domain: security-cryptography
+    audit_level: low
+
+  - domain: dotnet-architecture
+    audit_level: high
+
+  - domain: typescript-frontend
+    audit_level: high
+
+  - domain: spec-driven-development
+    audit_level: high
+
+  - domain: project-management
+    audit_level: high
+
+default_audit_level: medium
+```
+
+## Como se usa al activar el modo asymmetric
+
+```bash
+# El juez expertise-asymmetry-judge lee este fichero automaticamente cuando
+# esta activo dentro del Recommendation Tribunal. Para inspeccionar el audit
+# trail despues de algunas interacciones:
+
+bash scripts/recommendation-tribunal-search.sh --summary
+
+# Para ver una recomendacion concreta y su rewrite:
+bash scripts/recommendation-tribunal-search.sh --hash <prefix> --json
+```
+
+## Honestidad radical (Rule #24)
+
+Marca como `blind` lo que NO se puede auditar — no lo que prefieres que se te explique. Sobreusar `blind` convierte cada recomendacion en un ensayo de cuatro secciones; subusarlo te deja a merced del criterio del modelo en areas donde no puedes corregirlo.
+
+Si dudas: empieza por `medium` y mueve a `blind` solo cuando detectes que en un dominio aceptas recomendaciones sin mirar (esa es la senal real de blindness).
+
+## Referencias
+
+- SPEC-125, seccion 5 — Asymmetric-expertise mode
+- `.opencode/agents/expertise-asymmetry-judge.md` — juez que consume este fichero
+- `scripts/recommendation-tribunal/expertise-rewrite.sh` — reescritura mecanica
+- `docs/rules/domain/savia-ethical-principles.md` (autonomia humana, no manipulacion)

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=2e44d6443a2a6f23cdff50c9deb8af5bdecb19cf920915ef0f93a70468eb4c93
-timestamp=2026-06-05T06:05:14Z
+diff_hash=92fa84a58bfb9fa3fddbc50bd030571bdcc5e203b37eb3938e07b1e4eb4ef97e
+timestamp=2026-06-05T06:05:46Z
 branch=feature/spec-125-slice-2-asymmetric-expertise
-head_commit=2aaa6ad6
-signature=411c6790d229b27fa4810d547810a35ef132dca0f8401b7ae11d6b0e4cd2c764
+head_commit=b95d7f45
+signature=9a2f41d3c2b5070bb7f57cb1d74e7ba26d201081fb624466fb60b43f621c16ac

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=5ea209141eb37df4e19b11f1309e8c98b7be640260a360c3cae21ab933455ca2
-timestamp=2026-06-04T21:31:26Z
-branch=feature/spec-187-iah-principles-alignment
-head_commit=c78a0165
-signature=eaa61f876048384cf09a2403364e22eb26903ef96778ee65cdd000f3f35e4522
+diff_hash=2e44d6443a2a6f23cdff50c9deb8af5bdecb19cf920915ef0f93a70468eb4c93
+timestamp=2026-06-05T06:05:14Z
+branch=feature/spec-125-slice-2-asymmetric-expertise
+head_commit=2aaa6ad6
+signature=411c6790d229b27fa4810d547810a35ef132dca0f8401b7ae11d6b0e4cd2c764

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=92fa84a58bfb9fa3fddbc50bd030571bdcc5e203b37eb3938e07b1e4eb4ef97e
-timestamp=2026-06-05T06:05:46Z
+timestamp=2026-06-05T06:11:04Z
 branch=feature/spec-125-slice-2-asymmetric-expertise
-head_commit=b95d7f45
+head_commit=cb303a6d
 signature=9a2f41d3c2b5070bb7f57cb1d74e7ba26d201081fb624466fb60b43f621c16ac

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: adb7a272384c | resources: 1193
-> 555 commands · 100 skills · 70 agents · 468 scripts
+> hash: 9f8112872fde | resources: 1194
+> 555 commands · 100 skills · 70 agents · 469 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
@@ -1050,6 +1050,7 @@
 [quality] qa-wizard — engineer,interactive,onboarding,wizard — cmd:.claude/commands/qa-wizard.md
 [quality] rbac-management — acceso,audita,gestionan,permisos,roles — skill:.claude/skills/rbac-management/SKILL.md
 [quality] rbac-manager — access,audit,based,control,grant — cmd:.claude/commands/rbac-manager.md
+[quality] recommendation-tribunal-search — audit,inspection,recommendation,search,slice — script:scripts/recommendation-tribunal-search.sh
 [quality] record-start — audit,recording,replay,session,start — cmd:.claude/commands/record-start.md
 [quality] ref-resolve — preview,references,resolve,resource — cmd:.claude/commands/ref-resolve.md
 [quality] release-readiness — checklist,compliance,deployment,docs,features — cmd:.claude/commands/release-readiness.md

--- a/.scm/categories/quality.scm
+++ b/.scm/categories/quality.scm
@@ -1,5 +1,5 @@
 # quality — Savia Capability Map (L1)
-> 227 resources
+> 228 resources
 
 - **/a11y-audit** (cmd): Auditoría de accesibilidad WCAG 2.2 completa con escaneo de HTML/componentes. Detecta: alt text faltante, problemas de contraste, navegación por teclado, etiquetas ARIA, gestión de focus, jerarquía de encabezados, etiquetas de formularios.
 - **/a11y-fix** (cmd): Correcciones automáticas de accesibilidad con verificación y preview. Genera código de fix para issues detectados por /a11y-audit. Preview antes de aplicar. Verifica que no introduce nuevos problemas. Covers: alt text, ARIA attributes, focu
@@ -83,6 +83,7 @@
 - **qa-wizard** (cmd): Interactive wizard for QA engineer onboarding
 - **rbac-management** (skill): Usar cuando se gestionan roles, permisos o se audita el acceso de usuarios.
 - **rbac-manager** (cmd): Role-based access control — grant, revoke, audit roles and permissions
+- **recommendation-tribunal-search** (script): recommendation-tribunal-search.sh — SPEC-125 Slice 2: CLI for audit-trail inspection.
 - **record-start** (cmd): Start recording session for audit and replay
 - **ref-resolve** (cmd): Resolve and preview resource references
 - **release-readiness** (cmd): Checklist de release — features, tests, docs, compliance, deployment

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "a19bab4b4af0",
-  "total": 1193,
+  "hash": "2e2060f71a75",
+  "total": 1194,
   "resources": [
     {
       "category": "analysis",
@@ -13501,6 +13501,20 @@
       "kind": "cmd",
       "path": ".claude/commands/rbac-manager.md",
       "description": "Role-based access control — grant, revoke, audit roles and permissions"
+    },
+    {
+      "category": "quality",
+      "name": "recommendation-tribunal-search",
+      "intents": [
+        "audit",
+        "inspection",
+        "recommendation",
+        "search",
+        "slice"
+      ],
+      "kind": "script",
+      "path": "scripts/recommendation-tribunal-search.sh",
+      "description": "recommendation-tribunal-search.sh — SPEC-125 Slice 2: CLI for audit-trail inspection."
     },
     {
       "category": "quality",

--- a/CHANGELOG.d/spec-125-slice-2-asymmetric-expertise.md
+++ b/CHANGELOG.d/spec-125-slice-2-asymmetric-expertise.md
@@ -1,0 +1,12 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SPEC-125 Slice 2: scripts/recommendation-tribunal/expertise-rewrite.sh — rewrite calibrado en areas blind con razonamiento + alternativas + verificacion
+- SPEC-125 Slice 2: scripts/recommendation-tribunal-search.sh — CLI de inspeccion del audit-trail con filtros --from/--to/--verdict/--risk/--hash y modos --summary/--json
+- SPEC-125 Slice 2: .claude/profiles/users/template/expertise.md — TEMPLATE generico para que cada usuario declare sus areas de expertise (audit_level: blind/low/medium/high)
+- SPEC-125 Slice 2: tests/test-spec-125-slice-2-asymmetric-expertise.bats — suite BATS certificada por SPEC-055 quality gate
+

--- a/docs/propuestas/SPEC-125-recommendation-tribunal-realtime.md
+++ b/docs/propuestas/SPEC-125-recommendation-tribunal-realtime.md
@@ -294,10 +294,13 @@ Artefactos:
 
 ### Slice 2 (M, 8-10h) — Asymmetric expertise + audit trail
 
-- `~/.claude/profiles/users/monica/expertise.md` (sembrado inicial — qué áreas marca Mónica como `blind`)
-- `scripts/recommendation-tribunal/expertise-rewrite.sh` (rewrite con explanation/alternatives/verification)
-- `output/recommendation-tribunal/<date>/<hash>.json` (audit log persistence)
-- `scripts/recommendation-tribunal-search.sh` (CLI de inspección de audit trail)
+> **Status (2026-06-05):** Slice 2 artifacts delivered. Wire orchestrator -> expertise-rewrite is deferred to Slice 2-advanced (requires real Task tool wiring outside scope of artifact PR).
+
+- `.claude/profiles/users/template/expertise.md` (TEMPLATE generico — datos personales son responsabilidad del usuario, NO se commitean)
+- `scripts/recommendation-tribunal/expertise-rewrite.sh` (rewrite con explanation/alternatives/verification — solo activo en `audit_level: blind`)
+- `output/recommendation-tribunal/<date>/<hash>.json` (audit log persistence — ya emitido por Slice 1)
+- `scripts/recommendation-tribunal-search.sh` (CLI de inspeccion de audit trail con filtros --from/--to/--verdict/--risk/--hash + --summary + --json)
+- `tests/test-spec-125-slice-2-asymmetric-expertise.bats` (BATS suite certificada por SPEC-055 quality gate)
 
 ### Slice 3 (M, 8-10h) — Memory feedback loop + calibración
 

--- a/scripts/recommendation-tribunal-search.sh
+++ b/scripts/recommendation-tribunal-search.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# recommendation-tribunal-search.sh — SPEC-125 Slice 2: CLI for audit-trail inspection.
+#
+# Reads JSONL files under output/recommendation-tribunal/<date>/<hash>.json,
+# applies filters, and emits matching records.
+#
+# Usage:
+#   recommendation-tribunal-search.sh [--from YYYY-MM-DD] [--to YYYY-MM-DD]
+#                                     [--verdict PASS|WARN|VETO|PENDING-SLICE-2]
+#                                     [--risk low|medium|high]
+#                                     [--hash <prefix>]
+#                                     [--summary]
+#                                     [--json]
+#
+# Default scope: today's directory.
+# Default output: human summary (one line per record).
+# --json: emit raw records (one JSON object per line).
+# --summary: aggregated counts (verdicts, risks).
+#
+# Exit codes:
+#   0  ok (zero or more records matched)
+#   2  usage / args invalid
+#   3  audit-trail directory missing
+#
+# Reference: SPEC-125 § 8 (audit trail).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+AUDIT_BASE="${RECOMMENDATION_TRIBUNAL_AUDIT_DIR:-$ROOT_DIR/output/recommendation-tribunal}"
+
+FROM_DATE=""
+TO_DATE=""
+VERDICT=""
+RISK=""
+HASH_PREFIX=""
+MODE="human"
+
+usage() {
+  sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    -h|--help) usage ;;
+    --from) FROM_DATE="${2:-}"; shift 2 ;;
+    --to) TO_DATE="${2:-}"; shift 2 ;;
+    --verdict) VERDICT="${2:-}"; shift 2 ;;
+    --risk) RISK="${2:-}"; shift 2 ;;
+    --hash) HASH_PREFIX="${2:-}"; shift 2 ;;
+    --json) MODE="json"; shift ;;
+    --summary) MODE="summary"; shift ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+# ── Resolve scan range ──────────────────────────────────────────────────────
+
+if [[ ! -d "$AUDIT_BASE" ]]; then
+  echo "ERROR: audit-trail directory missing: $AUDIT_BASE" >&2
+  exit 3
+fi
+
+# Default to today only when no range specified
+if [[ -z "$FROM_DATE" && -z "$TO_DATE" ]]; then
+  FROM_DATE=$(date +%Y-%m-%d)
+  TO_DATE="$FROM_DATE"
+fi
+[[ -z "$FROM_DATE" ]] && FROM_DATE="0000-01-01"
+[[ -z "$TO_DATE" ]] && TO_DATE="9999-12-31"
+
+# ── Collect candidate files ────────────────────────────────────────────────
+
+candidates=()
+while IFS= read -r -d '' dir; do
+  date_dir=$(basename "$dir")
+  # Skip non-date entries
+  [[ "$date_dir" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue
+  # Range filter
+  if [[ "$date_dir" < "$FROM_DATE" || "$date_dir" > "$TO_DATE" ]]; then
+    continue
+  fi
+  while IFS= read -r -d '' f; do
+    candidates+=("$f")
+  done < <(find "$dir" -maxdepth 1 -name '*.json' -type f -print0 2>/dev/null)
+done < <(find "$AUDIT_BASE" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+
+# ── Filter and emit ─────────────────────────────────────────────────────────
+
+# Per-file filtering uses python3 to handle JSONL safely (one record per line).
+filter_py='
+import json,sys,os
+verdict_filter = os.environ.get("VERDICT","")
+risk_filter    = os.environ.get("RISK","")
+hash_filter    = os.environ.get("HASH","")
+mode           = os.environ.get("MODE","human")
+records        = []
+for path in sys.argv[1:]:
+  try:
+    with open(path) as f:
+      for line in f:
+        line = line.strip()
+        if not line: continue
+        try:
+          d = json.loads(line)
+        except json.JSONDecodeError:
+          continue
+        if verdict_filter and d.get("verdict","") != verdict_filter: continue
+        cls = d.get("classification",{}) if isinstance(d.get("classification"),dict) else {}
+        if risk_filter and cls.get("risk_class","") != risk_filter: continue
+        if hash_filter and not d.get("draft_hash","").startswith(hash_filter): continue
+        records.append(d)
+  except Exception:
+    continue
+if mode == "json":
+  for r in records:
+    print(json.dumps(r))
+elif mode == "summary":
+  from collections import Counter
+  vc = Counter(r.get("verdict","?") for r in records)
+  rc = Counter((r.get("classification",{}) or {}).get("risk_class","?") for r in records)
+  print(f"records={len(records)}")
+  print("verdicts: " + (", ".join(f"{k}={v}" for k,v in sorted(vc.items())) or "(none)"))
+  print("risks:    " + (", ".join(f"{k}={v}" for k,v in sorted(rc.items())) or "(none)"))
+else:
+  for r in records:
+    ts   = r.get("ts","?")
+    h    = (r.get("draft_hash","") or "")[:12]
+    verd = r.get("verdict","?")
+    risk = (r.get("classification",{}) or {}).get("risk_class","?")
+    prev = (r.get("draft_preview","") or "").replace("\n"," ")[:60]
+    print(f"{ts}  {h}  risk={risk:<6}  verdict={verd:<18}  {prev}")
+'
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  case "$MODE" in
+    summary) printf 'records=0\nverdicts: (none)\nrisks:    (none)\n' ;;
+    *) : ;;  # silent (no records)
+  esac
+  exit 0
+fi
+
+VERDICT="$VERDICT" RISK="$RISK" HASH="$HASH_PREFIX" MODE="$MODE" \
+  python3 -c "$filter_py" "${candidates[@]}"
+
+exit 0

--- a/scripts/recommendation-tribunal/expertise-rewrite.sh
+++ b/scripts/recommendation-tribunal/expertise-rewrite.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# expertise-rewrite.sh — SPEC-125 Slice 2: Asymmetric-expertise rewrite.
+#
+# When the expertise-asymmetry-judge classifies a draft as falling into a
+# `blind` audit area (the active user explicitly cannot evaluate the recommendation
+# on technical merits), this script rewrites the draft to add three obligatory
+# sections that preserve the user's epistemic sovereignty:
+#
+#   1. **Por qué creo esto** — explicit reasoning chain
+#   2. **Alternativas que descarté** — counterfactual options
+#   3. **Cómo verificar tú misma** — concrete verification commands/queries
+#
+# This is the §5 rewrite phase from SPEC-125. It does NOT decide audit_level
+# (that is the expertise-asymmetry-judge's job); it only applies the rewrite
+# when the verdict declares mode=blind.
+#
+# Usage:
+#   echo "$DRAFT" | expertise-rewrite.sh \
+#       --audit-level blind \
+#       --reasoning "$REASONING" \
+#       --alternatives "$ALTERNATIVES_JSON" \
+#       --verification "$VERIFICATION_STEPS" \
+#       --domain postgres-tuning
+#
+# Or invoked from aggregate.sh output:
+#   echo "$DRAFT" | expertise-rewrite.sh --judge-json /path/to/expertise-verdict.json
+#
+# Exit codes:
+#   0  ok — rewritten draft on stdout (or original if audit_level != blind)
+#   2  usage / args invalid
+#   3  judge JSON file missing/unreadable
+#   4  malformed judge JSON
+#
+# Reference: SPEC-125 § 5 (Asymmetric-expertise mode).
+
+set -uo pipefail
+
+AUDIT_LEVEL=""
+REASONING=""
+ALTERNATIVES=""
+VERIFICATION=""
+DOMAIN=""
+JUDGE_JSON=""
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# //; s/^#//'
+  exit 2
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    -h|--help) usage ;;
+    --audit-level) AUDIT_LEVEL="${2:-}"; shift 2 ;;
+    --reasoning) REASONING="${2:-}"; shift 2 ;;
+    --alternatives) ALTERNATIVES="${2:-}"; shift 2 ;;
+    --verification) VERIFICATION="${2:-}"; shift 2 ;;
+    --domain) DOMAIN="${2:-}"; shift 2 ;;
+    --judge-json) JUDGE_JSON="${2:-}"; shift 2 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+# ── Resolve from judge JSON when provided ───────────────────────────────────
+
+if [[ -n "$JUDGE_JSON" ]]; then
+  if [[ ! -r "$JUDGE_JSON" ]]; then
+    echo "ERROR: judge JSON not readable: $JUDGE_JSON" >&2
+    exit 3
+  fi
+  parsed=$(python3 -c "
+import json,sys
+try:
+  with open('$JUDGE_JSON') as f: d = json.load(f)
+  print(d.get('audit_level','medium'))
+  print(d.get('reasoning',''))
+  print(d.get('domain',''))
+  alts = d.get('alternatives_considered',[])
+  if isinstance(alts, list):
+    print('|'.join(json.dumps(a) for a in alts))
+  else:
+    print('')
+  vrf = d.get('verification_steps',[])
+  if isinstance(vrf, list):
+    print('|'.join(vrf))
+  else:
+    print(str(vrf))
+except Exception as e:
+  print(f'PARSE_ERROR:{e}', file=sys.stderr); sys.exit(4)
+" 2>&1)
+  ec=$?
+  if [[ $ec -ne 0 ]]; then
+    echo "ERROR: malformed judge JSON: $parsed" >&2
+    exit 4
+  fi
+  AUDIT_LEVEL=$(printf '%s\n' "$parsed" | sed -n '1p')
+  REASONING=$(printf '%s\n' "$parsed" | sed -n '2p')
+  DOMAIN=$(printf '%s\n' "$parsed" | sed -n '3p')
+  ALTERNATIVES=$(printf '%s\n' "$parsed" | sed -n '4p')
+  VERIFICATION=$(printf '%s\n' "$parsed" | sed -n '5p')
+fi
+
+# ── Read draft from stdin ───────────────────────────────────────────────────
+
+DRAFT=$(cat)
+
+# Empty draft is a no-op (preserves Slice 1 hook contract).
+if [[ -z "$DRAFT" ]]; then
+  printf '%s' "$DRAFT"
+  exit 0
+fi
+
+# ── Skip rewrite when not blind ─────────────────────────────────────────────
+#
+# Only `blind` triggers the rewrite. low/medium/high/missing all pass through.
+# Spec § 5: "Cuando una recomendación cae en un área `blind`, el
+# expertise-asymmetry-judge re-escribe el output".
+if [[ "$AUDIT_LEVEL" != "blind" ]]; then
+  printf '%s' "$DRAFT"
+  exit 0
+fi
+
+# ── Build rewrite ───────────────────────────────────────────────────────────
+
+calibration_banner="[CALIBRATION: blind-area${DOMAIN:+ — $DOMAIN}] Esta recomendación cae en un área que has marcado como no-auditable. Las secciones siguientes son obligatorias para que puedas decidir sin depender de mi criterio."
+
+# Section 1 — Por qué creo esto (always present, even if reasoning empty)
+section_why="**Por qué creo esto**:"$'\n'
+if [[ -n "$REASONING" ]]; then
+  section_why+="$REASONING"
+else
+  section_why+="(razonamiento no proporcionado por el juez — pedir explicación explícita antes de actuar)"
+fi
+
+# Section 2 — Alternativas que descarté
+section_alts="**Alternativas que descarté**:"$'\n'
+if [[ -n "$ALTERNATIVES" ]]; then
+  # ALTERNATIVES is pipe-separated JSON objects or plain lines
+  IFS='|' read -ra alt_arr <<< "$ALTERNATIVES"
+  for a in "${alt_arr[@]}"; do
+    [[ -z "$a" ]] && continue
+    # Try JSON decode; fall back to literal
+    decoded=$(python3 -c "
+import json,sys
+try:
+  d = json.loads('''$a''')
+  if isinstance(d, dict):
+    opt = d.get('option', d.get('label', ''))
+    rej = d.get('rejected_because', d.get('reason', ''))
+    print(f'- {opt}: {rej}' if opt else f'- {d}')
+  else:
+    print(f'- {d}')
+except Exception:
+  print('- $a')
+" 2>/dev/null) || decoded="- $a"
+    section_alts+="$decoded"$'\n'
+  done
+else
+  section_alts+="(ninguna alternativa registrada — pedir comparativa antes de actuar)"$'\n'
+fi
+
+# Section 3 — Cómo verificar tú misma
+section_verify="**Cómo verificar tú misma**:"$'\n'
+if [[ -n "$VERIFICATION" ]]; then
+  IFS='|' read -ra vrf_arr <<< "$VERIFICATION"
+  for v in "${vrf_arr[@]}"; do
+    [[ -z "$v" ]] && continue
+    section_verify+="- $v"$'\n'
+  done
+else
+  section_verify+="(no se han propuesto pasos de verificación — el juez debió incluirlos; pedirlos antes de actuar)"$'\n'
+fi
+
+# ── Emit mutated draft ──────────────────────────────────────────────────────
+
+printf '%s\n\n---\n%s\n\n%s\n%s\n%s\n' \
+  "$DRAFT" \
+  "$calibration_banner" \
+  "$section_why" \
+  "$section_alts" \
+  "$section_verify"
+
+exit 0

--- a/tests/test-spec-125-slice-2-asymmetric-expertise.bats
+++ b/tests/test-spec-125-slice-2-asymmetric-expertise.bats
@@ -1,0 +1,250 @@
+#!/usr/bin/env bats
+# Ref: SPEC-125 — Recommendation Tribunal Slice 2 (Asymmetric expertise + audit trail).
+# Spec: docs/propuestas/SPEC-125-recommendation-tribunal-realtime.md sections 5 + 8.
+# Targets:
+#   scripts/recommendation-tribunal/expertise-rewrite.sh
+#   scripts/recommendation-tribunal-search.sh
+#   .claude/profiles/users/template/expertise.md
+
+setup() {
+  set -uo pipefail
+  ROOT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  SCRIPT="scripts/recommendation-tribunal/expertise-rewrite.sh"
+  REWRITE_ABS="$ROOT_DIR/scripts/recommendation-tribunal/expertise-rewrite.sh"
+  SEARCH_ABS="$ROOT_DIR/scripts/recommendation-tribunal-search.sh"
+  TEMPLATE_ABS="$ROOT_DIR/.claude/profiles/users/template/expertise.md"
+  TMPDIR_T=$(mktemp -d)
+  AUDIT_FIXT="$TMPDIR_T/audit"
+  mkdir -p "$AUDIT_FIXT/2026-06-04" "$AUDIT_FIXT/2026-06-05"
+}
+
+teardown() {
+  [ -n "${TMPDIR_T:-}" ] && [ -d "$TMPDIR_T" ] && rm -rf "$TMPDIR_T"
+}
+
+# ── Existence + safety identity ─────────────────────────────────────────────
+
+@test "expertise-rewrite: file exists, has shebang, executable" {
+  [ -f "$REWRITE_ABS" ]
+  head -1 "$REWRITE_ABS" | grep -q '^#!'
+  [ -x "$REWRITE_ABS" ]
+}
+
+@test "tribunal-search: file exists, has shebang, executable" {
+  [ -f "$SEARCH_ABS" ]
+  head -1 "$SEARCH_ABS" | grep -q '^#!'
+  [ -x "$SEARCH_ABS" ]
+}
+
+@test "expertise template: file exists with valid frontmatter" {
+  [ -f "$TEMPLATE_ABS" ]
+  grep -q '^schema_version:' "$TEMPLATE_ABS"
+  grep -q '^audit_level_default:' "$TEMPLATE_ABS"
+}
+
+@test "both scripts declare 'set -uo pipefail'" {
+  grep -q "set -uo pipefail" "$REWRITE_ABS"
+  grep -q "set -uo pipefail" "$SEARCH_ABS"
+}
+
+@test "both scripts pass bash -n syntax check" {
+  bash -n "$REWRITE_ABS"
+  bash -n "$SEARCH_ABS"
+}
+
+# ── expertise-rewrite: positive cases ───────────────────────────────────────
+
+@test "rewrite: blind audit_level produces calibration banner" {
+  run bash -c "echo 'Recomendacion X' | bash '$REWRITE_ABS' --audit-level blind --domain demo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CALIBRATION"* ]]
+  [[ "$output" == *"blind-area"* ]]
+  [[ "$output" == *"demo"* ]]
+}
+
+@test "rewrite: blind output includes three obligatory sections" {
+  run bash -c "echo 'Recomendacion X' | bash '$REWRITE_ABS' --audit-level blind --reasoning 'because A' --verification 'cmd1|cmd2'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"creo esto"* ]]
+  [[ "$output" == *"Alternativas"* ]]
+  [[ "$output" == *"verificar"* ]]
+}
+
+@test "rewrite: high audit_level passes draft through unchanged" {
+  run bash -c "echo 'Plain draft' | bash '$REWRITE_ABS' --audit-level high"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "Plain draft" ]]
+}
+
+@test "rewrite: medium audit_level passes draft through unchanged" {
+  run bash -c "echo 'Plain draft' | bash '$REWRITE_ABS' --audit-level medium"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "Plain draft" ]]
+}
+
+@test "rewrite: low audit_level passes draft through unchanged" {
+  run bash -c "echo 'Plain draft' | bash '$REWRITE_ABS' --audit-level low"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "Plain draft" ]]
+}
+
+@test "rewrite: verification array becomes bullet list" {
+  run bash -c "echo 'Z' | bash '$REWRITE_ABS' --audit-level blind --verification 'EXPLAIN ANALYZE|pg_stat_database'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"- EXPLAIN ANALYZE"* ]]
+  [[ "$output" == *"- pg_stat_database"* ]]
+}
+
+@test "rewrite: alternatives array as JSON dicts becomes bullet list" {
+  run bash -c "echo 'Z' | bash '$REWRITE_ABS' --audit-level blind --alternatives '{\"option\":\"A\",\"rejected_because\":\"slow\"}|{\"option\":\"B\",\"rejected_because\":\"unsafe\"}'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"A: slow"* ]]
+  [[ "$output" == *"B: unsafe"* ]]
+}
+
+# ── expertise-rewrite: negative cases ───────────────────────────────────────
+
+@test "negative: rewrite fails with usage when no args provided" {
+  run bash "$REWRITE_ABS"
+  [ "$status" -eq 2 ]
+}
+
+@test "negative: rewrite rejects unknown argument" {
+  run bash -c "echo 'X' | bash '$REWRITE_ABS' --bogus"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown"* || "$output" == *"ERROR"* ]]
+}
+
+@test "negative: rewrite reports error for missing judge JSON file" {
+  run bash -c "echo 'X' | bash '$REWRITE_ABS' --judge-json '$TMPDIR_T/does-not-exist.json'"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"not readable"* || "$output" == *"missing"* || "$output" == *"ERROR"* ]]
+}
+
+@test "negative: rewrite handles malformed judge JSON (invalid syntax)" {
+  bad="$TMPDIR_T/bad.json"
+  printf 'not-json{' > "$bad"
+  run bash -c "echo 'X' | bash '$REWRITE_ABS' --judge-json '$bad'"
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"malformed"* || "$output" == *"ERROR"* ]]
+}
+
+@test "negative: rewrite blind without reasoning still emits placeholder (graceful)" {
+  run bash -c "echo 'X' | bash '$REWRITE_ABS' --audit-level blind"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"razonamiento no proporcionado"* || "$output" == *"pedir explicacion"* ]]
+}
+
+# ── expertise-rewrite: edge cases ───────────────────────────────────────────
+
+@test "edge: rewrite handles empty stdin draft (no output, no crash)" {
+  run bash -c "echo -n '' | bash '$REWRITE_ABS' --audit-level blind"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "edge: rewrite reads judge JSON with zero alternatives (boundary)" {
+  judge="$TMPDIR_T/judge.json"
+  printf '%s\n' '{"audit_level":"blind","reasoning":"r","domain":"d","alternatives_considered":[],"verification_steps":[]}' > "$judge"
+  run bash -c "echo 'Z' | bash '$REWRITE_ABS' --judge-json '$judge'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ninguna alternativa"* ]]
+  [[ "$output" == *"no se han propuesto"* ]]
+}
+
+@test "edge: rewrite preserves original draft as first content line" {
+  run bash -c "echo 'ORIGINAL_LINE_42' | bash '$REWRITE_ABS' --audit-level blind"
+  [ "$status" -eq 0 ]
+  first_line=$(printf '%s\n' "$output" | head -1)
+  [ "$first_line" = "ORIGINAL_LINE_42" ]
+}
+
+# ── tribunal-search: positive + negative + edge ─────────────────────────────
+
+@test "search: --summary on empty audit dir reports zero records" {
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-05 --summary"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"records=0"* ]]
+}
+
+@test "search: filters by verdict correctly" {
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"a1b2c3d4","draft_preview":"x","classification":{"risk_class":"medium"},"verdict":"VETO"}' > "$AUDIT_FIXT/2026-06-04/a1b2c3d4.json"
+  printf '%s\n' '{"ts":"2026-06-04T10:01:00Z","draft_hash":"e5f6","draft_preview":"y","classification":{"risk_class":"high"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/e5f6.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --verdict VETO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VETO"* ]]
+  [[ "$output" != *"PASS"* ]]
+}
+
+@test "search: filters by risk correctly" {
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"a1b2c3d4","draft_preview":"x","classification":{"risk_class":"high"},"verdict":"VETO"}' > "$AUDIT_FIXT/2026-06-04/a1b2c3d4.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --risk high --summary"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"records=1"* ]]
+  [[ "$output" == *"high=1"* ]]
+}
+
+@test "search: filters by hash prefix correctly" {
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"prefix12345xyz","draft_preview":"a","classification":{"risk_class":"medium"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/prefix.json"
+  printf '%s\n' '{"ts":"2026-06-04T10:01:00Z","draft_hash":"otherhash99","draft_preview":"b","classification":{"risk_class":"medium"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/other.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --hash prefix12 --summary"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"records=1"* ]]
+}
+
+@test "search: --json mode emits one record per line" {
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"h1","draft_preview":"x","classification":{"risk_class":"medium"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/h1.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --json"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; [json.loads(l) for l in sys.stdin if l.strip()]"
+}
+
+@test "negative: search rejects unknown argument" {
+  run bash "$SEARCH_ABS" --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown"* || "$output" == *"ERROR"* ]]
+}
+
+@test "negative: search fails when audit-trail directory is missing" {
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$TMPDIR_T/does-not-exist" run bash "$SEARCH_ABS"
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"missing"* || "$output" == *"ERROR"* ]]
+}
+
+@test "edge: search skips non-date directories under audit base (boundary)" {
+  mkdir -p "$AUDIT_FIXT/not-a-date"
+  printf '%s\n' '{"ts":"x","draft_hash":"x","verdict":"x"}' > "$AUDIT_FIXT/not-a-date/x.json"
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"valid","draft_preview":"v","classification":{"risk_class":"medium"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/valid.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --summary"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"records=1"* ]]
+}
+
+@test "edge: search ignores empty JSONL lines (zero-length records)" {
+  printf '\n\n' > "$AUDIT_FIXT/2026-06-04/empty.json"
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"v","draft_preview":"v","classification":{"risk_class":"low"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/valid.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --summary"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"records=1"* ]]
+}
+
+@test "edge: search caps results when no matches (graceful empty)" {
+  printf '%s\n' '{"ts":"2026-06-04T10:00:00Z","draft_hash":"v","draft_preview":"v","classification":{"risk_class":"low"},"verdict":"PASS"}' > "$AUDIT_FIXT/2026-06-04/v.json"
+  RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$AUDIT_FIXT" run bash -c "bash '$SEARCH_ABS' --from 2026-06-04 --to 2026-06-04 --verdict NOPE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ── Template invariants ─────────────────────────────────────────────────────
+
+@test "template: documents the four audit_level values blind low medium high" {
+  grep -q '^| `blind` |' "$TEMPLATE_ABS"
+  grep -q '^| `low` |' "$TEMPLATE_ABS"
+  grep -q '^| `medium` |' "$TEMPLATE_ABS"
+  grep -q '^| `high` |' "$TEMPLATE_ABS"
+}
+
+@test "template: references SPEC-125 section 5" {
+  grep -q "SPEC-125" "$TEMPLATE_ABS"
+  grep -q -i "Asymmetric" "$TEMPLATE_ABS"
+}


### PR DESCRIPTION
# PR — SPEC-125 Slice 2: asymmetric expertise + audit-trail CLI

## Qué hace este PR (en lenguaje no técnico)

Este pull request añade la segunda fase del Recommendation Tribunal, el guardia que revisa en tiempo real las recomendaciones que Savia da durante una conversación normal. La primera fase (Slice 1) ya estaba en el repositorio: clasificaba los borradores, los pasaba por cuatro jueces en paralelo y agregaba su veredicto, pero todavía no hacía nada visible al usuario porque el hook estaba listo para conectar pero sin activar. Esta segunda fase entrega tres piezas que faltaban para que el sistema sea útil. Primero, un script de reescritura que sólo entra en acción cuando el usuario ha declarado un área concreta como punto ciego (audit_level: blind); en esos casos, en lugar de soltar la recomendación a pelo, Savia añade tres secciones obligatorias por debajo: por qué cree esa recomendación, qué alternativas descartó y cómo puede el usuario verificar por sí mismo si la recomendación es buena, sin tener que confiar a ciegas. Segundo, una herramienta de línea de comandos que permite al usuario inspeccionar todo el rastro de auditoría que Savia va generando turn a turn, con filtros por fecha, por veredicto, por nivel de riesgo y por hash del borrador, en modo legible para humano o en JSONL para procesarlo después con otras herramientas. Tercero, una plantilla genérica para que cualquier usuario pueda declarar sus propias áreas de expertise (programación, finanzas, salud, lo que sea) y marcar cuáles son ciegas, bajas, medias o altas; los datos personales reales no van en el repositorio público, sino en el directorio personal de cada uno. La suite de tests que acompaña al PR tiene treinta y dos casos cubriendo positivos, negativos y bordes, y pasa el quality gate de SPEC-055 sin depender de ningún servicio externo.

## Resumen técnico

| Pieza | Path | Slice 2 ref |
|---|---|---|
| Rewrite blind-area | scripts/recommendation-tribunal/expertise-rewrite.sh | sec 5 |
| Audit-trail CLI | scripts/recommendation-tribunal-search.sh | sec 8 |
| Expertise TEMPLATE | .claude/profiles/users/template/expertise.md | sec 5 |
| BATS suite | tests/test-spec-125-slice-2-asymmetric-expertise.bats | --- |
| Frontmatter SPEC-125 | docs/propuestas/SPEC-125-recommendation-tribunal-realtime.md | sec 6 |

## Status decisions

- TEMPLATE genérico (no datos personales en el repo público).
- Wire orchestrator -> expertise-rewrite NO incluido en este PR (deferred a Slice 2-advanced; requiere wiring real con Task tool fuera del alcance de un PR de artefactos).
- Audit-trail JSON shape ya definida en Slice 1; este PR consume sin modificar.

## Verificación local

- bash scripts/ci-test-quality-gate.sh -> PASS.
- bats tests/test-spec-125-slice-2-asymmetric-expertise.bats -> 32/32 OK.
- Smoke tests scripts: rewrite con cuatro audit_levels + judge-json malformado + search con fixtures sintéticas.

## Refs

- SPEC-125 sec 5 (Asymmetric-expertise mode) y sec 8 (Audit-trail CLI).
- SPEC-055 (CI test quality gate).
- Rule sobre zero-project-leakage (TEMPLATE no contiene datos reales).
- Rule sobre Radical Honesty (el TEMPLATE recuerda explicitamente honestidad sobre auto-evaluacion).
## Summary
feat(spec-125): Slice 2 - asymmetric expertise + audit-trail CLI
### Changes
- cb303a6d chore: re-sign confidentiality post-merge with main
- b95d7f45 Merge remote-tracking branch 'origin/main' into feature/spec-125-slice-2-asymmetric-expertise
- 350b2254 chore(spec-125-slice-2): re-sign confidentiality after Slice 2 commit
- 2aaa6ad6 feat(spec-125): Slice 2 - asymmetric expertise + audit-trail CLI
### Stats
10 files changed across 4 commits.
## Test plan
- [x] CI passed  - [x] Signed
