### PR TITLE
feat(spec-190): Slice 4 — api+frontend CTF fixtures + init stubs

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=662f16970ab68274658772ed05843ae2263da5bc1add47b805143c19c1e64958
-timestamp=2026-06-05T19:12:56Z
-branch=feature/spec-190-application-code-twin
-head_commit=6d601a1d
-signature=6f73d0ee3ba235b60ed690699de690da4830136c5b94fee30648f54544d3e4a5
+diff_hash=0ea47feca377a4f2bdde584ff69b10a834dc501fa6502265bb8c721eb258f564
+timestamp=2026-06-05T20:01:36Z
+branch=feature/spec-190-slice-4
+head_commit=3a3beb93
+signature=71c2df51909d0e3f3f60a8954409f6d9a994170e8f97db9570cc80d3d2b70c6a

--- a/CHANGELOG.d/spec-190-slice-4.md
+++ b/CHANGELOG.d/spec-190-slice-4.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SPEC-190 Slice 4: api CTF fixtures (routes, error-codes), frontend CTF fixture (item-list-component), extended code-twin-init.sh with api/frontend DRAFT stubs, 52 lint tests (98 sobre 100), 42 init tests (88 sobre 100)
+

--- a/scripts/code-twin-init.sh
+++ b/scripts/code-twin-init.sh
@@ -172,10 +172,54 @@ status: DRAFT
 <!-- Approve and set status: STABLE before running code-twin-lint.sh -->
 STUB
 
+# Create api DRAFT stubs
+for stub in routes error-codes; do
+  cat > "${TWIN_DIR}/api/${stub}.md" << STUB
+---
+module_id: api-${stub}
+layer: api
+version: "0.1.0"
+last_sync: "${NOW}"
+token_budget: 300
+stale_after_days: 7
+depends_on: []
+provides:
+  - TODO
+status: DRAFT
+---
+# api-${stub} — ${SLUG}
+
+<!-- TODO: document API ${stub} here -->
+<!-- Approve and set status: STABLE before running code-twin-lint.sh -->
+STUB
+done
+
+# Create frontend DRAFT stubs
+cat > "${TWIN_DIR}/frontend/components.md" << STUB
+---
+module_id: frontend-components
+layer: frontend
+version: "0.1.0"
+last_sync: "${NOW}"
+token_budget: 300
+stale_after_days: 14
+depends_on: []
+provides:
+  - TODO
+status: DRAFT
+---
+# Frontend Components — ${SLUG}
+
+<!-- TODO: document UI components, props, state, behaviour here -->
+<!-- Approve and set status: STABLE before running code-twin-lint.sh -->
+STUB
+
 echo "OK: code-twin scaffold created at ${TWIN_DIR}"
 echo "  layers: meta/ domain/ application/ infrastructure/ api/ frontend/"
 echo "  domain stubs: entities.md value-objects.md business-rules.md (DRAFT)"
 echo "  application stubs: use-cases.md commands.md queries.md (DRAFT)"
 echo "  infrastructure stubs: db/schema.md repos/example-repository.md external/example-client.md (DRAFT)"
+echo "  api stubs: routes.md error-codes.md (DRAFT)"
+echo "  frontend stubs: components.md (DRAFT)"
 echo "  next: edit stubs, set status: STABLE, then run code-twin-extract.sh"
 exit 0

--- a/tests/fixtures/code-twin/api/error-codes.md
+++ b/tests/fixtures/code-twin/api/error-codes.md
@@ -1,0 +1,28 @@
+---
+module_id: api-error-codes
+layer: api
+version: "1.0.0"
+last_sync: "2026-06-01T14:30:00Z"
+token_budget: 200
+stale_after_days: 30
+depends_on: []
+provides:
+  - VALIDATION_ERROR
+  - NOT_FOUND
+  - UNAUTHORIZED
+  - FORBIDDEN
+  - INVALID_STATE
+status: STABLE
+---
+# API Error Codes — fixture-project
+
+All error responses follow `{ error: { code, status, message } }`.
+
+| code | status | when |
+|------|--------|------|
+| VALIDATION_ERROR | 400 | input fails schema or business validation |
+| UNAUTHORIZED | 401 | missing or invalid bearer token |
+| FORBIDDEN | 403 | valid token but insufficient role |
+| NOT_FOUND | 404 | resource does not exist |
+| INVALID_STATE | 422 | operation not allowed in current state |
+| INTERNAL_ERROR | 500 | unhandled exception — never exposes stack trace |

--- a/tests/fixtures/code-twin/api/routes.md
+++ b/tests/fixtures/code-twin/api/routes.md
@@ -1,0 +1,44 @@
+---
+module_id: api-routes
+layer: api
+version: "1.0.0"
+last_sync: "2026-06-01T14:30:00Z"
+token_budget: 450
+stale_after_days: 7
+depends_on:
+  - item-use-cases
+  - item-queries
+provides:
+  - POST /items
+  - GET /items
+  - GET /items/:id
+  - DELETE /items/:id
+status: STABLE
+---
+# API Routes — fixture-project
+
+## POST /items
+
+**Auth**: Bearer token required (role: user)
+**Body**: `{ title: string }`
+**Calls**: `CreateItemUseCase`
+**Returns**: `201 { record_id, title, state }` | `400 VALIDATION_ERROR` | `401 UNAUTHORIZED`
+
+## GET /items
+
+**Auth**: Bearer token required
+**Query params**: `state?: ItemState`, `page?: int (default 1)`, `limit?: int (default 20)`
+**Calls**: `ListItemsQuery`
+**Returns**: `200 { items: ItemDto[], total: int }` | `401 UNAUTHORIZED`
+
+## GET /items/:id
+
+**Auth**: Bearer token required
+**Calls**: `GetItemByIdQuery`
+**Returns**: `200 ItemDto` | `404 NOT_FOUND` | `401 UNAUTHORIZED`
+
+## DELETE /items/:id
+
+**Auth**: Bearer token required (role: admin)
+**Calls**: `ArchiveItemUseCase`
+**Returns**: `204 No Content` | `404 NOT_FOUND` | `403 FORBIDDEN` | `422 INVALID_STATE`

--- a/tests/fixtures/code-twin/frontend/item-list-component.md
+++ b/tests/fixtures/code-twin/frontend/item-list-component.md
@@ -1,0 +1,42 @@
+---
+module_id: ItemListComponent
+layer: frontend
+version: "1.0.0"
+last_sync: "2026-06-01T14:30:00Z"
+token_budget: 320
+stale_after_days: 14
+depends_on:
+  - api-routes
+provides:
+  - ItemListComponent
+status: STABLE
+---
+# ItemListComponent — fixture-project
+
+Displays a paginated, filterable list of items. Standalone component.
+
+## Props
+
+| prop | type | required | default |
+|------|------|----------|---------|
+| initialState | ItemState | no | undefined (all) |
+| pageSize | number | no | 20 |
+
+## State
+
+| key | type | description |
+|-----|------|-------------|
+| items | ItemDto[] | current page results |
+| total | number | total matching items |
+| page | number | current page (1-indexed) |
+| loading | boolean | true while fetch in flight |
+| error | string \| null | last error message |
+
+## Behaviour
+
+- On mount: calls `GET /items?state={initialState}&page=1&limit={pageSize}`
+- On page change: re-fetches with new `page`
+- On filter change: resets to page=1, re-fetches
+- Empty state: renders `<EmptyState message="No items found" />`
+- Loading state: renders `<Spinner />`
+- Error state: renders `<ErrorBanner message={error} />`

--- a/tests/test-spec-190-code-twin-init.bats
+++ b/tests/test-spec-190-code-twin-init.bats
@@ -216,6 +216,54 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# API + Frontend stubs (Slice 4)
+# ---------------------------------------------------------------------------
+
+@test "Slice4: creates api/routes.md stub" {
+  bash "$INIT" "$TMP_PROJECT"
+  [ -f "$TMP_PROJECT/code-twin/api/routes.md" ]
+}
+
+@test "Slice4: creates api/error-codes.md stub" {
+  bash "$INIT" "$TMP_PROJECT"
+  [ -f "$TMP_PROJECT/code-twin/api/error-codes.md" ]
+}
+
+@test "Slice4: api stubs have layer: api" {
+  bash "$INIT" "$TMP_PROJECT"
+  grep -q "^layer: api" "$TMP_PROJECT/code-twin/api/routes.md"
+  grep -q "^layer: api" "$TMP_PROJECT/code-twin/api/error-codes.md"
+}
+
+@test "Slice4: api stubs have status DRAFT" {
+  bash "$INIT" "$TMP_PROJECT"
+  grep -q "status: DRAFT" "$TMP_PROJECT/code-twin/api/routes.md"
+  grep -q "status: DRAFT" "$TMP_PROJECT/code-twin/api/error-codes.md"
+}
+
+@test "Slice4: creates frontend/components.md stub" {
+  bash "$INIT" "$TMP_PROJECT"
+  [ -f "$TMP_PROJECT/code-twin/frontend/components.md" ]
+}
+
+@test "Slice4: frontend stub has layer: frontend" {
+  bash "$INIT" "$TMP_PROJECT"
+  grep -q "^layer: frontend" "$TMP_PROJECT/code-twin/frontend/components.md"
+}
+
+@test "Slice4: frontend stub has status DRAFT" {
+  bash "$INIT" "$TMP_PROJECT"
+  grep -q "status: DRAFT" "$TMP_PROJECT/code-twin/frontend/components.md"
+}
+
+@test "Slice4: api DRAFT stubs are rejected by linter (by design)" {
+  bash "$INIT" "$TMP_PROJECT"
+  run bash "$LINT" "$TMP_PROJECT/code-twin/api/routes.md"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"DRAFT"* ]]
+}
+
+# ---------------------------------------------------------------------------
 # Error handling (AC-5)
 # ---------------------------------------------------------------------------
 

--- a/tests/test-spec-190-code-twin-lint.bats
+++ b/tests/test-spec-190-code-twin-lint.bats
@@ -521,6 +521,25 @@ SCHEMA
 }
 
 # ---------------------------------------------------------------------------
+# Slice 4 fixtures: api + frontend CTFs
+# ---------------------------------------------------------------------------
+
+@test "Slice4: fixture api/routes.md → exit 0" {
+  run bash "$LINT" "$FX/api/routes.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "Slice4: fixture api/error-codes.md → exit 0" {
+  run bash "$LINT" "$FX/api/error-codes.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "Slice4: fixture frontend/item-list-component.md → exit 0" {
+  run bash "$LINT" "$FX/frontend/item-list-component.md"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
 # Safety & structure checks
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR implementa el Slice 4 de SPEC-190 "Application Code Twin", que completa la cobertura de fixtures CTF para las capas api y frontend.

**API**: se añaden dos Code Twin Files que documentan la capa de entrada HTTP del proyecto fixture. `api/routes.md` describe los cuatro endpoints (POST /items, GET /items, GET /items/:id, DELETE /items/:id) con sus requisitos de autenticación, parámetros, casos de uso que invocan y códigos de respuesta posibles. `api/error-codes.md` es el catálogo centralizado de códigos de error de la API, con el formato de respuesta normalizado y la tabla de todos los códigos (400 al 500).

**Frontend**: se añade `frontend/item-list-component.md` que documenta el componente de lista de items con su tabla de props, estado interno, y comportamiento completo (fetch en mount, paginación, filtrado, estados de loading/empty/error).

**Init script**: `code-twin-init.sh` ahora genera stubs DRAFT para api (routes.md, error-codes.md) y frontend (components.md) al crear un nuevo code-twin. Los stubs son rechazados por el linter hasta que el humano los completa y los marca STABLE.

Con este slice, el scaffolding cubre las seis capas completas: domain, application, infrastructure, api, frontend y meta. La suite BATS alcanza 52 tests para el linter (98 sobre 100) y 42 tests para el init (88 sobre 100).

Scope-trace: skip — scripts/code-twin-*.sh y tests/fixtures/code-twin/ son entregables core de SPEC-190 pero la spec no incluye path hints explícitos para todos los artefactos.
## Summary
feat(spec-190): Slice 4 — api+frontend CTF fixtures + init stubs
### Changes
- 3a3beb93 feat(spec-190): Slice 4 — api+frontend CTF fixtures, init stubs, 52+42 BATS tests (98+88 sobre 100)
### Stats
8 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
