### PR TITLE
feat(spec-169): Slices 1+2 — twin schema, linter, forbidden-fields, pilot + 33 tests (97/100)

### DIFF
--- a/.claude/hooks-allowlist.tsv
+++ b/.claude/hooks-allowlist.tsv
@@ -3,3 +3,4 @@
 # Each entry MUST cite spec/rule explaining deliberate non-registration.
 recommendation-tribunal-pre-output.sh	SPEC-125 Slice 1 — WIRE-READY, activation requires deliberate human review of full tribunal infrastructure batch. See header of the .sh file.
 recommendation-tribunal-followup.sh	SPEC-125 Slice 3 — WIRE-READY, NO-OP por defecto. Activacion requiere edicion humana de .claude/settings.json y RECOMMENDATION_TRIBUNAL_FOLLOWUP_ACTIVE=1. Mismo gate que Slice 1 (recommendation-tribunal-pre-output.sh).
+twin-posttooluse.sh	SPEC-169 AC-4 — Hook PostToolUse WIRE-READY, NO-OP por defecto sin TWIN_HOOK_ENABLED=true. Activacion requiere configuracion explicita en settings.json.

--- a/.claude/hooks/twin-posttooluse.sh
+++ b/.claude/hooks/twin-posttooluse.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # twin-posttooluse.sh — Hook PostToolUse: dispara refresh de twins en eventos relevantes
 # Spec: SPEC-169 AC-4
+set -uo pipefail
 # Profile tier: standard
 # Hook: PostToolUse (mcp__github__*)
 # Eventos: cierre de sprint (branch merge), cambio de estado de work item,
 #          merge de PR que toque projects/*/
 # Wire-ready: TWIN_HOOK_ENABLED=true activa el refresh automático.
 # Sin esa variable, el hook es no-op (safe by default).
-set -uo pipefail
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$HOOK_DIR/../.." && pwd)}"

--- a/.claude/hooks/twin-posttooluse.sh
+++ b/.claude/hooks/twin-posttooluse.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# twin-posttooluse.sh — Hook PostToolUse: dispara refresh de twins en eventos relevantes
+# Spec: SPEC-169 AC-4
+# Profile tier: standard
+# Hook: PostToolUse (mcp__github__*)
+# Eventos: cierre de sprint (branch merge), cambio de estado de work item,
+#          merge de PR que toque projects/*/
+# Wire-ready: TWIN_HOOK_ENABLED=true activa el refresh automático.
+# Sin esa variable, el hook es no-op (safe by default).
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$HOOK_DIR/../.." && pwd)}"
+REFRESH_SCRIPT="${ROOT_DIR}/scripts/twin-refresh.sh"
+
+# Guard: no-op unless explicitly enabled
+TWIN_HOOK_ENABLED="${TWIN_HOOK_ENABLED:-false}"
+[[ "$TWIN_HOOK_ENABLED" != "true" ]] && exit 0
+
+# Read PostToolUse input
+INPUT=""
+if [[ ! -t 0 ]]; then
+  INPUT=$(timeout 3 cat 2>/dev/null) || true
+fi
+[[ -z "$INPUT" ]] && exit 0
+
+command -v jq &>/dev/null || exit 0
+
+# Detect affected project from tool output
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+OUTPUT=$(printf '%s' "$INPUT" | jq -r '.tool_result // empty' 2>/dev/null || true)
+
+# Extract project slug from any projects/* path in output
+SLUG=$(printf '%s' "$OUTPUT" | grep -oE 'projects/[a-z][a-z0-9_-]+/' | head -1 | sed 's|projects/||;s|/$||' || true)
+
+[[ -z "$SLUG" ]] && exit 0
+
+TWIN_FILE="${ROOT_DIR}/projects/${SLUG}/twin.md"
+[[ ! -f "$TWIN_FILE" ]] && exit 0
+
+# Only trigger on relevant tool events
+case "$TOOL_NAME" in
+  mcp__github__create_pull_request|\
+  mcp__github__merge_pull_request|\
+  mcp__azuredevops__update_work_item)
+    bash "$REFRESH_SCRIPT" "$SLUG" >/dev/null 2>&1 || true
+    ;;
+esac
+
+exit 0

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=94065fc00db9747244e5eee49842bcef0ecd623ff4583592fce53ddb64f708ab
-timestamp=2026-06-05T16:37:24Z
+diff_hash=d53995f7855a73d82cbcdb98929a547b8a198831358e19239213e25b9fbf5571
+timestamp=2026-06-05T16:43:48Z
 branch=feature/spec-169-project-twin
-head_commit=3503d0e8
-signature=8b7997cbe058d850b1c4e8f43b3f5853eeff68eaaff1f72bbd8690171cba61bb
+head_commit=397921a2
+signature=59fbbf0b8e16f95b147313b1c0e0e44f8e0e863b8d3be5eb013181b2a143b6d8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=522129c41a6a9e5d7e80c77d6e920cb004348d3b349bcecaad5e38111e2fce7a
-timestamp=2026-06-05T15:48:28Z
-branch=feature/spec-157-context-preflight-check
-head_commit=b6427df7
-signature=aaee67c51bb03883efb03d909dc56d8ffd53757e9970985783e29e998a051378
+diff_hash=e7969f90e857d7abae0fde4305f5b1605dd996d5161ff97a855e99f3378f6209
+timestamp=2026-06-05T16:35:14Z
+branch=feature/spec-169-project-twin
+head_commit=80155933
+signature=8a8c89978af2eb7e4da8ab9a3140be0e8c88c51435b2bc959bd5f1d36eb10d30

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=567a1f18e50b8409768bb7da0930a31aea43860bbc24170056db4acd065fa4ae
-timestamp=2026-06-05T16:37:05Z
+diff_hash=94065fc00db9747244e5eee49842bcef0ecd623ff4583592fce53ddb64f708ab
+timestamp=2026-06-05T16:37:24Z
 branch=feature/spec-169-project-twin
-head_commit=6598c8a2
-signature=1ef752c94c9df0d5dbb98279eb64ca81b45a6fda120b227fa7d7dfc936fbb11a
+head_commit=3503d0e8
+signature=8b7997cbe058d850b1c4e8f43b3f5853eeff68eaaff1f72bbd8690171cba61bb

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d17f4fabbe6f7a09f9e8b4ae35a8c521098a24b42fd5c346f0deb3e5fd8d44b1
-timestamp=2026-06-05T16:52:35Z
+diff_hash=493aa2006cffb11994c8e74db90ec8765998a2e52b2f806304ba153a006bf9a8
+timestamp=2026-06-05T17:19:01Z
 branch=feature/spec-169-project-twin
-head_commit=5b42c43b
-signature=e7255060f5402e4b578bdf2701465d4bdf2d1487f01cc628fa5873b2764e2bf2
+head_commit=a234677a
+signature=2523a434107f9484f3668cb7f2b734c6e615c99ed01bb95fd0f63daede91cf49

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e7969f90e857d7abae0fde4305f5b1605dd996d5161ff97a855e99f3378f6209
-timestamp=2026-06-05T16:35:14Z
+diff_hash=567a1f18e50b8409768bb7da0930a31aea43860bbc24170056db4acd065fa4ae
+timestamp=2026-06-05T16:37:05Z
 branch=feature/spec-169-project-twin
-head_commit=80155933
-signature=8a8c89978af2eb7e4da8ab9a3140be0e8c88c51435b2bc959bd5f1d36eb10d30
+head_commit=6598c8a2
+signature=1ef752c94c9df0d5dbb98279eb64ca81b45a6fda120b227fa7d7dfc936fbb11a

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=d53995f7855a73d82cbcdb98929a547b8a198831358e19239213e25b9fbf5571
-timestamp=2026-06-05T16:43:48Z
+timestamp=2026-06-05T16:49:00Z
 branch=feature/spec-169-project-twin
-head_commit=397921a2
+head_commit=acac1af7
 signature=59fbbf0b8e16f95b147313b1c0e0e44f8e0e863b8d3be5eb013181b2a143b6d8

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d53995f7855a73d82cbcdb98929a547b8a198831358e19239213e25b9fbf5571
-timestamp=2026-06-05T16:49:00Z
+diff_hash=d17f4fabbe6f7a09f9e8b4ae35a8c521098a24b42fd5c346f0deb3e5fd8d44b1
+timestamp=2026-06-05T16:52:35Z
 branch=feature/spec-169-project-twin
-head_commit=acac1af7
-signature=59fbbf0b8e16f95b147313b1c0e0e44f8e0e863b8d3be5eb013181b2a143b6d8
+head_commit=5b42c43b
+signature=e7255060f5402e4b578bdf2701465d4bdf2d1487f01cc628fa5873b2764e2bf2

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ scripts/tests/screenshots
 # Configuraciones locales
 .claude/settings.local.*
 scripts/confidentiality-blocklist.local.txt
+.claude/rules/twin-anon-projects.local.txt
 
 # Informes de auditoria
 audit-report-*

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 96a7a008ea11 | resources: 1195
-> 555 commands · 100 skills · 70 agents · 470 scripts
+> hash: 804884bdefd8 | resources: 1200
+> 555 commands · 100 skills · 70 agents · 475 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
@@ -295,6 +295,9 @@
 [development] tech-research-agent — autónoma,específico,investigación,tema,técnica — skill:.claude/skills/tech-research-agent/SKILL.md
 [development] tolaria-open — base,desktop,knowledge,open,path — cmd:.claude/commands/tolaria-open.md
 [development] tribunal-benchmark — benchmark,phase,spec,tribunal — script:scripts/tribunal-benchmark.sh
+[development] twin-anonymize — anonymize,datos,organización,spec,twin — script:scripts/twin-anonymize.sh
+[development] twin-load — carga,load,muestra,proyecto,spec — script:scripts/twin-load.sh
+[development] twin-refresh — predicciones,recalcula,refresh,spec,twin — script:scripts/twin-refresh.sh
 [development] ua-analyze — anything,codebase,generate,graph,knowledge — cmd:.claude/commands/ua-analyze.md
 [development] ua-diff — analyze,changes,codebase,graph,impact — cmd:.claude/commands/ua-diff.md
 [development] ua-domain — business,codebase,concepts,domain,extract — cmd:.claude/commands/ua-domain.md
@@ -926,6 +929,7 @@
 [planning] tribunal-status — depth,evaluations,pending,queue,recent — cmd:.claude/commands/tribunal-status.md
 [planning] truth-tribunal-orchestrator — aggregates,applies,convenes,drives,iteration — agent:.claude/agents/truth-tribunal-orchestrator.md
 [planning] truth-tribunal-worker — consume,queued,tribunal,truth,verification — script:scripts/truth-tribunal-worker.sh
+[planning] twin-decay-check — check,days,decay,escanea,marca — script:scripts/twin-decay-check.sh
 [planning] typescript-developer —  — agent:.claude/agents/typescript-developer.md
 [planning] ua-bridge — anything,between,bridge,savia,understand — script:scripts/ua-bridge.sh
 [planning] ua-dashboard — browser,dashboard,graph,interactive,knowledge — cmd:.claude/commands/ua-dashboard.md
@@ -1189,6 +1193,7 @@
 [quality] testplan-generate — generación,pbis,plan,pruebas,specs — cmd:.claude/commands/testplan-generate.md
 [quality] testplan-results —  — cmd:.claude/commands/testplan-results.md
 [quality] testplan-status —  — cmd:.claude/commands/testplan-status.md
+[quality] twin-linter — contra,linter,schema,spec,twin — script:scripts/twin-linter.sh
 [quality] verification-lattice — allá,capa,code,estándar,multi — skill:.claude/skills/verification-lattice/SKILL.md
 [quality] visual-digest — ambigüedades,capturas,contexto,contextual,detectan — agent:.claude/agents/visual-digest.md
 [quality] visual-qa — against,analysis,analyze,assurance,capabilities — cmd:.claude/commands/visual-qa.md

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 153 resources
+> 156 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **/speckit.checklist** (cmd): Alias spec-kit compatible. Gate de calidad final con verification-lattice multi-capa. Invoca skill verification-lattice. Compatible con github/spec-kit.
@@ -140,6 +140,9 @@
 - **tech-research-agent** (skill): Usar cuando se necesita investigación técnica autónoma sobre un tema específico.
 - **tolaria-open** (cmd): Open Tolaria desktop knowledge base on the Savia workspace (or specified path)
 - **tribunal-benchmark** (script): tribunal-benchmark.sh — SPEC-106 Phase 3.
+- **twin-anonymize** (script): twin-anonymize.sh — Genera vista N1 de un twin sin datos de organización (SPEC-169 AC-6)
+- **twin-load** (script): twin-load.sh — Carga y muestra el twin de un proyecto (SPEC-169 AC-2, AC-5)
+- **twin-refresh** (script): twin-refresh.sh — Recalcula predicciones del twin sin LLM (SPEC-169 AC-3, AC-V2)
 - **ua-analyze** (cmd): Generate knowledge graph for any codebase using Understand-Anything
 - **ua-diff** (cmd): Analyze impact of uncommitted changes on the codebase graph
 - **ua-domain** (cmd): Extract business domain concepts and processes from any codebase

--- a/.scm/categories/planning.scm
+++ b/.scm/categories/planning.scm
@@ -1,5 +1,5 @@
 # planning — Savia Capability Map (L1)
-> 528 resources
+> 529 resources
 
 - **/accreditation-track** (cmd): >
 - **/decide-architecture** (cmd): Clasifica una tarea como WORKFLOW (deterministica) o AGENT (loop). Bias hacia workflow per Anthropic. Sugiere plantilla inicial. Mide accuracy contra corpus curado de 20 tareas.
@@ -486,6 +486,7 @@
 - **tribunal-status** (cmd): Show Truth Tribunal queue depth, recent verdicts, and pending evaluations
 - **truth-tribunal-orchestrator** (agent): Truth Tribunal orchestrator — convenes 7 judges, aggregates scores, applies vetos, drives iteration
 - **truth-tribunal-worker** (script): truth-tribunal-worker.sh — Consume queued Truth Tribunal verification
+- **twin-decay-check** (script): twin-decay-check.sh — Escanea todos los twins y marca STALE los que superaron stale_after_days
 - **typescript-developer** (agent): >
 - **ua-bridge** (script): ua-bridge.sh — Bridge between Savia and Understand-Anything
 - **ua-dashboard** (cmd): Start the interactive knowledge graph dashboard in browser

--- a/.scm/categories/quality.scm
+++ b/.scm/categories/quality.scm
@@ -1,5 +1,5 @@
 # quality — Savia Capability Map (L1)
-> 228 resources
+> 229 resources
 
 - **/a11y-audit** (cmd): Auditoría de accesibilidad WCAG 2.2 completa con escaneo de HTML/componentes. Detecta: alt text faltante, problemas de contraste, navegación por teclado, etiquetas ARIA, gestión de focus, jerarquía de encabezados, etiquetas de formularios.
 - **/a11y-fix** (cmd): Correcciones automáticas de accesibilidad con verificación y preview. Genera código de fix para issues detectados por /a11y-audit. Preview antes de aplicar. Verifica que no introduce nuevos problemas. Covers: alt text, ARIA attributes, focu
@@ -221,6 +221,7 @@
 - **testplan-generate** (cmd): Generación de plan de pruebas desde specs SDD o PBIs
 - **testplan-results** (cmd): >
 - **testplan-status** (cmd): >
+- **twin-linter** (script): twin-linter.sh — Valida twin.md contra schema SPEC-169
 - **verification-lattice** (skill): Usar cuando se necesita verificación multi-capa más allá del code review estándar.
 - **visual-digest** (agent): Digestión de imágenes con OCR contextual — 5 pasadas. Fotos de pizarras, notas manuscritas, diagramas en papel, capturas de reuniones. Usa contexto REAL del proyecto para resolver ambigüedades. PROACTIVELY cuando se detectan imágenes en car
 - **visual-qa** (cmd): Visual quality assurance via screenshot analysis. Analyze UI screenshots against design specs and reference images using vision capabilities.

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "660cc4f98a8f",
-  "total": 1195,
+  "hash": "50b58e6fc78b",
+  "total": 1200,
   "resources": [
     {
       "category": "analysis",
@@ -3785,6 +3785,48 @@
       "kind": "script",
       "path": "scripts/tribunal-benchmark.sh",
       "description": "tribunal-benchmark.sh — SPEC-106 Phase 3."
+    },
+    {
+      "category": "development",
+      "name": "twin-anonymize",
+      "intents": [
+        "anonymize",
+        "datos",
+        "organización",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "path": "scripts/twin-anonymize.sh",
+      "description": "twin-anonymize.sh — Genera vista N1 de un twin sin datos de organización (SPEC-169 AC-6)"
+    },
+    {
+      "category": "development",
+      "name": "twin-load",
+      "intents": [
+        "carga",
+        "load",
+        "muestra",
+        "proyecto",
+        "spec"
+      ],
+      "kind": "script",
+      "path": "scripts/twin-load.sh",
+      "description": "twin-load.sh — Carga y muestra el twin de un proyecto (SPEC-169 AC-2, AC-5)"
+    },
+    {
+      "category": "development",
+      "name": "twin-refresh",
+      "intents": [
+        "predicciones",
+        "recalcula",
+        "refresh",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "path": "scripts/twin-refresh.sh",
+      "description": "twin-refresh.sh — Recalcula predicciones del twin sin LLM (SPEC-169 AC-3, AC-V2)"
     },
     {
       "category": "development",
@@ -11861,6 +11903,20 @@
     },
     {
       "category": "planning",
+      "name": "twin-decay-check",
+      "intents": [
+        "check",
+        "days",
+        "decay",
+        "escanea",
+        "marca"
+      ],
+      "kind": "script",
+      "path": "scripts/twin-decay-check.sh",
+      "description": "twin-decay-check.sh — Escanea todos los twins y marca STALE los que superaron stale_after_days"
+    },
+    {
+      "category": "planning",
       "name": "typescript-developer",
       "intents": [],
       "kind": "agent",
@@ -15241,6 +15297,20 @@
       "kind": "cmd",
       "path": ".claude/commands/testplan-status.md",
       "description": ">"
+    },
+    {
+      "category": "quality",
+      "name": "twin-linter",
+      "intents": [
+        "contra",
+        "linter",
+        "schema",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "path": "scripts/twin-linter.sh",
+      "description": "twin-linter.sh — Valida twin.md contra schema SPEC-169"
     },
     {
       "category": "quality",

--- a/CHANGELOG.d/spec-169-project-twin.md
+++ b/CHANGELOG.d/spec-169-project-twin.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SPEC-169 Project Twin — artefacto versionado por proyecto: twin.md schema, linter (AC-7 campos prohibidos), refresher determinista <5s, loader con cap 2000 tokens (AC-2), hook PostToolUse, decay check, anonymize N1 (AC-6). 33+ tests BATS score 97.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(70), commands(560), profiles, hooks(74/76reg), rules/{domain,languages}, skills(99), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(70), commands(560), profiles, hooks(75/76reg), rules/{domain,languages}, skills(99), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-06-05 | **Version:** v6.15.0 | **554 commands · 70 agents · 101 skills · 73 hooks · 388 test suites · Active backlog 20 items (~103h)** — ver `## Active Stack — 2026-06-05`
+**Updated:** 2026-06-05 | **Version:** v6.16.0 | **554 commands · 70 agents · 101 skills · 74 hooks · 389 test suites · Active backlog 19 items (~97h)** — ver `## Active Stack — 2026-06-05`
 
 ---
 
@@ -622,7 +622,7 @@ Specs APPROVED antes de 2026-04-26 NO requieren la sección retroactivamente. SE
 | Status | Count | Notas |
 |--------|-------|-------|
 | Implemented (merged) | ~100 | incl. SPEC-125, 155, 156 (slices 1+2), 158, 180, 184, 185, 186, SE-081/082/083/084/086/089/091/092/093/094/100/104/153/160/161/162/167 |
-| Proposed (active backlog) | 20 | ver `## Active Stack — 2026-06-05` |
+| Proposed (active backlog) | 19 | ver `## Active Stack — 2026-06-05` |
 | Approved (no PR yet) | ~5 | SPEC-OPC-AGENTSYNC, SPEC-SCM-COVERAGE, SPEC-SCM-FRESHCHECK, SPEC-OPC-CROSS-AUDIT |
 | Research / time-boxed | 2 | SPEC-023, SPEC-027, SPEC-162 (self-evolving tools) |
 | Archive | 24 | renumbered/superseded — ver `docs/propuestas/archive/` |
@@ -719,6 +719,7 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | SPEC-184 | Write-time non-blocking validators | PR #808 |
 | SPEC-158 | /decide-architecture workflow vs agent gate | PR #809 |
 | SPEC-125 Slices 1-3 | Recommendation Tribunal + expertise asymmetry + memory feedback loop | PR #812, #813 |
+| SPEC-157 | Context Pre-Flight Check — multi-source token estimator + PreToolUse hook | PR #814 |
 
 ### Tier 1 — Wave 1 Era 199 — CERRADO (SPEC-180 + SPEC-184 + SPEC-185 merged PR #806/807/808)
 
@@ -732,10 +733,9 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 
 | # | ID | Título | Esfuerzo | Deps |
 |---|---|---|---|---|
-| 1 | SPEC-157 | Context Pre-Flight Check | 6h | SPEC-156 ✓ |
-| 2 | SPEC-169 | Project Twin artefacto versionado | 11h | SPEC-156 ✓ + zero-leakage ✓ |
-| 3 | SPEC-159 | Async Tribunal Fan-out | 8h | — |
-| 4 | SPEC-160 (tool-erg) | Tool Ergonomics Auto-Audit | 5h | — |
+| 1 | SPEC-169 | Project Twin artefacto versionado | 11h | SPEC-156 ✓ + zero-leakage ✓ |
+| 2 | SPEC-159 | Async Tribunal Fan-out | 8h | — |
+| 3 | SPEC-160 (tool-erg) | Tool Ergonomics Auto-Audit | 5h | — |
 
 ### Tier 3 — Era 197 Flowsint + Wave 2/3 Era 199 (multiplicadores, total ~24h)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-06-05 | **Version:** v6.16.0 | **554 commands · 70 agents · 101 skills · 74 hooks · 389 test suites · Active backlog 19 items (~97h)** — ver `## Active Stack — 2026-06-05`
+**Updated:** 2026-06-05 | **Version:** v6.17.0 | **555 commands · 70 agents · 101 skills · 75 hooks · 390 test suites · Active backlog 18 items (~86h)** — ver `## Active Stack — 2026-06-05`
 
 ---
 
@@ -733,7 +733,7 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 
 | # | ID | Título | Esfuerzo | Deps |
 |---|---|---|---|---|
-| 1 | SPEC-169 | Project Twin artefacto versionado | 11h | SPEC-156 ✓ + zero-leakage ✓ |
+| 1 | SPEC-169 | Project Twin artefacto versionado | 11h | SPEC-156 ✓ + zero-leakage ✓ — IN_REVIEW PR #815 |
 | 2 | SPEC-159 | Async Tribunal Fan-out | 8h | — |
 | 3 | SPEC-160 (tool-erg) | Tool Ergonomics Auto-Audit | 5h | — |
 
@@ -765,7 +765,7 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 
 ### Decisión operativa (próximas 3 sesiones)
 
-1. **Sprint inmediato**: Tier 2 — SPEC-157 (6h, desbloquea agentes contexto) → SPEC-169 (11h, dep SPEC-156 ✓ + zero-leakage ✓).
+1. **Sprint inmediato**: Tier 2 — SPEC-157 (6h, implementada PR #814) → SPEC-169 (11h, IN_REVIEW PR #815) → SPEC-159 (8h, siguiente).
 2. **Sprint siguiente**: SPEC-159 (8h, zero deps) → SPEC-160 (5h, zero deps).
 3. **Después**: Tier 3 en orden (SE-151 → SE-152 → SPEC-181/182).
 
@@ -784,9 +784,9 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | # | ID | Propuesta | Status | Esfuerzo | Notas |
 |---|----|-----------|--------|----------|-------|
 | 1 | SPEC-156 | Token Budget Frontmatter | IMPLEMENTED | 4h | Tier 1A. Slice 1 (frontmatter 70/70 agentes) PR #790. Slice 2 (hook PreToolUse) PR #791 mergeado 2026-06-01. |
-| 2 | SPEC-157 | Context Pre-Flight Check | PROPOSED | 6h | Tier 1B. Depende de SPEC-156. |
+| 2 | SPEC-157 | Context Pre-Flight Check | IMPLEMENTED (PR #814) | 6h | Tier 1B. Depende de SPEC-156. |
 | 3 | SPEC-158 | Workflow vs Agent Decision Gate | IMPLEMENTED (2026-06-04) | 3h | Tier 1C. Comando /decide-architecture. |
-| 4 | SPEC-169 | Project Twin como artefacto versionado | PROPOSED | 11h | Tier 1B. Twin = proyecto. Refresh event-driven, predicciones acotadas, N4 + N1 anonimizado. Depende de SPEC-156 + skill `zero-project-leakage`. Compatible con SPEC-165 no bloqueante. |
+| 4 | SPEC-169 | Project Twin como artefacto versionado | IN_REVIEW (PR #815) | 11h | Tier 1B. Twin = proyecto. Refresh event-driven, predicciones acotadas, N4 + N1 anonimizado. Depende de SPEC-156 + skill `zero-project-leakage`. Compatible con SPEC-165 no bloqueante. |
 
 ### Tier 2 — MEDIUM (sprint siguiente, total 13h)
 

--- a/docs/case-studies/pryct-lp-anon.twin.md
+++ b/docs/case-studies/pryct-lp-anon.twin.md
@@ -1,7 +1,7 @@
 ---
-twin_id: "proyecto-alpha"
+twin_id: "pryct-lp-anon"
 spec_version: "1.0"
-last_refresh: "2026-06-05T16:34:36Z"
+last_refresh: "2026-06-XX"
 stale_after_days: 14
 token_budget: 2000
 health: green
@@ -9,19 +9,19 @@ predictions:
   sprint_slip:
     value: 0.10
     confidence: 0.65
-    evidence_ref: "/home/monica/savia/projects/proyecto-alpha/sprints/sprint-001"
+    evidence_ref: "case-study/sprints/sprint-001"
   next_blocker:
-    value: "no blockers detected"
+    value: "[blocker details redacted]"
     confidence: 0.7
-    evidence_ref: "/home/monica/savia/projects/proyecto-alpha/CLAUDE.md"
+    evidence_ref: "case-study/CLAUDE.md"
   scope_drift:
     value: 0.30
     confidence: 0.6
-    evidence_ref: "/home/monica/savia/projects/proyecto-alpha/backlog"
+    evidence_ref: "case-study/backlog"
   aggregate_health:
     value: green
     confidence: 0.75
-    evidence_ref: "/home/monica/savia/projects/proyecto-alpha/twin.md"
+    evidence_ref: "case-study/twin.md"
 ---
 
 ## Estado

--- a/docs/propuestas/SPEC-169-project-twin.md
+++ b/docs/propuestas/SPEC-169-project-twin.md
@@ -1,7 +1,7 @@
 ---
 spec_id: SPEC-169
 title: Project Twin como artefacto versionado
-status: PROPOSED
+status: IMPLEMENTED
 tier: 1B
 effort: 10-12h
 era: 198

--- a/docs/rules/domain/project-twin-as-code.md
+++ b/docs/rules/domain/project-twin-as-code.md
@@ -1,0 +1,70 @@
+# Project Twin as Code — Regla canónica
+# Spec: SPEC-169 · Status: IMPLEMENTED
+
+> El twin de un proyecto es su reflejo versionado en markdown: estado,
+> predicciones y reglas de negocio en un solo artefacto actualizable.
+
+## Localización
+
+`projects/{slug}/twin.md` — tracked por git, N2 (proyecto).
+
+## Schema obligatorio (frontmatter)
+
+```yaml
+---
+twin_id: "{slug}"
+spec_version: "1.0"
+last_refresh: "YYYY-MM-DDTHH:MM:SSZ"
+stale_after_days: 14
+token_budget: 2000
+health: green | yellow | red
+predictions:
+  sprint_slip:      { value: 0.0-1.0, confidence: 0.0-1.0, evidence_ref: "..." }
+  next_blocker:     { value: "descripción", confidence: 0.0-1.0, evidence_ref: "..." }
+  scope_drift:      { value: 0.0-1.0, confidence: 0.0-1.0, evidence_ref: "..." }
+  aggregate_health: { value: green|yellow|red, confidence: 0.0-1.0, evidence_ref: "..." }
+---
+```
+
+## Secciones obligatorias (en orden)
+
+1. `## Estado` — sprint activo, items abiertos, bloqueantes conocidos
+2. `## Reglas` — reglas de negocio del proyecto (referencia a `reglas-negocio.md` si existe)
+3. `## Predicciones` — las 4 predicciones del frontmatter en prosa con fuente citable
+
+## Sección opcional
+
+4. `## Grafo` — dependencias entre specs/PBIs (requires SE-162 ✓)
+
+## Campos prohibidos en el cuerpo
+
+Los campos siguientes nunca pueden aparecer en el cuerpo del twin
+(el linter `scripts/twin-linter.sh` los bloquea en pre-commit):
+
+- `assigned_to`, `assignee`, `owner`
+- `evaluation`, `competencia`, `performance`
+- `1on1`, `one_on_one`, `feedback_personal`
+- `salary`, `salario`, `compensation`
+- Handles nominativos (`@nombre-real`) — solo roles (`@backend-lead`)
+
+## Decay
+
+Si `last_refresh` supera `stale_after_days` días, el linter emite
+`STALE` y bloquea `/twin-load` hasta refresh o reset manual.
+
+## Vista pública (N1)
+
+`/twin-anonymize {slug}` genera `docs/case-studies/{slug-anon}.twin.md`
+sin nombre de organización, sin handles, solo métricas relativas.
+Ver `docs/rules/domain/zero-project-leakage.md`.
+
+## Telemetría
+
+- `output/twin-runs/loads.jsonl` — cada `/twin-load` (append-only)
+- `output/twin-runs/refresh-{slug}.jsonl` — cada refresh (append-only)
+
+## Referencias
+
+- `docs/propuestas/SPEC-169-project-twin.md`
+- `docs/rules/domain/zero-project-leakage.md`
+- `docs/propuestas/SPEC-156-token-budget-frontmatter.md`

--- a/projects/proyecto-alpha/twin.md
+++ b/projects/proyecto-alpha/twin.md
@@ -1,0 +1,57 @@
+---
+twin_id: "proyecto-alpha"
+spec_version: "1.0"
+last_refresh: "2026-06-05T16:27:48Z"
+stale_after_days: 14
+token_budget: 2000
+health: yellow
+predictions:
+  sprint_slip:
+    value: 0.3
+    confidence: 0.7
+    evidence_ref: "projects/proyecto-alpha/sprints/sprint-001/estado.md"
+  next_blocker:
+    value: "Módulo SSO pendiente de validación con proveedor externo"
+    confidence: 0.8
+    evidence_ref: "projects/proyecto-alpha/CLAUDE.md#SPRINT_GOAL"
+  scope_drift:
+    value: 0.1
+    confidence: 0.6
+    evidence_ref: "projects/proyecto-alpha/backlog"
+  aggregate_health:
+    value: yellow
+    confidence: 0.75
+    evidence_ref: "projects/proyecto-alpha/CLAUDE.md#VELOCITY_ULTIMA_SP"
+---
+
+## Estado
+
+Sprint activo: Sprint 2026-04 (2026-03-02 → 2026-03-13).
+Velocity última: 30 SP (media 32 SP, -6%).
+Objetivo: Completar módulo autenticación SSO + dashboard usuario.
+Bloqueantes: validación proveedor externo SSO pendiente.
+
+## Reglas
+
+Ver  para reglas completas.
+Resumen: ciclo mínimo 2 semanas, WIP limit 3 items/desarrollador,
+Definition of Done incluye tests e2e + revisión de seguridad.
+
+## Predicciones
+
+**Slip de sprint (confianza 0.70)**: probabilidad 0.30 de no cerrar
+el sprint goal al 100%. El SSO lleva 2 días de bloqueo por validación
+con proveedor externo; si no se resuelve en 24h el slip es inevitable.
+Fuente: estado sprint-001.
+
+**Próximo bloqueante (confianza 0.80)**: integración SSO con proveedor
+externo. Acción recomendada: escalar hoy si no hay respuesta.
+Fuente: CLAUDE.md SPRINT_GOAL.
+
+**Drift de scope (confianza 0.60)**: mínimo (0.10). Backlog estable,
+sin PBIs añadidos al sprint desde el planning.
+Fuente: directorio backlog.
+
+**Salud agregada (confianza 0.75)**: YELLOW. Velocity dentro de rango
+pero bloqueante activo. Sin acción correctiva → RED en 48h.
+Fuente: VELOCITY_ULTIMA_SP en CLAUDE.md.

--- a/projects/proyecto-alpha/twin.md
+++ b/projects/proyecto-alpha/twin.md
@@ -1,7 +1,7 @@
 ---
 twin_id: "proyecto-alpha"
 spec_version: "1.0"
-last_refresh: "2026-06-05T16:34:36Z"
+last_refresh: "2026-06-05T16:36:58Z"
 stale_after_days: 14
 token_budget: 2000
 health: green

--- a/scripts/twin-anonymize.sh
+++ b/scripts/twin-anonymize.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# twin-anonymize.sh — Genera vista N1 de un twin sin datos de organización (SPEC-169 AC-6)
+# Usage: bash scripts/twin-anonymize.sh {slug} [--out docs/case-studies/{slug-anon}.twin.md]
+# Exit: 0 OK | 2 ERROR
+# Applies: zero-project-leakage rules (removes org name, handles, real paths)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${TWIN_ROOT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+SLUG="${1:-}"
+[[ -z "$SLUG" ]] && { echo "Usage: twin-anonymize.sh {slug} [--out <path>]" >&2; exit 2; }
+
+TWIN_FILE="${ROOT_DIR}/projects/${SLUG}/twin.md"
+[[ ! -f "$TWIN_FILE" ]] && { echo "ERROR: twin not found: ${TWIN_FILE}" >&2; exit 2; }
+
+# Default output path
+SLUG_ANON=$(echo "$SLUG" | sed 's/[aeiouAEIOU]//g' | cut -c1-8)-anon
+OUT_DIR="${ROOT_DIR}/docs/case-studies"
+OUT_FILE="${OUT_DIR}/${SLUG_ANON}.twin.md"
+
+# Parse --out override
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out) OUT_FILE="${2:-$OUT_FILE}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+CONTENT=$(cat "$TWIN_FILE")
+
+# ── Anonymization transformations ────────────────────────────────────────────
+# 1. Replace twin_id with anon slug
+CONTENT=$(echo "$CONTENT" | sed "s|twin_id: \"${SLUG}\"|twin_id: \"${SLUG_ANON}\"|g")
+
+# 1b. Strip absolute ROOT_DIR prefix from all paths
+CONTENT=$(echo "$CONTENT" | sed "s|${ROOT_DIR}/||g")
+
+# 2. Replace projects/{slug}/ paths with generic evidence ref
+CONTENT=$(echo "$CONTENT" | sed "s|projects/${SLUG}/|case-study/|g")
+
+# 3. Remove any handle-like patterns (@word)
+CONTENT=$(echo "$CONTENT" | sed -E 's/@[a-z][a-z0-9_-]+/@role/g')
+
+# 4. Replace org-looking names in paths (CamelCase or ALL_CAPS identifiers)
+CONTENT=$(echo "$CONTENT" | sed -E 's/ProyectoAlpha|ProyectoBeta|TrazaBios|SaviaWeb/[PROJECT]/gI')
+
+# 5. Redact free-text blocker descriptions (keep only type hint)
+# Replace specific-looking blocker text (>20 chars) with placeholder
+CONTENT=$(echo "$CONTENT" | sed -E 's/(value: "[^"]{20,}")/value: "[blocker details redacted]"/g')
+
+# 6. Strip last_refresh timestamp precision to month
+CONTENT=$(echo "$CONTENT" | sed -E 's/(last_refresh: ")[0-9]{4}-([0-9]{2})-[0-9]{2}T[^"]*/\12026-\2-XX/g')
+
+mkdir -p "$OUT_DIR"
+printf '%s\n' "$CONTENT" > "$OUT_FILE"
+
+echo "OK: anonymized twin written to ${OUT_FILE}"
+exit 0

--- a/scripts/twin-anonymize.sh
+++ b/scripts/twin-anonymize.sh
@@ -43,8 +43,15 @@ CONTENT=$(echo "$CONTENT" | sed "s|projects/${SLUG}/|case-study/|g")
 # 3. Remove any handle-like patterns (@word)
 CONTENT=$(echo "$CONTENT" | sed -E 's/@[a-z][a-z0-9_-]+/@role/g')
 
-# 4. Replace org-looking names in paths (CamelCase or ALL_CAPS identifiers)
-CONTENT=$(echo "$CONTENT" | sed -E 's/ProyectoAlpha|ProyectoBeta|TrazaBios|SaviaWeb/[PROJECT]/gI')
+# 4. Replace org-specific project names loaded from local gitignored list
+# Add project names (one per line) to: .claude/rules/twin-anon-projects.local.txt
+LOCAL_PROJECTS_FILE="${ROOT_DIR}/.claude/rules/twin-anon-projects.local.txt"
+if [[ -f "$LOCAL_PROJECTS_FILE" ]]; then
+  while IFS= read -r proj || [[ -n "$proj" ]]; do
+    [[ -z "$proj" || "$proj" == \#* ]] && continue
+    CONTENT=$(echo "$CONTENT" | sed -E "s|${proj}|[PROJECT]|gI")
+  done < "$LOCAL_PROJECTS_FILE"
+fi
 
 # 5. Redact free-text blocker descriptions (keep only type hint)
 # Replace specific-looking blocker text (>20 chars) with placeholder

--- a/scripts/twin-decay-check.sh
+++ b/scripts/twin-decay-check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# twin-decay-check.sh — Escanea todos los twins y marca STALE los que superaron stale_after_days
+# Spec: SPEC-169 (decay policy)
+# Usage: bash scripts/twin-decay-check.sh [--fix]
+# --fix: ejecuta twin-refresh.sh en cada twin STALE
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${TWIN_ROOT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+LINTER="$SCRIPT_DIR/twin-linter.sh"
+REFRESH="$SCRIPT_DIR/twin-refresh.sh"
+FIX_MODE="${1:-}"
+
+STALE_COUNT=0
+OK_COUNT=0
+
+while IFS= read -r twin_file; do
+  slug=$(echo "$twin_file" | sed "s|${ROOT_DIR}/projects/||;s|/twin.md||")
+  exit_code=0
+  bash "$LINTER" "$twin_file" >/dev/null 2>&1 || exit_code=$?
+  if [[ "$exit_code" -eq 1 ]]; then
+    echo "STALE: ${slug}"
+    STALE_COUNT=$((STALE_COUNT + 1))
+    if [[ "$FIX_MODE" == "--fix" ]]; then
+      bash "$REFRESH" "$slug" >/dev/null 2>&1 && echo "  → refreshed OK" || echo "  → refresh FAILED"
+    fi
+  elif [[ "$exit_code" -eq 0 ]]; then
+    OK_COUNT=$((OK_COUNT + 1))
+  fi
+done < <(find "${ROOT_DIR}/projects" -name "twin.md" -type f 2>/dev/null | sort)
+
+echo "decay-check: ${OK_COUNT} OK, ${STALE_COUNT} STALE"
+[[ "$STALE_COUNT" -gt 0 ]] && exit 1
+exit 0

--- a/scripts/twin-forbidden-fields.txt
+++ b/scripts/twin-forbidden-fields.txt
@@ -1,0 +1,15 @@
+# twin-forbidden-fields.txt — Campos prohibidos en cuerpo de twin.md
+# Spec: SPEC-169 AC-7 — Una entrada por línea, formato: regex_pattern
+# El linter scripts/twin-linter.sh carga este fichero en runtime.
+# Editar aquí para extender la lista; el linter no necesita cambios.
+\bassigned_to\b
+\bassignee\b
+\bowner\b
+\bevaluation\b
+\bcompetencia\b
+\bperformance\b
+\b1on1\b
+\bone_on_one\b
+\bfeedback_personal\b
+\bsalar(io|y)\b
+\bcompensation\b

--- a/scripts/twin-linter.sh
+++ b/scripts/twin-linter.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# twin-linter.sh — Valida twin.md contra schema SPEC-169
+# Spec: SPEC-169 · AC-1, AC-7
+# Usage: bash scripts/twin-linter.sh <path/to/twin.md>
+# Exit: 0 OK | 1 STALE | 2 INVALID | 3 FORBIDDEN_FIELD
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TWIN_FILE="${1:-}"
+FORBIDDEN_FILE="${SCRIPT_DIR}/twin-forbidden-fields.txt"
+
+[[ -z "$TWIN_FILE" ]] && { echo "Usage: twin-linter.sh <twin.md>" >&2; exit 2; }
+[[ ! -f "$TWIN_FILE" ]] && { echo "ERROR: file not found: $TWIN_FILE" >&2; exit 2; }
+
+frontmatter() { awk '/^---$/{c++;if(c==2)exit;next} c==1{print}' "$TWIN_FILE"; }
+fm_field()    { frontmatter | grep -E "^${1}:" | head -1 | sed -E "s/^${1}:[[:space:]]*//" | tr -d '"'; }
+has_section() { grep -qE "^## ${1}" "$TWIN_FILE"; }
+
+ERRORS=0
+
+# 1. Required frontmatter fields
+for field in twin_id spec_version last_refresh stale_after_days token_budget health; do
+  [[ -z "$(fm_field "$field")" ]] && { echo "INVALID: missing '$field'" >&2; ERRORS=$((ERRORS+1)); }
+done
+
+# 2. Predictions block
+for pred in sprint_slip next_blocker scope_drift aggregate_health; do
+  frontmatter | grep -qE "^[[:space:]]+${pred}:" || { echo "INVALID: missing prediction '${pred}'" >&2; ERRORS=$((ERRORS+1)); }
+done
+
+# confidence in [0,1]
+while IFS= read -r line; do
+  echo "$line" | grep -qE "confidence:[[:space:]]*[0-9]" || continue
+  conf=$(echo "$line" | grep -oE "[0-9]+\.[0-9]+|[0-9]+" | head -1)
+  awk -v c="$conf" 'BEGIN{exit(c>=0&&c<=1)?0:1}' || { echo "INVALID: confidence out of range: $conf" >&2; ERRORS=$((ERRORS+1)); }
+done < <(frontmatter)
+
+# evidence_ref non-null
+while IFS= read -r line; do
+  echo "$line" | grep -qE "evidence_ref:[[:space:]]*$" && { echo "INVALID: empty evidence_ref" >&2; ERRORS=$((ERRORS+1)); }
+done < <(frontmatter)
+
+# 3. Required sections
+for section in "Estado" "Reglas" "Predicciones"; do
+  has_section "$section" || { echo "INVALID: missing section '## ${section}'" >&2; ERRORS=$((ERRORS+1)); }
+done
+
+[[ "$ERRORS" -gt 0 ]] && exit 2
+
+# 4. Forbidden fields (AC-7) — read patterns from config file
+BODY=$(awk '/^---$/{c++; if(c==2){found=1;next}} found{print}' "$TWIN_FILE")
+FORBIDDEN_FOUND=0
+if [[ -f "$FORBIDDEN_FILE" ]]; then
+  while IFS= read -r pat; do
+    [[ -z "$pat" || "$pat" == \#* ]] && continue
+    echo "$BODY" | grep -qiE "$pat" && { echo "FORBIDDEN: pattern '${pat}' in body" >&2; FORBIDDEN_FOUND=$((FORBIDDEN_FOUND+1)); }
+  done < "$FORBIDDEN_FILE"
+fi
+[[ "$FORBIDDEN_FOUND" -gt 0 ]] && exit 3
+
+# 5. Decay check (bash only, no Python)
+last_refresh=$(fm_field "last_refresh")
+stale_days=$(fm_field "stale_after_days")
+if [[ -n "$last_refresh" && -n "$stale_days" ]]; then
+  ref_epoch=$(date -d "${last_refresh}" +%s 2>/dev/null || true)
+  now_epoch=$(date +%s)
+  if [[ -n "$ref_epoch" ]]; then
+    delta_days=$(( (now_epoch - ref_epoch) / 86400 ))
+    if [[ "$delta_days" -gt "$stale_days" ]]; then
+      echo "STALE: last_refresh=${last_refresh} exceeds stale_after_days=${stale_days}" >&2
+      exit 1
+    fi
+  fi
+fi
+
+echo "OK: ${TWIN_FILE}"
+exit 0

--- a/scripts/twin-load.sh
+++ b/scripts/twin-load.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# twin-load.sh — Carga y muestra el twin de un proyecto (SPEC-169 AC-2, AC-5)
+# Usage: bash scripts/twin-load.sh {slug} [--summary]
+# Exit: 0 OK | 1 STALE | 2 ERROR | 3 N4_IN_N1_BLOCKED
+# AC-2: token output ≤ token_budget declared in twin.md
+# AC-5: refuses N4 content in N1 context
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${TWIN_ROOT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+LINTER="$SCRIPT_DIR/twin-linter.sh"
+TELEMETRY_DIR="${ROOT_DIR}/output/twin-runs"
+LOADS_LOG="${TELEMETRY_DIR}/loads.jsonl"
+
+SLUG="${1:-}"
+MODE="${2:-}"
+
+[[ -z "$SLUG" ]] && { echo "Usage: twin-load.sh {slug} [--summary]" >&2; exit 2; }
+
+TWIN_FILE="${ROOT_DIR}/projects/${SLUG}/twin.md"
+[[ ! -f "$TWIN_FILE" ]] && { echo "ERROR: twin not found for project '${SLUG}': ${TWIN_FILE}" >&2; exit 2; }
+
+# ── AC-5: N4 context guard ────────────────────────────────────────────────────
+# If TWIN_CONTEXT env var is N1 (public), refuse N4 twin content (projects/ is N2).
+# Projects/ twins are N2 by default; anonymized twins in docs/case-studies/ are N1.
+CONTEXT_LAYER="${TWIN_CONTEXT:-N2}"
+if [[ "$CONTEXT_LAYER" == "N1" ]]; then
+  echo "BLOCKED: N4 content (projects/${SLUG}/twin.md) refused in N1 context." >&2
+  echo "Use /twin-anonymize to get the public-safe version." >&2
+  exit 3
+fi
+
+# ── Validate (calls linter) ───────────────────────────────────────────────────
+lint_exit=0
+bash "$LINTER" "$TWIN_FILE" >/dev/null 2>&1 || lint_exit=$?
+
+if [[ "$lint_exit" -eq 2 ]]; then
+  echo "ERROR: ${SLUG}/twin.md failed schema validation. Run twin-linter.sh for details." >&2
+  exit 2
+fi
+
+if [[ "$lint_exit" -eq 1 ]]; then
+  echo "WARN: ${SLUG}/twin.md is STALE — refresh recommended before loading." >&2
+fi
+
+# ── Estimate token count ──────────────────────────────────────────────────────
+TWIN_CONTENT=$(cat "$TWIN_FILE")
+CHAR_COUNT=${#TWIN_CONTENT}
+TOKEN_EST=$(( CHAR_COUNT / 4 ))
+
+# Read budget from frontmatter
+TOKEN_BUDGET=$(grep -E "^token_budget:" "$TWIN_FILE" | head -1 | grep -oE "[0-9]+" || echo "2000")
+
+if [[ "$TOKEN_EST" -gt "$TOKEN_BUDGET" ]]; then
+  echo "WARN: estimated tokens ${TOKEN_EST} exceeds budget ${TOKEN_BUDGET}. Content will be truncated." >&2
+  TWIN_CONTENT="${TWIN_CONTENT:0:$(( TOKEN_BUDGET * 4 ))}"
+fi
+
+# ── Summary mode ─────────────────────────────────────────────────────────────
+if [[ "$MODE" == "--summary" ]]; then
+  HEALTH=$(grep -E "^health:" "$TWIN_FILE" | head -1 | sed 's/.*: *//' | tr -d '"')
+  LAST_REFRESH=$(grep -E "^last_refresh:" "$TWIN_FILE" | head -1 | sed 's/.*: *//' | tr -d '"')
+  echo "=== Twin: ${SLUG} ==="
+  echo "Health:       ${HEALTH}"
+  echo "Last refresh: ${LAST_REFRESH}"
+  echo "Tokens (est): ${TOKEN_EST}/${TOKEN_BUDGET}"
+  if [[ "$lint_exit" -eq 1 ]]; then echo "Status:       STALE"; else echo "Status:       OK"; fi
+  # Print only Estado section
+  awk '/^## Estado/{found=1} found{print} /^## [^E]/{if(found) exit}' "$TWIN_FILE"
+else
+  echo "$TWIN_CONTENT"
+fi
+
+# ── Telemetry (AC-8) ─────────────────────────────────────────────────────────
+mkdir -p "$TELEMETRY_DIR"
+printf '{"ts":"%s","slug":"%s","mode":"%s","tokens_est":%d,"budget":%d,"lint_exit":%d}\n' \
+  "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$SLUG" "${MODE:---load}" \
+  "$TOKEN_EST" "$TOKEN_BUDGET" "$lint_exit" >> "$LOADS_LOG" 2>/dev/null || true
+
+[[ "$lint_exit" -eq 1 ]] && exit 1
+exit 0

--- a/scripts/twin-refresh.sh
+++ b/scripts/twin-refresh.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# twin-refresh.sh — Recalcula predicciones del twin sin LLM (SPEC-169 AC-3, AC-V2)
+# Usage: bash scripts/twin-refresh.sh {slug} [--dry-run]
+# Exit: 0 OK | 2 ERROR
+# Determinista: lee evidence_refs, calcula 4 predicciones, escribe diff auditable
+set -uo pipefail
+export LC_NUMERIC=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${TWIN_ROOT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+LINTER="$SCRIPT_DIR/twin-linter.sh"
+TELEMETRY_DIR="${ROOT_DIR}/output/twin-runs"
+
+SLUG="${1:-}"
+DRY_RUN="${2:-}"
+
+[[ -z "$SLUG" ]] && { echo "Usage: twin-refresh.sh {slug} [--dry-run]" >&2; exit 2; }
+
+TWIN_FILE="${ROOT_DIR}/projects/${SLUG}/twin.md"
+[[ ! -f "$TWIN_FILE" ]] && { echo "ERROR: twin not found: ${TWIN_FILE}" >&2; exit 2; }
+
+PROJECT_DIR="${ROOT_DIR}/projects/${SLUG}"
+CLAUDE_MD="${PROJECT_DIR}/CLAUDE.md"
+BACKLOG_DIR="${PROJECT_DIR}/backlog"
+SPRINTS_DIR="${PROJECT_DIR}/sprints"
+
+START_TS=$(date +%s%N)
+
+# ── Evidence collection (deterministic, no LLM) ──────────────────────────────
+
+# sprint_slip: based on open items in latest sprint dir
+SPRINT_SLIP_VAL=0.2
+SPRINT_SLIP_CONF=0.6
+SPRINT_SLIP_REF="${SPRINTS_DIR}"
+if [[ -d "$SPRINTS_DIR" ]]; then
+  sprint_count=$(find "$SPRINTS_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  # Heuristic: if >1 sprint dir, check if latest has open items
+  if [[ "$sprint_count" -gt 0 ]]; then
+    latest_sprint=$(find "$SPRINTS_DIR" -mindepth 1 -maxdepth 1 -type d | sort | tail -1)
+    open_count=$(find "$latest_sprint" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+    SPRINT_SLIP_VAL=$(awk -v o="$open_count" 'BEGIN{v=o>5?0.5:o>2?0.3:0.1; printf "%.2f",v}')
+    SPRINT_SLIP_CONF=0.65
+    SPRINT_SLIP_REF="${latest_sprint}"
+  fi
+fi
+
+# next_blocker: check CLAUDE.md for any BLOCKED or bloqueante keywords
+NEXT_BLOCKER_VAL="no blockers detected"
+NEXT_BLOCKER_CONF=0.7
+NEXT_BLOCKER_REF="${CLAUDE_MD}"
+if [[ -f "$CLAUDE_MD" ]]; then
+  if grep -qiE "BLOCKED|bloqueante|bloqueado|pending.*extern" "$CLAUDE_MD" 2>/dev/null; then
+    NEXT_BLOCKER_VAL=$(grep -iEm1 "BLOCKED|bloqueante|bloqueado|pending.*extern" "$CLAUDE_MD" | head -c 80 | tr -d '"')
+    NEXT_BLOCKER_CONF=0.8
+  fi
+fi
+
+# scope_drift: count unplanned items in backlog vs sprint count
+SCOPE_DRIFT_VAL=0.05
+SCOPE_DRIFT_CONF=0.6
+SCOPE_DRIFT_REF="${BACKLOG_DIR}"
+if [[ -d "$BACKLOG_DIR" ]]; then
+  backlog_items=$(find "$BACKLOG_DIR" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+  SCOPE_DRIFT_VAL=$(awk -v b="$backlog_items" 'BEGIN{v=b>20?0.3:b>10?0.15:0.05; printf "%.2f",v}')
+fi
+
+# aggregate_health: derive from slip + blocker
+HEALTH_VAL="green"
+HEALTH_CONF=0.75
+HEALTH_REF="${TWIN_FILE}"
+SLIP_NUM=$(awk -v s="$SPRINT_SLIP_VAL" 'BEGIN{printf "%.0f",s*10}')
+if [[ "$SLIP_NUM" -ge 4 ]] || [[ "$NEXT_BLOCKER_VAL" != "no blockers detected" ]]; then
+  HEALTH_VAL="yellow"
+fi
+if [[ "$SLIP_NUM" -ge 6 ]]; then
+  HEALTH_VAL="red"
+  HEALTH_CONF=0.8
+fi
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ── Build updated twin ────────────────────────────────────────────────────────
+# Read existing body (everything after second ---)
+BODY=$(awk '/^---$/{c++; if(c==2){found=1;next}} found{print}' "$TWIN_FILE")
+
+NEW_TWIN=$(cat << TWIN
+---
+twin_id: "${SLUG}"
+spec_version: "1.0"
+last_refresh: "${NOW}"
+stale_after_days: 14
+token_budget: 2000
+health: ${HEALTH_VAL}
+predictions:
+  sprint_slip:
+    value: ${SPRINT_SLIP_VAL}
+    confidence: ${SPRINT_SLIP_CONF}
+    evidence_ref: "${SPRINT_SLIP_REF}"
+  next_blocker:
+    value: "${NEXT_BLOCKER_VAL}"
+    confidence: ${NEXT_BLOCKER_CONF}
+    evidence_ref: "${NEXT_BLOCKER_REF}"
+  scope_drift:
+    value: ${SCOPE_DRIFT_VAL}
+    confidence: ${SCOPE_DRIFT_CONF}
+    evidence_ref: "${SCOPE_DRIFT_REF}"
+  aggregate_health:
+    value: ${HEALTH_VAL}
+    confidence: ${HEALTH_CONF}
+    evidence_ref: "${HEALTH_REF}"
+---
+${BODY}
+TWIN
+)
+
+# ── Diff output (always shown) ────────────────────────────────────────────────
+OLD_HEALTH=$(grep -E "^health:" "$TWIN_FILE" | head -1 | sed 's/.*: *//')
+OLD_REFRESH=$(grep -E "^last_refresh:" "$TWIN_FILE" | head -1 | sed 's/.*: *//' | tr -d '"')
+echo "=== twin-refresh diff: ${SLUG} ==="
+echo "  health:       ${OLD_HEALTH} → ${HEALTH_VAL}"
+echo "  last_refresh: ${OLD_REFRESH} → ${NOW}"
+echo "  sprint_slip:  ${SPRINT_SLIP_VAL} (conf ${SPRINT_SLIP_CONF})"
+echo "  next_blocker: ${NEXT_BLOCKER_VAL} (conf ${NEXT_BLOCKER_CONF})"
+echo "  scope_drift:  ${SCOPE_DRIFT_VAL} (conf ${SCOPE_DRIFT_CONF})"
+
+[[ "$DRY_RUN" == "--dry-run" ]] && { echo "[dry-run] no changes written."; exit 0; }
+
+# Write updated twin
+printf '%s\n' "$NEW_TWIN" > "$TWIN_FILE"
+
+# Validate result
+bash "$LINTER" "$TWIN_FILE" >/dev/null 2>&1 || { echo "ERROR: refresh produced invalid twin" >&2; exit 2; }
+
+# ── Telemetry (AC-8) ─────────────────────────────────────────────────────────
+END_TS=$(date +%s%N)
+ELAPSED_MS=$(( (END_TS - START_TS) / 1000000 ))
+mkdir -p "$TELEMETRY_DIR"
+REFRESH_LOG="${TELEMETRY_DIR}/refresh-${SLUG}.jsonl"
+printf '{"ts":"%s","slug":"%s","health":"%s","elapsed_ms":%d,"slip":%.2f}\n' \
+  "$NOW" "$SLUG" "$HEALTH_VAL" "$ELAPSED_MS" "$SPRINT_SLIP_VAL" >> "$REFRESH_LOG" 2>/dev/null || true
+
+echo "OK: refresh complete in ${ELAPSED_MS}ms"
+exit 0

--- a/tests/fixtures/twin/evidence.md
+++ b/tests/fixtures/twin/evidence.md
@@ -1,0 +1,1 @@
+evidence.md

--- a/tests/fixtures/twin/forbidden-field.md
+++ b/tests/fixtures/twin/forbidden-field.md
@@ -1,0 +1,34 @@
+---
+twin_id: "test-bad"
+spec_version: "1.0"
+last_refresh: "2026-06-05T00:00:00Z"
+stale_after_days: 14
+token_budget: 2000
+health: green
+predictions:
+  sprint_slip:
+    value: 0.1
+    confidence: 0.9
+    evidence_ref: "x"
+  next_blocker:
+    value: "none"
+    confidence: 0.8
+    evidence_ref: "x"
+  scope_drift:
+    value: 0.05
+    confidence: 0.7
+    evidence_ref: "x"
+  aggregate_health:
+    value: green
+    confidence: 0.85
+    evidence_ref: "x"
+---
+
+## Estado
+Sprint ok.
+
+## Reglas
+assigned_to: dev-frontend
+
+## Predicciones
+Sin novedades.

--- a/tests/fixtures/twin/missing-field.md
+++ b/tests/fixtures/twin/missing-field.md
@@ -1,0 +1,33 @@
+---
+twin_id: "test-project"
+spec_version: "1.0"
+last_refresh: "2026-06-05T16:28:17Z"
+stale_after_days: 14
+health: green
+predictions:
+  sprint_slip:
+    value: 0.1
+    confidence: 0.9
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  next_blocker:
+    value: "none"
+    confidence: 0.8
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  scope_drift:
+    value: 0.05
+    confidence: 0.7
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  aggregate_health:
+    value: green
+    confidence: 0.85
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+---
+
+## Estado
+Sprint activo.
+
+## Reglas
+Regla 1.
+
+## Predicciones
+Sin slip.

--- a/tests/fixtures/twin/missing-section.md
+++ b/tests/fixtures/twin/missing-section.md
@@ -1,0 +1,31 @@
+---
+twin_id: "test-project"
+spec_version: "1.0"
+last_refresh: "2026-06-05T16:28:17Z"
+stale_after_days: 14
+token_budget: 2000
+health: green
+predictions:
+  sprint_slip:
+    value: 0.1
+    confidence: 0.9
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  next_blocker:
+    value: "none"
+    confidence: 0.8
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  scope_drift:
+    value: 0.05
+    confidence: 0.7
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  aggregate_health:
+    value: green
+    confidence: 0.85
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+---
+
+## Estado
+Sprint activo.
+
+## Reglas
+Regla 1.

--- a/tests/fixtures/twin/stale.md
+++ b/tests/fixtures/twin/stale.md
@@ -1,0 +1,34 @@
+---
+twin_id: "test-project"
+spec_version: "1.0"
+last_refresh: "2023-01-01T00:00:00Z"
+stale_after_days: 14
+token_budget: 2000
+health: green
+predictions:
+  sprint_slip:
+    value: 0.1
+    confidence: 0.9
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  next_blocker:
+    value: "none"
+    confidence: 0.8
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  scope_drift:
+    value: 0.05
+    confidence: 0.7
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  aggregate_health:
+    value: green
+    confidence: 0.85
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+---
+
+## Estado
+Sprint activo.
+
+## Reglas
+Regla 1.
+
+## Predicciones
+Sin slip.

--- a/tests/fixtures/twin/valid.md
+++ b/tests/fixtures/twin/valid.md
@@ -1,0 +1,37 @@
+---
+twin_id: "test-project"
+spec_version: "1.0"
+last_refresh: "2026-06-05T16:28:17Z"
+stale_after_days: 14
+token_budget: 2000
+health: green
+predictions:
+  sprint_slip:
+    value: 0.1
+    confidence: 0.9
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  next_blocker:
+    value: "none detected"
+    confidence: 0.8
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  scope_drift:
+    value: 0.05
+    confidence: 0.7
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  aggregate_health:
+    value: green
+    confidence: 0.85
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+---
+
+## Estado
+
+Sprint activo: Sprint 1. Items: 5 abiertos, 0 bloqueantes.
+
+## Reglas
+
+Regla 1: WIP limit 3.
+
+## Predicciones
+
+Sin slip esperado. Sin bloqueantes. Scope estable. Salud verde.

--- a/tests/test-spec-125-slice-3-memory-feedback-loop.bats
+++ b/tests/test-spec-125-slice-3-memory-feedback-loop.bats
@@ -121,11 +121,11 @@ JSON
   RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$TMP_AUDIT" \
     bash "$RECORDER" --hash bbbccc --text "vetaste de mas"
   local first
-  first=$(grep '"user_response_classification"' "$TMP_AUDIT/2026-06-05/bbbcccdddeee.json")
+  first=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['user_response_classification'])" "$TMP_AUDIT/2026-06-05/bbbcccdddeee.json")
   RECOMMENDATION_TRIBUNAL_AUDIT_DIR="$TMP_AUDIT" \
     bash "$RECORDER" --hash bbbccc --text "vetaste de mas"
   local second
-  second=$(grep '"user_response_classification"' "$TMP_AUDIT/2026-06-05/bbbcccdddeee.json")
+  second=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['user_response_classification'])" "$TMP_AUDIT/2026-06-05/bbbcccdddeee.json")
   [ "$first" = "$second" ]
 }
 

--- a/tests/test-spec-169-twin-linter.bats
+++ b/tests/test-spec-169-twin-linter.bats
@@ -241,3 +241,116 @@ TWIN
   last=$(grep "^last_refresh:" "$REPO_ROOT/projects/proyecto-alpha/twin.md" | head -1 | sed 's/.*: *//' | tr -d '"')
   [[ "$last" > "2026-06-04" ]]
 }
+
+# ── Loader: twin-load.sh (Slice 3) ────────────────────────────────────────────
+@test "loader: script exists and executable" {
+  [[ -x "$REPO_ROOT/scripts/twin-load.sh" ]]
+}
+
+@test "loader: no args exits 2 with usage" {
+  run bash "$REPO_ROOT/scripts/twin-load.sh"
+  [[ "$status" -eq 2 ]]
+  [[ "$output" =~ "Usage" ]]
+}
+
+@test "loader: unknown slug exits 2" {
+  run bash "$REPO_ROOT/scripts/twin-load.sh" nonexistent-slug-zzz
+  [[ "$status" -eq 2 ]]
+}
+
+@test "loader: --summary prints health and tokens" {
+  run bash "$REPO_ROOT/scripts/twin-load.sh" "proyecto-alpha" "--summary"
+  [[ "$status" -eq 0 ]] || [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "Health:" ]]
+  [[ "$output" =~ "Tokens" ]]
+}
+
+@test "loader: N1 context blocks projects twin (AC-5)" {
+  run env TWIN_CONTEXT=N1 bash "$REPO_ROOT/scripts/twin-load.sh" "proyecto-alpha"
+  [[ "$status" -eq 3 ]]
+  [[ "$output" =~ "BLOCKED" ]]
+}
+
+@test "loader: SPEC-169 cited in header" {
+  grep -q "SPEC-169" "$REPO_ROOT/scripts/twin-load.sh"
+}
+
+# ── Refresher: twin-refresh.sh (Slice 4) ──────────────────────────────────────
+@test "refresher: script exists and executable" {
+  [[ -x "$REPO_ROOT/scripts/twin-refresh.sh" ]]
+}
+
+@test "refresher: no args exits 2" {
+  run bash "$REPO_ROOT/scripts/twin-refresh.sh"
+  [[ "$status" -eq 2 ]]
+}
+
+@test "refresher: dry-run on pilot exits 0" {
+  run bash "$REPO_ROOT/scripts/twin-refresh.sh" "proyecto-alpha" "--dry-run"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "dry-run" ]]
+}
+
+@test "refresher: dry-run shows diff (AC-V2 auditable)" {
+  run bash "$REPO_ROOT/scripts/twin-refresh.sh" "proyecto-alpha" "--dry-run"
+  [[ "$output" =~ "health:" ]]
+  [[ "$output" =~ "sprint_slip:" ]]
+}
+
+@test "refresher: real refresh completes under 5000ms (AC-V2)" {
+  start=$(date +%s%3N)
+  bash "$REPO_ROOT/scripts/twin-refresh.sh" "proyecto-alpha" >/dev/null 2>&1
+  end=$(date +%s%3N)
+  elapsed=$(( end - start ))
+  [[ "$elapsed" -lt 5000 ]]
+}
+
+# ── Decay check: twin-decay-check.sh (Slice 5) ────────────────────────────────
+@test "decay: script exists and executable" {
+  [[ -x "$REPO_ROOT/scripts/twin-decay-check.sh" ]]
+}
+
+@test "decay: workspace scan exits 0 with fresh pilot" {
+  run bash "$REPO_ROOT/scripts/twin-decay-check.sh"
+  [[ "$status" -eq 0 ]] || [[ "$status" -eq 1 ]]
+  [[ "$output" =~ "decay-check:" ]]
+}
+
+# ── Anonymize: twin-anonymize.sh (Slice 6, AC-6) ─────────────────────────────
+@test "anonymize: script exists and executable" {
+  [[ -x "$REPO_ROOT/scripts/twin-anonymize.sh" ]]
+}
+
+@test "anonymize: no args exits 2" {
+  run bash "$REPO_ROOT/scripts/twin-anonymize.sh"
+  [[ "$status" -eq 2 ]]
+}
+
+@test "anonymize: produces output file (AC-6)" {
+  run bash "$REPO_ROOT/scripts/twin-anonymize.sh" "proyecto-alpha"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" =~ "OK:" ]]
+}
+
+@test "anonymize: output contains no real project slug" {
+  bash "$REPO_ROOT/scripts/twin-anonymize.sh" "proyecto-alpha" >/dev/null 2>&1 || true
+  anon_file=$(find "$REPO_ROOT/docs/case-studies" -name "*anon.twin.md" | head -1)
+  [[ -n "$anon_file" ]]
+  ! grep -q "twin_id: \"proyecto-alpha\"" "$anon_file"
+}
+
+@test "anonymize: output strips absolute paths" {
+  anon_file=$(find "$REPO_ROOT/docs/case-studies" -name "*anon.twin.md" | head -1)
+  [[ -n "$anon_file" ]]
+  ! grep -qE "/home/|/Users/" "$anon_file"
+}
+
+# ── Hook: twin-posttooluse.sh (Slice 5) ──────────────────────────────────────
+@test "hook: twin-posttooluse.sh exists in .claude/hooks" {
+  [[ -f "$REPO_ROOT/.claude/hooks/twin-posttooluse.sh" ]]
+}
+
+@test "hook: no-op by default without TWIN_HOOK_ENABLED=true" {
+  run env TWIN_HOOK_ENABLED=false bash "$REPO_ROOT/.claude/hooks/twin-posttooluse.sh" <<< '{}'
+  [[ "$status" -eq 0 ]]
+}

--- a/tests/test-spec-169-twin-linter.bats
+++ b/tests/test-spec-169-twin-linter.bats
@@ -1,0 +1,243 @@
+#!/usr/bin/env bats
+# SCRIPT='scripts/twin-linter.sh'
+# test-spec-169-twin-linter.bats — BATS suite for SPEC-169 Project Twin linter
+# Spec: SPEC-169 AC-1, AC-7, AC-9
+# Score target: ≥85 (SPEC-055 quality gate)
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/twin-linter.sh"
+FIXTURES="$REPO_ROOT/tests/fixtures/twin"
+
+setup() {
+  TMP_DIR="$(mktemp -d)"
+  [[ -f "$LINTER" ]] || { echo "linter not found: $LINTER" >&2; return 1; }
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+make_twin() {
+  # make_twin <file> [extra_body] — writes a valid twin to a temp file
+  local out="$TMP_DIR/${1:-twin.md}"
+  local now; now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  cat > "$out" << TWIN
+---
+twin_id: "tmp-project"
+spec_version: "1.0"
+last_refresh: "${now}"
+stale_after_days: 14
+token_budget: 2000
+health: green
+predictions:
+  sprint_slip:
+    value: 0.1
+    confidence: 0.9
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  next_blocker:
+    value: "none detected"
+    confidence: 0.8
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  scope_drift:
+    value: 0.05
+    confidence: 0.7
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+  aggregate_health:
+    value: green
+    confidence: 0.85
+    evidence_ref: "tests/fixtures/twin/evidence.md"
+---
+
+## Estado
+Sprint ok. Items: 3 abiertos, 0 bloqueantes.
+
+## Reglas
+WIP limit 3 items.
+
+## Predicciones
+Sin slip. Sin bloqueantes. Scope estable. Salud verde.
+${2:-}
+TWIN
+  echo "$out"
+}
+
+# ── Existence + safety ────────────────────────────────────────────────────────
+@test "linter: script exists and is executable" {
+  [[ -x "$LINTER" ]]
+}
+
+@test "linter: has set -uo pipefail" {
+  grep -q "set -uo pipefail" "$LINTER"
+}
+
+@test "linter: SPEC-169 cited in header" {
+  grep -q "SPEC-169" "$LINTER"
+}
+
+@test "linter: AC-7 cited in header" {
+  grep -q "AC-7" "$LINTER"
+}
+
+@test "linter: under 120 lines" {
+  [[ "$(wc -l < "$LINTER")" -lt 120 ]]
+}
+
+# ── Usage / error handling ────────────────────────────────────────────────────
+@test "linter: no args exits 2 with usage" {
+  run bash "$LINTER"
+  [[ "$status" -eq 2 ]]
+  [[ "$output" =~ "Usage" ]]
+}
+
+@test "linter: nonexistent file exits 2" {
+  run bash "$LINTER" "$TMP_DIR/nonexistent.md"
+  [[ "$status" -eq 2 ]]
+}
+
+# ── Valid fixture ─────────────────────────────────────────────────────────────
+@test "linter: valid twin exits 0" {
+  run bash "$LINTER" "$FIXTURES/valid.md"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "linter: valid twin prints OK" {
+  run bash "$LINTER" "$FIXTURES/valid.md"
+  [[ "$output" =~ "OK:" ]]
+}
+
+@test "linter: dynamically created valid twin exits 0 (mktemp isolation)" {
+  f=$(make_twin "dynamic.md")
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 0 ]]
+}
+
+# ── Required frontmatter fields (fm_field coverage) ──────────────────────────
+@test "linter: missing token_budget exits 2" {
+  run bash "$LINTER" "$FIXTURES/missing-field.md"
+  [[ "$status" -eq 2 ]]
+}
+
+@test "linter: missing token_budget reports INVALID" {
+  run bash "$LINTER" "$FIXTURES/missing-field.md"
+  [[ "$output" =~ "INVALID" ]]
+}
+
+@test "linter: empty twin_id exits 2" {
+  f="$TMP_DIR/no-id.md"
+  sed 's/twin_id: "tmp-project"/twin_id: ""/' "$(make_twin noid.md)" > "$f"
+  # empty string still present; test missing entirely
+  sed -i '/^twin_id:/d' "$f"
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 2 ]]
+}
+
+# ── Required sections (has_section coverage) ─────────────────────────────────
+@test "linter: missing Predicciones section exits 2" {
+  run bash "$LINTER" "$FIXTURES/missing-section.md"
+  [[ "$status" -eq 2 ]]
+}
+
+@test "linter: missing Estado section exits 2" {
+  f="$TMP_DIR/no-estado.md"
+  sed '/^## Estado/,/^## Reglas/{/^## Estado/d}' "$FIXTURES/valid.md" > "$f"
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 2 ]]
+}
+
+# ── Forbidden fields (AC-7, frontmatter body scan) ────────────────────────────
+@test "linter: forbidden field assigned_to exits 3" {
+  run bash "$LINTER" "$FIXTURES/forbidden-field.md"
+  [[ "$status" -eq 3 ]]
+}
+
+@test "linter: forbidden field reports FORBIDDEN" {
+  run bash "$LINTER" "$FIXTURES/forbidden-field.md"
+  [[ "$output" =~ "FORBIDDEN" ]]
+}
+
+@test "linter: forbidden-fields config file exists" {
+  [[ -f "$REPO_ROOT/scripts/twin-forbidden-fields.txt" ]]
+}
+
+@test "linter: forbidden-fields has at least 8 patterns" {
+  count=$(grep -cvE "^#|^$" "$REPO_ROOT/scripts/twin-forbidden-fields.txt")
+  [[ "$count" -ge 8 ]]
+}
+
+@test "linter: inline forbidden field in tmp twin exits 3" {
+  f=$(make_twin "bad-inline.md")
+  printf "\nassigned_to: dev-lead\n" >> "$f"
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 3 ]]
+}
+
+# ── Stale check ───────────────────────────────────────────────────────────────
+@test "linter: stale twin exits 1" {
+  run bash "$LINTER" "$FIXTURES/stale.md"
+  [[ "$status" -eq 1 ]]
+}
+
+@test "linter: stale twin reports STALE" {
+  run bash "$LINTER" "$FIXTURES/stale.md"
+  [[ "$output" =~ "STALE" ]]
+}
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+@test "edge: confidence 1.0 boundary is valid" {
+  f=$(make_twin "conf-boundary.md")
+  sed -i 's/confidence: 0.9/confidence: 1.0/' "$f"
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "edge: confidence 0.0 boundary is valid" {
+  f=$(make_twin "conf-zero.md")
+  sed -i 's/confidence: 0.9/confidence: 0.0/' "$f"
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "edge: empty file exits 2" {
+  f="$TMP_DIR/empty.md"
+  touch "$f"
+  run bash "$LINTER" "$f"
+  [[ "$status" -eq 2 ]]
+}
+
+# ── Rule doc (AC-9) ───────────────────────────────────────────────────────────
+@test "rule doc: project-twin-as-code.md exists" {
+  [[ -f "$REPO_ROOT/docs/rules/domain/project-twin-as-code.md" ]]
+}
+
+@test "rule doc: under 150 lines (AC-9)" {
+  [[ "$(wc -l < "$REPO_ROOT/docs/rules/domain/project-twin-as-code.md")" -lt 150 ]]
+}
+
+@test "rule doc: SPEC-169 referenced" {
+  grep -q "SPEC-169" "$REPO_ROOT/docs/rules/domain/project-twin-as-code.md"
+}
+
+@test "rule doc: forbidden fields section documented" {
+  grep -qiE "prohibid|forbidden" "$REPO_ROOT/docs/rules/domain/project-twin-as-code.md"
+}
+
+# ── Pilot twin (AC-V1) ────────────────────────────────────────────────────────
+@test "pilot: proyecto-alpha/twin.md exists" {
+  [[ -f "$REPO_ROOT/projects/proyecto-alpha/twin.md" ]]
+}
+
+@test "pilot: proyecto-alpha twin passes linter" {
+  run bash "$LINTER" "$REPO_ROOT/projects/proyecto-alpha/twin.md"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "pilot: twin.md has all 4 predictions" {
+  for pred in sprint_slip next_blocker scope_drift aggregate_health; do
+    grep -q "$pred" "$REPO_ROOT/projects/proyecto-alpha/twin.md"
+  done
+}
+
+@test "pilot: twin.md last_refresh after SPEC-169 spec creation date" {
+  last=$(grep "^last_refresh:" "$REPO_ROOT/projects/proyecto-alpha/twin.md" | head -1 | sed 's/.*: *//' | tr -d '"')
+  [[ "$last" > "2026-06-04" ]]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR implementa SPEC-169 "Project Twin como artefacto versionado" — un gemelo digital de cada proyecto en formato markdown (`projects/{slug}/twin.md`) que Savia puede leer, refrescar y publicar de forma segura.

El twin captura el estado actual del proyecto (sprint activo, bloqueantes, métricas de velocity) en un fichero versionado con frontmatter declarativo. Incluye cuatro predicciones automáticas calculadas sin LLM: probabilidad de slip del sprint, próximo bloqueante, drift de scope y salud agregada (verde/amarillo/rojo). Cada predicción lleva su fuente citable y su nivel de confianza.

El sistema tiene cinco herramientas: un linter que valida el schema y bloquea campos prohibidos como datos personales o evaluaciones individuales (AC-7); un refresher determinista que recalcula las predicciones en menos de 200ms; un loader que respeta el presupuesto de tokens declarado en el frontmatter (máx. 2000 tokens, AC-2) y bloquea la carga en contexto público (AC-5); un script de decay que detecta twins con más de 14 días sin actualizar; y un anonimizador que genera una versión sin datos de organización para compartir públicamente (AC-6). Hay también un hook PostToolUse wire-ready que dispara refresh automático al cerrar un sprint o fusionar un PR, desactivado por defecto.

El piloto real funciona: `projects/proyecto-alpha/twin.md` fue refrescado, validado y anonimizado en esta misma implementación. Suite de 53 tests BATS con score 97 sobre 100.

Scope-trace: skip — scripts/twin-*.sh, .claude/hooks/twin-posttooluse.sh, docs/rules/domain/project-twin-as-code.md y docs/case-studies/*.twin.md son entregables core de SPEC-169 pero la spec carece de path hints explícitos.
## Summary
feat(spec-169): Slices 1+2 — twin schema, linter, forbidden-fields, pilot + 33 tests (97/100)
### Changes
- acac1af7 chore(sign): update signature post G7 fix
- 397921a2 fix(spec-169): move org project names to gitignored local file (G7 scan)
- 0edc7818 chore(sign): update signature post twin timestamp
- 3503d0e8 chore(twin-pilot): refresh timestamp updated by test run
- 6c9f211a chore(sign): update signature post G5b fix
- 6598c8a2 fix(spec-169): move set -uo pipefail to line 4 in hook (G5b)
- 73922595 chore(sign): update signature for SPEC-169
- 80155933 chore(scm): regenerate capability map — SPEC-169 scripts + hook (5 new)
- 44ee3964 feat(spec-169): Slices 3-6 — loader, refresher, decay, anonymize, hook PostToolUse + 53 tests (97/100)
- 4ffc036f feat(spec-169): Slices 1+2 — twin schema, linter, forbidden-fields, pilot + 33 tests (97/100)
- aa179103 chore(roadmap): mark SPEC-157 closed, SPEC-169 → #1 Tier 2, v6.16.0
### Stats
28 files changed across 11 commits.
## Test plan
- [x] CI passed  - [x] Signed
