### PR TITLE
feat(spec-190): Slice 5 — code-twin-simulate.sh symbolic engine

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=0ea47feca377a4f2bdde584ff69b10a834dc501fa6502265bb8c721eb258f564
-timestamp=2026-06-05T20:01:36Z
-branch=feature/spec-190-slice-4
-head_commit=3a3beb93
-signature=71c2df51909d0e3f3f60a8954409f6d9a994170e8f97db9570cc80d3d2b70c6a
+diff_hash=903577983aec41cacb4664ce900d2f2848938b99f9159b0891e08cdab0850231
+timestamp=2026-06-05T20:51:53Z
+branch=feature/spec-190-slice-5
+head_commit=9d7ace5d
+signature=dc91b8a107e0ac6645201e20e437528e8a097546402e35b54ba299287b797bc4

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=903577983aec41cacb4664ce900d2f2848938b99f9159b0891e08cdab0850231
-timestamp=2026-06-05T20:51:53Z
+timestamp=2026-06-05T20:57:10Z
 branch=feature/spec-190-slice-5
-head_commit=9d7ace5d
+head_commit=81796ab7
 signature=dc91b8a107e0ac6645201e20e437528e8a097546402e35b54ba299287b797bc4

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 08e150f5ed5c | resources: 1202
-> 555 commands · 100 skills · 70 agents · 477 scripts
+> hash: 7f8617797709 | resources: 1203
+> 555 commands · 100 skills · 70 agents · 478 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
@@ -187,6 +187,7 @@
 [development] code-reviewer —  — agent:.claude/agents/code-reviewer.md
 [development] code-twin-init — code,estructura,init,proyecto,scaffold — script:scripts/code-twin-init.sh
 [development] code-twin-lint — code,files,index,jsonl,lint — script:scripts/code-twin-lint.sh
+[development] code-twin-simulate — code,simulate,slice,spec,twin — script:scripts/code-twin-simulate.sh
 [development] codebase-map — agentes,comandos,dependencias,generar,internas — cmd:.claude/commands/codebase-map.md
 [development] codebase-map — agentes,comandos,dependencias,mapa,reglas — skill:.claude/skills/codebase-map/SKILL.md
 [development] codegraph — callees,callers,código,indexación,navegación — skill:.claude/skills/codegraph/SKILL.md

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 158 resources
+> 159 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **/speckit.checklist** (cmd): Alias spec-kit compatible. Gate de calidad final con verification-lattice multi-capa. Invoca skill verification-lattice. Compatible con github/spec-kit.
@@ -32,6 +32,7 @@
 - **code-reviewer** (agent): >
 - **code-twin-init** (script): code-twin-init.sh — Scaffold estructura vacía de ACT para un proyecto
 - **code-twin-lint** (script): code-twin-lint.sh — Valida Code Twin Files (CTF), CTI (index.md) y seeds JSONL
+- **code-twin-simulate** (script): code-twin-simulate.sh — SPEC-190 Slice 5
 - **codebase-map** (cmd): Generar mapa de dependencias internas del workspace: comandos → agentes → reglas → skills
 - **codebase-map** (skill): Usar cuando se necesita un mapa de dependencias del workspace (comandos→agentes→reglas→skills).
 - **codegraph** (skill): Usar cuando se necesita indexación AST persistente para navegación de callers/callees en el código.

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "87618a2402bb",
-  "total": 1202,
+  "hash": "346ddf49e119",
+  "total": 1203,
   "resources": [
     {
       "category": "analysis",
@@ -2334,6 +2334,20 @@
       "kind": "script",
       "path": "scripts/code-twin-lint.sh",
       "description": "code-twin-lint.sh — Valida Code Twin Files (CTF), CTI (index.md) y seeds JSONL"
+    },
+    {
+      "category": "development",
+      "name": "code-twin-simulate",
+      "intents": [
+        "code",
+        "simulate",
+        "slice",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "path": "scripts/code-twin-simulate.sh",
+      "description": "code-twin-simulate.sh — SPEC-190 Slice 5"
     },
     {
       "category": "development",

--- a/CHANGELOG.d/spec-190-slice-5-simulate.md
+++ b/CHANGELOG.d/spec-190-slice-5-simulate.md
@@ -1,0 +1,9 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- SPEC-190 Slice 5: code-twin-simulate.sh — symbolic simulation engine (Python); seeds users.jsonl (sim: convention); 51 BATS tests (93 sobre 100); AC-3+AC-4
+

--- a/scripts/code-twin-simulate.py
+++ b/scripts/code-twin-simulate.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+code-twin-simulate.py — SPEC-190 Slice 5
+
+Symbolic simulation engine for Application Code Twin (ACT).
+Reads a CTF (Code Twin File) and simulates the target method symbolically
+using seed data and heuristic confidence scoring.
+
+Usage:
+  python3 scripts/code-twin-simulate.py <module_id> <method> <args_json> <seeds_dir>
+
+Arguments:
+  module_id   — CTF module_id to locate (e.g. AuthService)
+  method      — method to simulate (e.g. login)
+  args_json   — JSON object with method arguments (e.g. '{"email":"...","password":"..."}')
+  seeds_dir   — directory containing *.jsonl seed files; twin_dir = parent(seeds_dir)
+
+Exit codes:
+  0 — simulation succeeded, result produced
+  1 — simulation raised a domain error (INVALID_CREDENTIALS, USER_DISABLED, …)
+  2 — engine error (missing CTF, bad args, seeds not found)
+
+Output:
+  Line 1: [SIMULATION — NOT GROUND TRUTH] confidence=<value>
+  Line 2+: JSON payload
+
+IMPORTANT: Output is NEVER ground truth. confidence is NEVER 1.0.
+"""
+
+import sys
+import os
+import json
+import re
+import pathlib
+import uuid
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+HEADER = "[SIMULATION \u2014 NOT GROUND TRUTH]"
+CONFIDENCE_BASE = 0.95
+CONFIDENCE_PENALTY_BCRYPT = 0.05
+CONFIDENCE_PENALTY_JWT = 0.02
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def err(msg: str, code: int = 2) -> None:
+    """Print error to stderr and exit with given code."""
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def load_jsonl(path: pathlib.Path) -> list:
+    """Load a JSONL file and return a list of dicts."""
+    rows = []
+    with open(path, encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, 1):
+            raw = raw.strip()
+            if raw:
+                try:
+                    rows.append(json.loads(raw))
+                except json.JSONDecodeError as exc:
+                    err(f"Invalid JSON at {path}:{lineno}: {exc}")
+    return rows
+
+
+def find_ctf(twin_dir: str, module_id: str):
+    """
+    Scan twin_dir recursively for a .md file whose frontmatter contains
+    `module_id: <module_id>`. Returns (Path, content_str) or (None, None).
+    """
+    pattern = re.compile(
+        rf"^module_id:\s*{re.escape(module_id)}\s*$", re.MULTILINE
+    )
+    for p in sorted(pathlib.Path(twin_dir).rglob("*.md")):
+        try:
+            content = p.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if pattern.search(content):
+            return p, content
+    return None, None
+
+
+def extract_method_block(content: str, method: str):
+    """
+    Extract the markdown block for a given method from a CTF.
+    Returns the raw block text or None.
+    """
+    pattern = re.compile(
+        rf"####\s+{re.escape(method)}\s*\([^)]*\).*?(?=\n####|\Z)",
+        re.DOTALL,
+    )
+    m = pattern.search(content)
+    return m.group(0) if m else None
+
+
+def extract_logic_steps(block: str) -> list:
+    """Extract numbered logic steps from a method block."""
+    logic_m = re.search(
+        r"\*\*Logic\*\*:(.*?)(?=\*\*Side effects\*\*|\*\*Edge cases\*\*|\Z)",
+        block,
+        re.DOTALL,
+    )
+    if not logic_m:
+        return []
+    return re.findall(r"^\d+\.\s+(.+)$", logic_m.group(1), re.MULTILINE)
+
+
+def extract_edge_cases(block: str) -> list:
+    """Extract edge case descriptions from a method block."""
+    edge_m = re.search(
+        r"\*\*Edge cases\*\*:(.*?)(?=\n####|\Z)", block, re.DOTALL
+    )
+    if not edge_m:
+        return []
+    return re.findall(r"[^\u2192\n]+\u2192[^\u2192\n]+", edge_m.group(1))
+
+
+def calculate_confidence(steps: list, edges: list) -> float:
+    """
+    Calculate simulation confidence (0.0–<1.0).
+    Base 0.95; deduct for external services that cannot be perfectly simulated.
+    Confidence is NEVER 1.0.
+    """
+    conf = CONFIDENCE_BASE
+    all_text = " ".join(steps + edges).lower()
+    if "bcrypt" in all_text:
+        conf -= CONFIDENCE_PENALTY_BCRYPT
+    if "jwt" in all_text:
+        conf -= CONFIDENCE_PENALTY_JWT
+    # Hard cap: never 1.0
+    return round(min(conf, 0.99), 4)
+
+
+# ---------------------------------------------------------------------------
+# Symbolic password check (sim: convention)
+# ---------------------------------------------------------------------------
+
+def sim_password_check(password: str, hash_str: str) -> bool:
+    """
+    Symbolic bcrypt replacement.
+    If hash starts with 'sim:', compare password to the suffix.
+    Real bcrypt hashes cannot be verified — return False (conservative).
+    """
+    if hash_str.startswith("sim:"):
+        expected = hash_str[4:]
+        return password == expected
+    return False
+
+
+def sim_token(user_id: str, roles: list) -> str:
+    """Generate a deterministic-ish simulation token. NOT a real JWT."""
+    short_id = re.sub(r"[^a-zA-Z0-9]", "", user_id)[:8]
+    suffix = uuid.uuid4().hex[:8]
+    return f"sim-token-{short_id}-{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Method handlers
+# ---------------------------------------------------------------------------
+
+def simulate_login(args_json: str, seeds_dir: str, logic: dict) -> tuple:
+    """
+    Simulate AuthService.login symbolically.
+
+    Follows CTF logic:
+      1. UserRepository.findByEmail(email) — READ
+      2. bcrypt.compare / disabled check
+      3. JwtService.sign — fake token
+      4. UserRepository.updateLastLogin — WRITE
+
+    Returns (result_dict, exit_code).
+    """
+    try:
+        args = json.loads(args_json)
+    except json.JSONDecodeError as exc:
+        err(f"Invalid args JSON: {exc}")
+
+    email = args.get("email")
+    password = args.get("password")
+    if not email or password is None:
+        err("args must contain 'email' and 'password'")
+
+    seeds_path = pathlib.Path(seeds_dir) / "users.jsonl"
+    if not seeds_path.exists():
+        err(f"Seeds file not found: {seeds_path}")
+
+    users = load_jsonl(seeds_path)
+    confidence = calculate_confidence(logic["steps"], logic["edges"])
+    db_trace = []
+    side_effects = []
+
+    # Step 1: UserRepository.findByEmail(email) — always a READ
+    db_trace.append({"op": "READ", "table": "users", "filter": f"email={email}"})
+    user = next((u for u in users if u.get("email") == email), None)
+
+    if user is None:
+        return {
+            "confidence": confidence,
+            "result": None,
+            "error": {
+                "code": "INVALID_CREDENTIALS",
+                "status": 401,
+                "message": "Invalid credentials",
+            },
+            "db_trace": db_trace,
+            "side_effects": side_effects,
+        }, 1
+
+    # Edge case: user.disabled=true → THROW 403 USER_DISABLED
+    if user.get("disabled", False):
+        return {
+            "confidence": confidence,
+            "result": None,
+            "error": {
+                "code": "USER_DISABLED",
+                "status": 403,
+                "message": "User account is disabled",
+            },
+            "db_trace": db_trace,
+            "side_effects": side_effects,
+        }, 1
+
+    # Step 2: bcrypt.compare(password, user.passwordHash)
+    if not sim_password_check(password, user.get("password_hash", "")):
+        return {
+            "confidence": confidence,
+            "result": None,
+            "error": {
+                "code": "INVALID_CREDENTIALS",
+                "status": 401,
+                "message": "Invalid credentials",
+            },
+            "db_trace": db_trace,
+            "side_effects": side_effects,
+        }, 1
+
+    # Step 3: JwtService.sign(...)
+    token = sim_token(user["id"], user.get("roles", []))
+
+    # Step 4: UserRepository.updateLastLogin(user.id, now) — WRITE
+    db_trace.append({"op": "WRITE", "table": "users", "fields": ["last_login_at"]})
+    side_effects.append("DB WRITE users.last_login_at")
+
+    return {
+        "confidence": confidence,
+        "result": {
+            "token": token,
+            "user": {
+                "id": user["id"],
+                "roles": user.get("roles", []),
+            },
+        },
+        "db_trace": db_trace,
+        "side_effects": side_effects,
+    }, 0
+
+
+# Registry of supported method handlers
+METHOD_HANDLERS = {
+    "login": simulate_login,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if len(sys.argv) != 5:
+        err(
+            f"Usage: {os.path.basename(sys.argv[0])} "
+            "<module_id> <method> <args_json> <seeds_dir>"
+        )
+
+    module_id = sys.argv[1]
+    method = sys.argv[2]
+    args_json = sys.argv[3]
+    seeds_dir = sys.argv[4]
+
+    if not os.path.isdir(seeds_dir):
+        err(f"seeds_dir not found or not a directory: {seeds_dir}")
+
+    twin_dir = str(pathlib.Path(seeds_dir).parent)
+
+    ctf_path, ctf_content = find_ctf(twin_dir, module_id)
+    if ctf_path is None:
+        err(f"CTF not found for module_id='{module_id}' in '{twin_dir}'")
+
+    block = extract_method_block(ctf_content, method)
+    if block is None:
+        err(f"Method '{method}' not found in CTF '{ctf_path}'")
+
+    steps = extract_logic_steps(block)
+    edges = extract_edge_cases(block)
+    logic = {"steps": steps, "edges": edges}
+
+    handler = METHOD_HANDLERS.get(method)
+    if handler is None:
+        err(f"No simulation handler registered for method '{method}'")
+
+    result, exit_code = handler(args_json, seeds_dir, logic)
+    confidence = result["confidence"]
+
+    payload = {
+        "module_id": module_id,
+        "method": method,
+        **result,
+    }
+
+    print(f"{HEADER} confidence={confidence}")
+    print(json.dumps(payload, indent=2))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/code-twin-simulate.sh
+++ b/scripts/code-twin-simulate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# code-twin-simulate.sh — SPEC-190 Slice 5
+# Wrapper for the Application Code Twin symbolic simulation engine.
+#
+# Usage:
+#   bash scripts/code-twin-simulate.sh <module_id> <method> <args_json> <seeds_dir>
+#
+# Exit codes (delegated from code-twin-simulate.py):
+#   0 — simulation succeeded
+#   1 — domain error (INVALID_CREDENTIALS, USER_DISABLED, …)
+#   2 — engine error (bad args, CTF not found, seeds missing)
+#
+# IMPORTANT: Output is NEVER ground truth. Always check the confidence field.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "${SCRIPT_DIR}/code-twin-simulate.py" "$@"

--- a/tests/fixtures/code-twin/seeds/users.jsonl
+++ b/tests/fixtures/code-twin/seeds/users.jsonl
@@ -1,0 +1,5 @@
+{"id":"sim-alice-001","email":"alice@test.com","password_hash":"sim:correct","roles":["user"],"disabled":false,"last_login_at":null,"created_at":"2026-01-15T10:00:00Z"}
+{"id":"sim-bob-002","email":"bob@test.com","password_hash":"sim:admin-pass","roles":["admin","user"],"disabled":false,"last_login_at":"2026-06-01T09:30:00Z","created_at":"2026-02-20T14:00:00Z"}
+{"id":"sim-charlie-003","email":"charlie@test.com","password_hash":"sim:correct","roles":["user"],"disabled":true,"last_login_at":"2026-03-10T11:00:00Z","created_at":"2026-03-01T08:00:00Z"}
+{"id":"sim-diana-004","email":"diana@test.com","password_hash":"sim:diana-pass","roles":["user","moderator"],"disabled":false,"last_login_at":"2026-05-30T16:45:00Z","created_at":"2026-04-10T12:00:00Z"}
+{"id":"sim-eve-005","email":"eve@test.com","password_hash":"sim:eve-pass","roles":["user"],"disabled":false,"last_login_at":null,"created_at":"2026-06-04T17:00:00Z"}

--- a/tests/test-spec-190-code-twin-simulate.bats
+++ b/tests/test-spec-190-code-twin-simulate.bats
@@ -1,0 +1,327 @@
+#!/usr/bin/env bats
+# SCRIPT='scripts/code-twin-simulate.sh'
+# test-spec-190-code-twin-simulate.bats — BATS suite for SPEC-190 Slice 5 (simulate)
+# Spec: SPEC-190 AC-3, AC-4
+# Score target: ≥85 (SPEC-055 quality gate)
+# Exercises: symbolic simulation, confidence scoring, db_trace, side_effects,
+#            domain errors (INVALID_CREDENTIALS, USER_DISABLED), engine errors
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SIM="$REPO_ROOT/scripts/code-twin-simulate.sh"
+SEEDS="$REPO_ROOT/tests/fixtures/code-twin/seeds"
+
+AC3_ARGS='{"email":"alice@test.com","password":"correct"}'
+AC4_ARGS='{"email":"notexist@test.com","password":"irrelevant"}'
+DISABLED_ARGS='{"email":"charlie@test.com","password":"correct"}'
+WRONGPW_ARGS='{"email":"alice@test.com","password":"wrong-password"}'
+
+# ---------------------------------------------------------------------------
+# Isolation setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  TMP_OUT="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMP_OUT"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Run simulator and return only the JSON (lines 2+)
+sim_json() {
+  bash "$SIM" "$@" | tail -n +2
+}
+
+# ---------------------------------------------------------------------------
+# Safety verification
+# ---------------------------------------------------------------------------
+
+@test "safety: script contains set -uo pipefail" {
+  grep -q "set -uo pipefail" "$SIM"
+}
+
+@test "safety: output captured correctly to file" {
+  bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS" > "$TMP_OUT/out.txt"
+  [ -s "$TMP_OUT/out.txt" ]
+}
+
+# ---------------------------------------------------------------------------
+# Engine validation
+# ---------------------------------------------------------------------------
+
+@test "engine: missing args exits 2" {
+  run bash "$SIM"
+  [ "$status" -eq 2 ]
+}
+
+@test "engine: seeds-dir-not-found exits 2" {
+  run bash "$SIM" AuthService login '{"email":"a@b.com","password":"x"}' "/tmp/no-seeds-$$"
+  [ "$status" -eq 2 ]
+}
+
+@test "engine: unknown module_id exits 2" {
+  run bash "$SIM" NoSuchModule login '{"email":"a@b.com","password":"x"}' "$SEEDS"
+  [ "$status" -eq 2 ]
+}
+
+@test "engine: unknown method exits 2" {
+  run bash "$SIM" AuthService noSuchMethod '{"email":"a@b.com","password":"x"}' "$SEEDS"
+  [ "$status" -eq 2 ]
+}
+
+@test "engine: empty args JSON exits 2" {
+  run bash "$SIM" AuthService login '{}' "$SEEDS"
+  [ "$status" -eq 2 ]
+}
+
+@test "engine: invalid JSON args exits 2" {
+  run bash "$SIM" AuthService login 'not-json' "$SEEDS"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: happy path — alice login success
+# ---------------------------------------------------------------------------
+
+@test "AC-3: exit 0 on successful login" {
+  run bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS"
+  [ "$status" -eq 0 ]
+}
+
+@test "AC-3: first output line is simulation header" {
+  run bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"[SIMULATION"* ]]
+}
+
+@test "AC-3: header contains NOT GROUND TRUTH" {
+  run bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"NOT GROUND TRUTH"* ]]
+}
+
+@test "AC-3: header shows confidence=0.88" {
+  run bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == *"confidence=0.88"* ]]
+}
+
+@test "AC-3: JSON confidence equals 0.88" {
+  val=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq '.confidence')
+  [ "$val" = "0.88" ]
+}
+
+@test "AC-3: JSON confidence >= 0.85" {
+  val=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq '.confidence')
+  python3 -c "assert $val >= 0.85, '$val < 0.85'"
+}
+
+@test "AC-3: output lines 2+ are valid JSON" {
+  run bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS"
+  [ "$status" -eq 0 ]
+  echo "$output" | tail -n +2 | jq . > /dev/null
+}
+
+@test "AC-3: result.token is present and non-empty" {
+  token=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.result.token')
+  [ -n "$token" ]
+  [ "$token" != "null" ]
+}
+
+@test "AC-3: result.token starts with sim-token-" {
+  token=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.result.token')
+  [[ "$token" == sim-token-* ]]
+}
+
+@test "AC-3: result.user.id is alice" {
+  uid=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.result.user.id')
+  [ "$uid" = "sim-alice-001" ]
+}
+
+@test "AC-3: result.user.roles is non-empty array" {
+  count=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq '.result.user.roles | length')
+  [ "$count" -gt 0 ]
+}
+
+@test "AC-3: db_trace has exactly 2 ops" {
+  count=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq '.db_trace | length')
+  [ "$count" -eq 2 ]
+}
+
+@test "AC-3: db_trace first op is READ" {
+  op=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.db_trace[0].op')
+  [ "$op" = "READ" ]
+}
+
+@test "AC-3: db_trace first op table is users" {
+  tbl=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.db_trace[0].table')
+  [ "$tbl" = "users" ]
+}
+
+@test "AC-3: db_trace second op is WRITE" {
+  op=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.db_trace[1].op')
+  [ "$op" = "WRITE" ]
+}
+
+@test "AC-3: db_trace WRITE table is users" {
+  tbl=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.db_trace[1].table')
+  [ "$tbl" = "users" ]
+}
+
+@test "AC-3: db_trace WRITE fields include last_login_at" {
+  result=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.db_trace[1].fields | contains(["last_login_at"])')
+  [ "$result" = "true" ]
+}
+
+@test "AC-3: side_effects is non-empty" {
+  count=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq '.side_effects | length')
+  [ "$count" -gt 0 ]
+}
+
+@test "AC-3: side_effects[0] mentions last_login_at" {
+  se=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.side_effects[0]')
+  [[ "$se" == *"last_login_at"* ]]
+}
+
+@test "AC-3: execution time under 3 seconds" {
+  start=$SECONDS
+  bash "$SIM" AuthService login "$AC3_ARGS" "$SEEDS" > /dev/null
+  elapsed=$(( SECONDS - start ))
+  [ "$elapsed" -lt 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: user not found → INVALID_CREDENTIALS 401
+# ---------------------------------------------------------------------------
+
+@test "AC-4: exits 1 on not-found user" {
+  run bash "$SIM" AuthService login "$AC4_ARGS" "$SEEDS"
+  [ "$status" -eq 1 ]
+}
+
+@test "AC-4: header present even on error" {
+  run bash "$SIM" AuthService login "$AC4_ARGS" "$SEEDS"
+  [[ "${lines[0]}" == *"NOT GROUND TRUTH"* ]]
+}
+
+@test "AC-4: error.code is INVALID_CREDENTIALS" {
+  code=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq -r '.error.code')
+  [ "$code" = "INVALID_CREDENTIALS" ]
+}
+
+@test "AC-4: error.status is 401" {
+  status=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq '.error.status')
+  [ "$status" -eq 401 ]
+}
+
+@test "AC-4: result is null" {
+  result=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq '.result')
+  [ "$result" = "null" ]
+}
+
+@test "AC-4: db_trace has exactly 1 op (READ only, no WRITE)" {
+  count=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq '.db_trace | length')
+  [ "$count" -eq 1 ]
+}
+
+@test "AC-4: db_trace single op is READ" {
+  op=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq -r '.db_trace[0].op')
+  [ "$op" = "READ" ]
+}
+
+@test "AC-4: side_effects is empty array" {
+  count=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq '.side_effects | length')
+  [ "$count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Disabled user edge case
+# ---------------------------------------------------------------------------
+
+@test "disabled: exits 1" {
+  run bash "$SIM" AuthService login "$DISABLED_ARGS" "$SEEDS"
+  [ "$status" -eq 1 ]
+}
+
+@test "disabled: error.code is USER_DISABLED" {
+  code=$(sim_json AuthService login "$DISABLED_ARGS" "$SEEDS" | jq -r '.error.code')
+  [ "$code" = "USER_DISABLED" ]
+}
+
+@test "disabled: error.status is 403" {
+  status=$(sim_json AuthService login "$DISABLED_ARGS" "$SEEDS" | jq '.error.status')
+  [ "$status" -eq 403 ]
+}
+
+@test "disabled: db_trace has 1 READ and no WRITE" {
+  count=$(sim_json AuthService login "$DISABLED_ARGS" "$SEEDS" | jq '.db_trace | length')
+  [ "$count" -eq 1 ]
+}
+
+@test "disabled: side_effects is empty" {
+  count=$(sim_json AuthService login "$DISABLED_ARGS" "$SEEDS" | jq '.side_effects | length')
+  [ "$count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Wrong password edge case
+# ---------------------------------------------------------------------------
+
+@test "wrong-password: exits 1" {
+  run bash "$SIM" AuthService login "$WRONGPW_ARGS" "$SEEDS"
+  [ "$status" -eq 1 ]
+}
+
+@test "wrong-password: error.code is INVALID_CREDENTIALS" {
+  code=$(sim_json AuthService login "$WRONGPW_ARGS" "$SEEDS" | jq -r '.error.code')
+  [ "$code" = "INVALID_CREDENTIALS" ]
+}
+
+@test "wrong-password: db_trace has 1 READ (no WRITE)" {
+  count=$(sim_json AuthService login "$WRONGPW_ARGS" "$SEEDS" | jq '.db_trace | length')
+  [ "$count" -eq 1 ]
+}
+
+@test "wrong-password: side_effects is empty" {
+  count=$(sim_json AuthService login "$WRONGPW_ARGS" "$SEEDS" | jq '.side_effects | length')
+  [ "$count" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Output structure invariants
+# ---------------------------------------------------------------------------
+
+@test "output: module_id in JSON matches input" {
+  mid=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.module_id')
+  [ "$mid" = "AuthService" ]
+}
+
+@test "output: method in JSON matches input" {
+  mth=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq -r '.method')
+  [ "$mth" = "login" ]
+}
+
+@test "output: confidence key present in all paths" {
+  result=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq 'has("confidence")')
+  [ "$result" = "true" ]
+}
+
+@test "output: confidence is never 1.0 on success" {
+  conf=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | jq '.confidence')
+  python3 -c "assert $conf < 1.0, 'confidence must never be 1.0'"
+}
+
+@test "output: confidence is never 1.0 on error paths" {
+  conf=$(sim_json AuthService login "$AC4_ARGS" "$SEEDS" | jq '.confidence')
+  python3 -c "assert $conf < 1.0, 'confidence must never be 1.0'"
+}
+
+@test "output: db_trace entries have op and table fields" {
+  result=$(sim_json AuthService login "$AC3_ARGS" "$SEEDS" | \
+    jq '[.db_trace[] | has("op") and has("table")] | all')
+  [ "$result" = "true" ]
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR implementa el Slice 4 de SPEC-190 "Application Code Twin", que completa la cobertura de fixtures CTF para las capas api y frontend.

**API**: se añaden dos Code Twin Files que documentan la capa de entrada HTTP del proyecto fixture. `api/routes.md` describe los cuatro endpoints (POST /items, GET /items, GET /items/:id, DELETE /items/:id) con sus requisitos de autenticación, parámetros, casos de uso que invocan y códigos de respuesta posibles. `api/error-codes.md` es el catálogo centralizado de códigos de error de la API, con el formato de respuesta normalizado y la tabla de todos los códigos (400 al 500).

**Frontend**: se añade `frontend/item-list-component.md` que documenta el componente de lista de items con su tabla de props, estado interno, y comportamiento completo (fetch en mount, paginación, filtrado, estados de loading/empty/error).

**Init script**: `code-twin-init.sh` ahora genera stubs DRAFT para api (routes.md, error-codes.md) y frontend (components.md) al crear un nuevo code-twin. Los stubs son rechazados por el linter hasta que el humano los completa y los marca STABLE.

Con este slice, el scaffolding cubre las seis capas completas: domain, application, infrastructure, api, frontend y meta. La suite BATS alcanza 52 tests para el linter (98 sobre 100) y 42 tests para el init (88 sobre 100).

Scope-trace: skip — scripts/code-twin-*.sh y tests/fixtures/code-twin/ son entregables core de SPEC-190 pero la spec no incluye path hints explícitos para todos los artefactos.
## Summary
feat(spec-190): Slice 5 — code-twin-simulate.sh symbolic engine
### Changes
- 9d7ace5d feat(spec-190): Slice 5 — code-twin-simulate.sh Python engine + seeds + 51 BATS (93/100)
### Stats
9 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
