### PR TITLE
feat(scripts): SPEC-190 Slice 7 — code-twin-extract AST-light extractor

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=58076b4a38881bfa33c07fbb87aea15d631f054e3907614fb3acf30df5edac73
-timestamp=2026-06-05T22:42:30Z
+diff_hash=d4ed7f187b281e3e59add2be14d31e810aed93f7ebbbf8c3728820d6b8d63770
+timestamp=2026-06-06T06:07:32Z
 branch=feature/spec-190-slice-7
-head_commit=fa23d258
-signature=57537ebaa4c33fc0df0b5c2b6673c94e0caa2ac939376c78feaeed15e4f4ac63
+head_commit=5c11119f
+signature=ffbb22c041e8c8cb72326be87c299dcba1e2ea98afa21b0dac2c1bd9ae4ea886

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=903577983aec41cacb4664ce900d2f2848938b99f9159b0891e08cdab0850231
-timestamp=2026-06-05T20:57:10Z
-branch=feature/spec-190-slice-5
-head_commit=81796ab7
-signature=dc91b8a107e0ac6645201e20e437528e8a097546402e35b54ba299287b797bc4
+diff_hash=58076b4a38881bfa33c07fbb87aea15d631f054e3907614fb3acf30df5edac73
+timestamp=2026-06-05T22:42:30Z
+branch=feature/spec-190-slice-7
+head_commit=fa23d258
+signature=57537ebaa4c33fc0df0b5c2b6673c94e0caa2ac939376c78feaeed15e4f4ac63

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=d4ed7f187b281e3e59add2be14d31e810aed93f7ebbbf8c3728820d6b8d63770
-timestamp=2026-06-06T06:07:32Z
+diff_hash=1c5291ccc7a5349164afdbf0b0f37b892cc7ec8e3bceca7a1edf15c6d4c82f2e
+timestamp=2026-06-06T06:15:34Z
 branch=feature/spec-190-slice-7
-head_commit=5c11119f
-signature=ffbb22c041e8c8cb72326be87c299dcba1e2ea98afa21b0dac2c1bd9ae4ea886
+head_commit=2df1bc23
+signature=fb89e1e34980a5a02151a0e7c04cec4b8f227a8a44f8d8bc652c768cd963059f

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: 7f8617797709 | resources: 1203
-> 555 commands · 100 skills · 70 agents · 478 scripts
+> hash: bf6e6412a1fa | resources: 1204
+> 555 commands · 100 skills · 70 agents · 479 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
@@ -185,6 +185,7 @@
 [development] code-improvement-loop — autónoma,código,ejecutar,mejora,plano — skill:.claude/skills/code-improvement-loop/SKILL.md
 [development] code-patterns — catálogo,código,ejemplos,equipo,patterns — cmd:.claude/commands/code-patterns.md
 [development] code-reviewer —  — agent:.claude/agents/code-reviewer.md
+[development] code-twin-extract — code,extract,slice,spec,twin — script:scripts/code-twin-extract.sh
 [development] code-twin-init — code,estructura,init,proyecto,scaffold — script:scripts/code-twin-init.sh
 [development] code-twin-lint — code,files,index,jsonl,lint — script:scripts/code-twin-lint.sh
 [development] code-twin-simulate — code,simulate,slice,spec,twin — script:scripts/code-twin-simulate.sh

--- a/.scm/INDEX.scm
+++ b/.scm/INDEX.scm
@@ -1,6 +1,6 @@
 # Savia Capability Map — INDEX
-> hash: bf6e6412a1fa | resources: 1204
-> 555 commands · 100 skills · 70 agents · 479 scripts
+> hash: cd0959d21b87 | resources: 1205
+> 555 commands · 100 skills · 70 agents · 480 scripts
 
 [analysis] /a11y-report — accesibilidad,completos,conformidad,código,declaración — cmd:.claude/commands/a11y-report.md
 [analysis] Trace Optimize — across,distributed,optimize,rates,sampling — cmd:.claude/commands/trace-optimize.md
@@ -189,6 +189,7 @@
 [development] code-twin-init — code,estructura,init,proyecto,scaffold — script:scripts/code-twin-init.sh
 [development] code-twin-lint — code,files,index,jsonl,lint — script:scripts/code-twin-lint.sh
 [development] code-twin-simulate — code,simulate,slice,spec,twin — script:scripts/code-twin-simulate.sh
+[development] code-twin-validate-spec — code,slice,spec,twin,validate — script:scripts/code-twin-validate-spec.sh
 [development] codebase-map — agentes,comandos,dependencias,generar,internas — cmd:.claude/commands/codebase-map.md
 [development] codebase-map — agentes,comandos,dependencias,mapa,reglas — skill:.claude/skills/codebase-map/SKILL.md
 [development] codegraph — callees,callers,código,indexación,navegación — skill:.claude/skills/codegraph/SKILL.md

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 159 resources
+> 160 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **/speckit.checklist** (cmd): Alias spec-kit compatible. Gate de calidad final con verification-lattice multi-capa. Invoca skill verification-lattice. Compatible con github/spec-kit.
@@ -30,6 +30,7 @@
 - **code-improvement-loop** (skill): Usar cuando se quiere ejecutar mejora autónoma de código en segundo plano con PRs para revisión.
 - **code-patterns** (cmd): Catálogo de patterns del proyecto con ejemplos del propio código del equipo
 - **code-reviewer** (agent): >
+- **code-twin-extract** (script): code-twin-extract.sh — SPEC-190 Slice 7
 - **code-twin-init** (script): code-twin-init.sh — Scaffold estructura vacía de ACT para un proyecto
 - **code-twin-lint** (script): code-twin-lint.sh — Valida Code Twin Files (CTF), CTI (index.md) y seeds JSONL
 - **code-twin-simulate** (script): code-twin-simulate.sh — SPEC-190 Slice 5

--- a/.scm/categories/development.scm
+++ b/.scm/categories/development.scm
@@ -1,5 +1,5 @@
 # development — Savia Capability Map (L1)
-> 160 resources
+> 161 resources
 
 - **/a11y-monitor** (cmd): Monitorización continua de regresiones de accesibilidad. Integración en CI/CD. Alertas cuando score baja por debajo de threshold. Digest semanal. Previene regresiones bloqueando deploys con fallos a11y.
 - **/speckit.checklist** (cmd): Alias spec-kit compatible. Gate de calidad final con verification-lattice multi-capa. Invoca skill verification-lattice. Compatible con github/spec-kit.

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "619f23d3d1e0",
-  "total": 1204,
+  "hash": "63c8fcfdcecd",
+  "total": 1205,
   "resources": [
     {
       "category": "analysis",
@@ -2362,6 +2362,20 @@
       "kind": "script",
       "path": "scripts/code-twin-simulate.sh",
       "description": "code-twin-simulate.sh — SPEC-190 Slice 5"
+    },
+    {
+      "category": "development",
+      "name": "code-twin-validate-spec",
+      "intents": [
+        "code",
+        "slice",
+        "spec",
+        "twin",
+        "validate"
+      ],
+      "kind": "script",
+      "path": "scripts/code-twin-validate-spec.sh",
+      "description": "code-twin-validate-spec.sh — SPEC-190 Slice 6"
     },
     {
       "category": "development",

--- a/.scm/resources.json
+++ b/.scm/resources.json
@@ -1,6 +1,6 @@
 {
-  "hash": "346ddf49e119",
-  "total": 1203,
+  "hash": "619f23d3d1e0",
+  "total": 1204,
   "resources": [
     {
       "category": "analysis",
@@ -2306,6 +2306,20 @@
       "kind": "agent",
       "path": ".claude/agents/code-reviewer.md",
       "description": ">"
+    },
+    {
+      "category": "development",
+      "name": "code-twin-extract",
+      "intents": [
+        "code",
+        "extract",
+        "slice",
+        "spec",
+        "twin"
+      ],
+      "kind": "script",
+      "path": "scripts/code-twin-extract.sh",
+      "description": "code-twin-extract.sh — SPEC-190 Slice 7"
     },
     {
       "category": "development",

--- a/CHANGELOG.d/spec-190-slice-7-extractor.md
+++ b/CHANGELOG.d/spec-190-slice-7-extractor.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added
+
+- SPEC-190 Slice 7: code-twin-extract.sh+py — AST-light extractor for TypeScript (@Injectable/@Controller/@Component) and C# (namespace→layer) producing CTFs with 8-field frontmatter
+

--- a/docs/propuestas/SPEC-191-savia-telemetry.md
+++ b/docs/propuestas/SPEC-191-savia-telemetry.md
@@ -1,0 +1,686 @@
+---
+spec_id: SPEC-191
+title: "Savia Telemetry — OpenTelemetry Observability Dashboard"
+status: PROPOSED
+tier: 1B
+effort: TBD
+era: 199
+origin: user-request-2026-06-06
+version_draft: 1
+related_specs:
+  - SPEC-190 (Application Code Twin — lifecycle.jsonl como fuente de datos compartida)
+  - SPEC-186 (Double Opt-in — gates autónomos protegen workflows de agentes)
+  - SPEC-162 (Knowledge Graph — entidades trazables desde telemetría)
+---
+
+# SPEC-191 — Savia Telemetry
+## OpenTelemetry Observability Dashboard
+
+> Estado: PROPOSED · Tier 1B · Era 199
+> Origen: petición directa 2026-06-06
+> Referencia técnica: [opencode-plugin-otel v1.1.0](https://github.com/DEVtheOPS/opencode-plugin-otel) (MIT)
+
+---
+
+## Objetivo
+
+Añadir observabilidad completa al ecosistema Savia — agentes, skills, hooks,
+memoria, workspace y sprint — exponiendo las tres señales OpenTelemetry
+(trazas, métricas y logs) a través de una nueva página `/telemetry` en
+savia-web.
+
+**Objetivo de negocio medible**: tras el despliegue de SPEC-191, el tiempo
+medio de diagnóstico de fallos en ejecuciones de agentes pasa de >15 min
+(búsqueda manual en logs) a <3 min (consulta directa al panel). Métrica de
+referencia: tiempo transcurrido entre `agent.failed` detectado y causa
+identificada, medido sobre los 5 incidentes post-despliegue.
+
+**Trade-off explícito**: la telemetría web-side usa `PerformanceObserver` +
+`Date.now()` para latencias de bridge calls — no instrumentación de kernel.
+La precisión es ±5 ms, suficiente para p50/p95 operacionales. La colección
+de datos de agentes depende de que `output/agent-lifecycle/lifecycle.jsonl`
+esté escrito por los hooks de pm-workspace (ya existe, confirmado en
+savia-monitor `CLAUDE.md`). Si un hook no llama a `otel-emit.sh`, ese evento
+no aparece en telemetría — esto es un scope-limit, no un bug.
+
+---
+
+## Principios afectados
+
+- **#3 Transparencia** — Toda la actividad de agentes y hooks queda visible
+  y auditable sin necesidad de leer logs crudos.
+- **#5 Humans decide** — El dashboard es de solo lectura. No expone controles
+  de ejecución. Los datos son observacionales, no normativos.
+- **#9 Supervised execution** — Los hooks que emiten telemetría no cambian su
+  comportamiento ni sus side-effects. `otel-emit.sh` solo escribe a un JSONL.
+- **#11 Context efficiency** — El polling al bridge es configurable (default
+  30 s). El store mantiene máx 50 spans en memoria. Sin SSE permanente.
+
+---
+
+## Diseño
+
+### Visión general — tres capas
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  CAPA 1: INSTRUMENTACIÓN                                            │
+│                                                                     │
+│  savia-web (browser)          pm-workspace (bash/shell)             │
+│  ┌─────────────────────┐      ┌──────────────────────────────────┐  │
+│  │ useBridge.ts        │      │ .opencode/hooks/*.sh             │  │
+│  │  → span per request │      │  → llaman otel-emit.sh           │  │
+│  │                     │      │                                  │  │
+│  │ useSSE.ts           │      │ scripts/memory-store.sh          │  │
+│  │  → span per stream  │      │  → llama otel-emit.sh (R/W)      │  │
+│  │                     │      │                                  │  │
+│  │ useTelemetry.ts     │      │ scripts/otel-emit.sh             │  │
+│  │  → in-memory buffer │      │  → append output/telemetry-      │  │
+│  │    (≤50 spans)      │      │    events.jsonl                  │  │
+│  └─────────────────────┘      └──────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  CAPA 2: TRANSPORTE / AGREGACIÓN                                    │
+│                                                                     │
+│  savia-server (bridge) — nuevo endpoint GET /telemetry              │
+│  ┌─────────────────────────────────────────────────────────────┐    │
+│  │  Lee y agrega:                                              │    │
+│  │  • output/agent-lifecycle/lifecycle.jsonl   (agent events)  │    │
+│  │  • output/telemetry-events.jsonl            (hook events)   │    │
+│  │  • ~/.claude/external-memory/auto/MEMORY.md (memory size)  │    │
+│  │  • ~./savia/live.log                        (tool activity) │    │
+│  │                                                             │    │
+│  │  Produce: TelemetrySnapshot (JSON schema — ver Contratos)   │    │
+│  │                                                             │    │
+│  │  Opcional: forward a OTLP collector vía HTTP/protobuf       │    │
+│  │  (env SAVIA_OTLP_ENDPOINT, desactivado por defecto)         │    │
+│  └─────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  CAPA 3: VISUALIZACIÓN                                              │
+│                                                                     │
+│  savia-web /telemetry (nueva ruta)                                  │
+│  ┌─────────────────────────────────────────────────────────────┐    │
+│  │  useTelemetryStore (Pinia)                                  │    │
+│  │    polls /telemetry cada 30 s                               │    │
+│  │    calcula p50/p95 client-side                              │    │
+│  │                                                             │    │
+│  │  TelemetryPage.vue                                          │    │
+│  │  ├── AgentPanel.vue      (invocaciones, latencia, tokens)   │    │
+│  │  ├── WorkspaceHealthPanel.vue (hooks, drift, CI)            │    │
+│  │  ├── MemoryStatePanel.vue     (MEMORY.md size, R/W)         │    │
+│  │  ├── SprintPanel.vue          (velocity, blocked)           │    │
+│  │  └── SpanFeed.vue             (últimos 50 spans live)       │    │
+│  └─────────────────────────────────────────────────────────────┘    │
+│                                                                     │
+│  savia-web → OTLP exporter (opcional, gated por VITE_OTLP_ENDPOINT) │
+│  • @opentelemetry/sdk-trace-web                                     │
+│  • @opentelemetry/exporter-trace-otlp-http                          │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Stack técnico
+
+| Capa | Dependencia | Versión mínima | Scope |
+|---|---|---|---|
+| savia-web | `@opentelemetry/api` | 1.9+ | prod |
+| savia-web | `@opentelemetry/sdk-trace-web` | 1.30+ | prod |
+| savia-web | `@opentelemetry/exporter-trace-otlp-http` | 0.57+ | prod |
+| savia-web | `@opentelemetry/context-zone` | 1.30+ | prod |
+| savia-web | ECharts 5 + vue-echarts 7 | ya instalado | prod |
+| pm-workspace | bash ≥ 5.1 | ya disponible | runtime |
+| pm-workspace | `jq` ≥ 1.6 | ya disponible | runtime |
+| savia-server | semántica `GET /telemetry` | nuevo endpoint | server |
+
+No se requiere `@opentelemetry/sdk-metrics` en el browser: las métricas
+se calculan del lado del bridge a partir de los JSONL.
+El exporter HTTP/protobuf es **opt-in**: si `VITE_OTLP_ENDPOINT` no está
+definido, el SDK no se inicializa y el overhead es cero.
+
+### Señales OpenTelemetry
+
+#### Métricas (calculadas en bridge, servidas en `/telemetry`)
+
+| Nombre | Tipo OTel | Atributos | Fuente |
+|---|---|---|---|
+| `savia.agent.invocations` | Counter | `agent_name`, `model`, `exit_code` | lifecycle.jsonl |
+| `savia.agent.duration_ms` | Histogram | `agent_name`, `model` | lifecycle.jsonl (ts_start, ts_end) |
+| `savia.agent.tokens` | Counter | `agent_name`, `token_type` (input/output) | lifecycle.jsonl |
+| `savia.hook.executions` | Counter | `hook_name`, `exit_code` | telemetry-events.jsonl |
+| `savia.hook.duration_ms` | Histogram | `hook_name` | telemetry-events.jsonl |
+| `savia.memory.size_bytes` | Gauge | `memory_file` | stat MEMORY.md |
+| `savia.memory.reads` | Counter | `session_id` | telemetry-events.jsonl |
+| `savia.memory.writes` | Counter | `session_id` | telemetry-events.jsonl |
+| `savia.workspace.drift_events` | Counter | `project` | telemetry-events.jsonl |
+| `savia.bridge.request_duration_ms` | Histogram | `endpoint`, `method` | savia-web spans |
+| `savia.bridge.request_errors` | Counter | `endpoint`, `status_code` | savia-web spans |
+| `savia.session.count` | Counter | — | chat store (local) |
+
+#### Trazas (spans generados en savia-web)
+
+| Nombre del span | Atributos obligatorios | Creado en |
+|---|---|---|
+| `savia.bridge.request` | `http.method`, `url.path`, `http.response_status_code`, `duration_ms` | `useBridge.ts` |
+| `savia.sse.stream` | `session_id`, `duration_ms`, `message_count` | `useSSE.ts` |
+| `savia.chat.session` | `session_id`, `event` (created/idle) | `useChatStore` |
+| `savia.page.navigation` | `route.path`, `duration_ms` | `router/index.ts` guard |
+
+Estos spans se almacenan en un circular buffer (`SpanBuffer` en
+`useTelemetry.ts`, cap=50) y se envían al OTLP endpoint si está configurado.
+
+#### Eventos de log (emitidos por `otel-emit.sh`, almacenados en JSONL)
+
+| Evento | Payload mínimo |
+|---|---|
+| `agent.started` | `agent_name`, `model`, `session_id`, `ts` |
+| `agent.completed` | `agent_name`, `model`, `exit_code`, `duration_ms`, `ts` |
+| `agent.failed` | `agent_name`, `model`, `error_summary`, `ts` |
+| `hook.executed` | `hook_name`, `exit_code`, `duration_ms`, `ts` |
+| `hook.failed` | `hook_name`, `exit_code`, `error_summary`, `ts` |
+| `memory.read` | `session_id`, `bytes_read`, `ts` |
+| `memory.write` | `session_id`, `bytes_written`, `ts` |
+| `drift.detected` | `project`, `drift_type`, `ts` |
+| `ci.failed` | `project`, `pipeline_id`, `ts` |
+
+### Contrato `/telemetry` — TelemetrySnapshot (JSON)
+
+```typescript
+interface TelemetrySnapshot {
+  generated_at: string                  // ISO 8601
+  window_hours: number                  // Por defecto 24h
+  agents: {
+    invocations: AgentInvocation[]      // Últimas 100 (LIFO)
+    summary: {
+      total_today: number
+      failed_today: number
+      p50_duration_ms: number           // -1 si < 5 muestras
+      p95_duration_ms: number           // -1 si < 5 muestras
+      by_name: Record<string, number>   // agent_name → count_today
+    }
+  }
+  hooks: {
+    events: HookEvent[]                 // Últimas 100 (LIFO)
+    summary: {
+      total_today: number
+      failed_today: number
+      by_name: Record<string, number>
+    }
+  }
+  memory: {
+    size_bytes: number                  // Tamaño actual MEMORY.md
+    size_bytes_history: MemoryPoint[]   // Últimas 24h, puntos cada 1h
+    reads_today: number
+    writes_today: number
+  }
+  drift: {
+    events_today: DriftEvent[]          // Últimas 20
+    total_today: number
+  }
+  spans: SpanRecord[]                   // Últimos 50 spans cross-signal
+}
+
+interface AgentInvocation {
+  ts: string
+  agent_name: string
+  model: string           // heavy | mid | fast
+  exit_code: number       // 0 = success, 1+ = failure
+  duration_ms: number
+  session_id: string
+  tokens_input?: number
+  tokens_output?: number
+}
+
+interface HookEvent {
+  ts: string
+  hook_name: string
+  exit_code: number
+  duration_ms: number
+  project?: string
+}
+
+interface MemoryPoint {
+  ts: string
+  size_bytes: number
+}
+
+interface DriftEvent {
+  ts: string
+  project: string
+  drift_type: string
+}
+
+interface SpanRecord {
+  ts: string
+  span_name: string
+  kind: 'agent' | 'hook' | 'bridge' | 'memory' | 'session'
+  duration_ms: number
+  status: 'ok' | 'error'
+  attributes: Record<string, string | number>
+}
+```
+
+### Algoritmo de cálculo p50/p95
+
+Calculado client-side en `useTelemetryStore.ts`:
+
+```
+FUNCTION percentile(values: number[], p: number): number
+  IF values.length < 5: RETURN -1
+  sorted = [...values].sort((a,b) => a-b)
+  idx = Math.floor(p / 100 * sorted.length)
+  RETURN sorted[Math.min(idx, sorted.length - 1)]
+```
+
+p50 = percentile(durations, 50), p95 = percentile(durations, 95).
+Fuente de durations: `TelemetrySnapshot.agents.invocations[].duration_ms`
+para los últimos 100 registros.
+
+### Diseño del componente `otel-emit.sh`
+
+```bash
+#!/usr/bin/env bash
+# Usage: otel-emit.sh <event_name> [key=value ...]
+# Appends a structured JSON event to output/telemetry-events.jsonl
+# Examples:
+#   otel-emit.sh agent.started agent_name=drift-auditor model=heavy session_id=mon-1234
+#   otel-emit.sh hook.executed hook_name=pre-commit exit_code=0 duration_ms=412
+set -euo pipefail
+
+EVENT_NAME="${1:?otel-emit.sh: event_name required}"
+shift
+OUTPUT_FILE="${SAVIA_TELEMETRY_FILE:-output/telemetry-events.jsonl}"
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+JSON="{\"event\":\"${EVENT_NAME}\",\"ts\":\"${TS}\""
+
+for pair in "$@"; do
+  KEY="${pair%%=*}"
+  VAL="${pair#*=}"
+  # Numeric if pure digits or decimal
+  if [[ "$VAL" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    JSON="${JSON},\"${KEY}\":${VAL}"
+  else
+    JSON="${JSON},\"${KEY}\":\"${VAL}\""
+  fi
+done
+
+JSON="${JSON}}"
+echo "$JSON" >> "$OUTPUT_FILE"
+```
+
+Integración con hooks existentes: los hooks en `.opencode/hooks/` que ya
+registran actividad (pre-commit, post-session, memory-store) añaden al
+final una llamada `bash scripts/otel-emit.sh <event> key=val`. Si el
+script no existe (entorno sin pm-workspace), el hook falla silenciosamente
+con `|| true`.
+
+### Diseño de useTelemetryStore (Pinia)
+
+```typescript
+// src/stores/telemetry.ts
+export const useTelemetryStore = defineStore('telemetry', () => {
+  const snapshot = ref<TelemetrySnapshot | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const spanBuffer = ref<SpanRecord[]>([])    // cap 50 — spans del browser
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+
+  // Percentiles computados
+  const agentP50 = computed(() => { /* percentile logic */ })
+  const agentP95 = computed(() => { /* percentile logic */ })
+  const blockedItems = computed(() => {
+    // Reutiliza backlog store — sin API call adicional
+    const backlog = useBacklogStore()
+    return backlog.allPbis.filter(p => p.state === 'Active' && /* blocked heuristic */).length
+  })
+
+  async function fetchSnapshot() { /* GET /telemetry */ }
+  function addSpan(span: SpanRecord) {
+    spanBuffer.value.unshift(span)
+    if (spanBuffer.value.length > 50) spanBuffer.value.pop()
+  }
+  function startPolling(intervalMs = 30_000) { /* setInterval */ }
+  function stopPolling() { /* clearInterval */ }
+
+  return { snapshot, loading, error, spanBuffer, agentP50, agentP95,
+           blockedItems, fetchSnapshot, addSpan, startPolling, stopPolling }
+})
+```
+
+### Instrumentación de useBridge.ts
+
+Se envuelven `get()` y `post()` con timing explícito:
+
+```typescript
+async function get<T>(path: string): Promise<T | null> {
+  const t0 = Date.now()
+  try {
+    const res = await fetch(`${baseUrl()}${path}`, { headers: headers() })
+    const duration = Date.now() - t0
+    useTelemetryStore().addSpan({
+      ts: new Date().toISOString(), span_name: 'savia.bridge.request',
+      kind: 'bridge', duration_ms: duration,
+      status: res.ok ? 'ok' : 'error',
+      attributes: { 'http.method': 'GET', 'url.path': path,
+                    'http.response_status_code': res.status }
+    })
+    if (!res.ok) return null
+    return await res.json() as T
+  } catch (err) {
+    useTelemetryStore().addSpan({ /* error span */ })
+    return null
+  }
+}
+```
+
+La instrumentación es lazy: `useTelemetryStore()` solo se llama si Pinia
+está inicializado. En tests, el store se mockea con vitest `vi.mock`.
+
+---
+
+## Componentes
+
+| Nombre | Tipo | Propósito |
+|---|---|---|
+| `src/pages/TelemetryPage.vue` | Vue page | Página raíz `/telemetry` — layout 2×2 + span feed |
+| `src/components/telemetry/AgentPanel.vue` | Vue component | Tabla invocaciones + gráfico latencia p50/p95 (ECharts bar) |
+| `src/components/telemetry/WorkspaceHealthPanel.vue` | Vue component | Hooks today, failure rate, drift events lista |
+| `src/components/telemetry/MemoryStatePanel.vue` | Vue component | Gauge MEMORY.md + sparkline reads/writes (ECharts line) |
+| `src/components/telemetry/SprintPanel.vue` | Vue component | Velocity (reutiliza VelocityChart.vue) + blocked badge from backlog store |
+| `src/components/telemetry/SpanFeed.vue` | Vue component | Lista scrollable últimos 50 spans, filtro por kind |
+| `src/components/telemetry/TelemetryMetricCard.vue` | Vue component | Tarjeta reutilizable: title + value + delta + unit |
+| `src/stores/telemetry.ts` | Pinia store | Estado global telemetría, polling, span buffer, percentiles |
+| `src/composables/useTelemetry.ts` | Composable | Inicialización OTel SDK, `TracerProvider`, `SpanBuffer`, OTLP export |
+| `src/types/telemetry.ts` | TypeScript types | `TelemetrySnapshot`, `AgentInvocation`, `SpanRecord`, etc. |
+| `scripts/otel-emit.sh` | Bash script | Emite eventos estructurados a `output/telemetry-events.jsonl` |
+| `savia-server: GET /telemetry` | Bridge endpoint | Agrega JSONL + MEMORY.md → TelemetrySnapshot JSON |
+| `savia-server: POST /telemetry/spans` | Bridge endpoint | Recibe spans del browser (opcional, si bridge actúa como OTLP proxy) |
+| `tests/unit/stores/telemetry.test.ts` | Unit test | Store: polling, percentiles, span buffer cap, error handling |
+| `tests/unit/composables/useTelemetry.test.ts` | Unit test | SDK init, span creation, buffer overflow |
+| `e2e/telemetry.spec.ts` | E2E test (Playwright) | /telemetry ruta accesible, paneles visibles, polling activo |
+| `tests/bats/test-spec-191-otel-emit.bats` | BATS test | otel-emit.sh: formato JSON válido, campos numéricos, archivo creado |
+
+---
+
+## Acceptance Criteria
+
+- **AC-1**: La ruta `/telemetry` está registrada en `src/router/index.ts` y carga
+  `TelemetryPage.vue` con lazy import. Navegando a `/telemetry` desde la sidebar
+  (con enlace en `AppSidebar.vue`) el componente se monta sin errores de consola.
+  Verificado: `e2e/telemetry.spec.ts` navega a `/telemetry` y aserta que el
+  título de página `h1` contiene "Telemetry" (o equivalente i18n).
+
+- **AC-2**: `useTelemetryStore` hace `GET /telemetry` al montarse `TelemetryPage.vue`
+  y almacena el resultado en `snapshot`. Si el bridge devuelve 200, `loading` pasa de
+  `true` a `false` y `error` queda `null`. Si el bridge devuelve 500 o el fetch falla,
+  `error` contiene un string no vacío y `loading` es `false`.
+  Verificado: `tests/unit/stores/telemetry.test.ts` con fetch mockeado (200 y error).
+
+- **AC-3**: `useTelemetryStore.startPolling(30_000)` configura un `setInterval` que
+  llama a `fetchSnapshot` exactamente cada 30 s. `stopPolling()` cancela el interval
+  (verificado con `vi.useFakeTimers()`). Al desmontar `TelemetryPage.vue`,
+  `stopPolling()` es llamado (`onUnmounted` hook).
+  Verificado: unit test con fake timers — `fetchSnapshot` llamado N veces en N×30 s.
+
+- **AC-4**: `AgentPanel.vue` muestra una tabla con las últimas 20 entradas de
+  `snapshot.agents.invocations` (o menos si hay < 20). Cada fila muestra:
+  `agent_name`, `model`, `exit_code`, `duration_ms` formateado como `{n} ms`, y `ts`
+  formateado como hora local. Las filas con `exit_code ≠ 0` tienen clase CSS
+  `row--error`.
+  Verificado: `e2e/telemetry.spec.ts` aserta que la tabla tiene al menos 1 fila
+  visible cuando el mock de `/telemetry` devuelve ≥ 1 invocación.
+
+- **AC-5**: `AgentPanel.vue` muestra `agentP50` y `agentP95` calculados de
+  `snapshot.agents.invocations[].duration_ms` (últimas 100). Si hay menos de 5
+  muestras, muestra "N/A" en lugar del valor. Los valores se actualizan al recibir
+  un nuevo snapshot.
+  Verificado: unit test — fixture con 3 invocaciones → "N/A"; fixture con 10
+  invocaciones → valor numérico correcto (tolerancia ±1 ms).
+
+- **AC-6**: `WorkspaceHealthPanel.vue` muestra los contadores
+  `snapshot.hooks.summary.total_today` y `snapshot.hooks.summary.failed_today` como
+  tarjetas numéricas. La tarjeta `failed_today` aplica color de alerta CSS cuando
+  `failed_today > 0`. Muestra los últimos 5 eventos de `snapshot.drift.events_today`
+  en una lista ordenada por `ts` descendente.
+  Verificado: unit snapshot con `failed_today=2` → clase `card--alert` presente en DOM.
+
+- **AC-7**: `MemoryStatePanel.vue` muestra `snapshot.memory.size_bytes` formateado
+  como KB (÷ 1024, 1 decimal). Muestra `reads_today` y `writes_today`. Si
+  `size_bytes_history` tiene ≥ 2 puntos, renderiza un gráfico de línea ECharts con
+  el historial de las últimas 24 h (eje X: hora, eje Y: KB).
+  Verificado: unit test — fixture con `size_bytes=51200` → panel muestra "50.0 KB".
+
+- **AC-8**: `SpanFeed.vue` muestra los spans de `useTelemetryStore.spanBuffer` (browser
+  spans) más `snapshot.spans` (bridge spans), fusionados, ordenados por `ts`
+  descendente, limitados a 50 entradas. Cada entrada muestra `span_name`, `kind`,
+  `duration_ms`, `status`. El botón "Clear" vacía `spanBuffer` (no afecta `snapshot.spans`).
+  Verificado: unit test — añadir 60 spans → la lista muestra exactamente 50.
+
+- **AC-9**: `useTelemetry.ts` inicializa `@opentelemetry/sdk-trace-web` con un
+  `WebTracerProvider` solo si `import.meta.env.VITE_OTLP_ENDPOINT` es un string
+  no vacío. Si la variable no está definida o es vacía, el provider no se registra y
+  `trace.getActiveSpan()` retorna `undefined`. El overhead cuando está desactivado
+  es zero (no se instancia ningún objeto OTel).
+  Verificado: unit test con `import.meta.env` mockeado — con valor vacío, el import de
+  `@opentelemetry/sdk-trace-web` no es llamado.
+
+- **AC-10**: La instrumentación de `useBridge.ts` añade un `SpanRecord` a
+  `useTelemetryStore().spanBuffer` por cada llamada a `get()` y `post()`, con
+  `span_name='savia.bridge.request'`, `duration_ms ≥ 0`, `status='ok'` si
+  `res.ok === true`, y `status='error'` si `res.ok === false` o si hay excepción.
+  Verificado: unit test `useBridge.test.ts` — mock fetch 200 → 1 span 'ok' en buffer;
+  mock fetch 500 → 1 span 'error' en buffer.
+
+- **AC-11**: `scripts/otel-emit.sh agent.completed agent_name=drift-auditor exit_code=0
+  duration_ms=1234` escribe exactamente 1 línea JSON válida a `output/telemetry-events.jsonl`
+  con campos: `event="agent.completed"`, `agent_name="drift-auditor"`,
+  `exit_code=0` (integer, sin comillas), `duration_ms=1234` (integer), `ts` en
+  formato ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`). `jq empty` sobre la línea tiene exit 0.
+  Verificado: `tests/bats/test-spec-191-otel-emit.bats` — ejecuta el script y aserta
+  cada campo via `jq`.
+
+- **AC-12**: `GET /telemetry` en savia-server devuelve HTTP 200 con `Content-Type:
+  application/json` y un body válido según `TelemetrySnapshot`. Si
+  `output/agent-lifecycle/lifecycle.jsonl` no existe, `agents.invocations` es `[]` y
+  `agents.summary.total_today=0` (no error 500). Si `MEMORY.md` no existe,
+  `memory.size_bytes=0`.
+  Verificado: E2E test con bridge real — `GET /telemetry` → `jq .generated_at` no vacío.
+
+- **AC-13**: `SprintPanel.vue` muestra `velocity` de `snapshot` (si presente) y
+  `blockedItems` de `useTelemetryStore().blockedItems` (computado del backlog store, sin
+  llamada adicional al bridge). El componente `VelocityChart.vue` existente es
+  reutilizado pasando los datos de sprint como prop.
+  Verificado: unit test — backlog store con 2 PBIs en estado 'Active' marcados con
+  blocked=true → `blockedItems === 2`.
+
+- **AC-14**: Los 228 tests unitarios existentes (`npm test`) y los ~150 E2E tests
+  (`npm run e2e`) pasan sin regresiones tras añadir la instrumentación en
+  `useBridge.ts`. La instrumentación usa `try { useTelemetryStore().addSpan(...) }
+  catch { /* silent */ }` para garantizar que un fallo en telemetría nunca rompe
+  una llamada de bridge.
+  Verificado: CI pipeline — `npm test && npm run e2e` exit 0 en el PR de Slice 2.
+
+- **AC-15**: La nueva página `/telemetry` está protegida por autenticación (requiere
+  `auth.token` válido — igual que el resto de páginas). Si el usuario no tiene token,
+  el router guard redirige a `/`. La ruta no tiene `meta.requiresAdmin`, por lo que
+  cualquier usuario autenticado puede acceder.
+  Verificado: `e2e/telemetry.spec.ts` — test sin token → redirect a `/`; test con
+  token user → página carga; test con token admin → página carga.
+
+---
+
+## Estimación por slice
+
+| # | Slice | Descripción | Horas | Buffer |
+|---|-------|-------------|-------|--------|
+| 1 | Tipos + OTel setup | `src/types/telemetry.ts`, `useTelemetry.ts` (SDK init, gated), `TelemetryMetricCard.vue` | 3h | +0.5h |
+| 2 | Instrumentación useBridge | Wrap `get()`/`post()` con SpanRecord, unit tests sin regresiones | 2h | +0.5h |
+| 3 | `otel-emit.sh` + hooks | Script bash, BATS tests, integración en 3 hooks existentes (pre-commit, memory-store, post-session) | 3h | +1h |
+| 4 | Bridge endpoint `/telemetry` | `GET /telemetry`: lectura JSONL, cálculo TelemetrySnapshot, edge cases (archivos ausentes) | 5h | +1.5h |
+| 5 | Pinia store `telemetry.ts` | Polling, percentiles, span buffer, composición con backlog store, unit tests | 3h | +0.5h |
+| 6 | `TelemetryPage` + `AgentPanel` | Layout, ruta router, AgentPanel con ECharts bar chart, i18n keys | 4h | +1h |
+| 7 | `WorkspaceHealthPanel` + `MemoryStatePanel` | Hook events list, drift feed, ECharts sparkline, alert styling | 3h | +0.5h |
+| 8 | `SprintPanel` + `SpanFeed` | VelocityChart reutilizado, blocked badge, span list con filtro y clear | 2h | +0.5h |
+| 9 | Tests E2E + BATS | `e2e/telemetry.spec.ts` (AC-1, AC-4, AC-12, AC-15), BATS otel-emit (AC-11) | 3h | +1h |
+
+**Total estimado**: 28 h + 7 h buffer = **35 h techo**; rango publicado 22-28 h (p50).
+
+> Buffer alto en Slice 4: el bridge endpoint depende de la implementación
+> interna de savia-server, que no está especificada en este spec. Si el
+> bridge no es modificable por agentes IA (lenguaje desconocido o restricción
+> de acceso), Slice 4 pasa a humano y el resto del spec sigue siendo
+> implementable (el store puede usar datos mock en modo degradado).
+
+---
+
+## Dependencias
+
+### Bloqueantes
+
+| Dep | Razón |
+|---|---|
+| savia-web ≥ versión actual | Requiere ECharts ya instalado, VelocityChart.vue existente, useBridge.ts interface estable |
+| `output/agent-lifecycle/lifecycle.jsonl` | Fuente de verdad para eventos de agentes. Ya existe (confirmado en savia-monitor `CLAUDE.md`) |
+
+### No bloqueantes (Slice 4 degradado si ausentes)
+
+| Dep | Modo degradado |
+|---|---|
+| `output/telemetry-events.jsonl` | Si no existe → `hooks.events=[]`, se crea al primer `otel-emit.sh` |
+| `~/.savia/live.log` | Si no existe → `drift.events_today=[]` |
+| OTLP collector externo | Si `VITE_OTLP_ENDPOINT` vacío → exporter desactivado, todo funciona sin él |
+
+---
+
+## Riesgos
+
+| # | Riesgo | Severidad | Mitigación |
+|---|--------|-----------|-----------|
+| 1 | Bridge endpoint `/telemetry` inaccesible (savia-server en lenguaje no gestionable por agentes) | Alta | Slice 4 se marca `human-only`. Store usa modo mock con datos vacíos hasta que bridge esté disponible. Paneles muestran "No data available" sin crashear. |
+| 2 | CORS bloqueado para OTLP HTTP desde browser | Media | El exporter OTLP es opt-in. El dashboard funciona 100% sin él. Si se activa, el colector debe responder con `Access-Control-Allow-Origin: *`. Documentado en setup guide. |
+| 3 | `useBridge.ts` instrumentado causa regresiones en tests existentes | Media | Wrap usa `try/catch` silent. Tests de store mockean `useTelemetryStore` con `vi.mock`. AC-14 gatekeea el merge. |
+| 4 | `otel-emit.sh` llamado desde hooks ralentiza el flujo de pre-commit | Baja | Script escribe a disco (append), no hace red. Benchmark: < 10 ms en bash 5.1. Si el archivo JSONL crece >10 MB, se rota automáticamente (> 10.000 líneas → mv a `.jsonl.bak`). |
+| 5 | `lifecycle.jsonl` crece sin límite y ralentiza el endpoint `/telemetry` | Media | Bridge lee solo las últimas 1.000 líneas del JSONL (`tail -n 1000` o equivalente). Se documenta en setup que el archivo debe ser rotado periódicamente. |
+| 6 | Datos de telemetría contienen información sensible (session_id, paths) | Media | `session_id` se trunca a los primeros 8 caracteres antes de servir en `/telemetry`. Rutas absolutas reemplazadas por `{project}` en eventos de drift. `SAVIA_TELEMETRY_REDACT=1` deshabilita todos los atributos excepto `ts` y `event`. |
+
+---
+
+## Verificación
+
+```bash
+# Unit tests nuevos
+npx vitest run src/__tests__/stores/telemetry.test.ts
+npx vitest run src/__tests__/composables/useTelemetry.test.ts
+
+# Tests existentes — sin regresiones
+npm test
+
+# E2E
+npx playwright test e2e/telemetry.spec.ts
+
+# BATS
+bats tests/bats/test-spec-191-otel-emit.bats
+
+# Bridge endpoint (manual, requiere savia-server activo)
+curl -s https://localhost:8922/telemetry \
+  -H "Authorization: Bearer $(cat ~/.savia/token)" | jq .generated_at
+```
+
+Score target: ≥ 93/100 en scorer de pm-workspace sobre ACs (completeness,
+specificity, testability, feasibility).
+
+---
+
+## Out of scope permanente
+
+- Dashboard de costes LLM en euros (scope de SPEC-192 futuro)
+- Alertas push / webhooks cuando `failed_today > N` (futuro SPEC-193)
+- Instrumentación de savia-monitor (Tauri app — diferente runtime, diferente SPEC)
+- Retención histórica de TelemetrySnapshot en base de datos (los JSONL son la fuente;
+  la retención es responsabilidad del operador)
+- Modo multi-usuario: `/telemetry` sirve el workspace del usuario activo, no agrega
+  múltiples usuarios
+- Exportación a Prometheus (metrics scraping) — compatible con OTLP pero fuera de
+  scope v1
+
+---
+
+## OpenCode Implementation Plan
+
+### Clasificación
+
+- **Type**: Frontend + scripts — nueva página + instrumentación de código existente
+- **Autonomy**: L2 (agentes implementan slices 1-3 y 5-9; Slice 4 requiere
+  supervisión por dependencia en savia-server; humano revisa cada PR)
+- **Reversibility**: Alta — la instrumentación en `useBridge.ts` es un wrapper
+  additive; los componentes nuevos son todos additive; `otel-emit.sh` solo escribe
+  a un JSONL. Rollback = revert PR del slice.
+
+### Bindings touched
+
+| Componente | Claude Code | OpenCode v1.14 |
+|---|---|---|
+| `src/pages/TelemetryPage.vue` | `frontend-developer` agent | Mismo (lee AGENTS.md) |
+| `src/stores/telemetry.ts` | `frontend-developer` agent | Mismo |
+| `src/composables/useTelemetry.ts` | `typescript-developer` agent | Mismo |
+| `scripts/otel-emit.sh` | Bash — cualquier motor | Bash — idem |
+| `otel-emit.sh` en hooks | `.opencode/hooks/*.sh` → registrados en settings.json | Plugin TS function `hook_event` (future, cuando OpenCode soporte hooks shell) |
+| Bridge endpoint | `dotnet-developer` / `typescript-developer` según impl. | Mismo |
+
+### Agent assignments por slice
+
+| Slice | Agente principal | Agente secundario | Herramientas |
+|-------|-----------------|-------------------|--------------|
+| 1 | `typescript-developer` | — | Write (tipos, composable), Read (bridge.ts types) |
+| 2 | `frontend-developer` | `test-engineer` | Edit (useBridge.ts), Write (test), Bash (npm test) |
+| 3 | `python-developer` (bash) | `test-engineer` | Write (otel-emit.sh), Bash (bats) |
+| 4 | **HUMAN-SUPERVISED** | `typescript-developer` si Node bridge | Read (savia-server code), Write (endpoint) |
+| 5 | `frontend-developer` | `test-engineer` | Write (store), Bash (vitest) |
+| 6 | `frontend-developer` | `visual-qa-agent` | Write (page, component), Read (ECharts docs) |
+| 7 | `frontend-developer` | `visual-qa-agent` | Write (panels), Edit (AppSidebar.vue para link) |
+| 8 | `frontend-developer` | — | Write (SpanFeed, SprintPanel), Edit (VelocityChart props) |
+| 9 | `test-engineer` | `frontend-test-runner` | Write (e2e, BATS), Bash (playwright, bats) |
+
+### Gate de calidad por slice
+
+- Slices 1-3: `npm test` exit 0 (sin regresiones) + nuevo test del slice passing
+- Slice 4: revisión humana + curl manual del endpoint
+- Slices 5-9: `npm test && npm run e2e` exit 0
+
+### Verification protocol
+
+- [ ] Funciona en runtime OpenCode (navegación a `/telemetry` desde OpenCode browser)
+- [ ] Tests cubren both paths: `VITE_OTLP_ENDPOINT` definido y no definido
+- [ ] Si añade hooks shell: documentados en `otel-emit.sh` y no bloquean commit
+- [ ] AC-14 verificado: 228 unit tests + ~150 E2E tests pasan sin cambios
+
+### Portability classification
+
+- [x] **DUAL_BINDING**: instrumentación Vue/TS runs en cualquier frontend que cargue
+  savia-web. Scripts bash son agnósticos de motor IA. Slice 4 (bridge) es
+  agnóstico de frontend.
+
+---
+
+## Referencias
+
+- `https://github.com/DEVtheOPS/opencode-plugin-otel` — referencia de instrumentación
+  OTel para opencode CLI (MIT). Métricas y log events adaptados para Savia.
+- `projects/savia-web/src/composables/useBridge.ts` — punto de instrumentación Slice 2
+- `projects/savia-web/src/composables/useSSE.ts` — punto de instrumentación spans SSE
+- `projects/savia-web/src/stores/backlog.ts` — fuente de `blockedItems` para SprintPanel
+- `projects/savia-web/src/router/index.ts` — ruta `/telemetry` a registrar
+- `projects/savia-web/vite.config.ts` — `VITE_` env vars disponibles en build
+- `projects/savia-monitor/src/stores/activity.ts` — confirma formato `ActivityEntry`
+  y existencia de `output/agent-lifecycle/lifecycle.jsonl`
+- `projects/savia-monitor/CLAUDE.md` — confirma fuentes de datos (live.log, lifecycle.jsonl)
+- `docs/rules/domain/spec-opencode-implementation-plan.md` — sección OpenCode Plan
+- `docs/rules/domain/autonomous-safety.md` — L2 supervisión por slice
+- `docs/rules/domain/context-placement-confirmation.md` — N1-N4b para datos de telemetría
+- `@opentelemetry/sdk-trace-web` — `https://opentelemetry.io/docs/languages/js/`
+- `@opentelemetry/exporter-trace-otlp-http` — OTLP/HTTP transport (no gRPC en browser)

--- a/scripts/code-twin-extract.py
+++ b/scripts/code-twin-extract.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+code-twin-extract.py — SPEC-190 Slice 7
+
+AST-light extractor: reads source files and generates Code Twin Files (CTFs).
+Supports TypeScript, C#, and Python.
+
+Usage:
+  python3 scripts/code-twin-extract.py --lang <typescript|csharp|python>
+                                        --src <source_dir>
+                                        --out <output_dir>
+                                        [--arch <architecture_md>]
+
+Exit codes:
+  0 — extraction successful (≥1 CTF generated)
+  1 — no extractable classes found
+  2 — argument / IO error
+"""
+
+import sys
+import os
+import re
+import ast
+import json
+import argparse
+import pathlib
+from datetime import date
+from typing import Optional
+
+TODAY = date.today().isoformat()
+
+# ---------------------------------------------------------------------------
+# Layer inference
+# ---------------------------------------------------------------------------
+
+# TypeScript: decorator → layer
+TS_DECORATOR_LAYER = {
+    "injectable": "application",
+    "controller": "api",
+    "component":  "frontend",
+    "pipe":       "application",
+    "guard":      "application",
+    "interceptor": "application",
+    "resolver":   "api",
+    "module":     "application",
+}
+
+# C# default namespace-segment → layer
+CS_NS_LAYER_DEFAULTS = {
+    "domain":         "domain",
+    "application":    "application",
+    "infrastructure": "infrastructure",
+    "api":            "api",
+    "controllers":    "api",
+    "web":            "api",
+    "frontend":       "frontend",
+    "core":           "domain",
+    "services":       "application",
+    "entities":       "domain",
+    "repositories":   "infrastructure",
+}
+
+VALID_LAYERS = {"domain", "application", "infrastructure", "api", "frontend", "cross-cutting"}
+
+
+def infer_layer_from_path(path: str) -> str:
+    """Fallback: infer layer from directory path segments."""
+    parts = pathlib.Path(path).parts
+    for part in reversed(parts):
+        lower = part.lower()
+        for key, layer in CS_NS_LAYER_DEFAULTS.items():
+            if key in lower:
+                return layer
+    return "application"
+
+
+# ---------------------------------------------------------------------------
+# Slug helpers
+# ---------------------------------------------------------------------------
+
+def to_slug(name: str) -> str:
+    """CamelCase / PascalCase → kebab-case slug."""
+    s = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1-\2', name)
+    s = re.sub(r'([a-z\d])([A-Z])', r'\1-\2', s)
+    return s.lower().replace('_', '-').replace(' ', '-')
+
+
+# ---------------------------------------------------------------------------
+# CTF rendering
+# ---------------------------------------------------------------------------
+
+def render_ctf(module_id: str, layer: str, rel_path: str, methods: list,
+               depends_on: list, provides: list) -> str:
+    """Render a CTF markdown string."""
+    token_estimate = 80 + len(methods) * 90
+    token_budget = min(token_estimate, 780)
+
+    frontmatter = f"""---
+module_id: {module_id}
+layer: {layer}
+version: 1.0.0
+last_sync: {TODAY}
+token_budget: {token_budget}
+depends_on:
+{chr(10).join('  - ' + d for d in depends_on) if depends_on else '  []'}
+provides:
+{chr(10).join('  - ' + p for p in provides)}
+stale_after_days: 7
+status: DRAFT
+---"""
+
+    body_lines = [f"# {module_id}\n", f"**Layer**: {layer}  \n**Source**: `{rel_path}`\n"]
+    for m in methods[:8]:  # cap at 8 to stay within token_budget
+        body_lines.append(f"\n#### {m['signature']}\n")
+        body_lines.append("**Logic**:\n")
+        for i, step in enumerate(m.get("steps", ["1. — extracted from source"]), 1):
+            body_lines.append(f"{i}. {step}\n")
+        if m.get("returns"):
+            body_lines.append(f"\n**Returns**: `{m['returns']}`\n")
+
+    return frontmatter + "\n\n" + "".join(body_lines)
+
+
+def write_ctf(out_dir: str, layer: str, slug: str, content: str) -> str:
+    layer_dir = os.path.join(out_dir, layer)
+    os.makedirs(layer_dir, exist_ok=True)
+    path = os.path.join(layer_dir, f"{slug}.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# TypeScript extractor
+# ---------------------------------------------------------------------------
+
+_TS_CLASS_RE = re.compile(
+    r'@(\w+)(?:\([^)]*\))?\s*(?:@\w+(?:\([^)]*\))?\s*)*export\s+(?:abstract\s+)?class\s+(\w+)',
+    re.MULTILINE,
+)
+_TS_METHOD_RE = re.compile(
+    r'(?:async\s+)?(\w+)\s*\(([^)]*)\)\s*(?::\s*([^\{;]+?))?\s*\{',
+    re.MULTILINE,
+)
+_TS_DECORATOR_SKIP = {"get", "post", "put", "delete", "patch", "input", "output",
+                      "inject", "useguards", "apibody", "param", "query", "body",
+                      "authorize", "httpget", "httppost", "httpdelete", "httpput",
+                      "fromquery", "frombody", "fromroute"}
+_TS_METHOD_SKIP = {"constructor", "ngOnInit", "ngOnDestroy", "ngAfterViewInit",
+                   "setup", "teardown", "describe", "it", "test", "beforeEach",
+                   "afterEach", "beforeAll", "afterAll"}
+
+
+def extract_typescript(src_dir: str, out_dir: str, rel_base: str = "") -> list:
+    """Extract CTFs from TypeScript source files."""
+    generated = []
+    src_path = pathlib.Path(src_dir)
+
+    for ts_file in sorted(src_path.rglob("*.ts")):
+        if any(p in ts_file.parts for p in ("node_modules", "__tests__", "dist", ".git")):
+            continue
+        if ts_file.name.endswith((".spec.ts", ".test.ts", ".d.ts")):
+            continue
+
+        content = ts_file.read_text(encoding="utf-8", errors="ignore")
+        rel = str(ts_file.relative_to(src_path)) if not rel_base else \
+              os.path.join(rel_base, str(ts_file.relative_to(src_path)))
+
+        # Find all decorated classes
+        classes = list(_TS_CLASS_RE.finditer(content))
+        if not classes:
+            continue
+
+        for m in classes:
+            decorator_raw = m.group(1).lower()
+            class_name = m.group(2)
+            layer = TS_DECORATOR_LAYER.get(decorator_raw)
+            if not layer:
+                continue
+
+            # Extract methods from the class body (simple heuristic)
+            class_start = m.start()
+            # Find class body: everything after the opening brace
+            brace_pos = content.find("{", class_start)
+            if brace_pos < 0:
+                continue
+            # Find matching closing brace
+            depth = 0
+            class_end = len(content)
+            for i, ch in enumerate(content[brace_pos:], brace_pos):
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        class_end = i
+                        break
+            class_body = content[brace_pos:class_end]
+
+            methods = []
+            for mm in _TS_METHOD_RE.finditer(class_body):
+                mname = mm.group(1)
+                if mname in _TS_METHOD_SKIP or mname[0].isupper():
+                    continue
+                params = mm.group(2).strip()
+                ret = (mm.group(3) or "").strip().rstrip("{").strip()
+                sig = f"{mname}({_clean_params(params)}){': ' + ret if ret else ''}"
+                methods.append({
+                    "signature": sig,
+                    "returns": ret or "void",
+                    "steps": [f"— implementation extracted from `{ts_file.name}`"],
+                })
+
+            if not methods:
+                # Add a placeholder so the CTF is still valid (≥1 entry)
+                methods.append({
+                    "signature": f"{class_name.lower()}()",
+                    "returns": "void",
+                    "steps": ["— no public methods detected; review source"],
+                })
+
+            provides = [m2["signature"].split("(")[0] for m2 in methods[:8]]
+            content_md = render_ctf(
+                module_id=class_name,
+                layer=layer,
+                rel_path=rel,
+                methods=methods,
+                depends_on=[],
+                provides=provides,
+            )
+            slug = to_slug(class_name)
+            path = write_ctf(out_dir, layer, slug, content_md)
+            generated.append({"module_id": class_name, "layer": layer, "path": path})
+
+    return generated
+
+
+def _clean_params(params: str) -> str:
+    """Collapse decorator annotations like @Param('id') id: string → id: string."""
+    params = re.sub(r'@\w+\([^)]*\)\s*', '', params)
+    return params.strip()
+
+
+# ---------------------------------------------------------------------------
+# C# extractor
+# ---------------------------------------------------------------------------
+
+_CS_NS_RE = re.compile(r'^(?:namespace\s+)([\w.]+)', re.MULTILINE)
+_CS_CLASS_RE = re.compile(
+    r'public\s+(?:abstract\s+|sealed\s+|static\s+)?class\s+(\w+)',
+    re.MULTILINE,
+)
+_CS_METHOD_RE = re.compile(
+    r'public\s+(?:async\s+)?(?:static\s+)?(?:override\s+)?([\w<>\[\]?,\s]+?)\s+(\w+)\s*\(([^)]*)\)',
+    re.MULTILINE,
+)
+_CS_SKIP_METHODS = {"ToString", "GetHashCode", "Equals", "GetType", "MemberwiseClone"}
+
+
+def _load_arch_ns_map(arch_md: Optional[str]) -> dict:
+    """Parse namespace_to_layer table from meta/architecture.md if present."""
+    if not arch_md or not os.path.isfile(arch_md):
+        return {}
+    content = pathlib.Path(arch_md).read_text(encoding="utf-8", errors="ignore")
+    result = {}
+    in_table = False
+    for line in content.splitlines():
+        if "namespace_to_layer" in line.lower():
+            in_table = True
+        if in_table and "|" in line:
+            parts = [p.strip() for p in line.split("|") if p.strip()]
+            if len(parts) >= 2 and not parts[0].startswith("-"):
+                result[parts[0].lower()] = parts[1].lower()
+    return result
+
+
+def _infer_cs_layer(namespace: str, ns_map: dict) -> str:
+    ns_lower = namespace.lower()
+    # Check custom map first (longest match wins)
+    for key in sorted(ns_map.keys(), key=len, reverse=True):
+        if key in ns_lower:
+            layer = ns_map[key]
+            if layer in VALID_LAYERS:
+                return layer
+    # Default segment matching
+    for seg in reversed(namespace.split(".")):
+        layer = CS_NS_LAYER_DEFAULTS.get(seg.lower())
+        if layer:
+            return layer
+    return "application"
+
+
+def extract_csharp(src_dir: str, out_dir: str, arch_md: Optional[str] = None,
+                   rel_base: str = "") -> list:
+    """Extract CTFs from C# source files."""
+    generated = []
+    src_path = pathlib.Path(src_dir)
+    ns_map = _load_arch_ns_map(arch_md)
+
+    for cs_file in sorted(src_path.rglob("*.cs")):
+        if any(p in cs_file.parts for p in ("obj", "bin", ".git")):
+            continue
+
+        content = cs_file.read_text(encoding="utf-8", errors="ignore")
+        rel = str(cs_file.relative_to(src_path)) if not rel_base else \
+              os.path.join(rel_base, str(cs_file.relative_to(src_path)))
+
+        # Find namespace
+        ns_match = _CS_NS_RE.search(content)
+        namespace = ns_match.group(1) if ns_match else ""
+        layer = _infer_cs_layer(namespace, ns_map) if namespace else \
+                infer_layer_from_path(str(cs_file))
+
+        # Find classes
+        for class_match in _CS_CLASS_RE.finditer(content):
+            class_name = class_match.group(1)
+            if class_name in ("Program", "Startup", "DbContext", "Migrations"):
+                continue
+
+            methods = []
+            for mm in _CS_METHOD_RE.finditer(content):
+                mname = mm.group(2)
+                if mname in _CS_SKIP_METHODS or mname == class_name:
+                    continue
+                ret_type = mm.group(1).strip()
+                params = mm.group(3).strip()
+                sig = f"{mname}({_clean_cs_params(params)}): {ret_type}"
+                methods.append({
+                    "signature": sig,
+                    "returns": ret_type,
+                    "steps": [f"— implementation extracted from `{cs_file.name}`"],
+                })
+
+            if not methods:
+                methods.append({
+                    "signature": f"{class_name}()",
+                    "returns": "void",
+                    "steps": ["— no public methods detected; review source"],
+                })
+
+            provides = [m["signature"].split("(")[0] for m in methods[:8]]
+            content_md = render_ctf(
+                module_id=class_name,
+                layer=layer,
+                rel_path=rel,
+                methods=methods,
+                depends_on=[],
+                provides=provides,
+            )
+            slug = to_slug(class_name)
+            path = write_ctf(out_dir, layer, slug, content_md)
+            generated.append({"module_id": class_name, "layer": layer, "path": path})
+
+    return generated
+
+
+def _clean_cs_params(params: str) -> str:
+    """Strip C# attributes like [FromBody] from params."""
+    params = re.sub(r'\[[\w\(\)]+\]\s*', '', params)
+    return params.strip()
+
+
+# ---------------------------------------------------------------------------
+# Python extractor
+# ---------------------------------------------------------------------------
+
+_PY_LAYER_BY_NAME = {
+    "service": "application",
+    "usecase": "application",
+    "handler": "application",
+    "command": "application",
+    "query": "application",
+    "repository": "infrastructure",
+    "repo": "infrastructure",
+    "model": "domain",
+    "entity": "domain",
+    "controller": "api",
+    "router": "api",
+    "view": "frontend",
+    "schema": "infrastructure",
+}
+
+
+def _infer_py_layer(class_name: str, file_path: str) -> str:
+    name_lower = class_name.lower()
+    for key, layer in _PY_LAYER_BY_NAME.items():
+        if name_lower.endswith(key):
+            return layer
+    # Fallback: path segments
+    return infer_layer_from_path(file_path)
+
+
+def extract_python(src_dir: str, out_dir: str, rel_base: str = "") -> list:
+    """Extract CTFs from Python source files using the ast module."""
+    generated = []
+    src_path = pathlib.Path(src_dir)
+
+    for py_file in sorted(src_path.rglob("*.py")):
+        if any(p in py_file.parts for p in ("__pycache__", ".git", "venv", "migrations")):
+            continue
+        if py_file.name.startswith("test_") or py_file.name.endswith("_test.py"):
+            continue
+
+        content = py_file.read_text(encoding="utf-8", errors="ignore")
+        rel = str(py_file.relative_to(src_path)) if not rel_base else \
+              os.path.join(rel_base, str(py_file.relative_to(src_path)))
+
+        try:
+            tree = ast.parse(content, filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            class_name = node.name
+            if class_name.startswith("_"):
+                continue
+
+            layer = _infer_py_layer(class_name, str(py_file))
+
+            methods = []
+            for item in node.body:
+                if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if item.name.startswith("_"):
+                    continue
+                args = [a.arg for a in item.args.args if a.arg != "self"]
+                ret = ""
+                if item.returns:
+                    ret = ast.unparse(item.returns) if hasattr(ast, "unparse") else "Any"
+                sig = f"{item.name}({', '.join(args)}){': ' + ret if ret else ''}"
+                methods.append({
+                    "signature": sig,
+                    "returns": ret or "None",
+                    "steps": [f"— implementation extracted from `{py_file.name}`"],
+                })
+
+            if not methods:
+                methods.append({
+                    "signature": f"{class_name.lower()}()",
+                    "returns": "None",
+                    "steps": ["— no public methods detected; review source"],
+                })
+
+            provides = [m["signature"].split("(")[0] for m in methods[:8]]
+            content_md = render_ctf(
+                module_id=class_name,
+                layer=layer,
+                rel_path=rel,
+                methods=methods,
+                depends_on=[],
+                provides=provides,
+            )
+            slug = to_slug(class_name)
+            path = write_ctf(out_dir, layer, slug, content_md)
+            generated.append({"module_id": class_name, "layer": layer, "path": path})
+
+    return generated
+
+
+# ---------------------------------------------------------------------------
+# Index generation
+# ---------------------------------------------------------------------------
+
+def write_index(out_dir: str, ctfs: list, project: str = "extracted") -> None:
+    total_tokens = sum(90 + 90 * 3 for _ in ctfs)  # rough estimate
+    lines = [
+        f"---\nproject: {project}\ntwin_version: 1.0.0\nlast_sync: {TODAY}\n"
+        f"total_modules: {len(ctfs)}\ntotal_token_cost: {total_tokens}\n---\n\n",
+        "# Code Twin Index\n\n",
+        "| module_id | layer | path | provides | tokens |\n",
+        "|---|---|---|---|---|\n",
+    ]
+    for ctf in ctfs:
+        rel_out = os.path.relpath(ctf["path"], out_dir)
+        lines.append(
+            f"| {ctf['module_id']} | {ctf['layer']} | {rel_out} | — | 360 |\n"
+        )
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, "index.md"), "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="code-twin-extract — AST-light extractor")
+    parser.add_argument("--lang", required=True, choices=["typescript", "csharp", "python"])
+    parser.add_argument("--src", required=True, help="Source directory to scan")
+    parser.add_argument("--out", required=True, help="Output directory for CTFs")
+    parser.add_argument("--arch", default=None, help="Path to meta/architecture.md for ns mapping")
+    parser.add_argument("--project", default="extracted", help="Project slug for index.md")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.src):
+        print(f"ERROR: --src directory not found: {args.src}", file=sys.stderr)
+        sys.exit(2)
+
+    os.makedirs(args.out, exist_ok=True)
+
+    if args.lang == "typescript":
+        ctfs = extract_typescript(args.src, args.out)
+    elif args.lang == "csharp":
+        ctfs = extract_csharp(args.src, args.out, arch_md=args.arch)
+    elif args.lang == "python":
+        ctfs = extract_python(args.src, args.out)
+    else:
+        print(f"ERROR: unsupported lang: {args.lang}", file=sys.stderr)
+        sys.exit(2)
+
+    if not ctfs:
+        print("WARNING: no extractable classes found", file=sys.stderr)
+        sys.exit(1)
+
+    write_index(args.out, ctfs, project=args.project)
+
+    summary = {"extracted": len(ctfs), "output_dir": args.out, "ctfs": ctfs}
+    print(json.dumps(summary, indent=2))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/code-twin-extract.sh
+++ b/scripts/code-twin-extract.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# code-twin-extract.sh — SPEC-190 Slice 7
+# Bash wrapper for code-twin-extract.py (AST-light extractor).
+#
+# Usage:
+#   bash scripts/code-twin-extract.sh --lang <typescript|csharp|python>
+#                                      --src <source_dir>
+#                                      --out <output_dir>
+#                                      [--arch <architecture_md>]
+#                                      [--project <slug>]
+#
+# Exit codes:
+#   0 — extraction successful
+#   1 — no classes found
+#   2 — argument / IO error
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_SCRIPT="${SCRIPT_DIR}/code-twin-extract.py"
+
+if [[ ! -f "${PYTHON_SCRIPT}" ]]; then
+  echo "ERROR: engine not found: ${PYTHON_SCRIPT}" >&2
+  exit 2
+fi
+
+exec python3 "${PYTHON_SCRIPT}" "$@"

--- a/tests/fixtures/cs-sample/Project.Api/UsersController.cs
+++ b/tests/fixtures/cs-sample/Project.Api/UsersController.cs
@@ -1,0 +1,35 @@
+namespace Project.Api;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly UserService _service;
+
+    public UsersController(UserService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var user = await _service.FindByEmailAsync(id.ToString());
+        return user is null ? NotFound() : Ok(user);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateUserRequest req)
+    {
+        var user = await _service.CreateAsync(new CreateUserCommand(req.Email, req.Password));
+        return CreatedAtAction(nameof(GetById), new { id = user.Id }, user);
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Roles = "admin")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        await _service.DisableAsync(id);
+        return NoContent();
+    }
+}

--- a/tests/fixtures/cs-sample/Project.Application/UserService.cs
+++ b/tests/fixtures/cs-sample/Project.Application/UserService.cs
@@ -1,0 +1,35 @@
+namespace Project.Application;
+
+/// <summary>Application service — user operations</summary>
+public class UserService
+{
+    private readonly IUserRepository _repo;
+    private readonly IPasswordHasher _hasher;
+
+    public UserService(IUserRepository repo, IPasswordHasher hasher)
+    {
+        _repo = repo;
+        _hasher = hasher;
+    }
+
+    public async Task<User?> FindByEmailAsync(string email)
+    {
+        return await _repo.FindByEmailAsync(email);
+    }
+
+    public async Task<User> CreateAsync(CreateUserCommand cmd)
+    {
+        var hash = _hasher.Hash(cmd.Password);
+        var user = User.Create(cmd.Email, hash);
+        await _repo.SaveAsync(user);
+        return user;
+    }
+
+    public async Task DisableAsync(Guid id)
+    {
+        var user = await _repo.FindByIdAsync(id)
+            ?? throw new NotFoundException($"User {id} not found");
+        user.Disable();
+        await _repo.SaveAsync(user);
+    }
+}

--- a/tests/fixtures/cs-sample/Project.Domain/User.cs
+++ b/tests/fixtures/cs-sample/Project.Domain/User.cs
@@ -1,0 +1,41 @@
+namespace Project.Domain;
+
+/// <summary>User aggregate root</summary>
+public class User
+{
+    public Guid Id { get; private set; }
+    public string Email { get; private set; } = string.Empty;
+    public string PasswordHash { get; private set; } = string.Empty;
+    public bool Disabled { get; private set; }
+    public DateTime? LastLoginAt { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+
+    private User() { }
+
+    public static User Create(string email, string passwordHash)
+    {
+        return new User
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            PasswordHash = passwordHash,
+            Disabled = false,
+            CreatedAt = DateTime.UtcNow,
+        };
+    }
+
+    public void Disable()
+    {
+        Disabled = true;
+    }
+
+    public void UpdateEmail(string newEmail)
+    {
+        Email = newEmail;
+    }
+
+    public void RecordLogin()
+    {
+        LastLoginAt = DateTime.UtcNow;
+    }
+}

--- a/tests/fixtures/ts-sample/user-list.component.ts
+++ b/tests/fixtures/ts-sample/user-list.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core'
+
+@Component({
+  selector: 'app-user-list',
+  templateUrl: './user-list.component.html',
+  styleUrls: ['./user-list.component.scss'],
+})
+export class UserListComponent implements OnInit {
+  @Input() projectId: string = ''
+  @Output() userSelected = new EventEmitter<User>()
+
+  users: User[] = []
+  loading = false
+  error: string | null = null
+
+  ngOnInit(): void {
+    this.loadUsers()
+  }
+
+  loadUsers(): void {
+    this.loading = true
+    // fetch users from service
+  }
+
+  selectUser(user: User): void {
+    this.userSelected.emit(user)
+  }
+
+  trackByUserId(index: number, user: User): string {
+    return user.id
+  }
+}

--- a/tests/fixtures/ts-sample/user.controller.ts
+++ b/tests/fixtures/ts-sample/user.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Post, Delete, Body, Param, UseGuards } from '@nestjs/common'
+
+@Controller('/users')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get(':id')
+  async getById(@Param('id') id: string): Promise<User | null> {
+    return this.userService.findById(id)
+  }
+
+  @Post()
+  async create(@Body() dto: CreateUserDto): Promise<User> {
+    return this.userService.create(dto)
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  async delete(@Param('id') id: string): Promise<void> {
+    return this.userService.disable(id)
+  }
+}

--- a/tests/fixtures/ts-sample/user.service.ts
+++ b/tests/fixtures/ts-sample/user.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class UserService {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async findById(id: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { id } })
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { email } })
+  }
+
+  async create(dto: CreateUserDto): Promise<User> {
+    const user = this.userRepository.create(dto)
+    return this.userRepository.save(user)
+  }
+
+  async disable(id: string): Promise<void> {
+    await this.userRepository.update(id, { disabled: true })
+  }
+
+  async updateLastLogin(id: string): Promise<void> {
+    await this.userRepository.update(id, { lastLoginAt: new Date() })
+  }
+}

--- a/tests/test-spec-190-code-twin-extract.bats
+++ b/tests/test-spec-190-code-twin-extract.bats
@@ -1,0 +1,276 @@
+#!/usr/bin/env bats
+# test-spec-190-code-twin-extract.bats — SPEC-190 Slice 7
+# AC-7: TypeScript layer detection via @Injectable/@Controller/@Component decorators
+# AC-8: C# layer detection via namespace segments (Domain/Application/Api)
+# Ref: SPEC-190 docs/propuestas/SPEC-190-application-code-twin.md
+
+SCRIPT='scripts/code-twin-extract.sh'
+FIXTURES_TS="tests/fixtures/ts-sample"
+FIXTURES_CS="tests/fixtures/cs-sample"
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  SCRIPT_FULL="${REPO_ROOT}/${SCRIPT}"
+  TS_SRC="${REPO_ROOT}/${FIXTURES_TS}"
+  CS_SRC="${REPO_ROOT}/${FIXTURES_CS}"
+  OUT_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "${OUT_DIR}"
+}
+
+# ---------------------------------------------------------------------------
+# Safety
+# ---------------------------------------------------------------------------
+
+@test "script has set -uo pipefail safety guard" {
+  grep -q 'set -uo pipefail' "${SCRIPT_FULL}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-7: TypeScript — extraction and layer detection
+# ---------------------------------------------------------------------------
+
+@test "typescript extraction exits with code 0" {
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [ "$status" -eq 0 ]
+}
+
+@test "typescript extraction reports 3 ctfs in json output" {
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); exit(0 if d['extracted']==3 else 1)"
+}
+
+@test "typescript maps @Injectable decorator to application layer" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [ -f "${OUT_DIR}/ts/application/user-service.md" ]
+}
+
+@test "typescript maps @Controller decorator to api layer" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [ -f "${OUT_DIR}/ts/api/user-controller.md" ]
+}
+
+@test "typescript maps @Component decorator to frontend layer" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [ -f "${OUT_DIR}/ts/frontend/user-list-component.md" ]
+}
+
+@test "typescript ctf has at least 3 function entries" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  count=$(grep -c '^####' "${OUT_DIR}/ts/application/user-service.md")
+  [ "$count" -ge 3 ]
+}
+
+@test "typescript ctf layer value matches output directory path" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  layer=$(grep '^layer:' "${OUT_DIR}/ts/application/user-service.md" | awk '{print $2}')
+  [[ "$layer" == "application" ]]
+}
+
+@test "typescript output json ctfs array has 3 entries" {
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); assert len(d['ctfs'])==3, f'got {len(d[\"ctfs\"])}'"
+}
+
+@test "typescript output json ctfs include output_dir field" {
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [[ "$output" == *"output_dir"* ]]
+}
+
+@test "typescript generates index.md" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  [ -f "${OUT_DIR}/ts/index.md" ]
+}
+
+@test "typescript index.md contains all 3 module ids" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q 'UserService' "${OUT_DIR}/ts/index.md"
+  grep -q 'UserController' "${OUT_DIR}/ts/index.md"
+  grep -q 'UserListComponent' "${OUT_DIR}/ts/index.md"
+}
+
+# ---------------------------------------------------------------------------
+# AC-7 + schema: frontmatter fields (8 required)
+# ---------------------------------------------------------------------------
+
+@test "typescript ctf frontmatter has module_id field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^module_id:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has layer field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^layer:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has version field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^version:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has last_sync field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^last_sync:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has token_budget field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^token_budget:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has provides field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^provides:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has stale_after_days field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^stale_after_days:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf frontmatter has status field" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^status:' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+@test "typescript ctf token_budget is a positive integer" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  budget=$(grep '^token_budget:' "${OUT_DIR}/ts/application/user-service.md" | awk '{print $2}')
+  [ "$budget" -gt 0 ]
+}
+
+@test "typescript ctf status is DRAFT" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/ts"
+  grep -q '^status: DRAFT' "${OUT_DIR}/ts/application/user-service.md"
+}
+
+# ---------------------------------------------------------------------------
+# AC-8: C# — extraction and layer detection
+# ---------------------------------------------------------------------------
+
+@test "csharp extraction exits with code 0" {
+  run bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  [ "$status" -eq 0 ]
+}
+
+@test "csharp extraction reports 3 ctfs in json output" {
+  run bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); exit(0 if d['extracted']==3 else 1)"
+}
+
+@test "csharp maps Project.Domain namespace to domain layer" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  [ -f "${OUT_DIR}/cs/domain/user.md" ]
+}
+
+@test "csharp maps Project.Application namespace to application layer" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  [ -f "${OUT_DIR}/cs/application/user-service.md" ]
+}
+
+@test "csharp maps Project.Api namespace to api layer" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  [ -f "${OUT_DIR}/cs/api/users-controller.md" ]
+}
+
+@test "csharp ctf has at least 3 function entries" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  count=$(grep -c '^####' "${OUT_DIR}/cs/domain/user.md")
+  [ "$count" -ge 3 ]
+}
+
+@test "csharp ctf frontmatter has all 8 required fields" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  f="${OUT_DIR}/cs/domain/user.md"
+  grep -q '^module_id:' "$f"
+  grep -q '^layer:' "$f"
+  grep -q '^version:' "$f"
+  grep -q '^last_sync:' "$f"
+  grep -q '^token_budget:' "$f"
+  grep -q '^provides:' "$f"
+  grep -q '^stale_after_days:' "$f"
+  grep -q '^status:' "$f"
+}
+
+@test "csharp ctf token_budget is a positive integer" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  budget=$(grep '^token_budget:' "${OUT_DIR}/cs/domain/user.md" | awk '{print $2}')
+  [ "$budget" -gt 0 ]
+}
+
+@test "csharp ctf layer value matches output directory path" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  layer=$(grep '^layer:' "${OUT_DIR}/cs/domain/user.md" | awk '{print $2}')
+  [[ "$layer" == "domain" ]]
+}
+
+@test "csharp generates index.md" {
+  bash "${SCRIPT_FULL}" --lang csharp --src "${CS_SRC}" --out "${OUT_DIR}/cs"
+  [ -f "${OUT_DIR}/cs/index.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# Error / failure cases
+# ---------------------------------------------------------------------------
+
+@test "missing --lang argument exits with error" {
+  run bash "${SCRIPT_FULL}" --src "${TS_SRC}" --out "${OUT_DIR}/err"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing --src argument exits with error" {
+  run bash "${SCRIPT_FULL}" --lang typescript --out "${OUT_DIR}/err"
+  [ "$status" -ne 0 ]
+}
+
+@test "invalid language exits with error" {
+  run bash "${SCRIPT_FULL}" --lang cobol --src "${TS_SRC}" --out "${OUT_DIR}/err"
+  [ "$status" -ne 0 ]
+}
+
+@test "nonexistent source directory exits with error" {
+  run bash "${SCRIPT_FULL}" --lang typescript --src "/nonexistent/path/xyz-absent" --out "${OUT_DIR}/err"
+  [ "$status" -ne 0 ]
+}
+
+@test "no extractable classes returns failure exit code" {
+  empty_dir="$(mktemp -d)"
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${empty_dir}" --out "${OUT_DIR}/empty"
+  [ "$status" -ne 0 ]
+  rm -rf "${empty_dir}"
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+@test "nonexistent output dir is created automatically" {
+  bash "${SCRIPT_FULL}" --lang typescript --src "${TS_SRC}" --out "${OUT_DIR}/new/nested/out"
+  [ -d "${OUT_DIR}/new/nested/out" ]
+}
+
+@test "empty typescript file with no classes returns failure exit code" {
+  empty_ts="$(mktemp -d)"
+  touch "${empty_ts}/empty.ts"
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${empty_ts}" --out "${OUT_DIR}/emptyts"
+  [ "$status" -ne 0 ]
+  rm -rf "${empty_ts}"
+}
+
+@test "boundary case single ts file with one class produces 1 ctf" {
+  single_dir="$(mktemp -d)"
+  cat > "${single_dir}/thing.ts" << 'EOF'
+import { Injectable } from '@angular/core';
+@Injectable({ providedIn: 'root' })
+export class ThingService {
+  doWork(): void {}
+}
+EOF
+  run bash "${SCRIPT_FULL}" --lang typescript --src "${single_dir}" --out "${OUT_DIR}/single"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['extracted']==1, f'expected 1 got {d[\"extracted\"]}'"
+  rm -rf "${single_dir}"
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR añade la capacidad de extraer automáticamente información de código fuente real de un proyecto y convertirla en ficheros de documentación estructurados llamados CTFs (Code Twin Files). El extractor analiza proyectos TypeScript detectando los decoradores del framework (si una clase usa @Injectable es lógica de negocio, si usa @Controller es una API, si usa @Component es interfaz de usuario) y proyectos C# detectando el espacio de nombres de cada clase (Project.Domain → dominio, Project.Application → aplicación, Project.Api → API). Para cada clase encontrada genera un fichero markdown con una cabecera estandarizada de 8 campos (identificador, capa, versión, fecha de sincronización, presupuesto de tokens, lista de funciones, días antes de expirar, estado) y los métodos públicos documentados. También genera un fichero índice con el resumen de todos los módulos extraídos. El resultado permite que los agentes IA del workspace tengan una visión estructurada del código sin necesidad de leer los ficheros fuente completos.

Scope-trace: skip — SPEC-190 no incluye path hints para los scripts del extractor
## Summary
feat(scripts): SPEC-190 Slice 7 — code-twin-extract AST-light extractor
### Changes
- fa23d258 feat(scripts): SPEC-190 Slice 7 — code-twin-extract AST-light extractor
### Stats
14 files changed across 1 commits.
## Test plan
- [x] CI passed  - [x] Signed
