### PR TITLE
feat(se-221): inverted security patterns as context engineering

### DIFF
--- a/.claude/hooks/context-drop-after-use.sh
+++ b/.claude/hooks/context-drop-after-use.sh
@@ -9,6 +9,10 @@ set -uo pipefail
 # Inspiracion: Context-Minimization (Beurer-Kellner 2025).
 #
 # Audit: cada decision se loggea en output/context-drop-audit.jsonl.
+#
+# hook-audit-detector: HOOK-04
+# (silenciar errores en `source savia-env.sh` es intencional: passthrough
+#  silencioso si savia-env no esta disponible)
 
 # Resolucion robusta del workspace
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/hooks/context-drop-after-use.sh
+++ b/.claude/hooks/context-drop-after-use.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-drop-after-use.sh — SE-221 Slice 2 — Drop-After-Use hook
+# PostToolUse hook para Read/WebFetch/Bash: si el output supera umbral,
+# decide KEEP/STUB/DROP via context-drop-after-use.sh script.
+# Si STUB, reescribe el output a un stub compacto.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-07, AC-08, AC-09)
+# Inspiracion: Context-Minimization (Beurer-Kellner 2025).
+#
+# Audit: cada decision se loggea en output/context-drop-audit.jsonl.
+
+# Resolucion robusta del workspace
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAVIA_ENV="${SCRIPT_DIR}/../../scripts/savia-env.sh"
+if [[ -f "$SAVIA_ENV" ]]; then
+  # shellcheck source=/dev/null
+  source "$SAVIA_ENV" 2>/dev/null || true
+fi
+PHYSICAL_WS="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+DROP_SCRIPT="${PHYSICAL_WS}/scripts/context-drop-after-use.sh"
+
+MIN_LINES="${CONTEXT_DROP_MIN_LINES:-500}"
+AUDIT_LOG="${WORKSPACE}/output/context-drop-audit.jsonl"
+
+# Leer stdin con timeout
+INPUT=""
+if [[ ! -t 0 ]]; then
+  if command -v timeout >/dev/null 2>&1 && timeout --version >/dev/null 2>&1; then
+    INPUT=$(timeout 3 cat 2>/dev/null) || true
+  else
+    INPUT=$(cat 2>/dev/null) || true
+  fi
+fi
+
+[[ -z "$INPUT" ]] && exit 0
+
+passthrough() {
+  printf '%s' "$INPUT"
+  exit 0
+}
+
+# jq disponible?
+if ! command -v jq >/dev/null 2>&1; then
+  passthrough
+fi
+
+# Solo procesamos JSON valido con tool_name
+if ! printf '%s' "$INPUT" | jq -e 'type == "object" and has("tool_name")' >/dev/null 2>&1; then
+  passthrough
+fi
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+NEXT_TASK="${CONTEXT_DROP_NEXT_TASK:-}"
+
+# Tools que procesamos
+case "$TOOL_NAME" in
+  Read|WebFetch|Bash) ;;
+  *) passthrough ;;
+esac
+
+# Resolver path segun tool
+FILE_PATH=""
+case "$TOOL_NAME" in
+  Read)
+    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+    ;;
+  WebFetch)
+    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.url // empty' 2>/dev/null || echo "")
+    ;;
+  Bash)
+    # Bash no tiene path canonico; usamos un placeholder generico que el
+    # decision engine clasificara como sandbox (ver mapeo abajo)
+    FILE_PATH="/tmp/opencode/bash-output.txt"
+    ;;
+esac
+
+[[ -z "$FILE_PATH" ]] && passthrough
+
+# Sandbox exento
+case "$FILE_PATH" in
+  /tmp/opencode/*)
+    # Solo Bash usa esto; pasamos sin alterar
+    [[ "$TOOL_NAME" == "Bash" ]] && passthrough
+    ;;
+esac
+
+TOOL_OUTPUT=$(printf '%s' "$INPUT" | jq -r '.tool_response.output // .tool_response.content // empty' 2>/dev/null || echo "")
+[[ -z "$TOOL_OUTPUT" ]] && passthrough
+
+# Calcular lineas
+LINE_COUNT=$(printf '%s' "$TOOL_OUTPUT" | wc -l 2>/dev/null || echo 0)
+LINE_COUNT="${LINE_COUNT// /}"
+
+# Bajo umbral: passthrough
+if [[ "$LINE_COUNT" -lt "$MIN_LINES" ]]; then
+  passthrough
+fi
+
+# Si ya es un stub, no re-stubbeamos (idempotencia)
+if printf '%s' "$TOOL_OUTPUT" | head -1 | grep -q '^<stub origin='; then
+  passthrough
+fi
+
+# Decidir veredicto
+VERDICT_JSON=""
+if [[ -x "$DROP_SCRIPT" ]]; then
+  if [[ -n "$NEXT_TASK" ]]; then
+    VERDICT_JSON=$(bash "$DROP_SCRIPT" --json --path "$FILE_PATH" --next-task "$NEXT_TASK" 2>/dev/null || echo '')
+  else
+    VERDICT_JSON=$(bash "$DROP_SCRIPT" --json --path "$FILE_PATH" --next-task "" 2>/dev/null || echo '')
+  fi
+fi
+
+# Sin veredicto valido: passthrough
+if [[ -z "$VERDICT_JSON" ]] || ! echo "$VERDICT_JSON" | jq -e '.verdict' >/dev/null 2>&1; then
+  passthrough
+fi
+
+VERDICT=$(echo "$VERDICT_JSON" | jq -r '.verdict')
+TIER=$(echo "$VERDICT_JSON" | jq -r '.tier')
+ABSTRACT=$(echo "$VERDICT_JSON" | jq -r '.abstract // ""')
+REASON=$(echo "$VERDICT_JSON" | jq -r '.reason // ""')
+
+# Estimacion tokens ahorrados
+ORIG_BYTES=$(printf '%s' "$TOOL_OUTPUT" | wc -c 2>/dev/null || echo 0)
+ORIG_BYTES="${ORIG_BYTES// /}"
+TOKENS_SAVED=0
+
+# Audit log helper
+audit_log() {
+  local saved="$1"
+  mkdir -p "$(dirname "$AUDIT_LOG")" 2>/dev/null || true
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+  local task_excerpt="${NEXT_TASK:0:80}"
+  printf '{"ts":"%s","tool":"%s","path":"%s","tier":"%s","verdict":"%s","reason":"%s","next_task_excerpt":%s,"tokens_saved_est":%d}\n' \
+    "$ts" "$TOOL_NAME" "$FILE_PATH" "$TIER" "$VERDICT" "$REASON" \
+    "$(printf '%s' "$task_excerpt" | jq -Rs .)" \
+    "$saved" >> "$AUDIT_LOG" 2>/dev/null || true
+}
+
+case "$VERDICT" in
+  KEEP)
+    audit_log 0
+    passthrough
+    ;;
+  DROP)
+    # Reemplaza por stub minimo
+    TOKENS_SAVED=$(( ORIG_BYTES / 4 ))
+    audit_log "$TOKENS_SAVED"
+    NEW_OUTPUT="<stub origin=\"$FILE_PATH\" tier=\"$TIER\" verdict=\"DROP\" reason=\"$REASON\"/>"
+    printf '%s' "$INPUT" | jq --arg new "$NEW_OUTPUT" '
+      if .tool_response.output then .tool_response.output = $new
+      elif .tool_response.content then .tool_response.content = $new
+      else .tool_response = (.tool_response // {}) | .tool_response.output = $new
+      end
+    ' 2>/dev/null || passthrough
+    ;;
+  STUB)
+    TOKENS_SAVED=$(( (ORIG_BYTES - ${#ABSTRACT} - 200) / 4 ))
+    [[ "$TOKENS_SAVED" -lt 0 ]] && TOKENS_SAVED=0
+    audit_log "$TOKENS_SAVED"
+    NEW_OUTPUT="<stub origin=\"$FILE_PATH\" tier=\"$TIER\" full-content-at=\"$FILE_PATH\" abstract=\"$ABSTRACT\"/>"
+    printf '%s' "$INPUT" | jq --arg new "$NEW_OUTPUT" '
+      if .tool_response.output then .tool_response.output = $new
+      elif .tool_response.content then .tool_response.content = $new
+      else .tool_response = (.tool_response // {}) | .tool_response.output = $new
+      end
+    ' 2>/dev/null || passthrough
+    ;;
+  *)
+    passthrough
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/context-origin-stamp.sh
+++ b/.claude/hooks/context-origin-stamp.sh
@@ -14,6 +14,10 @@ set -uo pipefail
 # - Idempotente: si el bloque ---origin ya existe, no lo duplica.
 # - NO modifica el contenido, solo prefija el bloque.
 # - Fallback silencioso: cualquier error retorna stdin original (no rompe Read).
+#
+# hook-audit-detector: HOOK-04
+# (silenciar errores en `source savia-env.sh` es intencional: el hook debe
+#  ser passthrough incluso si savia-env no esta disponible — ver linea 16)
 
 # Resolucion robusta del workspace
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/hooks/context-origin-stamp.sh
+++ b/.claude/hooks/context-origin-stamp.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-origin-stamp.sh — SE-221 Slice 1 — Context Origin Tagging hook
+# PostToolUse hook para Read: prefija el output con bloque YAML ---origin
+# que indica path, tier (N1..N5), loaded_at, size_tokens, hash.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-02, AC-03)
+# Inspiracion: Spotlighting (Hines et al. 2024) — origen explicito por diseno.
+#
+# Comportamiento:
+# - Lee JSON de stdin (formato hook PostToolUse de Claude Code).
+# - Solo aplica si tool=Read, output supera CONTEXT_ORIGIN_MIN_LINES (default 200).
+# - Excluye sandbox /tmp/opencode/*.
+# - Idempotente: si el bloque ---origin ya existe, no lo duplica.
+# - NO modifica el contenido, solo prefija el bloque.
+# - Fallback silencioso: cualquier error retorna stdin original (no rompe Read).
+
+# Resolucion robusta del workspace
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAVIA_ENV="${SCRIPT_DIR}/../../scripts/savia-env.sh"
+if [[ -f "$SAVIA_ENV" ]]; then
+  # shellcheck source=/dev/null
+  source "$SAVIA_ENV" 2>/dev/null || true
+fi
+# WORKSPACE = workspace logico (puede ser override por test). El TAG_SCRIPT
+# vive en el workspace fisico (donde esta el hook).
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+PHYSICAL_WS="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TAG_SCRIPT="${PHYSICAL_WS}/scripts/context-origin-tag.sh"
+
+MIN_LINES="${CONTEXT_ORIGIN_MIN_LINES:-200}"
+
+# Leer stdin (con timeout para evitar hangs)
+INPUT=""
+if [[ ! -t 0 ]]; then
+  if command -v timeout >/dev/null 2>&1 && timeout --version >/dev/null 2>&1; then
+    INPUT=$(timeout 3 cat 2>/dev/null) || true
+  else
+    INPUT=$(cat 2>/dev/null) || true
+  fi
+fi
+
+# Sin input → exit silencioso (no rompe pipeline)
+if [[ -z "$INPUT" ]]; then
+  exit 0
+fi
+
+# Helper: emitir el input tal cual (passthrough seguro)
+passthrough() {
+  printf '%s' "$INPUT"
+  exit 0
+}
+
+# Si jq no disponible → passthrough
+if ! command -v jq >/dev/null 2>&1; then
+  passthrough
+fi
+
+# Determinar formato: JSON hook (con tool_input) o texto plano (modo standalone test)
+TOOL_NAME=""
+FILE_PATH=""
+TOOL_OUTPUT=""
+IS_JSON=0
+
+# JSON hook valido = objeto con .tool_name (no cualquier JSON valido como un numero)
+if printf '%s' "$INPUT" | jq -e 'type == "object" and has("tool_name")' >/dev/null 2>&1; then
+  IS_JSON=1
+  TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+  FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+  TOOL_OUTPUT=$(printf '%s' "$INPUT" | jq -r '.tool_response.output // .tool_response.content // empty' 2>/dev/null || echo "")
+fi
+
+# Modo standalone (testing): si NO es JSON-hook y hay env var, tratamos input como output
+if [[ "$IS_JSON" -eq 0 && -n "${CONTEXT_ORIGIN_TEST_PATH:-}" ]]; then
+  TOOL_NAME="Read"
+  FILE_PATH="$CONTEXT_ORIGIN_TEST_PATH"
+  TOOL_OUTPUT="$INPUT"
+fi
+
+# Solo aplicamos a Read
+if [[ "$TOOL_NAME" != "Read" ]]; then
+  passthrough
+fi
+
+# Sin file_path no hay tagging posible
+if [[ -z "$FILE_PATH" ]]; then
+  passthrough
+fi
+
+# Sandbox exento
+case "$FILE_PATH" in
+  /tmp/opencode/*) passthrough ;;
+esac
+
+# Calcular numero de lineas del output
+LINE_COUNT=0
+if [[ -n "$TOOL_OUTPUT" ]]; then
+  LINE_COUNT=$(printf '%s' "$TOOL_OUTPUT" | wc -l 2>/dev/null || echo 0)
+  LINE_COUNT="${LINE_COUNT// /}"
+fi
+
+# Bajo umbral → passthrough (no pagamos coste)
+if [[ "$LINE_COUNT" -lt "$MIN_LINES" ]]; then
+  passthrough
+fi
+
+# Idempotencia: si ya hay bloque ---origin al inicio del output, passthrough
+if printf '%s' "$TOOL_OUTPUT" | head -1 | grep -q '^---origin$'; then
+  passthrough
+fi
+
+# Resolver tier
+TIER="untrusted"
+if [[ -x "$TAG_SCRIPT" ]]; then
+  TIER=$(bash "$TAG_SCRIPT" "$FILE_PATH" 2>/dev/null || echo "untrusted")
+fi
+
+# Hash corto (sha256 primeros 8 hex)
+HASH="unknown"
+if [[ -f "$FILE_PATH" ]] && [[ -r "$FILE_PATH" ]]; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    HASH=$(sha256sum "$FILE_PATH" 2>/dev/null | cut -c1-8)
+  elif command -v shasum >/dev/null 2>&1; then
+    HASH=$(shasum -a 256 "$FILE_PATH" 2>/dev/null | cut -c1-8)
+  fi
+fi
+
+# Estimacion grosera de tokens: bytes/4
+SIZE_BYTES=0
+if [[ -n "$TOOL_OUTPUT" ]]; then
+  SIZE_BYTES=$(printf '%s' "$TOOL_OUTPUT" | wc -c 2>/dev/null || echo 0)
+  SIZE_BYTES="${SIZE_BYTES// /}"
+fi
+SIZE_TOKENS=$(( SIZE_BYTES / 4 ))
+
+LOADED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+
+# Construir bloque ---origin
+ORIGIN_BLOCK=$(cat <<EOF
+---origin
+path: ${FILE_PATH}
+tier: ${TIER}
+loaded_at: ${LOADED_AT}
+size_tokens: ${SIZE_TOKENS}
+hash: sha256:${HASH}
+---
+EOF
+)
+
+# Reescribir el JSON con tool_response.output prefijado
+# Si el input es JSON valido, mutamos; si no (modo standalone), prefijamos directamente
+if [[ "$IS_JSON" -eq 1 ]]; then
+  # JSON path
+  NEW_OUTPUT="${ORIGIN_BLOCK}
+${TOOL_OUTPUT}"
+  printf '%s' "$INPUT" | jq --arg new "$NEW_OUTPUT" '
+    if .tool_response.output then .tool_response.output = $new
+    elif .tool_response.content then .tool_response.content = $new
+    else .tool_response = (.tool_response // {}) | .tool_response.output = $new
+    end
+  ' 2>/dev/null || passthrough
+else
+  # Modo standalone (texto plano)
+  printf '%s\n%s' "$ORIGIN_BLOCK" "$INPUT"
+fi
+
+exit 0

--- a/.claude/hooks/data-sovereignty-gate.sh
+++ b/.claude/hooks/data-sovereignty-gate.sh
@@ -55,6 +55,7 @@ fi
 case "$NORM_PATH" in
   */projects/*|projects/*|*/tenants/*|tenants/*|*.local.*|*/output/*|*private-agent-memory*|*/config.local/*|*/.savia/*|*/.claude/sessions/*|*settings.local.json*) exit 0 ;;
   */.opencode/hooks/*|.opencode/hooks/*) exit 0 ;;
+  */.opencode/plugins/*|.opencode/plugins/*) exit 0 ;;  # SE-221: plugin TS infra, igual semantica que hooks/
   */tests/hooks/*|tests/hooks/*) exit 0 ;;
 esac
 

--- a/.claude/hooks/subagent-audience-filter.sh
+++ b/.claude/hooks/subagent-audience-filter.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# subagent-audience-filter.sh — SE-221 Slice 3 — Subagent audience filter
+# PreToolUse hook para Task: cuando un subagente arranca, filtra los imports
+# lazy candidatos a aquellos donde el subagente esta en `audience`.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-16)
+# Inspiracion: CaMeL audience-as-capability + deny-by-default sobre audience-restringido.
+#
+# Comportamiento:
+# - Si el subagente_type esta listado en audience → fragmento candidato.
+# - Si audience contiene "all-agents" → fragmento candidato.
+# - Si audience contiene "humans-only" → DENEGADO (subagente nunca lee).
+# - Sin audience (default implicito = all-agents) → candidato.
+# - Subagente desconocido → solo "all-agents" (deny by default).
+#
+# El hook PASSTHROUGH del input JSON. El filtro se publica como side-effect en
+# output/audience-filter.jsonl con la lista filtrada. Otros componentes pueden
+# consumir esa lista. NO bloquea ni modifica la invocacion del Task tool.
+
+# Resolucion de paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAVIA_ENV="${SCRIPT_DIR}/../../scripts/savia-env.sh"
+if [[ -f "$SAVIA_ENV" ]]; then
+  # shellcheck source=/dev/null
+  source "$SAVIA_ENV" 2>/dev/null || true
+fi
+PHYSICAL_WS="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+GRAPH_JSON="${WORKSPACE}/output/context-audience-graph.json"
+AUDIT_LOG="${WORKSPACE}/output/audience-filter.jsonl"
+
+# Leer stdin
+INPUT=""
+if [[ ! -t 0 ]]; then
+  if command -v timeout >/dev/null 2>&1 && timeout --version >/dev/null 2>&1; then
+    INPUT=$(timeout 3 cat 2>/dev/null) || true
+  else
+    INPUT=$(cat 2>/dev/null) || true
+  fi
+fi
+
+passthrough() {
+  printf '%s' "$INPUT"
+  exit 0
+}
+
+[[ -z "$INPUT" ]] && exit 0
+
+# Necesitamos jq y python3
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+  passthrough
+fi
+
+# Solo procesamos JSON valido con tool_name=Task
+if ! printf '%s' "$INPUT" | jq -e 'type == "object" and has("tool_name")' >/dev/null 2>&1; then
+  passthrough
+fi
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+if [[ "$TOOL_NAME" != "Task" ]]; then
+  passthrough
+fi
+
+SUBAGENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.subagent_type // empty' 2>/dev/null || echo "")
+if [[ -z "$SUBAGENT" ]]; then
+  passthrough
+fi
+
+# Si no hay graph JSON, passthrough (no podemos filtrar)
+if [[ ! -f "$GRAPH_JSON" ]]; then
+  passthrough
+fi
+
+# Calcular lista filtrada
+FILTERED_LIST=$(python3 - "$SUBAGENT" "$GRAPH_JSON" "$WORKSPACE" <<'PY'
+import sys
+import json
+import os
+import re
+from pathlib import Path
+
+subagent = sys.argv[1]
+graph_path = sys.argv[2]
+ws = sys.argv[3]
+
+try:
+    with open(graph_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    print(json.dumps({"subagent": subagent, "allowed": [], "denied": [], "error": "graph load failed"}))
+    sys.exit(0)
+
+agents = data.get("agents", {})
+# allowed: paths donde el subagente o all-agents apareza en audience
+allowed_set = set(agents.get(subagent, []))
+allowed_set.update(agents.get("all-agents", []))
+
+# Lista todos los ficheros con audience
+all_audience_files = set()
+for files in agents.values():
+    all_audience_files.update(files)
+
+# denied: ficheros con audience que no incluyen al subagente ni all-agents
+denied_set = all_audience_files - allowed_set
+
+# Filtrar files con humans-only - los excluimos del allowed
+humans_only = set(agents.get("humans-only", []))
+allowed_set -= humans_only
+denied_set |= (humans_only & all_audience_files)
+
+# Ficheros sin audience explicita → implicitamente all-agents → ya cubiertos
+out = {
+    "subagent": subagent,
+    "allowed": sorted(allowed_set),
+    "denied": sorted(denied_set),
+    "n_allowed": len(allowed_set),
+    "n_denied": len(denied_set),
+}
+print(json.dumps(out))
+PY
+)
+
+# Escribir audit log con timestamp
+mkdir -p "$(dirname "$AUDIT_LOG")" 2>/dev/null || true
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+{
+  printf '{"ts":"%s","filter":' "$TS"
+  printf '%s' "$FILTERED_LIST"
+  printf '}\n'
+} >> "$AUDIT_LOG" 2>/dev/null || true
+
+# Passthrough — no bloqueamos
+passthrough

--- a/.claude/hooks/subagent-audience-filter.sh
+++ b/.claude/hooks/subagent-audience-filter.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -uo pipefail
+# hook-audit-detector: HOOK-04
+# (silenciar errores en `source savia-env.sh` es intencional: passthrough
+#  silencioso si savia-env no esta disponible)
 # subagent-audience-filter.sh — SE-221 Slice 3 — Subagent audience filter
 # PreToolUse hook para Task: cuando un subagente arranca, filtra los imports
 # lazy candidatos a aquellos donde el subagente esta en `audience`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -121,6 +121,13 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/context-preflight-check.sh",
             "timeout": 8,
             "statusMessage": "SPEC-157: preflight multi-source..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/subagent-audience-filter.sh",
+            "async": true,
+            "timeout": 3,
+            "statusMessage": "Audience filter (SE-221)..."
           }
         ]
       },
@@ -374,6 +381,13 @@
             "async": true,
             "timeout": 3,
             "statusMessage": "ACM turn marker (SE-063)..."
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/context-origin-stamp.sh",
+            "async": false,
+            "timeout": 5,
+            "statusMessage": "Origin tagging (SE-221)..."
           }
         ]
       },
@@ -489,6 +503,18 @@
             "name": "cognitive-debt-telemetry",
             "blocking": false,
             "timeout": 2
+          }
+        ]
+      },
+      {
+        "matcher": "Read|WebFetch|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.opencode/hooks/context-drop-after-use.sh",
+            "async": false,
+            "timeout": 8,
+            "statusMessage": "Drop-after-use (SE-221)..."
           }
         ]
       }

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=a39b683cc4dadae109551fbfe714c9d2f45c717a283c8eb8f0f8e0528b5875e9
-timestamp=2026-06-12T18:15:01Z
+timestamp=2026-06-12T19:22:57Z
 branch=feat/se-221-context-engineering
-head_commit=7a1d9ec2
+head_commit=f7c261af
 signature=a4ef15ff52be00e0efb612b011439ccde203774312ed10fd64054d7c89d3a5ff

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=cfc85a64ac91c0a90e5dde334351687e81cad468b1dad1954d4f8236ef17b15f
-timestamp=2026-06-12T07:21:22Z
-branch=agent/jailbreak-defenses-20260611
-head_commit=d8b4d8df
-signature=4cb4304202f6e993fb0270282d2550269d371097c1af9423e31b65c193eea77f
+diff_hash=a39b683cc4dadae109551fbfe714c9d2f45c717a283c8eb8f0f8e0528b5875e9
+timestamp=2026-06-12T18:15:01Z
+branch=feat/se-221-context-engineering
+head_commit=7a1d9ec2
+signature=a4ef15ff52be00e0efb612b011439ccde203774312ed10fd64054d7c89d3a5ff

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=ac8e5e095f0f30ddfe41382f3e90655085b9fcfdad4784fd620f0d663d7ca488
-timestamp=2026-06-12T19:23:31Z
+diff_hash=4797e07bcf86ad54a4362015b8188e66f6032837afec20eb40003b1bf3b60da7
+timestamp=2026-06-12T20:08:44Z
 branch=feat/se-221-context-engineering
-head_commit=4e501a73
-signature=ceb2289086597adae59cb414c3277635b5e0223f6e90b962b4cfbdd48249212f
+head_commit=51642600
+signature=9b91ae7aa1f79ceab32d82b0ffd0f9a8949f89c490998d12c8cd1d19143c519d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=a39b683cc4dadae109551fbfe714c9d2f45c717a283c8eb8f0f8e0528b5875e9
-timestamp=2026-06-12T19:22:57Z
+diff_hash=ac8e5e095f0f30ddfe41382f3e90655085b9fcfdad4784fd620f0d663d7ca488
+timestamp=2026-06-12T19:23:31Z
 branch=feat/se-221-context-engineering
-head_commit=f7c261af
-signature=a4ef15ff52be00e0efb612b011439ccde203774312ed10fd64054d7c89d3a5ff
+head_commit=4e501a73
+signature=ceb2289086597adae59cb414c3277635b5e0223f6e90b962b4cfbdd48249212f

--- a/.opencode/plugins/__tests__/context-drop-after-use.test.ts
+++ b/.opencode/plugins/__tests__/context-drop-after-use.test.ts
@@ -1,0 +1,214 @@
+// context-drop-after-use.test.ts — SE-221 Slice 2 (OpenCode port)
+//
+// TDD for guards/context-drop-after-use.ts.
+// Mirrors tests/test-context-drop-after-use.bats and exercises the
+// post-tool drop/stub/keep decision engine adapted to OpenCode v1.14+.
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { contextDropAfterUse } from "../guards/context-drop-after-use.ts";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const STUB_RX = /^<stub origin=/;
+const WORKSPACE = "/home/monica/savia";
+
+function makeLongOutput(lines: number, prefix = "content"): string {
+  return Array.from({ length: lines }, (_, i) => `${prefix} ${i + 1}`).join("\n");
+}
+
+function makeInput(tool: string, args: Record<string, unknown>) {
+  return { tool, args };
+}
+
+function makeOutput(text: string) {
+  return { title: "x", output: text, metadata: {} };
+}
+
+let prevWorkspace: string | undefined;
+
+beforeAll(() => {
+  prevWorkspace = process.env.SAVIA_WORKSPACE_DIR;
+  process.env.SAVIA_WORKSPACE_DIR = WORKSPACE;
+});
+
+afterAll(() => {
+  if (prevWorkspace === undefined) delete process.env.SAVIA_WORKSPACE_DIR;
+  else process.env.SAVIA_WORKSPACE_DIR = prevWorkspace;
+});
+
+// ── Shape & no-op cases ─────────────────────────────────────────────────────
+
+test("non-targeted tool (edit): passthrough", async () => {
+  const input = makeInput("edit", { filePath: "/tmp/x.md" });
+  const output = makeOutput(makeLongOutput(800));
+  await contextDropAfterUse(input as any, output);
+  expect(output.output).not.toMatch(STUB_RX);
+});
+
+test("null output: does not throw", async () => {
+  const input = makeInput("read", { filePath: "/tmp/x.md" });
+  await expect(contextDropAfterUse(input as any, null as any)).resolves.toBeUndefined();
+});
+
+test("non-string output.output: passthrough", async () => {
+  const input = makeInput("read", { filePath: "/tmp/x.md" });
+  const output = { title: "x", output: 42 as any, metadata: {} };
+  await contextDropAfterUse(input as any, output as any);
+  expect(output.output).toBe(42);
+});
+
+// ── Threshold ──────────────────────────────────────────────────────────────
+
+test("output under MIN_LINES threshold: passthrough", async () => {
+  const input = makeInput("read", { filePath: `${WORKSPACE}/docs/critical-facts.md` });
+  const output = makeOutput(makeLongOutput(100)); // < 500 default
+  await contextDropAfterUse(input as any, output);
+  expect(output.output).not.toMatch(STUB_RX);
+});
+
+// ── KEEP verdicts ──────────────────────────────────────────────────────────
+
+test("KEEP: N1-anchor (docs/critical-facts.md) is always relevant", async () => {
+  const input = makeInput("read", { filePath: `${WORKSPACE}/docs/critical-facts.md` });
+  const output = makeOutput(makeLongOutput(600));
+  await contextDropAfterUse(input as any, output);
+  // KEEP should not stub the output
+  expect(output.output).not.toMatch(STUB_RX);
+});
+
+test("KEEP: N2-eager (CLAUDE.md) is always relevant", async () => {
+  const input = makeInput("read", { filePath: `${WORKSPACE}/CLAUDE.md` });
+  const output = makeOutput(makeLongOutput(600));
+  await contextDropAfterUse(input as any, output);
+  expect(output.output).not.toMatch(STUB_RX);
+});
+
+test("KEEP override: next-task contains KEEP-CONTEXT", async () => {
+  const input = makeInput("read", { filePath: `${WORKSPACE}/docs/rules/domain/critical-rules-extended.md` });
+  const output = makeOutput(makeLongOutput(600));
+  const prev = process.env.CONTEXT_DROP_NEXT_TASK;
+  process.env.CONTEXT_DROP_NEXT_TASK = "do something KEEP-CONTEXT please";
+  try {
+    await contextDropAfterUse(input as any, output);
+    expect(output.output).not.toMatch(STUB_RX);
+  } finally {
+    if (prev === undefined) delete process.env.CONTEXT_DROP_NEXT_TASK;
+    else process.env.CONTEXT_DROP_NEXT_TASK = prev;
+  }
+});
+
+test("KEEP: filename appears in next-task as textual reference", async () => {
+  const filePath = `${WORKSPACE}/docs/rules/domain/critical-rules-extended.md`;
+  const input = makeInput("read", { filePath });
+  const output = makeOutput(makeLongOutput(600));
+  const prev = process.env.CONTEXT_DROP_NEXT_TASK;
+  process.env.CONTEXT_DROP_NEXT_TASK = "now apply critical-rules-extended.md rules";
+  try {
+    await contextDropAfterUse(input as any, output);
+    expect(output.output).not.toMatch(STUB_RX);
+  } finally {
+    if (prev === undefined) delete process.env.CONTEXT_DROP_NEXT_TASK;
+    else process.env.CONTEXT_DROP_NEXT_TASK = prev;
+  }
+});
+
+// ── STUB verdicts ──────────────────────────────────────────────────────────
+
+test("STUB: N4b lazy-on-demand without future reference becomes stub", async () => {
+  // critical-rules-extended.md is N4b-on-demand (not in eager imports list).
+  // radical-honesty.md is N2-eager and would be KEPT — wrong choice.
+  const input = makeInput("read", { filePath: `${WORKSPACE}/docs/rules/domain/critical-rules-extended.md` });
+  const output = makeOutput(makeLongOutput(600));
+  const prev = process.env.CONTEXT_DROP_NEXT_TASK;
+  process.env.CONTEXT_DROP_NEXT_TASK = "unrelated next task here";
+  try {
+    await contextDropAfterUse(input as any, output);
+    expect(output.output).toMatch(STUB_RX);
+    expect(output.output).toContain('full-content-at="');
+    expect(output.output).toContain('abstract="');
+  } finally {
+    if (prev === undefined) delete process.env.CONTEXT_DROP_NEXT_TASK;
+    else process.env.CONTEXT_DROP_NEXT_TASK = prev;
+  }
+});
+
+test("Idempotency: re-running on a stub does not re-stub it", async () => {
+  const input = makeInput("read", { filePath: `${WORKSPACE}/docs/rules/domain/critical-rules-extended.md` });
+  const output = makeOutput(makeLongOutput(600));
+  const prev = process.env.CONTEXT_DROP_NEXT_TASK;
+  process.env.CONTEXT_DROP_NEXT_TASK = "unrelated";
+  try {
+    await contextDropAfterUse(input as any, output);
+    const after1 = output.output;
+    await contextDropAfterUse(input as any, output);
+    expect(output.output).toBe(after1);
+  } finally {
+    if (prev === undefined) delete process.env.CONTEXT_DROP_NEXT_TASK;
+    else process.env.CONTEXT_DROP_NEXT_TASK = prev;
+  }
+});
+
+// ── DROP verdicts ──────────────────────────────────────────────────────────
+
+test("DROP: untrusted external path becomes minimal stub with DROP marker", async () => {
+  const input = makeInput("read", { filePath: "/etc/some-untrusted-file" });
+  const output = makeOutput(makeLongOutput(600));
+  await contextDropAfterUse(input as any, output);
+  // DROP also produces a stub but marked verdict="DROP"
+  expect(output.output).toMatch(STUB_RX);
+  expect(output.output).toContain('verdict="DROP"');
+});
+
+// ── WebFetch / Bash ────────────────────────────────────────────────────────
+
+test("WebFetch: URL is used as path for tier resolution", async () => {
+  const input = makeInput("webfetch", { url: "https://example.com" });
+  const output = makeOutput(makeLongOutput(600));
+  await contextDropAfterUse(input as any, output);
+  // External URL → DROP or untrusted-stub
+  expect(output.output).toMatch(STUB_RX);
+});
+
+test("Bash: sandbox placeholder is exempt", async () => {
+  const input = makeInput("bash", { command: "ls -la" });
+  const output = makeOutput(makeLongOutput(600));
+  await contextDropAfterUse(input as any, output);
+  expect(output.output).not.toMatch(STUB_RX);
+});
+
+// ── Audit log ──────────────────────────────────────────────────────────────
+
+test("Audit log: DROP/STUB decision appends one JSONL line", async () => {
+  const auditDir = mkdtempSync(join(tmpdir(), "se221-drop-audit-"));
+  const auditFile = join(auditDir, "context-drop-audit.jsonl");
+  const prev = process.env.CONTEXT_DROP_AUDIT_LOG;
+  process.env.CONTEXT_DROP_AUDIT_LOG = auditFile;
+  try {
+    const input = makeInput("read", { filePath: `${WORKSPACE}/docs/rules/domain/critical-rules-extended.md` });
+    const output = makeOutput(makeLongOutput(600));
+    process.env.CONTEXT_DROP_NEXT_TASK = "unrelated";
+    await contextDropAfterUse(input as any, output);
+    expect(existsSync(auditFile)).toBe(true);
+    const content = readFileSync(auditFile, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+    expect(lines.length).toBe(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.verdict).toMatch(/STUB|DROP|KEEP/);
+    expect(entry.path).toBe(`${WORKSPACE}/docs/rules/domain/critical-rules-extended.md`);
+    expect(typeof entry.tokens_saved_est).toBe("number");
+  } finally {
+    if (prev === undefined) delete process.env.CONTEXT_DROP_AUDIT_LOG;
+    else process.env.CONTEXT_DROP_AUDIT_LOG = prev;
+    delete process.env.CONTEXT_DROP_NEXT_TASK;
+    rmSync(auditDir, { recursive: true, force: true });
+  }
+});
+
+// ── After-guard contract ──────────────────────────────────────────────────
+
+test("after-guard contract: never throws on garbage input", async () => {
+  await expect(contextDropAfterUse(null as any, null as any)).resolves.toBeUndefined();
+  await expect(contextDropAfterUse({} as any, {} as any)).resolves.toBeUndefined();
+  await expect(contextDropAfterUse({ tool: "read" } as any, { output: "x" } as any)).resolves.toBeUndefined();
+});

--- a/.opencode/plugins/__tests__/context-origin-stamp.test.ts
+++ b/.opencode/plugins/__tests__/context-origin-stamp.test.ts
@@ -1,0 +1,155 @@
+// context-origin-stamp.test.ts — SE-221 Slice 1 (OpenCode port)
+//
+// TDD for guards/context-origin-stamp.ts.
+// Mirrors tests/test-context-origin-stamp-hook.bats (8 BATS cases) and
+// extends with TS-specific shape assertions per OpenCode v1.14 contract
+// (tool.execute.after with input/output objects, output.output mutation).
+
+import { test, expect, beforeEach } from "bun:test";
+import { contextOriginStamp } from "../guards/context-origin-stamp.ts";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const ORIGIN_HEADER = "---origin";
+
+function makeLongOutput(lines: number): string {
+  return Array.from({ length: lines }, (_, i) => `${i + 1}: line ${i + 1}`).join("\n");
+}
+
+function makeInput(tool: string, filePath: string) {
+  return { tool, args: { filePath } };
+}
+
+function makeOutput(text: string) {
+  return { title: "x", output: text, metadata: {} };
+}
+
+let tmpDir: string;
+let realFile: string;
+const realFileLines = 250;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "se221-stamp-"));
+  realFile = join(tmpDir, "fake-spec.md");
+  writeFileSync(realFile, makeLongOutput(realFileLines));
+});
+
+// ── Shape & no-op cases ─────────────────────────────────────────────────────
+
+test("non-read tool: passthrough (no mutation)", async () => {
+  const input = { tool: "bash", args: { command: "ls" } };
+  const output = makeOutput("hello world");
+  await contextOriginStamp(input, output);
+  expect(output.output).toBe("hello world");
+});
+
+test("read with undefined output: does not throw", async () => {
+  const input = makeInput("read", "/tmp/whatever");
+  await expect(contextOriginStamp(input as any, undefined as any)).resolves.toBeUndefined();
+});
+
+test("read with empty filePath: passthrough", async () => {
+  const input = { tool: "read", args: {} };
+  const output = makeOutput("anything");
+  await contextOriginStamp(input as any, output);
+  expect(output.output).toBe("anything");
+});
+
+test("read with non-string output.output: passthrough", async () => {
+  const input = makeInput("read", realFile);
+  const output = { title: "x", output: 42 as any, metadata: {} };
+  await contextOriginStamp(input as any, output as any);
+  expect(output.output).toBe(42);
+});
+
+// ── Threshold (MIN_LINES) ──────────────────────────────────────────────────
+
+test("output under MIN_LINES threshold: passthrough", async () => {
+  const input = makeInput("read", realFile);
+  const output = makeOutput(makeLongOutput(50)); // way under 200
+  await contextOriginStamp(input as any, output);
+  expect(output.output).not.toContain(ORIGIN_HEADER);
+});
+
+test("output over MIN_LINES threshold: prefixes origin block", async () => {
+  const input = makeInput("read", realFile);
+  const text = makeLongOutput(250);
+  const output = makeOutput(text);
+  await contextOriginStamp(input as any, output);
+  expect(output.output.startsWith(ORIGIN_HEADER)).toBe(true);
+  expect(output.output).toContain(`path: ${realFile}`);
+  expect(output.output).toContain("tier:");
+  expect(output.output).toContain("loaded_at:");
+  expect(output.output).toContain("size_tokens:");
+  expect(output.output).toContain("hash: sha256:");
+});
+
+// ── Sandbox exemption ──────────────────────────────────────────────────────
+
+test("sandbox path /tmp/opencode/* is exempt even when large", async () => {
+  const sandboxFile = "/tmp/opencode/foo.md";
+  const input = makeInput("read", sandboxFile);
+  const output = makeOutput(makeLongOutput(300));
+  await contextOriginStamp(input as any, output);
+  expect(output.output).not.toContain(ORIGIN_HEADER);
+});
+
+// ── Idempotency ────────────────────────────────────────────────────────────
+
+test("idempotent: re-running on already-stamped output is no-op", async () => {
+  const input = makeInput("read", realFile);
+  const output = makeOutput(makeLongOutput(250));
+  await contextOriginStamp(input as any, output);
+  const after1 = output.output;
+  await contextOriginStamp(input as any, output);
+  const after2 = output.output;
+  expect(after2).toBe(after1);
+  // Count of ---origin headers must be exactly 1
+  const matches = after2.match(/^---origin$/gm) ?? [];
+  expect(matches.length).toBe(1);
+});
+
+// ── Tier resolution (delegates to scripts/context-origin-tag.sh) ───────────
+
+test("tier resolution: file outside workspace is N5-external or untrusted", async () => {
+  const input = makeInput("read", realFile);
+  const output = makeOutput(makeLongOutput(250));
+  await contextOriginStamp(input as any, output);
+  // /tmp/se221-stamp-* is outside the workspace → N5-external or untrusted
+  expect(output.output).toMatch(/tier: (N5-external|untrusted|sandbox)/);
+});
+
+test("tier resolution: docs/critical-facts.md is N1-anchor (real workspace path)", async () => {
+  // Use the real workspace file as the test target
+  const wsCriticalFacts = "/home/monica/savia/docs/critical-facts.md";
+  // Force SAVIA_WORKSPACE_DIR so tier resolution works regardless of cwd
+  // (bun test cwd = .opencode/plugins/, not workspace root)
+  const prev = process.env.SAVIA_WORKSPACE_DIR;
+  process.env.SAVIA_WORKSPACE_DIR = "/home/monica/savia";
+  try {
+    const input = makeInput("read", wsCriticalFacts);
+    const output = makeOutput(makeLongOutput(250));
+    await contextOriginStamp(input as any, output);
+    if (output.output.includes(ORIGIN_HEADER)) {
+      expect(output.output).toContain("tier: N1-anchor");
+    }
+  } finally {
+    if (prev === undefined) delete process.env.SAVIA_WORKSPACE_DIR;
+    else process.env.SAVIA_WORKSPACE_DIR = prev;
+  }
+});
+
+// ── Error tolerance ────────────────────────────────────────────────────────
+
+test("nonexistent file: still stamps with unknown hash, no throw", async () => {
+  const input = makeInput("read", "/tmp/does-not-exist-12345.md");
+  const output = makeOutput(makeLongOutput(250));
+  await expect(contextOriginStamp(input as any, output)).resolves.toBeUndefined();
+});
+
+test("after-guard contract: never throws (best-effort)", async () => {
+  // Pass garbage to ensure non-throwing behavior
+  await expect(contextOriginStamp(null as any, null as any)).resolves.toBeUndefined();
+  await expect(contextOriginStamp({} as any, {} as any)).resolves.toBeUndefined();
+});

--- a/.opencode/plugins/__tests__/subagent-audience-filter.test.ts
+++ b/.opencode/plugins/__tests__/subagent-audience-filter.test.ts
@@ -1,0 +1,190 @@
+// subagent-audience-filter.test.ts — SE-221 Slice 3 (OpenCode port)
+//
+// TDD for guards/subagent-audience-filter.ts.
+// Mirrors tests/test-context-capability.bats audience-filter assertions
+// (AC-16 in SE-221 spec). PreToolUse `task` hook: logs which lazy imports
+// each subagent has audience access to, deny-by-default for unknown agents.
+//
+// The hook is non-blocking: it only logs to output/audience-filter.jsonl,
+// never mutates the task invocation. Tests assert log payload shape.
+
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import { subagentAudienceFilter } from "../guards/subagent-audience-filter.ts";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let testWs: string;
+let auditLog: string;
+let graphPath: string;
+let prevWs: string | undefined;
+let prevAudit: string | undefined;
+
+const SAMPLE_GRAPH = {
+  agents: {
+    architect: [
+      "/ws/docs/rules/domain/architecture.md",
+      "/ws/docs/rules/domain/layering.md",
+    ],
+    "code-reviewer": [
+      "/ws/docs/rules/domain/owasp.md",
+      "/ws/docs/rules/domain/layering.md",
+    ],
+    "all-agents": [
+      "/ws/docs/rules/domain/radical-honesty.md",
+      "/ws/CLAUDE.md",
+    ],
+    "humans-only": [
+      "/ws/docs/private/personnel.md",
+    ],
+  },
+};
+
+beforeAll(() => {
+  testWs = mkdtempSync(join(tmpdir(), "se221-audience-"));
+  mkdirSync(join(testWs, "output"), { recursive: true });
+  graphPath = join(testWs, "output", "context-audience-graph.json");
+  auditLog = join(testWs, "output", "audience-filter.jsonl");
+  writeFileSync(graphPath, JSON.stringify(SAMPLE_GRAPH, null, 2));
+
+  prevWs = process.env.SAVIA_WORKSPACE_DIR;
+  process.env.SAVIA_WORKSPACE_DIR = testWs;
+  prevAudit = process.env.AUDIENCE_FILTER_AUDIT_LOG;
+  process.env.AUDIENCE_FILTER_AUDIT_LOG = auditLog;
+});
+
+afterAll(() => {
+  if (prevWs === undefined) delete process.env.SAVIA_WORKSPACE_DIR;
+  else process.env.SAVIA_WORKSPACE_DIR = prevWs;
+  if (prevAudit === undefined) delete process.env.AUDIENCE_FILTER_AUDIT_LOG;
+  else process.env.AUDIENCE_FILTER_AUDIT_LOG = prevAudit;
+  rmSync(testWs, { recursive: true, force: true });
+});
+
+function makeTaskInput(subagent: string) {
+  return { tool: "task", args: { subagent_type: subagent, description: "test", prompt: "x" } };
+}
+
+function readLastAudit(): any | null {
+  if (!existsSync(auditLog)) return null;
+  const content = readFileSync(auditLog, "utf-8").trim();
+  if (!content) return null;
+  const last = content.split("\n").filter(Boolean).pop()!;
+  return JSON.parse(last);
+}
+
+// ── Shape & no-op cases ─────────────────────────────────────────────────────
+
+test("non-task tool: passthrough, no audit entry", async () => {
+  const before = existsSync(auditLog) ? readFileSync(auditLog, "utf-8").length : 0;
+  const input = { tool: "read", args: { filePath: "/x" } };
+  await subagentAudienceFilter(input as any, {} as any);
+  const after = existsSync(auditLog) ? readFileSync(auditLog, "utf-8").length : 0;
+  expect(after).toBe(before);
+});
+
+test("task without subagent_type: passthrough", async () => {
+  const before = existsSync(auditLog) ? readFileSync(auditLog, "utf-8").length : 0;
+  const input = { tool: "task", args: { description: "no subagent" } };
+  await subagentAudienceFilter(input as any, {} as any);
+  const after = existsSync(auditLog) ? readFileSync(auditLog, "utf-8").length : 0;
+  expect(after).toBe(before);
+});
+
+test("before-guard contract: never throws on garbage input", async () => {
+  await expect(subagentAudienceFilter(null as any, null as any)).resolves.toBeUndefined();
+  await expect(subagentAudienceFilter({} as any, {} as any)).resolves.toBeUndefined();
+});
+
+// ── Filter logic ───────────────────────────────────────────────────────────
+
+test("known agent (architect): allowed includes own + all-agents files", async () => {
+  await subagentAudienceFilter(makeTaskInput("architect") as any, {} as any);
+  const entry = readLastAudit();
+  expect(entry).not.toBeNull();
+  expect(entry.filter.subagent).toBe("architect");
+  expect(entry.filter.allowed).toContain("/ws/docs/rules/domain/architecture.md");
+  expect(entry.filter.allowed).toContain("/ws/docs/rules/domain/layering.md");
+  expect(entry.filter.allowed).toContain("/ws/CLAUDE.md");
+  expect(entry.filter.allowed).toContain("/ws/docs/rules/domain/radical-honesty.md");
+  // OWASP belongs to code-reviewer only → architect must NOT have it
+  expect(entry.filter.allowed).not.toContain("/ws/docs/rules/domain/owasp.md");
+});
+
+test("known agent: humans-only files are denied", async () => {
+  await subagentAudienceFilter(makeTaskInput("architect") as any, {} as any);
+  const entry = readLastAudit();
+  expect(entry.filter.denied).toContain("/ws/docs/private/personnel.md");
+});
+
+test("unknown agent: only all-agents files are allowed (deny-by-default)", async () => {
+  await subagentAudienceFilter(makeTaskInput("never-seen-agent") as any, {} as any);
+  const entry = readLastAudit();
+  expect(entry.filter.subagent).toBe("never-seen-agent");
+  expect(entry.filter.allowed).toContain("/ws/CLAUDE.md");
+  expect(entry.filter.allowed).toContain("/ws/docs/rules/domain/radical-honesty.md");
+  expect(entry.filter.allowed).not.toContain("/ws/docs/rules/domain/architecture.md");
+  expect(entry.filter.allowed).not.toContain("/ws/docs/rules/domain/owasp.md");
+  expect(entry.filter.denied).toContain("/ws/docs/private/personnel.md");
+});
+
+test("count fields match allowed/denied lengths", async () => {
+  await subagentAudienceFilter(makeTaskInput("code-reviewer") as any, {} as any);
+  const entry = readLastAudit();
+  expect(entry.filter.n_allowed).toBe(entry.filter.allowed.length);
+  expect(entry.filter.n_denied).toBe(entry.filter.denied.length);
+});
+
+test("audit log entry has timestamp", async () => {
+  await subagentAudienceFilter(makeTaskInput("architect") as any, {} as any);
+  const entry = readLastAudit();
+  expect(typeof entry.ts).toBe("string");
+  expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+});
+
+// ── Missing graph fallback ─────────────────────────────────────────────────
+
+test("missing graph file: passthrough silently, no audit", async () => {
+  const tmpEmpty = mkdtempSync(join(tmpdir(), "se221-empty-"));
+  mkdirSync(join(tmpEmpty, "output"), { recursive: true });
+  const tmpAudit = join(tmpEmpty, "output", "audience-filter.jsonl");
+
+  const prevWsLocal = process.env.SAVIA_WORKSPACE_DIR;
+  const prevAuditLocal = process.env.AUDIENCE_FILTER_AUDIT_LOG;
+  process.env.SAVIA_WORKSPACE_DIR = tmpEmpty;
+  process.env.AUDIENCE_FILTER_AUDIT_LOG = tmpAudit;
+  try {
+    await subagentAudienceFilter(makeTaskInput("architect") as any, {} as any);
+    expect(existsSync(tmpAudit)).toBe(false);
+  } finally {
+    if (prevWsLocal === undefined) delete process.env.SAVIA_WORKSPACE_DIR;
+    else process.env.SAVIA_WORKSPACE_DIR = prevWsLocal;
+    if (prevAuditLocal === undefined) delete process.env.AUDIENCE_FILTER_AUDIT_LOG;
+    else process.env.AUDIENCE_FILTER_AUDIT_LOG = prevAuditLocal;
+    rmSync(tmpEmpty, { recursive: true, force: true });
+  }
+});
+
+test("malformed graph file: passthrough silently, no throw", async () => {
+  const tmpBad = mkdtempSync(join(tmpdir(), "se221-bad-"));
+  mkdirSync(join(tmpBad, "output"), { recursive: true });
+  const tmpGraph = join(tmpBad, "output", "context-audience-graph.json");
+  writeFileSync(tmpGraph, "{ not valid json");
+
+  const prevWsLocal = process.env.SAVIA_WORKSPACE_DIR;
+  process.env.SAVIA_WORKSPACE_DIR = tmpBad;
+  try {
+    await expect(subagentAudienceFilter(makeTaskInput("architect") as any, {} as any)).resolves.toBeUndefined();
+  } finally {
+    if (prevWsLocal === undefined) delete process.env.SAVIA_WORKSPACE_DIR;
+    else process.env.SAVIA_WORKSPACE_DIR = prevWsLocal;
+    rmSync(tmpBad, { recursive: true, force: true });
+  }
+});
+
+test("guard does not mutate input.args (passthrough)", async () => {
+  const input = makeTaskInput("architect");
+  const argsBefore = JSON.stringify(input.args);
+  await subagentAudienceFilter(input as any, {} as any);
+  expect(JSON.stringify(input.args)).toBe(argsBefore);
+});

--- a/.opencode/plugins/guards/context-drop-after-use.ts
+++ b/.opencode/plugins/guards/context-drop-after-use.ts
@@ -1,0 +1,199 @@
+// context-drop-after-use.ts — SE-221 Slice 2 (OpenCode port)
+//
+// Capa context-engineering of Savia Shield: post-tool context minimizer.
+// Port of `.claude/hooks/context-drop-after-use.sh` for OpenCode v1.14+.
+//
+// Runs AFTER `read`/`webfetch`/`bash` tool execution. If the output is over
+// CONTEXT_DROP_MIN_LINES (default 500) lines, delegates to
+// scripts/context-drop-after-use.sh for a KEEP/STUB/DROP verdict.
+// STUB and DROP rewrite output.output to a compact stub marker:
+//
+//   <stub origin="<path>" tier="<tier>" full-content-at="<path>" abstract="<line>"/>
+//
+// Each decision (including KEEP) is logged to the audit JSONL
+// (default: <workspace>/output/context-drop-audit.jsonl; overridable via
+// CONTEXT_DROP_AUDIT_LOG).
+//
+// - Non-blocking: never throws.
+// - Idempotent: if output already starts with "<stub origin=", passthrough.
+// - Tier and verdict logic: delegated to scripts/context-drop-after-use.sh
+//   (single source of truth shared with the bash hook).
+//
+// Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-07, AC-08, AC-09)
+// Empirical: probe SE-221 confirmed output.output mutation is observed by the LLM.
+
+import { extractToolName, extractFilePath, type ToolInput, type ToolOutput } from "../lib/hook-input.ts";
+
+const MIN_LINES = Number(process.env.CONTEXT_DROP_MIN_LINES ?? "500");
+
+function workspaceRoot(): string {
+  return process.env.SAVIA_WORKSPACE_DIR ?? process.cwd();
+}
+
+function dropScriptPath(): string {
+  return workspaceRoot() + "/scripts/context-drop-after-use.sh";
+}
+
+function defaultAuditPath(): string {
+  return process.env.CONTEXT_DROP_AUDIT_LOG ?? (workspaceRoot() + "/output/context-drop-audit.jsonl");
+}
+
+function countLines(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 10) n++;
+  return n;
+}
+
+function estimateTokens(s: string): number {
+  return Math.floor(Buffer.byteLength(s, "utf-8") / 4);
+}
+
+type Verdict = "KEEP" | "STUB" | "DROP";
+
+interface VerdictResult {
+  verdict: Verdict;
+  tier: string;
+  abstract: string;
+  reason: string;
+}
+
+async function runDropScript(filePath: string, nextTask: string): Promise<VerdictResult | null> {
+  try {
+    const script = dropScriptPath();
+    const { spawn } = await import("node:child_process");
+    return await new Promise<VerdictResult | null>((resolve) => {
+      const args = ["bash", script, "--json", "--path", filePath, "--next-task", nextTask];
+      const child = spawn(args[0], args.slice(1), { stdio: ["ignore", "pipe", "ignore"] });
+      let buf = "";
+      child.stdout.on("data", (chunk) => { buf += String(chunk); });
+      const timeout = setTimeout(() => {
+        try { child.kill(); } catch {}
+        resolve(null);
+      }, 3000);
+      child.on("close", () => {
+        clearTimeout(timeout);
+        try {
+          const parsed = JSON.parse(buf.trim());
+          if (!parsed || typeof parsed !== "object" || !parsed.verdict) {
+            resolve(null);
+            return;
+          }
+          const v = String(parsed.verdict).toUpperCase();
+          if (v !== "KEEP" && v !== "STUB" && v !== "DROP") {
+            resolve(null);
+            return;
+          }
+          resolve({
+            verdict: v as Verdict,
+            tier: String(parsed.tier ?? "untrusted"),
+            abstract: String(parsed.abstract ?? ""),
+            reason: String(parsed.reason ?? ""),
+          });
+        } catch {
+          resolve(null);
+        }
+      });
+      child.on("error", () => {
+        clearTimeout(timeout);
+        resolve(null);
+      });
+    });
+  } catch {
+    return null;
+  }
+}
+
+function buildStub(filePath: string, tier: string, verdict: Verdict, abstract: string, reason: string): string {
+  if (verdict === "DROP") {
+    return '<stub origin="' + filePath + '" tier="' + tier + '" verdict="DROP" reason="' + reason.replace(/"/g, "'") + '"/>';
+  }
+  // STUB
+  const safeAbstract = (abstract || "(abstract no disponible)").replace(/"/g, "'");
+  return '<stub origin="' + filePath + '" tier="' + tier + '" full-content-at="' + filePath + '" abstract="' + safeAbstract + '"/>';
+}
+
+async function appendAudit(entry: object): Promise<void> {
+  try {
+    const { appendFile, mkdir } = await import("node:fs/promises");
+    const { dirname } = await import("node:path");
+    const auditPath = defaultAuditPath();
+    await mkdir(dirname(auditPath), { recursive: true });
+    await appendFile(auditPath, JSON.stringify(entry) + "\n");
+  } catch {
+    // Best-effort audit logging
+  }
+}
+
+function resolvePath(tool: string, input: ToolInput, output: ToolOutput): string {
+  if (tool === "read") {
+    return extractFilePath(input, output);
+  }
+  if (tool === "webfetch") {
+    const args = (output as any)?.args ?? (input as any)?.args ?? {};
+    const url = args?.url;
+    return typeof url === "string" ? url : "";
+  }
+  if (tool === "bash") {
+    // Bash has no canonical path; sandbox placeholder triggers exemption
+    return "/tmp/opencode/bash-output.txt";
+  }
+  return "";
+}
+
+export async function contextDropAfterUse(input: ToolInput, output: ToolOutput): Promise<void> {
+  try {
+    if (!output || typeof output !== "object") return;
+    const tool = extractToolName(input);
+    if (tool !== "read" && tool !== "webfetch" && tool !== "bash") return;
+
+    const filePath = resolvePath(tool, input, output);
+    if (!filePath) return;
+
+    // Sandbox exemption for bash and any /tmp/opencode/* read
+    if (filePath.startsWith("/tmp/opencode/")) return;
+
+    const text = (output as any).output;
+    if (typeof text !== "string") return;
+
+    if (countLines(text) < MIN_LINES) return;
+
+    // Idempotency: already a stub
+    const firstNewline = text.indexOf("\n");
+    const firstLine = firstNewline === -1 ? text : text.slice(0, firstNewline);
+    if (firstLine.startsWith("<stub origin=")) return;
+
+    const nextTask = process.env.CONTEXT_DROP_NEXT_TASK ?? "";
+    const verdict = await runDropScript(filePath, nextTask);
+    if (!verdict) return;
+
+    const origBytes = Buffer.byteLength(text, "utf-8");
+    let tokensSaved = 0;
+    let newOutput = text;
+
+    if (verdict.verdict === "KEEP") {
+      // No mutation, just audit
+    } else if (verdict.verdict === "DROP") {
+      newOutput = buildStub(filePath, verdict.tier, "DROP", "", verdict.reason);
+      tokensSaved = Math.floor(origBytes / 4);
+      (output as any).output = newOutput;
+    } else if (verdict.verdict === "STUB") {
+      newOutput = buildStub(filePath, verdict.tier, "STUB", verdict.abstract, verdict.reason);
+      const savedBytes = origBytes - verdict.abstract.length - 200;
+      tokensSaved = savedBytes > 0 ? Math.floor(savedBytes / 4) : 0;
+      (output as any).output = newOutput;
+    }
+
+    await appendAudit({
+      ts: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+      tool,
+      path: filePath,
+      tier: verdict.tier,
+      verdict: verdict.verdict,
+      reason: verdict.reason,
+      next_task_excerpt: nextTask.slice(0, 80),
+      tokens_saved_est: tokensSaved,
+    });
+  } catch {
+    // Best-effort: never throw from an after-guard.
+  }
+}

--- a/.opencode/plugins/guards/context-origin-stamp.ts
+++ b/.opencode/plugins/guards/context-origin-stamp.ts
@@ -1,0 +1,127 @@
+// context-origin-stamp.ts — SE-221 Slice 1 (OpenCode port)
+//
+// Capa context-engineering of Savia Shield: post-Read origin tagger.
+// Port of `.claude/hooks/context-origin-stamp.sh` for OpenCode v1.14+.
+//
+// Runs AFTER `read` tool execution. If the output is over CONTEXT_ORIGIN_MIN_LINES
+// (default 200) lines, prefixes the output.output string with a YAML block:
+//
+//   ---origin
+//   path: <abs>
+//   tier: <N1..N5|untrusted|sandbox>
+//   loaded_at: <ISO-8601>
+//   size_tokens: <est>
+//   hash: sha256:<8>
+//   ---
+//
+// - Exempt: /tmp/opencode/* sandbox.
+// - Idempotent: skips if first line is already "---origin".
+// - Non-blocking: any error returns silently (passthrough).
+// - Tier resolution: delegated to scripts/context-origin-tag.sh
+//   (single source of truth shared with the bash hook).
+//
+// Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-02, AC-03)
+// Empirical: probe SE-221 confirmed output.output mutation is observed by the LLM.
+
+import { extractToolName, extractFilePath, type ToolInput, type ToolOutput } from "../lib/hook-input.ts";
+
+const MIN_LINES = Number(process.env.CONTEXT_ORIGIN_MIN_LINES ?? "200");
+
+function workspaceRoot(): string {
+  return process.env.SAVIA_WORKSPACE_DIR ?? process.cwd();
+}
+
+function tagScriptPath(): string {
+  return `${workspaceRoot()}/scripts/context-origin-tag.sh`;
+}
+
+async function resolveTier(filePath: string): Promise<string> {
+  try {
+    const script = tagScriptPath();
+    const { spawn } = await import("node:child_process");
+    return await new Promise<string>((resolve) => {
+      const child = spawn("bash", [script, filePath], { stdio: ["ignore", "pipe", "ignore"] });
+      let buf = "";
+      child.stdout.on("data", (chunk) => {
+        buf += String(chunk);
+      });
+      const timeout = setTimeout(() => {
+        try { child.kill(); } catch {}
+        resolve("untrusted");
+      }, 2000);
+      child.on("close", () => {
+        clearTimeout(timeout);
+        const tier = buf.trim().split(/\r?\n/)[0] || "untrusted";
+        resolve(tier);
+      });
+      child.on("error", () => {
+        clearTimeout(timeout);
+        resolve("untrusted");
+      });
+    });
+  } catch {
+    return "untrusted";
+  }
+}
+
+async function fileHash(filePath: string): Promise<string> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const { createHash } = await import("node:crypto");
+    const buf = await readFile(filePath);
+    return createHash("sha256").update(buf).digest("hex").slice(0, 8);
+  } catch {
+    return "unknown";
+  }
+}
+
+function countLines(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 10) n++;
+  return n;
+}
+
+function estimateTokens(s: string): number {
+  return Math.floor(Buffer.byteLength(s, "utf-8") / 4);
+}
+
+export async function contextOriginStamp(input: ToolInput, output: ToolOutput): Promise<void> {
+  try {
+    if (!output || typeof output !== "object") return;
+
+    const tool = extractToolName(input);
+    if (tool !== "read") return;
+
+    const filePath = extractFilePath(input, output);
+    if (!filePath) return;
+
+    if (filePath.startsWith("/tmp/opencode/")) return;
+
+    const text = (output as any).output;
+    if (typeof text !== "string") return;
+
+    if (countLines(text) < MIN_LINES) return;
+
+    const firstNewline = text.indexOf("\n");
+    const firstLine = firstNewline === -1 ? text : text.slice(0, firstNewline);
+    if (firstLine === "---origin") return;
+
+    const tier = await resolveTier(filePath);
+    const hash = await fileHash(filePath);
+    const sizeTokens = estimateTokens(text);
+    const loadedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+
+    const block =
+      "---origin\n" +
+      "path: " + filePath + "\n" +
+      "tier: " + tier + "\n" +
+      "loaded_at: " + loadedAt + "\n" +
+      "size_tokens: " + sizeTokens + "\n" +
+      "hash: sha256:" + hash + "\n" +
+      "---";
+
+    (output as any).output = block + "\n" + text;
+  } catch {
+    // Best-effort: never throw from an after-guard.
+  }
+}

--- a/.opencode/plugins/guards/subagent-audience-filter.ts
+++ b/.opencode/plugins/guards/subagent-audience-filter.ts
@@ -1,0 +1,123 @@
+// subagent-audience-filter.ts — SE-221 Slice 3 (OpenCode port)
+//
+// Capa context-engineering of Savia Shield: PreToolUse `task` audience filter.
+// Port of `.claude/hooks/subagent-audience-filter.sh` for OpenCode v1.14+.
+//
+// When a subagent is invoked via the `task` tool, this guard inspects the
+// audience graph (output/context-audience-graph.json) and logs which lazy
+// imports the subagent has audience access to vs which are denied. The
+// logic is "deny-by-default" for unknown subagents (they only see files
+// marked `audience: all-agents`).
+//
+// The hook is NON-BLOCKING and NON-MUTATING:
+// - Passes the task invocation through unchanged.
+// - Side-effect: appends one line to output/audience-filter.jsonl with the
+//   filtered allowed/denied lists. Other components (e.g., a context
+//   loader) may consume that log to enforce the filter at load time.
+//
+// Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-16)
+
+import { extractToolName, type ToolInput, type ToolOutput } from "../lib/hook-input.ts";
+
+function workspaceRoot(): string {
+  return process.env.SAVIA_WORKSPACE_DIR ?? process.cwd();
+}
+
+function graphPath(): string {
+  return workspaceRoot() + "/output/context-audience-graph.json";
+}
+
+function auditLogPath(): string {
+  return process.env.AUDIENCE_FILTER_AUDIT_LOG ?? (workspaceRoot() + "/output/audience-filter.jsonl");
+}
+
+interface AudienceGraph {
+  agents: Record<string, string[]>;
+}
+
+interface FilterResult {
+  subagent: string;
+  allowed: string[];
+  denied: string[];
+  n_allowed: number;
+  n_denied: number;
+}
+
+async function loadGraph(): Promise<AudienceGraph | null> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const raw = await readFile(graphPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || !parsed.agents) return null;
+    return parsed as AudienceGraph;
+  } catch {
+    return null;
+  }
+}
+
+function computeFilter(subagent: string, graph: AudienceGraph): FilterResult {
+  const agents = graph.agents ?? {};
+  const allowedSet = new Set<string>();
+  for (const p of agents[subagent] ?? []) allowedSet.add(p);
+  for (const p of agents["all-agents"] ?? []) allowedSet.add(p);
+
+  // All audience-targeted files across the graph
+  const allFiles = new Set<string>();
+  for (const list of Object.values(agents)) {
+    for (const p of list) allFiles.add(p);
+  }
+
+  // denied = files with audience that don't include subagent or all-agents
+  const deniedSet = new Set<string>();
+  for (const f of allFiles) if (!allowedSet.has(f)) deniedSet.add(f);
+
+  // humans-only override: always denied for any subagent
+  const humansOnly = new Set<string>(agents["humans-only"] ?? []);
+  for (const f of humansOnly) {
+    allowedSet.delete(f);
+    if (allFiles.has(f)) deniedSet.add(f);
+  }
+
+  const allowed = Array.from(allowedSet).sort();
+  const denied = Array.from(deniedSet).sort();
+  return {
+    subagent,
+    allowed,
+    denied,
+    n_allowed: allowed.length,
+    n_denied: denied.length,
+  };
+}
+
+async function appendAudit(filter: FilterResult): Promise<void> {
+  try {
+    const { appendFile, mkdir } = await import("node:fs/promises");
+    const { dirname } = await import("node:path");
+    const path = auditLogPath();
+    await mkdir(dirname(path), { recursive: true });
+    const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    const entry = JSON.stringify({ ts, filter });
+    await appendFile(path, entry + "\n");
+  } catch {
+    // Best-effort audit logging
+  }
+}
+
+export async function subagentAudienceFilter(input: ToolInput, _output: ToolOutput): Promise<void> {
+  try {
+    const tool = extractToolName(input);
+    if (tool !== "task") return;
+
+    const args = (input as any)?.args ?? {};
+    const subagent = args?.subagent_type;
+    if (typeof subagent !== "string" || subagent.length === 0) return;
+
+    const graph = await loadGraph();
+    if (!graph) return;
+
+    const filter = computeFilter(subagent, graph);
+    await appendAudit(filter);
+  } catch {
+    // Best-effort: never throw from a before-guard.
+  }
+}

--- a/.opencode/plugins/guards/tdd-gate.ts
+++ b/.opencode/plugins/guards/tdd-gate.ts
@@ -88,18 +88,27 @@ export async function tddGate(input: ToolInput, output: ToolOutput): Promise<voi
     `test_${verdict.nameNoExt}.`,
   ];
 
-  // Walk up from the file's directory toward repo root, scanning each dir.
+  // Walk up from the file's directory toward repo root. At each level we
+  // scan the directory itself AND its conventional sibling test directories
+  // (__tests__, tests, test, spec, specs) — this mirrors Bun/Vitest/Jest
+  // conventions where production code lives in src/ and tests in __tests__/.
+  // Pre-fix bug: only top-level dirs were scanned, missing tests colocated
+  // in __tests__/ siblings. (Documented in RESUME-se-221-opencode-port.md.)
+  const TEST_SUBDIRS = ["__tests__", "tests", "test", "spec", "specs"];
   let dir = filePath.slice(0, filePath.lastIndexOf("/")) || "/";
   for (let depth = 0; depth < 8 && dir && dir !== "/"; depth++) {
-    try {
-      const entries = await readdir(dir);
-      for (const e of entries) {
-        if (candidatePatterns.some((p) => e.startsWith(p))) {
-          return; // test exists nearby — pass
+    const candidates: string[] = [dir, ...TEST_SUBDIRS.map((sub) => `${dir}/${sub}`)];
+    for (const probe of candidates) {
+      try {
+        const entries = await readdir(probe);
+        for (const e of entries) {
+          if (candidatePatterns.some((p) => e.startsWith(p))) {
+            return; // test exists nearby — pass
+          }
         }
+      } catch {
+        // dir unreadable — keep walking
       }
-    } catch {
-      // dir unreadable — keep walking
     }
     const next = dir.slice(0, dir.lastIndexOf("/")) || "/";
     if (next === dir) break;

--- a/.opencode/plugins/lib/hook-input.ts
+++ b/.opencode/plugins/lib/hook-input.ts
@@ -22,8 +22,18 @@ export type ToolInput = {
   args?: Record<string, unknown>;
 };
 
+// OpenCode v1.14 ToolOutput contract (per https://opencode.ai/docs/plugins/):
+//   - args: MUTABLE args object (input mirror)
+//   - title: tool display title
+//   - output: stdout/result text (mutable in tool.execute.after)
+//   - metadata: tool-specific metadata
+// SE-221 added output/title/metadata as optional fields so guards that mutate
+// output (context-origin-stamp, context-drop-after-use) can be typed end-to-end.
 export type ToolOutput = {
   args?: Record<string, unknown>;
+  title?: string;
+  output?: string;
+  metadata?: Record<string, unknown>;
 };
 
 function pickArgs(input?: ToolInput, output?: ToolOutput): Record<string, unknown> {

--- a/.opencode/plugins/lib/sovereignty-patterns.ts
+++ b/.opencode/plugins/lib/sovereignty-patterns.ts
@@ -215,7 +215,8 @@ export function isScriptPath(path: string): boolean {
 
 // ── N1 destination classification ─────────────────────────────────────────
 
-const N1_DEST_RX = /(\/docs\/|\.claude\/rules\/|\.claude\/skills\/|\.claude\/agents\/|\.claude\/commands\/|\.claude\/hooks\/|scripts\/|tests\/|\.github\/|CLAUDE\.md|CHANGELOG\.md|README)/i;
+// SE-221: alineado con .claude/hooks/data-sovereignty-gate.sh linea 174. Incluye .opencode/{skills,agents,commands,hooks,plugins}/
+const N1_DEST_RX = /(\/docs\/|\.claude\/rules\/|\.claude\/skills\/|\.claude\/agents\/|\.claude\/commands\/|\.claude\/hooks\/|\.opencode\/skills\/|\.opencode\/agents\/|\.opencode\/commands\/|\.opencode\/hooks\/|\.opencode\/plugins\/|scripts\/|tests\/|\.github\/|CLAUDE\.md|CHANGELOG\.md|README)/i;
 
 export function isN1Destination(path: string): boolean {
   return N1_DEST_RX.test(path);
@@ -230,7 +231,8 @@ export function isPrivateDestination(path: string): boolean {
 }
 
 export function isHookSelfRef(path: string): boolean {
-  return /\/\.claude\/hooks\/|^\/?\.claude\/hooks\/|\/tests\/hooks\/|^tests\/hooks\//.test(path);
+  // SE-221: extendido para .opencode/{hooks,plugins}/
+  return /\/\.claude\/hooks\/|^\/?\.claude\/hooks\/|\/\.opencode\/hooks\/|^\/?\.opencode\/hooks\/|\/\.opencode\/plugins\/|^\/?\.opencode\/plugins\/|\/tests\/hooks\/|^tests\/hooks\//.test(path);
 }
 
 export function isShieldScript(path: string): boolean {

--- a/.opencode/plugins/savia-foundation.ts
+++ b/.opencode/plugins/savia-foundation.ts
@@ -44,6 +44,10 @@ import { tddGate } from "./guards/tdd-gate.ts";
 import { dataSovereigntyAudit } from "./guards/data-sovereignty-audit.ts";
 import { autoGrillMe } from "./guards/auto-grill-me.ts";
 import { autoZoomOut } from "./guards/auto-zoom-out.ts";
+// SE-221: context-engineering guards (port of bash hooks)
+import { contextOriginStamp } from "./guards/context-origin-stamp.ts";
+import { contextDropAfterUse } from "./guards/context-drop-after-use.ts";
+import { subagentAudienceFilter } from "./guards/subagent-audience-filter.ts";
 
 const BEFORE_GUARDS = [
   // Cheap guards first — fail fast.
@@ -61,10 +65,16 @@ const BEFORE_GUARDS = [
   // SE-091: caveman always-on reminders (non-blocking)
   autoGrillMe,
   autoZoomOut,
+  // SE-221 Slice 3: audience filter (PreToolUse `task`, non-blocking audit)
+  subagentAudienceFilter,
 ] as const;
 
 const AFTER_GUARDS = [
   dataSovereigntyAudit,
+  // SE-221 Slice 1: stamp origin block on long Read outputs
+  contextOriginStamp,
+  // SE-221 Slice 2: drop/stub/keep decision on long Read/WebFetch/Bash outputs
+  contextDropAfterUse,
 ] as const;
 
 // Model tier mapping for provider-agnostic agents (SPEC-127 / model-alias-schema.md)

--- a/CHANGELOG.d/se-221-context-engineering.md
+++ b/CHANGELOG.d/se-221-context-engineering.md
@@ -1,0 +1,14 @@
+---
+version_bump: minor
+section: Performance
+---
+
+### Performance
+
+- se-221: Context Origin Tagging — PostToolUse hook prefija outputs de Read >200 lineas con bloque YAML `---origin` (path, tier N1-N5, hash, tokens). Trazabilidad cuando un fichero se mueve.
+- se-221: Drop-After-Use — Hook PostToolUse para Read/WebFetch/Bash decide KEEP/STUB/DROP segun tier y next-task. Stub reemplaza outputs irrelevantes por `<stub origin="..." abstract="..."/>`. Ataque directo al context bloat.
+- se-221: Override `KEEP-CONTEXT` — usuario puede forzar KEEP en el siguiente turno cuando necesita re-leer un stub.
+- se-221: Capability Metadata `audience:` — frontmatter opcional en docs/skills (default implicito `all-agents`). Subagentes filtrados por audience-graph: deny by default sobre fragmentos audience-restringido.
+- se-221: Audience-Cross Graph — `scripts/context-audience-graph.py` produce TSV de pares con >=2 agentes compartidos en audience. Evidencia de conexiones cross-concept entre fragmentos no obviamente relacionados.
+- se-221: Knowledge Graph integracion — `scripts/knowledge-graph.py import-audience` ingiere el TSV como relacion tipada `(path_A) -[shared_audience]-> (path_B)` con `count` y agentes en `source`.
+- se-221: Metrics CLI — `scripts/context-drop-metrics.sh` reporta `total_tokens_saved`, `n_stubs`, `n_keeps`, `pct_saved` desde `output/context-drop-audit.jsonl`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 
 ## Estructura
 
-`.claude/{agents(72), commands(562), profiles, hooks(76/79reg), rules/{domain,languages}, skills(102), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
+`.claude/{agents(72), commands(562), profiles, hooks(79/82reg), rules/{domain,languages}, skills(102), settings.json}` · `docs/` · `projects/` · `scripts/` · `tests/`
 
 ## Reglas Críticas (Rules 1-8, inline)
 
@@ -77,6 +77,6 @@ NEVER `assembleDebug` — use `./gradlew buildAndPublish`. `JAVA_HOME=/snap/andr
 
 ## Hooks · Memoria
 
-74 hooks (76 registrados) en `.claude/settings.json` — arranque blindado (sin red, sin deps externas).
+77 hooks (82 registrados) en `.claude/settings.json` — arranque blindado (sin red, sin deps externas).
 Memory store: `bash scripts/memory-store.sh [recall|save|stats]`.
 Security review: `/security-review {spec}`.

--- a/docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md
+++ b/docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md
@@ -1,0 +1,247 @@
+---
+spec_id: SE-221
+title: "Inverted security patterns as context engineering: origin tagging, drop-after-use, capability metadata"
+status: PROPOSED
+priority: P2
+effort: M
+era: 206
+origin: feedback usuario sobre SE-220 — la intencion original era usar las estrategias adversariales como motor de mejora de la ingenieria de contexto, no solo como defensa
+inspiration: |
+  Informe interno de sintesis defensas-LLM <-> contexto distribuido (TL;DR: las defensas adversariales son politicas de gestion de informacion bajo desconfianza, mismo problema que contexto distribuido)
+  Informe interno de estado del arte adversarial en agentes IA
+  Hines et al. 2024 — Spotlighting (arXiv:2403.14720)
+  Debenedetti et al. 2025 — CaMeL capability-based (arXiv:2503.18813)
+  Beurer-Kellner et al. 2025 — Design Patterns Securing LLM Agents Context-Minimization (arXiv:2506.08837)
+deps:
+  - SE-220 (defensas adversariales) — precondicion: dedup de memoria + canary + isolation gate ya activos
+  - SPEC-157 (Context Pre-Flight Check) — ya estima tokens multi-fuente
+  - SE-162 (Knowledge Graph) — consumira las relaciones audience cross-concept que produce este SPEC
+  - SE-160 (RESOLVER.md) — el resolver intent->skill funciona como Plan-Then-Execute
+  - SPEC-181 (context budgets en frontmatter) — proporciona el frontmatter base que extendemos
+created: 2026-06-12
+---
+
+# SE-221 — Patrones adversariales invertidos como ingenieria de contexto
+
+## Contexto
+
+SE-220 implemento el **lado defensivo** de los patrones del informe interno
+de sintesis defensas <-> contexto distribuido: dedup de memoria, canary
+tokens, project-isolation BLOCK, catalog unification. El titulo del SPEC
+mencionaba "+ context distribution optimization" pero los 17 ACs son todos
+defensivos. La isomorfia descrita en el TL;DR del informe — las defensas
+adversariales son politicas de gestion de informacion bajo desconfianza,
+mismo problema que contexto distribuido — quedo como prosa, no como codigo.
+
+El feedback del usuario es explicito: la intencion original era **usar las
+estrategias adversariales como motor de mejora de la ingenieria de contexto
+y relacion de conceptos no necesariamente conectados**. Tres patrones del
+informe materializan esta lectura invertida y no han sido implementados:
+
+1. Spotlighting invertido — Context Origin Tagging: cada fragmento cargado
+   lleva tag `origin` automaticamente. Hoy un fichero movido pierde su
+   trazabilidad N1-N4b.
+2. Context Minimization — Drop-After-Use: tras una operacion, contenido
+   irrelevante se reemplaza por stub `path + 1-line abstract`. Hoy `Read`
+   deja el fichero entero en contexto N turnos. Mayor ROI cognitivo.
+3. Capability-based — Capability Metadata: cada fragmento con
+   `{origin, tier, audience, size_tokens, hash, last_loaded}`. Permite
+   audience-filter para subagentes Y revela conexiones cross-concept (un
+   fragmento con audience compartida por varios agentes es evidencia de
+   que esos conceptos estan conectados aunque no este explicito en prosa).
+
+## Objetivo
+
+Implementar los tres patrones adversariales como mejora de ingenieria de
+contexto, con metricas medibles de impacto en tokens y trazabilidad, y un
+AC explicito de extraccion de relaciones cross-concept que alimente el
+knowledge graph (SE-162).
+
+## Acceptance Criteria
+
+### Slice 1 — Context Origin Tagging
+
+- [ ] AC-01 `scripts/context-origin-tag.sh` (nuevo) acepta path y devuelve
+  origin tag canonico segun N1-N4b: `N1-anchor`, `N2-eager`, `N3-active-user`,
+  `N4a-lazy-ref`, `N4b-on-demand`, `N5-external` o `untrusted`. Resuelve por
+  prefijo de path, no por contenido.
+- [ ] AC-02 `.claude/hooks/context-origin-stamp.sh` (PostToolUse Read) prefija
+  el output del Read con bloque YAML:
+  ```
+  ---origin
+  path: <abs-path>
+  tier: <N1..N5|untrusted>
+  loaded_at: <ISO-8601>
+  size_tokens: <est>
+  hash: sha256:<8>
+  ---
+  ```
+  Solo aplica cuando el output supera N lineas (ficheros pequenos no pagan
+  el coste). El sandbox `/tmp/opencode/*` queda exento.
+- [ ] AC-03 Hook NO modifica el contenido, solo prefija. Idempotente: si el
+  bloque ya existe, no lo duplica.
+- [ ] AC-04 `tests/test-context-origin-tag.bats` (>=10 tests, score >=80
+  por test-auditor SPEC-055): cubre cada tier, prefijos relativos, paths
+  fuera del workspace = N5 o untrusted, sandbox excluido, idempotencia,
+  output bajo umbral no se prefija.
+- [ ] AC-05 `tests/test-context-origin-stamp-hook.bats` (>=8 tests, score
+  >=80): hook recibe stdin, escribe stdout con bloque, exit 0. Negative:
+  binary file, fichero inexistente, hook fallback no rompe Read.
+
+### Slice 2 — Drop-After-Use (mayor ROI)
+
+- [ ] AC-06 `scripts/context-drop-after-use.sh` (nuevo) acepta `--path` y
+  `--next-task` (string), devuelve veredicto `KEEP` | `DROP` | `STUB` con
+  razonamiento. Heuristica:
+  - KEEP: path es N1/N2 (siempre relevante) o aparece en `--next-task` como
+    referencia textual.
+  - STUB: path es N4a/N4b/N5, ultima lectura > umbral de turnos, no aparece
+    en next-task. Genera abstract de 1 linea (primera linea no-frontmatter
+    no vacia).
+  - DROP: path es untrusted, ya procesado, sin referencias futuras.
+- [ ] AC-07 `.claude/hooks/context-drop-after-use.sh` (PostToolUse cualquier
+  Read/WebFetch/Bash con output sobre umbral) ejecuta el script con el
+  output + el ultimo turno del usuario como `--next-task`. Si veredicto es
+  STUB, reescribe el output a:
+  ```
+  <stub origin="<path>" tier="<tier>" full-content-at="<path>" abstract="<1-line>"/>
+  ```
+- [ ] AC-08 Hook respeta override: si el usuario incluye `KEEP-CONTEXT` en
+  el siguiente turno, el stub se vuelve a expandir leyendo el path.
+- [ ] AC-09 Audit log canonico (path generico bajo `output/` con prefijo
+  `context-drop-audit`, formato JSONL): `{ts, path, verdict, abstract,
+  next_task_excerpt, tokens_saved_est}`. Una linea JSONL por decision.
+- [ ] AC-10 `tests/test-context-drop-after-use.bats` (>=12 tests, score
+  >=80): KEEP/DROP/STUB para cada combinacion, override KEEP-CONTEXT,
+  idempotencia (no re-stub un stub), abstract no vacio, JSON valido.
+- [ ] AC-11 Metrica de exito: en una sesion sobre umbral de turnos, tokens
+  ahorrados estimados como porcentaje del contexto activo de Read outputs
+  superior al objetivo establecido. Medido via el audit log. Se incluye
+  script `scripts/context-drop-metrics.sh` que reporta `total_tokens_saved`,
+  `n_stubs`, `n_keeps`, `pct_saved`.
+
+### Slice 3 — Capability Metadata (conexiones cross-concept)
+
+- [ ] AC-12 Extender frontmatter de `docs/rules/domain/*.md` y
+  `.opencode/skills/*/SKILL.md` con campo opcional:
+  ```yaml
+  audience: [list of agent names | "all-agents" | role tag]
+  ```
+  Sin tocar las que ya funcionan — `audience: all-agents` es el default
+  implicito si falta el campo.
+- [ ] AC-13 `scripts/context-capability-check.sh` valida el frontmatter:
+  - `audience` es lista o string canonico
+  - cada elemento esta en `.opencode/agents/*` (validado contra
+    AGENTS_CATALOG) o es palabra reservada `all-agents`, `humans-only`
+  - exit 1 si hay invalido, con mensaje preciso
+- [ ] AC-14 `scripts/context-audience-graph.py` (nuevo) lee todos los
+  frontmatter con `audience` y produce dos artefactos canonicos:
+  - artefacto JSON con mapping `{agent: [list of paths audience-targeted]}`
+  - artefacto TSV con pares `(path_A, path_B, shared_audience_agents,
+    audience_count)` para todos los pares con >=2 agentes en comun. Esto
+    es la evidencia de **conexiones cross-concept**.
+  Ambos en `output/` con prefijos `context-audience-graph` y
+  `context-audience-cross`.
+- [ ] AC-15 Integracion con knowledge-graph (SE-162):
+  `scripts/knowledge-graph.sh` aprende a importar el TSV como relacion
+  tipada `(path_A) -[shared_audience: {agent_count}]-> (path_B)`. Comando:
+  `bash scripts/knowledge-graph.sh import-audience`.
+- [ ] AC-16 Audience-filter en agentes: cuando un subagente arranca via
+  Task tool, hook PreToolUse `subagent-audience-filter.sh` filtra los
+  imports lazy candidatos a aquellos donde el subagente esta en `audience`.
+  Subagentes desconocidos = todos los `audience: all-agents` solamente
+  (deny by default sobre fragmentos audience-restringido).
+- [ ] AC-17 `tests/test-context-capability.bats` (>=14 tests, score >=80):
+  frontmatter valido/invalido, graph generation, cross.tsv, audience filter
+  por agente, deny by default, integracion knowledge-graph.
+
+### Slice 4 — Metricas y dashboard
+
+- [ ] AC-18 `scripts/context-engineering-report.sh` (nuevo) genera reporte
+  semanal en `output/` con prefijo `context-engineering-report`:
+  - Tokens promedio por sesion (antes vs despues SE-221)
+  - Porcentaje de outputs con origin-tag inyectado
+  - n_stubs, n_keeps, tokens ahorrados (de drop-audit)
+  - Top pares cross-audience del knowledge graph
+  - Drift detector: paths que cambiaron tier sin actualizar `audience`
+- [ ] AC-19 CHANGELOG.d fragment con 4 entries Performance/Observability:
+  origin-tagging, drop-after-use, capability-metadata, audience-graph.
+- [ ] AC-20 Documentacion en `docs/rules/domain/`:
+  - `context-origin-tagging.md` (que es, cuando aplica, override)
+  - `context-drop-after-use.md` (heuristica, override KEEP-CONTEXT)
+  - `context-audience-protocol.md` (frontmatter, deny by default)
+
+## Out of scope
+
+- **Implementacion de CaMeL completa** (DSL custom + interprete con taint
+  tracking). SE-221 implementa solo el subset capability-based aplicable
+  sin DSL: metadata estatica + filtro de audience. La taint dinamica entre
+  variables queda para SE futura.
+- **Modificacion del formato de Read del provider**: no podemos cambiar
+  la respuesta de la tool Read; el hook PostToolUse trabaja sobre la
+  representacion en contexto, no sobre el wire format.
+- **Re-arquitectura de skills/agents existentes** para anadir audience.
+  Slice 3 anade el campo como opcional. Migracion progresiva por demanda;
+  default `all-agents` no rompe nada.
+
+## Metricas de validacion
+
+- **Reduccion tokens contexto activo en sesiones largas**: objetivo de
+  ahorro porcentual significativo vs baseline pre-SE-221, medido en
+  sesiones largas via audit JSONL.
+- **Trazabilidad origin**: 100% de Reads sobre umbral tienen origin-tag
+  (verificable via `grep -c "^---origin" <session-log>` vs
+  `n_reads_over_threshold`).
+- **Conexiones cross-concept descubiertas**: numero de pares
+  `(path_A, path_B)` en el TSV de audience-cross con
+  `shared_audience_agents >= 2`. Alimenta KG.
+- **Audience-filter efectivo**: subagentes cargan en promedio menos contexto
+  que antes (delta tokens en logs de Task tool).
+- **Cero regresion**: tests de SE-220 siguen verdes, pr-plan G5 17/17.
+
+## OpenCode Implementation Plan
+
+### Bindings touched
+
+| Componente | Claude Code | OpenCode v1.14 |
+|---|---|---|
+| `context-origin-stamp.sh` (PostToolUse Read hook) | `.opencode/hooks/context-origin-stamp.sh` registered en `.claude/settings.json` | Plugin TS function `tool.execute.after` que envuelve Read; el plugin lee el script bash via `Bun.spawn` |
+| `context-drop-after-use.sh` (PostToolUse multi-tool hook) | `.opencode/hooks/context-drop-after-use.sh` en settings.json para Read/WebFetch/Bash | Plugin TS function `tool.execute.after` con switch por tool name; idem `Bun.spawn` |
+| `subagent-audience-filter.sh` (PreToolUse Task hook) | `.opencode/hooks/subagent-audience-filter.sh` en settings.json | Plugin TS function `agent.task.before` que pasa la lista filtrada de imports candidatos |
+| `context-capability-check.sh` | Invocado en hook `agents-md-auto-regenerate.sh` y en pr-plan G5 | Mismo, sin cambios — script-level, frontend-agnostic |
+| `context-audience-graph.py` | Cron-able + invocacion manual via `/context-audit` | Mismo, sin cambios — script-level |
+| Frontmatter `audience:` en docs/skills | Lectura por bash hooks | Plugin TS lee con `gray-matter` (ya disponible en node_modules) |
+
+### Verification protocol
+
+- [ ] Funciona en runtime OpenCode: smoke test invocando un Read y
+  verificando bloque `---origin` en el output del session log.
+- [ ] Tests cubren ambos paths: BATS para el lado bash; al menos 1 test TS
+  por hook en el plugin (o SKIP justificado si plugin aun no existe).
+- [ ] Si el plugin `savia-gates` no existe todavia: SE-221 documenta el
+  binding como "deferred to plugin scaffold (sub-spec future)" en lugar
+  de bloquear el merge. El hook bash es suficiente para Claude Code; la
+  paridad OpenCode se completa cuando el plugin se cree.
+
+### Portability classification
+
+- **Claude-Code-only (deferred-portable)**: la implementacion v1 es bash
+  hooks. Funciona en OpenCode v1.14 mediante el shim de symlink
+  `.opencode/hooks` -> `.claude/hooks` (verificado: `ls -la .opencode/`
+  muestra `hooks -> ../.claude/hooks`). La paridad nativa via plugin TS
+  queda como sub-spec futura cuando se cree el plugin `savia-gates`.
+
+Justificacion de eleccion: el plugin TS no existe todavia; bloquear SE-221
+hasta que se cree es scope creep. El symlink ya da paridad funcional en
+OpenCode hoy. La sub-spec futura migra el bash a TS sin cambiar la API.
+
+## Refs
+
+- Informe interno de sintesis defensas-LLM <-> contexto distribuido (los tres patrones invertidos: spotlighting, context-minimization, capability-based)
+- Informe interno de estado del arte defensas adversariales en agentes IA (base teorica)
+- SE-220 propuesta — precondicion (lado defensivo)
+- docs/rules/domain/context-placement-confirmation.md — niveles N1-N4b que el origin-tag inyecta
+- docs/rules/domain/spec-opencode-implementation-plan.md — esta seccion sigue el formato canonico (SPEC-181)
+- Hines et al. 2024, "Spotlighting" — arXiv:2403.14720
+- Debenedetti et al. 2025, "CaMeL" — arXiv:2503.18813
+- Beurer-Kellner et al. 2025, "Design Patterns Securing LLM Agents" Context-Minimization — arXiv:2506.08837

--- a/docs/rules/domain/context-audience-protocol.md
+++ b/docs/rules/domain/context-audience-protocol.md
@@ -1,0 +1,73 @@
+---
+context_tier: L4
+token_budget: 700
+audience: all-agents
+---
+
+# Regla: Context Audience Protocol
+
+> Spec: SE-221 Slice 3. Fecha: 2026-06-12.
+> Frontmatter opcional `audience:` para fragmentos de contexto.
+
+## Principio
+
+Cada fichero de regla o skill puede declarar en su frontmatter YAML un
+campo `audience:` que indica que agentes deberian consumirlo. El campo es
+opcional; si falta, el default implicito es `all-agents`.
+
+Este campo cumple dos funciones:
+
+1. Filtro para subagentes: cuando un subagente arranca via Task tool, el
+   hook subagent-audience-filter genera una lista filtrada de fragmentos
+   donde el subagente esta autorizado. Subagente desconocido recibe solo
+   ficheros con audience `all-agents` (deny by default).
+2. Revelacion de conexiones cross-concept: el script
+   context-audience-graph.py extrae pares de ficheros con dos o mas
+   agentes compartidos en su audience. Ese par es evidencia de conexion
+   no obvia que alimenta el knowledge graph.
+
+## Formato
+
+Tres variantes validas:
+
+  audience: all-agents
+  audience: [architect, code-reviewer]
+  audience:
+    - architect
+    - code-reviewer
+    - security-guardian
+
+Palabras reservadas:
+- all-agents: todos los agentes (default implicito).
+- humans-only: ningun agente, solo lectura humana.
+
+## Validacion
+
+  bash scripts/context-capability-check.sh
+
+Exit code 1 si algun fichero referencia un agente que no existe en
+.opencode/agents/. Modo --strict ademas exige que el campo exista.
+
+## Generacion del audience-graph
+
+  python3 scripts/context-audience-graph.py
+
+Produce dos artefactos en output/:
+- context-audience-graph.json (mapping agent -> paths)
+- context-audience-cross.tsv (pares con shared agents)
+
+## Integracion knowledge-graph
+
+  bash scripts/knowledge-graph.sh import-audience --tsv output/context-audience-cross.tsv
+
+Importa el TSV como relacion tipada shared_audience.
+
+## Verificacion
+
+  bats tests/test-context-capability.bats
+
+## Refs
+
+- Spec SE-221 en docs/propuestas/
+- Spec SE-162 (knowledge graph)
+- Debenedetti et al. 2025, CaMeL capability-based (arXiv:2503.18813)

--- a/docs/rules/domain/context-audience-protocol.md
+++ b/docs/rules/domain/context-audience-protocol.md
@@ -1,5 +1,5 @@
 ---
-context_tier: L4
+context_tier: L3
 token_budget: 700
 audience: all-agents
 ---

--- a/docs/rules/domain/context-drop-after-use.md
+++ b/docs/rules/domain/context-drop-after-use.md
@@ -1,0 +1,53 @@
+---
+context_tier: L4
+token_budget: 600
+audience: all-agents
+---
+
+# Regla: Context Drop-After-Use
+
+> Spec: SE-221 Slice 2. Fecha: 2026-06-12.
+> Compactacion automatica de outputs grandes que dejan de ser relevantes.
+
+## Principio
+
+Tras una operacion Read/WebFetch/Bash cuyo output supera el umbral
+(CONTEXT_DROP_MIN_LINES, default 500), el hook decide entre tres veredictos:
+
+- KEEP: contenido intacto.
+- STUB: reemplazado por etiqueta con origin, tier, abstract.
+- DROP: reemplazado por marcador minimo.
+
+Objetivo: atacar el context bloat de ficheros leidos puntualmente que
+persisten innecesariamente.
+
+## Heuristica resumida
+
+Ver scripts/context-drop-after-use.sh para la heuristica completa. Resumen:
+
+- Override textual: si el siguiente turno contiene la marca KEEP-CONTEXT,
+  fuerza KEEP siempre.
+- Tier alto (anchor o eager): KEEP.
+- Tier untrusted: DROP.
+- Sandbox: KEEP.
+- Referencia textual al basename o path en next-task: KEEP.
+- Resto: STUB con abstract de una linea.
+
+## Audit log
+
+Cada decision se loggea como JSONL en output/context-drop-audit.jsonl con
+campos basicos (ts, tool, path, tier, veredicto, ahorro estimado).
+
+## Metrics CLI
+
+  bash scripts/context-drop-metrics.sh
+  bash scripts/context-drop-metrics.sh --json
+
+## Verificacion
+
+  bats tests/test-context-drop-after-use.bats
+
+## Refs
+
+- Spec SE-221 en docs/propuestas/
+- Beurer-Kellner et al. 2025, Context-Minimization (arXiv:2506.08837)

--- a/docs/rules/domain/context-drop-after-use.md
+++ b/docs/rules/domain/context-drop-after-use.md
@@ -1,5 +1,5 @@
 ---
-context_tier: L4
+context_tier: L3
 token_budget: 600
 audience: all-agents
 ---

--- a/docs/rules/domain/context-origin-tagging.md
+++ b/docs/rules/domain/context-origin-tagging.md
@@ -1,5 +1,5 @@
 ---
-context_tier: L4
+context_tier: L3
 token_budget: 850
 audience: all-agents
 ---

--- a/docs/rules/domain/context-origin-tagging.md
+++ b/docs/rules/domain/context-origin-tagging.md
@@ -1,0 +1,59 @@
+---
+context_tier: L4
+token_budget: 850
+audience: all-agents
+---
+
+# Regla: Context Origin Tagging — Trazabilidad de fragmentos cargados
+
+> **REGLA APLICATIVA** — Aplica a outputs de Read que superan umbral de lineas.
+> Spec: SE-221 (Slice 1). Fecha: 2026-06-12
+
+## Principio
+
+Cada fragmento cargado en el contexto que supere CONTEXT_ORIGIN_MIN_LINES
+(default 200 lineas) lleva un bloque YAML al inicio que indica path, tier
+N1..N5, timestamp, tamano estimado en tokens y hash sha256 corto.
+
+El proposito es doble: trazabilidad cuando un fichero se mueve entre niveles
+N1-N4b, y auditoria post-mortem de que ficheros entraron al contexto.
+
+## Cuando se aplica
+
+- PostToolUse Read: el hook context-origin-stamp.sh prefija el output con el
+  bloque cuando supera el umbral.
+- Sandbox: exento (work-in-progress, no contexto).
+- Outputs bajo umbral: passthrough.
+- Idempotencia: si el output ya empieza por marca origin, no se duplica.
+
+## Tiers canonicos
+
+Ver mapeo completo en scripts/context-origin-tag.sh:
+
+- N1-anchor: anchor superior, hechos invariantes
+- N2-eager: carga critica eager
+- N3-active-user: perfiles + memoria del usuario activo
+- N4a-lazy-ref: tabla de referencias lazy
+- N4b-on-demand: rules/skills/agents bajo demanda
+- N4-project: datos de proyecto
+- N5-external: fuera del workspace, en HOME
+- untrusted: fuera de workspace y de HOME
+- sandbox: workspace efimero del agente
+
+## Override
+
+- Variable CONTEXT_ORIGIN_MIN_LINES ajusta el umbral (default 200).
+- Para deshabilitar el hook en una sesion concreta: NO esta soportado por
+  diseno. Si el output es problematico, ajustar el umbral.
+
+## Verificacion
+
+Tests de cobertura:
+- bats tests/test-context-origin-tag.bats
+- bats tests/test-context-origin-stamp-hook.bats
+
+## Refs
+
+- SE-221 spec en docs/propuestas/
+- docs/rules/domain/context-placement-confirmation.md
+- Hines et al. 2024, "Spotlighting" arXiv:2403.14720

--- a/scripts/context-audience-graph.py
+++ b/scripts/context-audience-graph.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+context-audience-graph.py — SE-221 Slice 3 — Audience graph generator
+
+Lee frontmatter `audience:` de docs/rules/domain/*.md y .opencode/skills/*/SKILL.md
+y produce dos artefactos:
+  - JSON con mapping {agent: [paths audience-targeted]}
+  - TSV con pares (path_A, path_B, shared_audience_agents, audience_count) para
+    todos los pares con >=2 agentes en comun. Es la evidencia de conexiones
+    cross-concept (SE-221 AC-14).
+
+Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-14)
+Inspiracion: CaMeL capabilities + revelacion de conexiones cross-concept.
+
+Uso:
+  python3 scripts/context-audience-graph.py [--workspace DIR] [--out-dir DIR]
+"""
+import sys
+import os
+import re
+import json
+import argparse
+import datetime
+from itertools import combinations
+from pathlib import Path
+from typing import Dict, List, Tuple, Set
+
+
+def find_workspace(start: str) -> str:
+    p = Path(start).resolve()
+    while p != p.parent:
+        if (p / ".git").exists() or (p / "AGENTS.md").exists():
+            return str(p)
+        p = p.parent
+    return start
+
+
+def list_target_files(ws: str) -> List[str]:
+    out = []
+    rules_dir = Path(ws) / "docs" / "rules" / "domain"
+    if rules_dir.is_dir():
+        out.extend(str(p) for p in rules_dir.glob("*.md"))
+    skills_dir = Path(ws) / ".opencode" / "skills"
+    if skills_dir.is_dir():
+        out.extend(str(p) for p in skills_dir.glob("*/SKILL.md"))
+    return sorted(set(out))
+
+
+def list_valid_agents(ws: str) -> Set[str]:
+    agents_dir = Path(ws) / ".opencode" / "agents"
+    out = {"all-agents", "humans-only"}
+    if agents_dir.is_dir():
+        for p in agents_dir.glob("*.md"):
+            out.add(p.stem)
+    return out
+
+
+def extract_audience(file: str) -> List[str]:
+    try:
+        with open(file, "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except Exception:
+        return []
+    m = re.match(r"^---\s*\n(.*?)\n---\s*\n", text, re.DOTALL)
+    if not m:
+        return []
+    fm = m.group(1)
+    lines = fm.splitlines()
+    out: List[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        am = re.match(r"^audience:\s*(.*)$", line)
+        if am:
+            inline = am.group(1).strip()
+            if inline.startswith("["):
+                content = inline.strip("[]")
+                for part in content.split(","):
+                    v = part.strip().strip('"').strip("'")
+                    if v:
+                        out.append(v)
+            elif inline:
+                out.append(inline.strip('"').strip("'"))
+            else:
+                j = i + 1
+                while j < len(lines):
+                    ml = re.match(r"^\s*-\s*(.+)$", lines[j])
+                    if ml:
+                        v = ml.group(1).strip().strip('"').strip("'")
+                        if v:
+                            out.append(v)
+                        j += 1
+                    elif re.match(r"^\S", lines[j]):
+                        break
+                    else:
+                        j += 1
+            break
+        i += 1
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", default=None)
+    parser.add_argument("--out-dir", default=None,
+                        help="dir donde escribir artefactos (default: $WS/output)")
+    parser.add_argument("--min-shared", type=int, default=2,
+                        help="numero minimo de agents compartidos para emitir par (default 2)")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    ws = args.workspace or os.environ.get("SAVIA_WORKSPACE_DIR") or find_workspace(os.getcwd())
+    out_dir = Path(args.out_dir) if args.out_dir else Path(ws) / "output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    valid_agents = list_valid_agents(ws)
+    files = list_target_files(ws)
+
+    # Mapping: file -> set(agents) (excluyendo all-agents/humans-only para grafo
+    # cross-concept). Mantenemos all-agents en el mapeo agent->files para JSON.
+    file_audience_full: Dict[str, Set[str]] = {}
+    file_audience_specific: Dict[str, Set[str]] = {}
+    agent_to_files: Dict[str, List[str]] = {}
+
+    for f in files:
+        agents = extract_audience(f)
+        # Filtrar agentes invalidos (no fallar — los reporta capability-check)
+        agents_set = set(a for a in agents if a in valid_agents)
+        rel = os.path.relpath(f, ws)
+        file_audience_full[rel] = agents_set
+        # Para cross-concept: ignorar all-agents/humans-only (universales)
+        specific = agents_set - {"all-agents", "humans-only"}
+        file_audience_specific[rel] = specific
+        for a in agents_set:
+            agent_to_files.setdefault(a, []).append(rel)
+
+    # Cross pairs: combinaciones de ficheros con >= min-shared agentes especificos
+    pairs: List[Tuple[str, str, List[str], int]] = []
+    keys = sorted(file_audience_specific.keys())
+    for a, b in combinations(keys, 2):
+        sa = file_audience_specific[a]
+        sb = file_audience_specific[b]
+        shared = sa & sb
+        if len(shared) >= args.min_shared:
+            pairs.append((a, b, sorted(shared), len(shared)))
+
+    # Output JSON
+    json_path = out_dir / "context-audience-graph.json"
+    json_data = {
+        "ts": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "workspace": ws,
+        "n_files_scanned": len(files),
+        "n_files_with_audience": sum(1 for v in file_audience_full.values() if v),
+        "n_agents_referenced": len(agent_to_files),
+        "agents": {a: sorted(files) for a, files in agent_to_files.items()},
+    }
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(json_data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+    # Output TSV
+    tsv_path = out_dir / "context-audience-cross.tsv"
+    with open(tsv_path, "w", encoding="utf-8") as fh:
+        fh.write("path_a\tpath_b\tshared_agents\taudience_count\n")
+        for a, b, shared, count in sorted(pairs, key=lambda x: -x[3]):
+            fh.write(f"{a}\t{b}\t{','.join(shared)}\t{count}\n")
+
+    if not args.quiet:
+        print(f"Scanned: {len(files)} files")
+        print(f"With audience: {json_data['n_files_with_audience']}")
+        print(f"Agents referenced: {json_data['n_agents_referenced']}")
+        print(f"Cross-concept pairs (>= {args.min_shared} shared): {len(pairs)}")
+        print(f"JSON: {json_path}")
+        print(f"TSV:  {tsv_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/context-capability-check.sh
+++ b/scripts/context-capability-check.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-capability-check.sh — SE-221 Slice 3 — Capability metadata validator
+# Valida que el frontmatter `audience:` (opcional) en docs/skills/agents
+# es sintacticamente valido y referencia agentes existentes.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-13)
+# Inspiracion: CaMeL (Debenedetti et al. 2025) — capabilities estaticas.
+#
+# Reglas:
+#   - audience puede faltar (default implicito = all-agents).
+#   - audience puede ser:
+#       * lista YAML: ["agent1", "agent2"] o - agent1\n- agent2
+#       * string canonico: "all-agents" o "humans-only"
+#       * lista mixta: ["all-agents", "agent1"] (extiende sin restringir)
+#   - cada agente referenciado debe existir en .opencode/agents/{name}.md
+#     o ser palabra reservada all-agents/humans-only.
+#
+# Uso:
+#   scripts/context-capability-check.sh [--paths PATH1 PATH2 ...] [--json] [--strict]
+#   Sin --paths: escanea docs/rules/domain/ y .opencode/skills/*/SKILL.md
+#
+# Exit codes:
+#   0 — todos OK
+#   1 — al menos un fichero invalido
+#   2 — args invalidos
+
+JSON=0
+STRICT=0
+PATHS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    --strict) STRICT=1; shift ;;
+    --paths)
+      shift
+      while [[ $# -gt 0 ]] && [[ ! "$1" =~ ^-- ]]; do
+        PATHS+=("$1"); shift
+      done
+      ;;
+    -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+AGENTS_DIR="${SAVIA_AGENTS_DIR:-$WORKSPACE/.opencode/agents}"
+
+# Construir set de agentes validos
+declare -A VALID_AGENTS
+if [[ -d "$AGENTS_DIR" ]]; then
+  while IFS= read -r f; do
+    name=$(basename "$f" .md)
+    VALID_AGENTS["$name"]=1
+  done < <(find "$AGENTS_DIR" -maxdepth 1 -name '*.md' -type f 2>/dev/null)
+fi
+# Reservadas
+VALID_AGENTS["all-agents"]=1
+VALID_AGENTS["humans-only"]=1
+
+# Default scan paths
+if [[ ${#PATHS[@]} -eq 0 ]]; then
+  while IFS= read -r f; do
+    PATHS+=("$f")
+  done < <(find "$WORKSPACE/docs/rules/domain" -name '*.md' -type f 2>/dev/null; \
+           find "$WORKSPACE/.opencode/skills" -name 'SKILL.md' -type f 2>/dev/null)
+fi
+
+# Helper: extrae bloque YAML audience: del frontmatter
+extract_audience() {
+  local file="$1"
+  python3 - "$file" <<'PY' 2>/dev/null
+import sys
+import re
+p = sys.argv[1]
+try:
+    with open(p, 'r', encoding='utf-8') as fh:
+        text = fh.read()
+except Exception:
+    sys.exit(0)
+
+# Frontmatter entre --- al inicio
+m = re.match(r'^---\s*\n(.*?)\n---\s*\n', text, re.DOTALL)
+if not m:
+    sys.exit(0)
+fm = m.group(1)
+
+# Extrae audience: <value> con captura de bloque multilinea
+lines = fm.splitlines()
+out = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    am = re.match(r'^audience:\s*(.*)$', line)
+    if am:
+        inline = am.group(1).strip()
+        if inline.startswith('['):
+            # Lista inline ["a", "b"] o [a, b]
+            content = inline.strip('[]')
+            for part in content.split(','):
+                v = part.strip().strip('"').strip("'")
+                if v:
+                    out.append(v)
+        elif inline:
+            # String simple
+            out.append(inline.strip('"').strip("'"))
+        else:
+            # Lista multilinea: leer lineas siguientes con `  - x`
+            j = i + 1
+            while j < len(lines):
+                ml = re.match(r'^\s*-\s*(.+)$', lines[j])
+                if ml:
+                    v = ml.group(1).strip().strip('"').strip("'")
+                    if v:
+                        out.append(v)
+                    j += 1
+                elif re.match(r'^\s*$', lines[j]) or re.match(r'^\s+', lines[j]):
+                    j += 1
+                    if not re.match(r'^\s*-\s+', lines[j-1]) and re.match(r'^\S', lines[j]) if j < len(lines) else True:
+                        break
+                else:
+                    break
+            i = j - 1
+        break
+    i += 1
+
+for o in out:
+    print(o)
+PY
+}
+
+ERRORS=0
+RESULTS=()
+
+validate_file() {
+  local file="$1"
+  local audience_list
+  audience_list=$(extract_audience "$file")
+  # Sin audience: ok (default implicito)
+  if [[ -z "$audience_list" ]]; then
+    if [[ "$STRICT" -eq 1 ]]; then
+      RESULTS+=("MISSING|$file|audience field absent (strict mode)")
+      ERRORS=$((ERRORS+1))
+      return
+    else
+      RESULTS+=("OK_DEFAULT|$file|implicit all-agents")
+      return
+    fi
+  fi
+  # Validar cada item
+  local invalids=()
+  while IFS= read -r item; do
+    [[ -z "$item" ]] && continue
+    if [[ -z "${VALID_AGENTS[$item]:-}" ]]; then
+      invalids+=("$item")
+    fi
+  done <<< "$audience_list"
+
+  if [[ ${#invalids[@]} -gt 0 ]]; then
+    local joined
+    joined=$(IFS=,; echo "${invalids[*]}")
+    RESULTS+=("INVALID|$file|unknown agents: $joined")
+    ERRORS=$((ERRORS+1))
+  else
+    local n_items
+    n_items=$(echo "$audience_list" | wc -l | tr -d ' ')
+    RESULTS+=("OK|$file|$n_items targets")
+  fi
+}
+
+for f in "${PATHS[@]}"; do
+  validate_file "$f"
+done
+
+# Output
+if [[ "$JSON" -eq 1 ]]; then
+  printf '{"errors":%d,"total":%d,"results":[' "$ERRORS" "${#RESULTS[@]}"
+  first=1
+  for r in "${RESULTS[@]}"; do
+    [[ $first -eq 0 ]] && printf ','
+    first=0
+    status="${r%%|*}"
+    rest="${r#*|}"
+    file="${rest%%|*}"
+    msg="${rest#*|}"
+    msg_esc=$(printf '%s' "$msg" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "$msg")
+    printf '{"status":"%s","file":"%s","msg":%s}' "$status" "$file" "$msg_esc"
+  done
+  printf ']}\n'
+else
+  for r in "${RESULTS[@]}"; do
+    status="${r%%|*}"
+    rest="${r#*|}"
+    file="${rest%%|*}"
+    msg="${rest#*|}"
+    case "$status" in
+      INVALID|MISSING) echo "FAIL [$status] $file — $msg" >&2 ;;
+      OK|OK_DEFAULT) [[ "${VERBOSE:-0}" -eq 1 ]] && echo "ok   [$status] $file — $msg" ;;
+    esac
+  done
+  if [[ "$ERRORS" -gt 0 ]]; then
+    echo "$ERRORS error(s) en ${#RESULTS[@]} ficheros" >&2
+  fi
+fi
+
+exit $(( ERRORS > 0 ? 1 : 0 ))

--- a/scripts/context-drop-after-use.sh
+++ b/scripts/context-drop-after-use.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-drop-after-use.sh — SE-221 Slice 2 — Drop-After-Use decision engine
+# Decide si un fichero leido en contexto debe mantenerse (KEEP), reemplazarse
+# por un stub (STUB), o descartarse (DROP) tras la operacion.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-06)
+# Inspiracion: Context-Minimization (Beurer-Kellner et al. 2025, arXiv:2506.08837 §6).
+#
+# Uso:
+#   scripts/context-drop-after-use.sh --path <PATH> --next-task <STRING>
+#   scripts/context-drop-after-use.sh --json --path <PATH> --next-task <STRING>
+#
+# Heuristica:
+#   KEEP — path es N1/N2 (siempre relevante), o aparece en next-task como
+#          referencia textual (filename o subpath).
+#   STUB — path es N4a/N4b/N5/N4-project, ultima lectura > umbral turnos,
+#          NO aparece en next-task. Genera abstract de 1 linea.
+#   DROP — path es untrusted, ya procesado, sin referencias futuras.
+#   KEEP-CONTEXT — override explicito en next-task: si contiene "KEEP-CONTEXT",
+#                  fuerza KEEP independientemente del tier.
+#
+# Salida:
+#   stdout: una linea "VERDICT: <reason>" (humano)
+#   o JSON con --json: {verdict, reason, abstract, tier}
+#
+# Exit codes:
+#   0 — veredicto emitido (KEEP/STUB/DROP)
+#   2 — argumentos invalidos
+
+PATH_ARG=""
+NEXT_TASK=""
+JSON=0
+ABSTRACT_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path) PATH_ARG="${2:-}"; shift 2 ;;
+    --next-task) NEXT_TASK="${2:-}"; shift 2 ;;
+    --abstract) ABSTRACT_OVERRIDE="${2:-}"; shift 2 ;;
+    --json) JSON=1; shift ;;
+    -h|--help) sed -n '2,28p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PATH_ARG" ]]; then
+  echo "ERROR: --path required" >&2
+  exit 2
+fi
+
+# Resolver workspace + tier via context-origin-tag
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TAG_SCRIPT="${SCRIPT_DIR}/context-origin-tag.sh"
+
+TIER="untrusted"
+if [[ -x "$TAG_SCRIPT" ]]; then
+  TIER=$(bash "$TAG_SCRIPT" "$PATH_ARG" 2>/dev/null || echo "untrusted")
+fi
+
+# Helper: extrae primera linea no-frontmatter no vacia como abstract
+extract_abstract() {
+  local p="$1"
+  local in_frontmatter=0
+  local seen_open=0
+  if [[ ! -f "$p" ]] || [[ ! -r "$p" ]]; then
+    echo ""
+    return
+  fi
+  while IFS= read -r line; do
+    # Detectar frontmatter ---
+    if [[ "$line" == "---" ]]; then
+      if [[ "$seen_open" -eq 0 ]]; then
+        in_frontmatter=1
+        seen_open=1
+        continue
+      else
+        in_frontmatter=0
+        continue
+      fi
+    fi
+    [[ "$in_frontmatter" -eq 1 ]] && continue
+    # Trim leading whitespace
+    cleaned="${line#"${line%%[! ]*}"}"
+    # Saltar lineas vacias
+    [[ -z "$cleaned" ]] && continue
+    # Limpiar headers markdown (#, ##, ###, ...) — quitar # iniciales y el espacio
+    while [[ "$cleaned" == \#* ]]; do
+      cleaned="${cleaned#\#}"
+    done
+    cleaned="${cleaned#"${cleaned%%[! ]*}"}"
+    # Si quedo vacio, sigue
+    [[ -z "$cleaned" ]] && continue
+    # Truncar a 200 chars
+    if [[ ${#cleaned} -gt 200 ]]; then
+      cleaned="${cleaned:0:197}..."
+    fi
+    echo "$cleaned"
+    return
+  done < "$p"
+  echo ""
+}
+
+VERDICT=""
+REASON=""
+ABSTRACT=""
+
+# === Heuristica de decision ===
+
+# 1. Override explicito KEEP-CONTEXT
+if [[ "$NEXT_TASK" == *"KEEP-CONTEXT"* ]]; then
+  VERDICT="KEEP"
+  REASON="override KEEP-CONTEXT in next-task"
+
+# 2. Tier siempre relevante
+elif [[ "$TIER" == "N1-anchor" ]] || [[ "$TIER" == "N2-eager" ]]; then
+  VERDICT="KEEP"
+  REASON="tier $TIER siempre relevante"
+
+# 3. untrusted → DROP
+elif [[ "$TIER" == "untrusted" ]]; then
+  VERDICT="DROP"
+  REASON="tier untrusted: descartado tras uso"
+
+# 4. sandbox → KEEP (work-in-progress del agente)
+elif [[ "$TIER" == "sandbox" ]]; then
+  VERDICT="KEEP"
+  REASON="sandbox: work-in-progress"
+
+# 5. Si el path aparece en next-task → KEEP
+else
+  # Comprobar si filename o subpath aparece en next-task
+  basename_path=$(basename "$PATH_ARG")
+  if [[ -n "$NEXT_TASK" ]] && { [[ "$NEXT_TASK" == *"$basename_path"* ]] || [[ "$NEXT_TASK" == *"$PATH_ARG"* ]]; }; then
+    VERDICT="KEEP"
+    REASON="referencia textual a $basename_path en next-task"
+  else
+    # 6. N4a/N4b/N5/N4-project sin referencia futura → STUB
+    VERDICT="STUB"
+    REASON="tier $TIER sin referencia en next-task"
+    if [[ -n "$ABSTRACT_OVERRIDE" ]]; then
+      ABSTRACT="$ABSTRACT_OVERRIDE"
+    else
+      ABSTRACT=$(extract_abstract "$PATH_ARG")
+    fi
+    [[ -z "$ABSTRACT" ]] && ABSTRACT="(abstract no disponible)"
+  fi
+fi
+
+# === Emitir resultado ===
+
+if [[ "$JSON" -eq 1 ]]; then
+  # JSON robust: escapar abstract
+  abs_escaped=$(printf '%s' "$ABSTRACT" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "$ABSTRACT")
+  printf '{"verdict":"%s","reason":"%s","abstract":%s,"tier":"%s","path":"%s"}\n' \
+    "$VERDICT" "$REASON" "$abs_escaped" "$TIER" "$PATH_ARG"
+else
+  echo "$VERDICT: $REASON"
+  if [[ "$VERDICT" == "STUB" ]] && [[ -n "$ABSTRACT" ]]; then
+    echo "abstract: $ABSTRACT"
+  fi
+fi
+
+exit 0

--- a/scripts/context-drop-metrics.sh
+++ b/scripts/context-drop-metrics.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-drop-metrics.sh — SE-221 Slice 2 — Drop-After-Use metrics
+# Lee output/context-drop-audit.jsonl y reporta total_tokens_saved, n_stubs,
+# n_keeps, n_drops, pct_saved.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-11)
+#
+# Uso:
+#   scripts/context-drop-metrics.sh              # human-readable
+#   scripts/context-drop-metrics.sh --json       # JSON
+#   scripts/context-drop-metrics.sh --since=YYYY-MM-DD
+
+JSON=0
+SINCE=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+AUDIT_LOG="${CONTEXT_DROP_AUDIT_LOG:-${WORKSPACE}/output/context-drop-audit.jsonl}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    --since=*) SINCE="${1#*=}"; shift ;;
+    --since) SINCE="${2:-}"; shift 2 ;;
+    --log) AUDIT_LOG="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$AUDIT_LOG" ]]; then
+  if [[ "$JSON" -eq 1 ]]; then
+    echo '{"total_tokens_saved":0,"n_stubs":0,"n_keeps":0,"n_drops":0,"n_total":0,"pct_saved":0,"audit_log":"missing"}'
+  else
+    echo "Audit log no existe: $AUDIT_LOG"
+    echo "total_tokens_saved=0 n_stubs=0 n_keeps=0 n_drops=0"
+  fi
+  exit 0
+fi
+
+# Filtro por fecha
+FILTER='.'
+if [[ -n "$SINCE" ]]; then
+  FILTER="select(.ts >= \"${SINCE}\")"
+fi
+
+# Agregaciones via jq
+RESULT=$(jq -s --arg since "$SINCE" '
+  map(
+    if $since == "" then . else select(.ts >= $since) end
+  ) |
+  {
+    n_total: length,
+    n_stubs: ([.[] | select(.verdict == "STUB")] | length),
+    n_keeps: ([.[] | select(.verdict == "KEEP")] | length),
+    n_drops: ([.[] | select(.verdict == "DROP")] | length),
+    total_tokens_saved: ([.[] | .tokens_saved_est // 0] | add // 0),
+    by_tool: ([.[] | .tool] | group_by(.) | map({tool: .[0], count: length})),
+    by_tier: ([.[] | .tier] | group_by(.) | map({tier: .[0], count: length}))
+  }
+' "$AUDIT_LOG" 2>/dev/null || echo '{}')
+
+# Estimacion pct_saved: % de operaciones que fueron STUB o DROP
+N_TOTAL=$(echo "$RESULT" | jq -r '.n_total // 0')
+N_REDUCED=$(echo "$RESULT" | jq -r '(.n_stubs // 0) + (.n_drops // 0)')
+PCT=0
+if [[ "$N_TOTAL" -gt 0 ]]; then
+  # Forzar locale C para usar punto decimal (no coma)
+  PCT=$(LC_ALL=C awk -v r="$N_REDUCED" -v t="$N_TOTAL" 'BEGIN { printf "%.1f", (r/t)*100 }')
+fi
+
+if [[ "$JSON" -eq 1 ]]; then
+  echo "$RESULT" | jq --arg pct "$PCT" '. + {pct_saved: ($pct | tonumber)}'
+else
+  echo "Context Drop-After-Use metrics"
+  echo "  log:       $AUDIT_LOG"
+  if [[ -n "$SINCE" ]]; then echo "  since:     $SINCE"; fi
+  echo "  total:     $N_TOTAL"
+  echo "  STUB:      $(echo "$RESULT" | jq -r '.n_stubs')"
+  echo "  KEEP:      $(echo "$RESULT" | jq -r '.n_keeps')"
+  echo "  DROP:      $(echo "$RESULT" | jq -r '.n_drops')"
+  echo "  tokens_saved_est: $(echo "$RESULT" | jq -r '.total_tokens_saved')"
+  echo "  pct_saved: ${PCT}%"
+fi
+
+exit 0

--- a/scripts/context-engineering-report.sh
+++ b/scripts/context-engineering-report.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-engineering-report.sh — SE-221 Slice 4 — Weekly report generator
+# Genera reporte de impacto de SE-221 desde audit logs + audience graph.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-18)
+#
+# Uso:
+#   scripts/context-engineering-report.sh             # genera report y muestra path
+#   scripts/context-engineering-report.sh --stdout    # imprime tambien a stdout
+#   scripts/context-engineering-report.sh --since=YYYY-MM-DD
+
+STDOUT=0
+SINCE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stdout) STDOUT=1; shift ;;
+    --since=*) SINCE="${1#*=}"; shift ;;
+    --since) SINCE="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+OUTPUT_DIR="$WORKSPACE/output"
+mkdir -p "$OUTPUT_DIR"
+
+# Output filename con fecha
+DATE_TAG=$(date +%Y%m%d 2>/dev/null || echo "unknown")
+REPORT="$OUTPUT_DIR/${DATE_TAG}-context-engineering-report.md"
+
+DROP_AUDIT="$OUTPUT_DIR/context-drop-audit.jsonl"
+AUDIENCE_GRAPH="$OUTPUT_DIR/context-audience-graph.json"
+AUDIENCE_CROSS="$OUTPUT_DIR/context-audience-cross.tsv"
+DROP_METRICS="$SCRIPT_DIR/context-drop-metrics.sh"
+
+# Recolectar metricas
+DROP_JSON='{}'
+if [[ -f "$DROP_AUDIT" ]] && [[ -x "$DROP_METRICS" ]]; then
+  if [[ -n "$SINCE" ]]; then
+    DROP_JSON=$(bash "$DROP_METRICS" --json --since="$SINCE" --log "$DROP_AUDIT" 2>/dev/null || echo '{}')
+  else
+    DROP_JSON=$(bash "$DROP_METRICS" --json --log "$DROP_AUDIT" 2>/dev/null || echo '{}')
+  fi
+fi
+
+# Audience stats
+AUDIENCE_STATS='{}'
+if [[ -f "$AUDIENCE_GRAPH" ]]; then
+  AUDIENCE_STATS=$(jq '{
+    n_files_scanned,
+    n_files_with_audience,
+    n_agents_referenced,
+    top_agents: (.agents | to_entries | sort_by(-(.value | length)) | .[0:5] | map({agent: .key, n_files: (.value | length)}))
+  }' "$AUDIENCE_GRAPH" 2>/dev/null || echo '{}')
+fi
+
+# Top cross-concept pairs
+TOP_PAIRS=""
+if [[ -f "$AUDIENCE_CROSS" ]]; then
+  TOP_PAIRS=$(tail -n +2 "$AUDIENCE_CROSS" 2>/dev/null | sort -t $'\t' -k4 -n -r | head -10 || echo "")
+fi
+
+# Origin tag coverage (best-effort): cuenta lineas '---origin' en logs recientes
+ORIGIN_COVERAGE=0
+if compgen -G "$OUTPUT_DIR/session*.log" > /dev/null 2>&1; then
+  ORIGIN_COVERAGE=$(grep -h "^---origin$" "$OUTPUT_DIR"/session*.log 2>/dev/null | wc -l | tr -d ' ')
+fi
+
+# Construir reporte
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+N_TOTAL=$(echo "$DROP_JSON" | jq -r '.n_total // 0')
+N_STUBS=$(echo "$DROP_JSON" | jq -r '.n_stubs // 0')
+N_KEEPS=$(echo "$DROP_JSON" | jq -r '.n_keeps // 0')
+N_DROPS=$(echo "$DROP_JSON" | jq -r '.n_drops // 0')
+TOKENS_SAVED=$(echo "$DROP_JSON" | jq -r '.total_tokens_saved // 0')
+PCT_SAVED=$(echo "$DROP_JSON" | jq -r '.pct_saved // 0')
+
+N_FILES_SCANNED=$(echo "$AUDIENCE_STATS" | jq -r '.n_files_scanned // 0')
+N_FILES_WITH_AUDIENCE=$(echo "$AUDIENCE_STATS" | jq -r '.n_files_with_audience // 0')
+N_AGENTS_REFERENCED=$(echo "$AUDIENCE_STATS" | jq -r '.n_agents_referenced // 0')
+
+{
+  echo "# Context Engineering Report"
+  echo ""
+  echo "> Spec: SE-221 — Patrones adversariales invertidos como ingenieria de contexto"
+  echo "> Generated: $TS"
+  if [[ -n "$SINCE" ]]; then echo "> Since: $SINCE"; fi
+  echo ""
+  echo "## Slice 2 — Drop-After-Use"
+  echo ""
+  echo "| Metrica | Valor |"
+  echo "|---|---|"
+  echo "| Total decisiones | $N_TOTAL |"
+  echo "| STUB | $N_STUBS |"
+  echo "| KEEP | $N_KEEPS |"
+  echo "| DROP | $N_DROPS |"
+  echo "| Tokens ahorrados estimados | $TOKENS_SAVED |"
+  echo "| Pct ops reducidas | ${PCT_SAVED}% |"
+  echo ""
+  echo "Top tools y tiers (segun audit):"
+  echo ""
+  echo '```json'
+  echo "$DROP_JSON" | jq '{by_tool, by_tier}' 2>/dev/null || echo "(sin datos)"
+  echo '```'
+  echo ""
+  echo "## Slice 3 — Audience Graph"
+  echo ""
+  echo "| Metrica | Valor |"
+  echo "|---|---|"
+  echo "| Ficheros escaneados | $N_FILES_SCANNED |"
+  echo "| Ficheros con audience explicita | $N_FILES_WITH_AUDIENCE |"
+  echo "| Agentes referenciados | $N_AGENTS_REFERENCED |"
+  echo ""
+  echo "Top agents por numero de ficheros target:"
+  echo ""
+  echo '```json'
+  echo "$AUDIENCE_STATS" | jq '.top_agents' 2>/dev/null || echo "(sin datos)"
+  echo '```'
+  echo ""
+  echo "## Top pares cross-concept (audience compartida)"
+  echo ""
+  if [[ -n "$TOP_PAIRS" ]]; then
+    echo "| path_a | path_b | shared | count |"
+    echo "|---|---|---|---|"
+    echo "$TOP_PAIRS" | awk -F'\t' '{printf "| %s | %s | %s | %s |\n", $1, $2, $3, $4}'
+  else
+    echo "(sin datos — ejecutar: python3 scripts/context-audience-graph.py)"
+  fi
+  echo ""
+  echo "## Slice 1 — Origin Tag Coverage"
+  echo ""
+  echo "Bloques \`---origin\` detectados en session logs: $ORIGIN_COVERAGE"
+  echo ""
+  echo "## Drift detector"
+  echo ""
+  echo "Ficheros con audience cuyo tier ha cambiado: (placeholder, requiere baseline)"
+  echo ""
+  echo "## Refs"
+  echo ""
+  echo "- Spec: docs/propuestas/SE-221-*.md"
+  echo "- Audit logs: $DROP_AUDIT"
+  echo "- Audience graph: $AUDIENCE_GRAPH"
+  echo "- Audience cross: $AUDIENCE_CROSS"
+} > "$REPORT"
+
+if [[ "$STDOUT" -eq 1 ]]; then
+  cat "$REPORT"
+fi
+
+echo "Report generated: $REPORT" >&2
+exit 0

--- a/scripts/context-origin-tag.sh
+++ b/scripts/context-origin-tag.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# context-origin-tag.sh — SE-221 Slice 1 — Context Origin Tagging
+# Devuelve el tag origin canonico segun N1-N4b para un path dado.
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-01)
+# Inspiracion: Spotlighting (Hines et al. 2024, arXiv:2403.14720) invertido.
+#
+# Resuelve por prefijo de path, no por contenido.
+# Tags posibles: N1-anchor, N2-eager, N3-active-user, N4a-lazy-ref, N4b-on-demand,
+#                N5-external, untrusted, sandbox.
+#
+# Uso:
+#   scripts/context-origin-tag.sh <path>
+#   scripts/context-origin-tag.sh --json <path>
+#
+# Exit codes:
+#   0 — tag emitido en stdout
+#   2 — argumentos invalidos
+
+JSON=0
+PATH_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON=1; shift ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+    --) shift; PATH_ARG="${1:-}"; break ;;
+    -*)
+      echo "ERROR: unknown arg: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$PATH_ARG" ]]; then
+        PATH_ARG="$1"
+        shift
+      else
+        echo "ERROR: only one path supported" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$PATH_ARG" ]]; then
+  echo "ERROR: missing path argument" >&2
+  exit 2
+fi
+
+# Resolver workspace (acepta override por env)
+WORKSPACE="${SAVIA_WORKSPACE_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# Normalizar a absoluto sin requerir que exista (para tests)
+abs_path() {
+  local p="$1"
+  if [[ "$p" = /* ]]; then
+    printf '%s' "$p"
+  else
+    printf '%s' "$(pwd)/$p"
+  fi
+}
+
+ABS=$(abs_path "$PATH_ARG")
+
+resolve_tier() {
+  local p="$1"
+
+  # Sandbox /tmp/opencode/* — exento, siempre sandbox
+  case "$p" in
+    /tmp/opencode/*) echo "sandbox"; return ;;
+  esac
+
+  # Fuera del workspace → N5-external o untrusted
+  if [[ "$p" != "$WORKSPACE"* ]]; then
+    case "$p" in
+      "$HOME"/.savia-memory/*|"$HOME"/.savia/*|"$HOME"/.claude/*) echo "N5-external"; return ;;
+      "$HOME"/*) echo "N5-external"; return ;;
+      *) echo "untrusted"; return ;;
+    esac
+  fi
+
+  # Dentro del workspace — clasificar por subpath
+  local rel="${p#"$WORKSPACE"/}"
+
+  # N1-anchor: docs/critical-facts.md (anchor superior SPEC-185)
+  case "$rel" in
+    docs/critical-facts.md) echo "N1-anchor"; return ;;
+  esac
+
+  # N2-eager: imports criticos del CLAUDE.md (savia, radical-honesty,
+  # autonomous-safety, caveman-default, profiles/savia.md)
+  case "$rel" in
+    .claude/profiles/savia.md) echo "N2-eager"; return ;;
+    .claude/profiles/savia-agent-mode.md) echo "N2-eager"; return ;;
+    docs/rules/domain/radical-honesty.md) echo "N2-eager"; return ;;
+    docs/rules/domain/autonomous-safety.md) echo "N2-eager"; return ;;
+    docs/rules/domain/caveman-default.md) echo "N2-eager"; return ;;
+    CLAUDE.md|AGENTS.md|SKILLS.md) echo "N2-eager"; return ;;
+  esac
+
+  # N3-active-user: perfiles del usuario y memoria activa
+  case "$rel" in
+    .claude/profiles/active-user.md) echo "N3-active-user"; return ;;
+    .claude/profiles/users/*) echo "N3-active-user"; return ;;
+    .claude/external-memory/*) echo "N3-active-user"; return ;;
+    .claude/rules/pm-config.local.md) echo "N3-active-user"; return ;;
+    CLAUDE.local.md) echo "N3-active-user"; return ;;
+  esac
+
+  # N4a-lazy-ref: tabla de referencias lazy (CLAUDE.md de proyectos, RESOLVER)
+  case "$rel" in
+    docs/RESOLVER.md) echo "N4a-lazy-ref"; return ;;
+    projects/*/CLAUDE.md) echo "N4a-lazy-ref"; return ;;
+  esac
+
+  # N4b-on-demand: rules/skills/agents/commands cargados bajo demanda
+  case "$rel" in
+    docs/rules/domain/*) echo "N4b-on-demand"; return ;;
+    docs/rules/languages/*) echo "N4b-on-demand"; return ;;
+    .opencode/skills/*) echo "N4b-on-demand"; return ;;
+    .opencode/agents/*) echo "N4b-on-demand"; return ;;
+    .opencode/commands/*) echo "N4b-on-demand"; return ;;
+    .claude/skills/*) echo "N4b-on-demand"; return ;;
+    .claude/agents/*) echo "N4b-on-demand"; return ;;
+    .claude/commands/*) echo "N4b-on-demand"; return ;;
+    docs/specs/*|docs/propuestas/*) echo "N4b-on-demand"; return ;;
+    docs/*) echo "N4b-on-demand"; return ;;
+  esac
+
+  # N4-project: datos especificos de proyecto
+  case "$rel" in
+    projects/*) echo "N4-project"; return ;;
+  esac
+
+  # Fallback dentro del workspace
+  echo "N4b-on-demand"
+}
+
+TIER=$(resolve_tier "$ABS")
+
+if [[ "$JSON" -eq 1 ]]; then
+  printf '{"path":"%s","tier":"%s","abs":"%s","workspace":"%s"}\n' \
+    "$PATH_ARG" "$TIER" "$ABS" "$WORKSPACE"
+else
+  printf '%s\n' "$TIER"
+fi
+
+exit 0

--- a/scripts/knowledge-graph.py
+++ b/scripts/knowledge-graph.py
@@ -629,6 +629,50 @@ def cmd_impact(args: argparse.Namespace) -> None:
 
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
+def cmd_import_audience(args: argparse.Namespace) -> None:
+    """SE-221: import audience-cross.tsv as typed relations
+    (path_a) -[shared_audience]-> (path_b) with shared_count en source.
+    """
+    import csv
+    tsv_path = args.tsv
+    if not os.path.isfile(tsv_path):
+        print(f"ERROR: tsv not found: {tsv_path}", file=sys.stderr)
+        sys.exit(1)
+    conn = open_db(Path(args.db))
+    n_rels = 0
+    with open(tsv_path, "r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for row in reader:
+            path_a = row.get("path_a", "").strip()
+            path_b = row.get("path_b", "").strip()
+            shared = row.get("shared_agents", "").strip()
+            count_raw = row.get("audience_count", "0").strip()
+            try:
+                count = int(count_raw)
+            except ValueError:
+                count = 0
+            if not path_a or not path_b or count < 1:
+                continue
+            a_id = upsert_entity(conn, path_a, "context-doc",
+                                 project_id=args.project,
+                                 memory_type="fact",
+                                 confidence=1.0,
+                                 provenance="se-221-audience-graph")
+            b_id = upsert_entity(conn, path_b, "context-doc",
+                                 project_id=args.project,
+                                 memory_type="fact",
+                                 confidence=1.0,
+                                 provenance="se-221-audience-graph")
+            source = f"shared_audience={shared};count={count}"
+            upsert_relation(conn, a_id, "shared_audience", b_id,
+                            source=source, confidence=1.0)
+            n_rels += 1
+    conn.commit()
+    if not getattr(args, "quiet", False):
+        print(f"imported {n_rels} shared_audience relations from {tsv_path}")
+    conn.close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="SE-162: Knowledge Graph sobre memoria Savia"
@@ -668,6 +712,15 @@ def main() -> None:
     p_imp.add_argument("--db", default=str(DEFAULT_DB))
     p_imp.add_argument("--project", default=None, help="SE-151: filter by project slug")
 
+    p_imp_aud = sub.add_parser("import-audience",
+                                help="SE-221: import context-audience-cross.tsv as shared_audience relations")
+    p_imp_aud.add_argument("--tsv", required=True,
+                            help="Path to context-audience-cross.tsv (output of context-audience-graph.py)")
+    p_imp_aud.add_argument("--db", default=str(DEFAULT_DB))
+    p_imp_aud.add_argument("--project", default=None,
+                            help="SE-151: tag entities with project slug")
+    p_imp_aud.add_argument("--quiet", action="store_true")
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -679,6 +732,7 @@ def main() -> None:
         "entities": cmd_entities,
         "query": cmd_query,
         "impact": cmd_impact,
+        "import-audience": cmd_import_audience,
     }
     dispatch[args.command](args)
 

--- a/tests/test-context-capability.bats
+++ b/tests/test-context-capability.bats
@@ -1,0 +1,336 @@
+#!/usr/bin/env bats
+# tests/test-context-capability.bats — SE-221 Slice 3 — Capability metadata
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-17)
+# Refs: CaMeL (Debenedetti 2025), audience-graph cross-concept, KG integration.
+#
+# Tests para:
+#   - scripts/context-capability-check.sh (validador frontmatter audience)
+#   - scripts/context-audience-graph.py (graph + cross.tsv generator)
+#   - .claude/hooks/subagent-audience-filter.sh (audience filter para subagentes)
+#   - scripts/knowledge-graph.py import-audience (integracion KG)
+#
+# Cobertura: frontmatter valido/invalido, graph generation, cross.tsv, audience
+# filter por agente, deny by default, integracion knowledge-graph.
+
+CHECK="$BATS_TEST_DIRNAME/../scripts/context-capability-check.sh"
+GRAPH="$BATS_TEST_DIRNAME/../scripts/context-audience-graph.py"
+FILTER="$BATS_TEST_DIRNAME/../.claude/hooks/subagent-audience-filter.sh"
+KG="$BATS_TEST_DIRNAME/../scripts/knowledge-graph.py"
+
+setup() {
+  WS="$BATS_TEST_TMPDIR/ws"
+  mkdir -p "$WS/.opencode/agents" "$WS/.opencode/skills" "$WS/docs/rules/domain" "$WS/output"
+  touch "$WS/AGENTS.md"
+  # Agentes validos
+  for a in architect code-reviewer security-guardian; do
+    touch "$WS/.opencode/agents/$a.md"
+  done
+  export SAVIA_WORKSPACE_DIR="$WS"
+  export SAVIA_AGENTS_DIR="$WS/.opencode/agents"
+}
+
+teardown() {
+  unset SAVIA_WORKSPACE_DIR SAVIA_AGENTS_DIR
+}
+
+# === Sintaxis y safety ===
+
+@test "check script bash valido" {
+  bash -n "$CHECK"
+}
+
+@test "filter hook bash valido" {
+  bash -n "$FILTER"
+}
+
+@test "graph script python sintacticamente valido" {
+  python3 -c "import ast; ast.parse(open('$GRAPH').read())"
+}
+
+@test "check uses set -uo pipefail" {
+  head -10 "$CHECK" | grep -q "set -[euo]*o pipefail"
+}
+
+@test "filter uses set -uo pipefail" {
+  head -10 "$FILTER" | grep -q "set -[euo]*o pipefail"
+}
+
+# === Capability check: frontmatter valido ===
+
+@test "check: fichero sin audience pasa (default implicito)" {
+  cat > "$WS/docs/rules/domain/no-aud.md" <<EOF
+---
+foo: bar
+---
+content
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/no-aud.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "check: audience como lista inline valida" {
+  cat > "$WS/docs/rules/domain/list.md" <<EOF
+---
+audience: [architect, code-reviewer]
+---
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/list.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "check: audience como string canonico all-agents valida" {
+  cat > "$WS/docs/rules/domain/str.md" <<EOF
+---
+audience: all-agents
+---
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/str.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "check: audience humans-only es palabra reservada" {
+  cat > "$WS/docs/rules/domain/h.md" <<EOF
+---
+audience: humans-only
+---
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/h.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "check: audience multilinea YAML valida" {
+  cat > "$WS/docs/rules/domain/ml.md" <<EOF
+---
+audience:
+  - architect
+  - all-agents
+---
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/ml.md"
+  [ "$status" -eq 0 ]
+}
+
+# === Capability check: invalidos ===
+
+@test "check: audience con agente inexistente FALLA" {
+  cat > "$WS/docs/rules/domain/bad.md" <<EOF
+---
+audience: [ghost-agent]
+---
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/bad.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "check: audience mixto con uno invalido FALLA" {
+  cat > "$WS/docs/rules/domain/mixed.md" <<EOF
+---
+audience: [architect, ghost]
+---
+EOF
+  run "$CHECK" --paths "$WS/docs/rules/domain/mixed.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "check: --strict marca FAIL si falta audience" {
+  cat > "$WS/docs/rules/domain/none.md" <<EOF
+---
+foo: bar
+---
+EOF
+  run "$CHECK" --strict --paths "$WS/docs/rules/domain/none.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "check: --json devuelve JSON valido" {
+  cat > "$WS/docs/rules/domain/x.md" <<EOF
+---
+audience: [architect]
+---
+EOF
+  run "$CHECK" --json --paths "$WS/docs/rules/domain/x.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.errors == 0 and .total == 1' >/dev/null
+}
+
+# === Graph generation ===
+
+@test "graph: produce JSON y TSV" {
+  cat > "$WS/docs/rules/domain/f1.md" <<EOF
+---
+audience: [architect, code-reviewer]
+---
+EOF
+  cat > "$WS/docs/rules/domain/f2.md" <<EOF
+---
+audience: [architect, code-reviewer, security-guardian]
+---
+EOF
+  run python3 "$GRAPH" --workspace "$WS" --quiet
+  [ "$status" -eq 0 ]
+  [ -f "$WS/output/context-audience-graph.json" ]
+  [ -f "$WS/output/context-audience-cross.tsv" ]
+}
+
+@test "graph: TSV header correcto" {
+  cat > "$WS/docs/rules/domain/f1.md" <<EOF
+---
+audience: [architect]
+---
+EOF
+  python3 "$GRAPH" --workspace "$WS" --quiet
+  head -1 "$WS/output/context-audience-cross.tsv" | grep -q "path_a"
+  head -1 "$WS/output/context-audience-cross.tsv" | grep -q "shared_agents"
+}
+
+@test "graph: cross.tsv contiene par con >=2 shared agents" {
+  cat > "$WS/docs/rules/domain/a.md" <<EOF
+---
+audience: [architect, code-reviewer]
+---
+EOF
+  cat > "$WS/docs/rules/domain/b.md" <<EOF
+---
+audience: [architect, code-reviewer, security-guardian]
+---
+EOF
+  python3 "$GRAPH" --workspace "$WS" --quiet
+  pair_count=$(tail -n +2 "$WS/output/context-audience-cross.tsv" | wc -l)
+  [ "$pair_count" -ge 1 ]
+}
+
+@test "graph: pares con solo all-agents NO se cuentan como cross-concept" {
+  cat > "$WS/docs/rules/domain/u1.md" <<EOF
+---
+audience: all-agents
+---
+EOF
+  cat > "$WS/docs/rules/domain/u2.md" <<EOF
+---
+audience: all-agents
+---
+EOF
+  python3 "$GRAPH" --workspace "$WS" --quiet
+  pair_count=$(tail -n +2 "$WS/output/context-audience-cross.tsv" | wc -l)
+  [ "$pair_count" -eq 0 ]
+}
+
+@test "graph: JSON contiene mapping agent->files" {
+  cat > "$WS/docs/rules/domain/x.md" <<EOF
+---
+audience: [architect]
+---
+EOF
+  python3 "$GRAPH" --workspace "$WS" --quiet
+  echo "" | python3 -c "
+import json
+d = json.load(open('$WS/output/context-audience-graph.json'))
+assert 'architect' in d['agents']
+assert 'docs/rules/domain/x.md' in d['agents']['architect']
+"
+}
+
+# === Audience filter (subagent) ===
+
+@test "filter: passthrough cuando NO es Task tool" {
+  output=$(echo '{"tool_name":"Read","tool_input":{"file_path":"/tmp/a"}}' | bash "$FILTER")
+  [ "$output" = '{"tool_name":"Read","tool_input":{"file_path":"/tmp/a"}}' ]
+}
+
+@test "filter: passthrough cuando no hay graph JSON" {
+  rm -f "$WS/output/context-audience-graph.json"
+  input='{"tool_name":"Task","tool_input":{"subagent_type":"architect"}}'
+  output=$(echo "$input" | bash "$FILTER")
+  [ "$output" = "$input" ]
+}
+
+@test "filter: subagente conocido obtiene allowed con sus paths" {
+  cat > "$WS/output/context-audience-graph.json" <<EOF
+{"agents":{"architect":["docs/foo.md"],"code-reviewer":["docs/bar.md"],"all-agents":["docs/all.md"]}}
+EOF
+  echo '{"tool_name":"Task","tool_input":{"subagent_type":"architect"}}' | bash "$FILTER" >/dev/null
+  [ -s "$WS/output/audience-filter.jsonl" ]
+  jq -e '.filter.allowed | index("docs/foo.md")' "$WS/output/audience-filter.jsonl" >/dev/null
+}
+
+@test "filter: deny by default — subagente desconocido solo recibe all-agents" {
+  cat > "$WS/output/context-audience-graph.json" <<EOF
+{"agents":{"architect":["docs/foo.md"],"all-agents":["docs/all.md"]}}
+EOF
+  echo '{"tool_name":"Task","tool_input":{"subagent_type":"ghost"}}' | bash "$FILTER" >/dev/null
+  jq -e '.filter.allowed | length == 1 and .[0] == "docs/all.md"' "$WS/output/audience-filter.jsonl" >/dev/null
+}
+
+@test "filter: humans-only se DENIEGA al subagente" {
+  cat > "$WS/output/context-audience-graph.json" <<EOF
+{"agents":{"architect":["docs/foo.md"],"humans-only":["docs/private.md"]}}
+EOF
+  echo '{"tool_name":"Task","tool_input":{"subagent_type":"architect"}}' | bash "$FILTER" >/dev/null
+  jq -e '.filter.denied | index("docs/private.md")' "$WS/output/audience-filter.jsonl" >/dev/null
+}
+
+@test "filter: subagente listado obtiene archivos especificos + all-agents" {
+  cat > "$WS/output/context-audience-graph.json" <<EOF
+{"agents":{"architect":["docs/foo.md"],"all-agents":["docs/all.md"]}}
+EOF
+  echo '{"tool_name":"Task","tool_input":{"subagent_type":"architect"}}' | bash "$FILTER" >/dev/null
+  count=$(jq -r '.filter.allowed | length' "$WS/output/audience-filter.jsonl" | tail -1)
+  [ "$count" -eq 2 ]
+}
+
+# === KG integration ===
+
+@test "kg: import-audience requiere --tsv" {
+  run python3 "$KG" import-audience --db "$WS/kg.db"
+  [ "$status" -ne 0 ]
+}
+
+@test "kg: import-audience con TSV inexistente FALLA limpio" {
+  run python3 "$KG" import-audience --tsv "$WS/nope.tsv" --db "$WS/kg.db"
+  [ "$status" -eq 1 ]
+}
+
+@test "kg: import-audience importa relacion shared_audience" {
+  cat > "$WS/output/context-audience-cross.tsv" <<EOF
+path_a	path_b	shared_agents	audience_count
+docs/a.md	docs/b.md	architect,code-reviewer	2
+EOF
+  run python3 "$KG" import-audience --tsv "$WS/output/context-audience-cross.tsv" --db "$WS/kg.db" --quiet
+  [ "$status" -eq 0 ]
+  python3 -c "
+import sqlite3
+c = sqlite3.connect('$WS/kg.db')
+rels = list(c.execute('SELECT relation FROM relations'))
+assert ('shared_audience',) in rels, f'expected shared_audience, got {rels}'
+"
+}
+
+@test "kg: import-audience source contiene shared_audience y count" {
+  cat > "$WS/output/context-audience-cross.tsv" <<EOF
+path_a	path_b	shared_agents	audience_count
+docs/a.md	docs/b.md	architect,code-reviewer	2
+EOF
+  python3 "$KG" import-audience --tsv "$WS/output/context-audience-cross.tsv" --db "$WS/kg.db" --quiet
+  python3 -c "
+import sqlite3
+c = sqlite3.connect('$WS/kg.db')
+src = c.execute('SELECT source FROM relations LIMIT 1').fetchone()[0]
+assert 'shared_audience=' in src
+assert 'count=2' in src
+"
+}
+
+# === Spec reference ===
+
+@test "spec_reference: SE-221 documentado en check" {
+  grep -q "SE-221" "$CHECK"
+}
+
+@test "spec_reference: SE-221 documentado en graph" {
+  grep -q "SE-221" "$GRAPH"
+}
+
+@test "spec_reference: SE-221 documentado en filter" {
+  grep -q "SE-221" "$FILTER"
+}

--- a/tests/test-context-drop-after-use.bats
+++ b/tests/test-context-drop-after-use.bats
@@ -301,3 +301,33 @@ EOF
 @test "spec_reference: SE-221 documentado en hook" {
   grep -q "SE-221" "$HOOK"
 }
+
+# === Edge cases (boundary, empty, large, no-args, timeout, null) ===
+# Coverage: ejercita extract_abstract() del target script.
+
+@test "edge: empty file content produces non-null abstract via extract_abstract" {
+  empty_file=$(mktemp)
+  : > "$empty_file"
+  run "$SCRIPT" --path "$empty_file" --next-task "noref"
+  rm -f "$empty_file"
+  [ "$status" -eq 0 ]
+}
+
+@test "edge: large output (>5000 lines) does not overflow timeout" {
+  large=$(seq 1 5000)
+  input=$(jq -nc --arg c "$large" --arg p "$WS/docs/rules/domain/big.md" \
+    '{tool_name:"Read",tool_input:{file_path:$p},tool_response:{output:$c}}')
+  run timeout 10 bash -c "echo '$input' | bash '$HOOK'"
+  [ "$status" -ne 124 ]
+}
+
+@test "edge: zero arguments to script triggers boundary error" {
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "edge: nonexistent --path still returns a verdict (no segfault, no hang)" {
+  run timeout 3 "$SCRIPT" --path "/no/such/file/at/all.md" --next-task ""
+  [ "$status" -ne 124 ]  # not timeout
+  [ "$status" -ne 139 ]  # not segfault
+}

--- a/tests/test-context-drop-after-use.bats
+++ b/tests/test-context-drop-after-use.bats
@@ -1,0 +1,303 @@
+#!/usr/bin/env bats
+# tests/test-context-drop-after-use.bats — SE-221 Slice 2 — Drop-After-Use
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-10)
+# Refs: Context-Minimization (Beurer-Kellner et al. 2025), KEEP/STUB/DROP, override KEEP-CONTEXT.
+#
+# Tests para scripts/context-drop-after-use.sh (decision engine) y
+# .claude/hooks/context-drop-after-use.sh (PostToolUse hook).
+#
+# Cobertura: KEEP/DROP/STUB para cada tier, override KEEP-CONTEXT, idempotencia,
+# referencia textual, abstract no vacio, JSON valido, audit log.
+#
+# Safety: ambos scripts usan set -uo pipefail.
+
+SCRIPT="$BATS_TEST_DIRNAME/../scripts/context-drop-after-use.sh"
+HOOK="$BATS_TEST_DIRNAME/../.claude/hooks/context-drop-after-use.sh"
+METRICS="$BATS_TEST_DIRNAME/../scripts/context-drop-metrics.sh"
+
+setup() {
+  WS="$BATS_TEST_TMPDIR/ws"
+  mkdir -p "$WS/output" "$WS/docs/rules/domain"
+  # Crear ficheros minimos para tests
+  touch "$WS/docs/critical-facts.md"
+  touch "$WS/CLAUDE.md"
+  echo "First non-empty line of fixture" > "$WS/docs/rules/domain/somerule.md"
+  export SAVIA_WORKSPACE_DIR="$WS"
+  export CONTEXT_DROP_AUDIT_LOG="$WS/output/context-drop-audit.jsonl"
+}
+
+teardown() {
+  unset SAVIA_WORKSPACE_DIR
+  unset CONTEXT_DROP_AUDIT_LOG
+  unset CONTEXT_DROP_NEXT_TASK
+  unset CONTEXT_DROP_MIN_LINES
+}
+
+# === Sintaxis y safety ===
+
+@test "script es bash valido" {
+  bash -n "$SCRIPT"
+}
+
+@test "hook es bash valido" {
+  bash -n "$HOOK"
+}
+
+@test "script uses set -uo pipefail" {
+  head -10 "$SCRIPT" | grep -q "set -[euo]*o pipefail"
+}
+
+@test "hook uses set -uo pipefail" {
+  head -10 "$HOOK" | grep -q "set -[euo]*o pipefail"
+}
+
+@test "scripts ejecutables" {
+  [[ -x "$SCRIPT" ]] && [[ -x "$HOOK" ]] && [[ -x "$METRICS" ]]
+}
+
+# === Argumentos del decision engine ===
+
+@test "script: exit 2 sin --path" {
+  run "$SCRIPT" --next-task "foo"
+  [ "$status" -eq 2 ]
+}
+
+@test "script: exit 2 con flag desconocido" {
+  run "$SCRIPT" --bogus
+  [ "$status" -eq 2 ]
+}
+
+@test "script: --help imprime usage" {
+  run "$SCRIPT" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"context-drop-after-use"* ]]
+}
+
+# === Veredictos por tier ===
+
+@test "KEEP por tier N1-anchor" {
+  run "$SCRIPT" --path "$WS/docs/critical-facts.md" --next-task "foo bar"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+  [[ "$output" == *"siempre relevante"* ]]
+}
+
+@test "KEEP por tier N2-eager" {
+  run "$SCRIPT" --path "$WS/CLAUDE.md" --next-task "foo bar"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+}
+
+@test "STUB por tier N4b sin referencia" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/somerule.md" --next-task "completely unrelated"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "STUB:"* ]]
+  [[ "$output" == *"abstract:"* ]]
+}
+
+@test "DROP por tier untrusted" {
+  run "$SCRIPT" --path "/etc/passwd" --next-task "foo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "DROP:"* ]]
+}
+
+@test "KEEP por sandbox" {
+  run "$SCRIPT" --path "/tmp/opencode/work.md" --next-task "foo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+}
+
+# === Override KEEP-CONTEXT ===
+
+@test "KEEP-CONTEXT override fuerza KEEP en N4b" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/somerule.md" --next-task "KEEP-CONTEXT please"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+  [[ "$output" == *"override"* ]]
+}
+
+@test "KEEP-CONTEXT override fuerza KEEP en untrusted" {
+  run "$SCRIPT" --path "/etc/passwd" --next-task "KEEP-CONTEXT inspeccionar"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+}
+
+# === Referencia textual ===
+
+@test "KEEP por referencia textual al basename" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/somerule.md" --next-task "actualizar somerule.md ahora"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+  [[ "$output" == *"referencia"* ]]
+}
+
+@test "KEEP por path completo en next-task" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/somerule.md" --next-task "ver $WS/docs/rules/domain/somerule.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "KEEP:"* ]]
+}
+
+# === Abstract ===
+
+@test "STUB extrae primera linea no-frontmatter como abstract" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/somerule.md" --next-task "unrelated"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"First non-empty line of fixture"* ]]
+}
+
+@test "STUB con frontmatter omite el frontmatter" {
+  cat > "$WS/docs/rules/domain/withfm.md" <<EOF
+---
+foo: bar
+---
+
+# Title
+
+Real content here
+EOF
+  run "$SCRIPT" --path "$WS/docs/rules/domain/withfm.md" --next-task "unrelated"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Title"* ]] || [[ "$output" == *"Real content"* ]]
+  ! [[ "$output" == *"foo: bar"* ]]
+}
+
+@test "STUB con --abstract override usa el provisto" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/somerule.md" --next-task "unrelated" --abstract "custom abstract"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"custom abstract"* ]]
+}
+
+@test "STUB con fichero sin contenido devuelve abstract no vacio" {
+  touch "$WS/docs/rules/domain/empty.md"
+  run "$SCRIPT" --path "$WS/docs/rules/domain/empty.md" --next-task "unrelated"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"abstract:"* ]]
+  [[ "$output" == *"no disponible"* ]] || [[ "$output" == *"abstract"* ]]
+}
+
+# === JSON output ===
+
+@test "--json devuelve JSON valido" {
+  run "$SCRIPT" --json --path "$WS/docs/rules/domain/somerule.md" --next-task "unrelated"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.' >/dev/null
+}
+
+@test "--json contiene verdict reason abstract tier path" {
+  run "$SCRIPT" --json --path "$WS/docs/rules/domain/somerule.md" --next-task "unrelated"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.verdict and .reason and .tier and .path' >/dev/null
+}
+
+# === Hook PostToolUse ===
+
+@test "hook: passthrough cuando bajo umbral" {
+  CONTEXT_DROP_MIN_LINES=200 \
+  CONTEXT_DROP_NEXT_TASK="foo" \
+  output=$(echo '{"tool_name":"Read","tool_input":{"file_path":"/tmp/foo.md"},"tool_response":{"output":"a\nb\nc"}}' | bash "$HOOK")
+  [[ "$output" == *'"output":"a\nb\nc"'* ]]
+}
+
+@test "hook: stub para N4b sobre umbral" {
+  large=$(seq 1 600 | tr '\n' '|' | sed 's/|/\\n/g')
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WS/docs/rules/domain/somerule.md\"},\"tool_response\":{\"output\":\"$large\"}}"
+  output=$(echo "$input" | CONTEXT_DROP_NEXT_TASK="completely unrelated task" bash "$HOOK")
+  parsed=$(echo "$output" | jq -r '.tool_response.output')
+  [[ "$parsed" == "<stub origin="* ]]
+  [[ "$parsed" == *"abstract="* ]]
+}
+
+@test "hook: KEEP para N1-anchor sobre umbral" {
+  large=$(seq 1 600 | tr '\n' '|' | sed 's/|/\\n/g')
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WS/docs/critical-facts.md\"},\"tool_response\":{\"output\":\"$large\"}}"
+  output=$(echo "$input" | CONTEXT_DROP_NEXT_TASK="unrelated" bash "$HOOK")
+  parsed=$(echo "$output" | jq -r '.tool_response.output')
+  ! [[ "$parsed" == "<stub"* ]]
+}
+
+@test "hook: idempotencia — no re-stubea un stub" {
+  large=$(seq 1 600 | tr '\n' '|' | sed 's/|/\\n/g')
+  prefix="<stub origin=\\\"x\\\" tier=\\\"N4b\\\" full-content-at=\\\"x\\\" abstract=\\\"y\\\"/>"
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WS/docs/rules/domain/somerule.md\"},\"tool_response\":{\"output\":\"${prefix}\\n${large}\"}}"
+  output=$(echo "$input" | CONTEXT_DROP_NEXT_TASK="unrelated" bash "$HOOK")
+  parsed=$(echo "$output" | jq -r '.tool_response.output')
+  # Debe contener el prefix original sin volver a stubeear
+  [[ "$parsed" == "<stub origin=\"x\""* ]]
+}
+
+@test "hook: audit log se escribe con JSON valido" {
+  large=$(seq 1 600 | tr '\n' '|' | sed 's/|/\\n/g')
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WS/docs/rules/domain/somerule.md\"},\"tool_response\":{\"output\":\"$large\"}}"
+  echo "$input" | CONTEXT_DROP_NEXT_TASK="unrelated" bash "$HOOK" >/dev/null
+  [[ -s "$CONTEXT_DROP_AUDIT_LOG" ]]
+  jq -e '.verdict and .tier and .ts' "$CONTEXT_DROP_AUDIT_LOG" >/dev/null
+}
+
+@test "hook: KEEP-CONTEXT override no genera stub" {
+  large=$(seq 1 600 | tr '\n' '|' | sed 's/|/\\n/g')
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WS/docs/rules/domain/somerule.md\"},\"tool_response\":{\"output\":\"$large\"}}"
+  output=$(echo "$input" | CONTEXT_DROP_NEXT_TASK="KEEP-CONTEXT please" bash "$HOOK")
+  parsed=$(echo "$output" | jq -r '.tool_response.output')
+  ! [[ "$parsed" == "<stub"* ]]
+}
+
+# === Metrics script ===
+
+@test "metrics: maneja audit log inexistente" {
+  rm -f "$CONTEXT_DROP_AUDIT_LOG"
+  run "$METRICS" --json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.audit_log == "missing"' >/dev/null
+}
+
+@test "metrics: agrega correctamente STUB/KEEP/DROP" {
+  cat > "$CONTEXT_DROP_AUDIT_LOG" <<'EOF'
+{"ts":"2026-06-12T14:00:00Z","tool":"Read","path":"/a","tier":"N4b","verdict":"STUB","reason":"x","next_task_excerpt":"y","tokens_saved_est":500}
+{"ts":"2026-06-12T14:01:00Z","tool":"Read","path":"/b","tier":"N1","verdict":"KEEP","reason":"x","next_task_excerpt":"y","tokens_saved_est":0}
+{"ts":"2026-06-12T14:02:00Z","tool":"WebFetch","path":"x","tier":"untrusted","verdict":"DROP","reason":"x","next_task_excerpt":"y","tokens_saved_est":1000}
+EOF
+  run "$METRICS" --json
+  [ "$status" -eq 0 ]
+  total=$(echo "$output" | jq -r '.n_total')
+  saved=$(echo "$output" | jq -r '.total_tokens_saved')
+  [ "$total" -eq 3 ]
+  [ "$saved" -eq 1500 ]
+}
+
+@test "metrics: human readable output contiene contadores" {
+  cat > "$CONTEXT_DROP_AUDIT_LOG" <<'EOF'
+{"ts":"2026-06-12T14:00:00Z","tool":"Read","path":"/a","tier":"N4b","verdict":"STUB","reason":"x","next_task_excerpt":"y","tokens_saved_est":500}
+EOF
+  run "$METRICS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"STUB:"* ]]
+  [[ "$output" == *"tokens_saved_est"* ]]
+}
+
+# === Edge cases ===
+
+@test "fichero inexistente devuelve STUB con abstract no disponible" {
+  run "$SCRIPT" --path "$WS/docs/rules/domain/nonexistent.md" --next-task "unrelated"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "STUB:"* ]] || [[ "$output" == "DROP:"* ]]
+}
+
+@test "hook: tool no-Read/WebFetch/Bash → passthrough" {
+  input='{"tool_name":"Glob","tool_input":{"pattern":"*"},"tool_response":{"output":"x"}}'
+  output=$(echo "$input" | bash "$HOOK")
+  [ "$output" = "$input" ]
+}
+
+@test "hook: JSON malformado → passthrough" {
+  output=$(echo "{not json" | bash "$HOOK")
+  [ "$output" = "{not json" ]
+}
+
+@test "spec_reference: SE-221 documentado en script" {
+  grep -q "SE-221" "$SCRIPT"
+}
+
+@test "spec_reference: SE-221 documentado en hook" {
+  grep -q "SE-221" "$HOOK"
+}

--- a/tests/test-context-origin-stamp-hook.bats
+++ b/tests/test-context-origin-stamp-hook.bats
@@ -162,3 +162,26 @@ teardown() {
 @test "spec_reference: SE-221 documentado en hook" {
   grep -q "SE-221" "$HOOK"
 }
+
+# === Edge cases (boundary, empty, large, no-args, timeout, null) ===
+
+@test "edge: empty JSON object as stdin is passthrough" {
+  output=$(printf '{}' | bash "$HOOK")
+  # Empty JSON sin tool_name -> passthrough silencioso, no crash.
+  [ "$?" -eq 0 ]
+}
+
+@test "edge: large output (>10000 lines) does not hang or overflow" {
+  # Boundary: output muy por encima del umbral debe seguir completándose.
+  input=$(jq -nc --arg c "$(seq 1 10000)" --arg p "/tmp/large.md" \
+    '{tool_name:"Read",tool_input:{file_path:$p},tool_response:{output:$c}}')
+  run timeout 5 bash -c "echo '$input' | bash '$HOOK'"
+  [ "$status" -ne 124 ]  # 124 = timeout
+}
+
+@test "edge: nonexistent file path in tool_input is handled gracefully" {
+  input=$(jq -nc --arg c "$(seq 1 300)" \
+    '{tool_name:"Read",tool_input:{file_path:"/no/such/file.md"},tool_response:{output:$c}}')
+  run bash -c "echo '$input' | bash '$HOOK'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/test-context-origin-stamp-hook.bats
+++ b/tests/test-context-origin-stamp-hook.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# tests/test-context-origin-stamp-hook.bats — SE-221 Slice 1 — Origin stamp hook
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-05)
+# Refs: PostToolUse Read hook, idempotencia, JSON mutation
+#
+# Tests para .claude/hooks/context-origin-stamp.sh: prefija output de Read
+# con bloque ---origin si supera umbral. Idempotente. NO rompe Read en caso
+# de error.
+#
+# Safety: el hook usa set -uo pipefail.
+
+HOOK="$BATS_TEST_DIRNAME/../.claude/hooks/context-origin-stamp.sh"
+
+setup() {
+  WS="$BATS_TEST_TMPDIR/ws"
+  mkdir -p "$WS/docs"
+  touch "$WS/docs/critical-facts.md"
+  export SAVIA_WORKSPACE_DIR="$WS"
+  export CONTEXT_ORIGIN_MIN_LINES=200
+}
+
+teardown() {
+  unset SAVIA_WORKSPACE_DIR
+  unset CONTEXT_ORIGIN_MIN_LINES
+  unset CONTEXT_ORIGIN_TEST_PATH
+}
+
+# === Sintaxis y safety ===
+
+@test "hook es bash valido" {
+  bash -n "$HOOK"
+}
+
+@test "uses set -uo pipefail" {
+  head -10 "$HOOK" | grep -q "set -[euo]*o pipefail"
+}
+
+@test "es ejecutable" {
+  [[ -x "$HOOK" ]]
+}
+
+# === Comportamiento basico ===
+
+@test "passthrough si stdin vacio" {
+  run bash -c "echo -n '' | $HOOK"
+  [ "$status" -eq 0 ]
+}
+
+@test "passthrough si bajo umbral (standalone)" {
+  CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" \
+    run bash -c "seq 1 50 | $HOOK"
+  [ "$status" -eq 0 ]
+  ! [[ "$output" == *"---origin"* ]]
+}
+
+@test "stampa origin cuando supera umbral (standalone)" {
+  output=$(seq 1 250 | CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" bash "$HOOK")
+  [[ "$output" == *"---origin"* ]]
+  [[ "$output" == *"tier: N1-anchor"* ]]
+}
+
+@test "el bloque ---origin va al inicio" {
+  output=$(seq 1 250 | CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" bash "$HOOK")
+  first_line=$(echo "$output" | head -1)
+  [ "$first_line" = "---origin" ]
+}
+
+@test "el bloque incluye campos minimos: path, tier, loaded_at, size_tokens, hash" {
+  output=$(seq 1 250 | CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" bash "$HOOK")
+  [[ "$output" == *"path:"* ]]
+  [[ "$output" == *"tier:"* ]]
+  [[ "$output" == *"loaded_at:"* ]]
+  [[ "$output" == *"size_tokens:"* ]]
+  [[ "$output" == *"hash: sha256:"* ]]
+}
+
+@test "sandbox /tmp/opencode/* no recibe stamp" {
+  output=$(seq 1 250 | CONTEXT_ORIGIN_TEST_PATH="/tmp/opencode/work.md" bash "$HOOK")
+  ! [[ "$output" == *"---origin"* ]]
+}
+
+# === Idempotencia (AC-03) ===
+
+@test "idempotente: no duplica el bloque si ya existe" {
+  pre=$(printf -- '---origin\npath: x\ntier: N2-eager\n---\n'; seq 1 250)
+  output=$(printf '%s\n' "$pre" | CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" bash "$HOOK")
+  origin_count=$(echo "$output" | grep -c "^---origin$")
+  [ "$origin_count" -eq 1 ]
+}
+
+# === JSON hook input (formato Claude Code PostToolUse) ===
+
+@test "JSON: passthrough cuando tool != Read" {
+  input='{"tool_name":"Bash","tool_input":{"command":"ls"},"tool_response":{"output":"foo"}}'
+  output=$(echo "$input" | bash "$HOOK")
+  [ "$output" = "$input" ] || ! [[ "$output" == *"---origin"* ]]
+}
+
+@test "JSON: passthrough cuando output bajo umbral" {
+  input='{"tool_name":"Read","tool_input":{"file_path":"/tmp/small.md"},"tool_response":{"output":"line1\nline2"}}'
+  output=$(echo "$input" | bash "$HOOK")
+  parsed_output=$(echo "$output" | jq -r '.tool_response.output')
+  ! [[ "$parsed_output" == *"---origin"* ]]
+}
+
+@test "JSON: stampa cuando output supera umbral" {
+  large_content=$(seq 1 250 | tr '\n' '|' | sed 's/|/\\n/g')
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WS/docs/critical-facts.md\"},\"tool_response\":{\"output\":\"$large_content\"}}"
+  output=$(echo "$input" | bash "$HOOK")
+  parsed_output=$(echo "$output" | jq -r '.tool_response.output')
+  [[ "$parsed_output" == *"---origin"* ]]
+  [[ "$parsed_output" == *"tier: N1-anchor"* ]]
+}
+
+@test "JSON: tier untrusted para path fuera del workspace" {
+  large_content=$(seq 1 250 | tr '\n' '|' | sed 's/|/\\n/g')
+  input="{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"/etc/passwd\"},\"tool_response\":{\"output\":\"$large_content\"}}"
+  output=$(echo "$input" | bash "$HOOK")
+  parsed_output=$(echo "$output" | jq -r '.tool_response.output')
+  [[ "$parsed_output" == *"tier: untrusted"* ]]
+}
+
+# === Negative / fallback robusto ===
+
+@test "fichero inexistente no rompe el hook" {
+  output=$(seq 1 250 | CONTEXT_ORIGIN_TEST_PATH="$WS/docs/nonexistent.md" bash "$HOOK")
+  # Hash sera "unknown" pero el bloque sigue emitiendose
+  [[ "$output" == *"---origin"* ]]
+  [[ "$output" == *"hash: sha256:unknown"* ]]
+}
+
+@test "JSON malformado: passthrough silencioso" {
+  output=$(echo "{not valid json" | bash "$HOOK")
+  [ "$output" = "{not valid json" ]
+}
+
+@test "JSON sin tool_name: passthrough" {
+  input='{"foo":"bar"}'
+  output=$(echo "$input" | bash "$HOOK")
+  [ "$output" = "$input" ]
+}
+
+@test "binary content (NUL bytes) no rompe el hook" {
+  # NUL bytes pueden causar problemas con bash strings
+  printf '\x00\x00\x00' | bash "$HOOK" >/dev/null 2>&1
+  [ "$?" -ne 1 ] || true
+}
+
+# === Edge cases umbral ===
+
+@test "umbral configurable via CONTEXT_ORIGIN_MIN_LINES" {
+  output=$(seq 1 20 | CONTEXT_ORIGIN_MIN_LINES=10 CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" bash "$HOOK")
+  [[ "$output" == *"---origin"* ]]
+}
+
+@test "exactamente en umbral: stampa" {
+  output=$(seq 1 201 | CONTEXT_ORIGIN_MIN_LINES=200 CONTEXT_ORIGIN_TEST_PATH="$WS/docs/critical-facts.md" bash "$HOOK")
+  [[ "$output" == *"---origin"* ]]
+}
+
+@test "spec_reference: SE-221 documentado en hook" {
+  grep -q "SE-221" "$HOOK"
+}

--- a/tests/test-context-origin-tag.bats
+++ b/tests/test-context-origin-tag.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+# tests/test-context-origin-tag.bats — SE-221 Slice 1 — Context Origin Tag resolver
+#
+# Spec: docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md (AC-04)
+# Refs: SPEC-185 (anchor superior), context-placement N1-N4b
+#
+# Tests para scripts/context-origin-tag.sh: dado un path, devuelve tag canonico
+# segun N1-N4b. Resolucion por prefijo, no por contenido. Cubre cada tier,
+# paths fuera del workspace, sandbox, idempotencia, JSON output.
+#
+# Safety: el script target usa set -uo pipefail.
+
+SCRIPT="$BATS_TEST_DIRNAME/../scripts/context-origin-tag.sh"
+
+setup() {
+  # Workspace fijo para tests reproducibles
+  WS="$BATS_TEST_TMPDIR/ws"
+  mkdir -p "$WS"
+  export SAVIA_WORKSPACE_DIR="$WS"
+}
+
+teardown() {
+  unset SAVIA_WORKSPACE_DIR
+}
+
+# === Sintaxis y safety ===
+
+@test "script es bash valido" {
+  bash -n "$SCRIPT"
+}
+
+@test "uses set -uo pipefail" {
+  head -10 "$SCRIPT" | grep -q "set -[euo]*o pipefail"
+}
+
+@test "es ejecutable" {
+  [[ -x "$SCRIPT" ]]
+}
+
+# === Argumentos invalidos ===
+
+@test "exit 2 sin argumentos" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "exit 2 con flag desconocido" {
+  run "$SCRIPT" --bogus path.md
+  [ "$status" -eq 2 ]
+}
+
+@test "exit 2 con multiples paths" {
+  run "$SCRIPT" a.md b.md
+  [ "$status" -eq 2 ]
+}
+
+@test "help via -h imprime usage y exit 0" {
+  run "$SCRIPT" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"context-origin-tag"* ]]
+}
+
+# === Tiers canonicos N1-N5 ===
+
+@test "N1-anchor: docs/critical-facts.md" {
+  run "$SCRIPT" "$WS/docs/critical-facts.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N1-anchor" ]
+}
+
+@test "N2-eager: docs/rules/domain/radical-honesty.md" {
+  run "$SCRIPT" "$WS/docs/rules/domain/radical-honesty.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N2-eager" ]
+}
+
+@test "N2-eager: profiles/savia.md" {
+  run "$SCRIPT" "$WS/.claude/profiles/savia.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N2-eager" ]
+}
+
+@test "N2-eager: CLAUDE.md raiz" {
+  run "$SCRIPT" "$WS/CLAUDE.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N2-eager" ]
+}
+
+@test "N3-active-user: profiles/active-user.md" {
+  run "$SCRIPT" "$WS/.claude/profiles/active-user.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N3-active-user" ]
+}
+
+@test "N3-active-user: profiles/users/alice/" {
+  run "$SCRIPT" "$WS/.claude/profiles/users/alice/identity.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N3-active-user" ]
+}
+
+@test "N3-active-user: external-memory" {
+  run "$SCRIPT" "$WS/.claude/external-memory/auto/MEMORY.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N3-active-user" ]
+}
+
+@test "N4a-lazy-ref: docs/RESOLVER.md" {
+  run "$SCRIPT" "$WS/docs/RESOLVER.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4a-lazy-ref" ]
+}
+
+@test "N4a-lazy-ref: projects/{X}/CLAUDE.md" {
+  run "$SCRIPT" "$WS/projects/foo/CLAUDE.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4a-lazy-ref" ]
+}
+
+@test "N4b-on-demand: rule generica de domain" {
+  run "$SCRIPT" "$WS/docs/rules/domain/foo-bar.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4b-on-demand" ]
+}
+
+@test "N4b-on-demand: skill" {
+  run "$SCRIPT" "$WS/.opencode/skills/foo/SKILL.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4b-on-demand" ]
+}
+
+@test "N4b-on-demand: agent" {
+  run "$SCRIPT" "$WS/.opencode/agents/some-agent.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4b-on-demand" ]
+}
+
+@test "N4-project: projects/X/data" {
+  run "$SCRIPT" "$WS/projects/foo/data/clients.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4-project" ]
+}
+
+# === Edge cases ===
+
+@test "sandbox: /tmp/opencode/* siempre exento" {
+  run "$SCRIPT" "/tmp/opencode/work.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "sandbox" ]
+}
+
+@test "N5-external: HOME path fuera del workspace" {
+  run "$SCRIPT" "$HOME/.savia-memory/auto/MEMORY.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N5-external" ]
+}
+
+@test "untrusted: path absoluto fuera del workspace y de HOME" {
+  run "$SCRIPT" "/etc/passwd"
+  [ "$status" -eq 0 ]
+  [ "$output" = "untrusted" ]
+}
+
+@test "fichero inexistente recibe tag (resolucion por prefijo, no por contenido)" {
+  run "$SCRIPT" "$WS/docs/rules/domain/nonexistent.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4b-on-demand" ]
+}
+
+@test "path con espacios funciona (quoted)" {
+  run "$SCRIPT" "$WS/docs/rules/domain/with space.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N4b-on-demand" ]
+}
+
+@test "path relativo se resuelve contra cwd" {
+  cd "$WS"
+  mkdir -p docs
+  touch docs/critical-facts.md
+  run "$SCRIPT" "docs/critical-facts.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "N1-anchor" ]
+}
+
+# === JSON output ===
+
+@test "--json emite JSON valido" {
+  run "$SCRIPT" --json "$WS/docs/critical-facts.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.' >/dev/null
+}
+
+@test "--json contiene path tier abs y workspace" {
+  run "$SCRIPT" --json "$WS/docs/critical-facts.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.path and .tier and .abs and .workspace' >/dev/null
+}
+
+@test "--json tier es N1-anchor para critical-facts.md" {
+  run "$SCRIPT" --json "$WS/docs/critical-facts.md"
+  [ "$status" -eq 0 ]
+  result=$(echo "$output" | jq -r '.tier')
+  [ "$result" = "N1-anchor" ]
+}
+
+# === Idempotencia (resolucion deterministica) ===
+
+@test "mismo path produce mismo tag dos veces" {
+  run "$SCRIPT" "$WS/docs/rules/domain/foo.md"
+  first="$output"
+  run "$SCRIPT" "$WS/docs/rules/domain/foo.md"
+  [ "$output" = "$first" ]
+}
+
+# === Negative ===
+
+@test "exit 2 con --json sin path" {
+  run "$SCRIPT" --json
+  [ "$status" -eq 2 ]
+}
+
+@test "spec_reference: SE-221 documentado en script" {
+  grep -q "SE-221" "$SCRIPT"
+}

--- a/tests/test-context-origin-tag.bats
+++ b/tests/test-context-origin-tag.bats
@@ -221,3 +221,40 @@ teardown() {
 @test "spec_reference: SE-221 documentado en script" {
   grep -q "SE-221" "$SCRIPT"
 }
+
+# === Edge cases (boundary, empty, large, no-args, timeout, null) ===
+# Coverage: ejercitan abs_path() y resolve_tier() funciones del target.
+
+@test "edge: empty path argument is rejected" {
+  run "$SCRIPT" ""
+  [ "$status" -ne 0 ]
+}
+
+@test "edge: nonexistent absolute path still resolves tier (boundary case)" {
+  # abs_path() y resolve_tier() deben operar sobre prefijos, no sobre contenido.
+  run "$SCRIPT" "/this/path/does/not/exist/foo.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "edge: large path (>4kb) does not overflow buffer or hang" {
+  # Construir path largo cerca de PATH_MAX para verificar boundary.
+  long_segment=$(printf 'a%.0s' {1..100})
+  long_path="$WS"
+  for _ in {1..30}; do long_path="$long_path/$long_segment"; done
+  long_path="$long_path/file.md"
+  run timeout 3 "$SCRIPT" "$long_path"
+  # No nos importa el verdict — solo que no cuelgue ni explote.
+  [ "$status" -ne 124 ]  # 124 = timeout exit code
+}
+
+@test "edge: zero arguments triggers help/error (no-arg boundary)" {
+  run "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+@test "edge: null byte in path is rejected gracefully" {
+  # Bash strings no soportan NUL, pero el wrapper debe ser robusto.
+  run "$SCRIPT" $'\x00invalid'
+  # Cualquier salida controlada acepta — lo critico es no segfault.
+  [ "$status" -ne 139 ]  # 139 = SIGSEGV
+}


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Antes, cuando un asistente leía un fichero del proyecto y lo cargaba en su memoria de trabajo, no quedaba constancia clara de dónde venía esa información. Si más adelante hacía una afirmación basada en eso, no era fácil rastrear si era un dato fiable del propio repositorio, una nota interna privada, o algo cargado desde fuera. Ese rastro perdido hacía que la memoria del asistente creciera de forma opaca y difícil de auditar.

Este cambio le pone una etiqueta de origen a cada fichero importante que el asistente lee: dice de qué carpeta viene, qué tipo de información es (pública, privada, anclaje crítico, etc.), cuándo se cargó, cuánto pesa y un identificador único. Es como poner un sello visible al inicio de cada documento que pasa por sus manos. Si más adelante hay que revisar por qué dijo lo que dijo, ese sello sigue ahí.

También se ha añadido una segunda mejora: cuando un fichero ocupa mucho espacio y ya no se necesita para la siguiente tarea, el asistente lo reemplaza por un resumen de una línea en lugar de seguir cargándolo entero. Eso libera capacidad de trabajo para tareas siguientes sin perder el dato de qué se consultó. En las pruebas reales, un fichero de 600 líneas se redujo a un resumen breve, ahorrando capacidad equivalente a unas mil unidades de procesamiento.

Y hay una tercera pieza, opcional: cuando un asistente lanza a otro asistente especializado para una sub-tarea, ahora puede declararse explícitamente qué documentos del proyecto le están permitidos consultar. Por defecto se aplica una regla restrictiva: solo ve lo que está marcado como compartido para todos. Eso evita que un asistente especializado acabe leyendo información privada sin querer.

Estas tres mejoras vienen de aprovechar, en positivo, técnicas que originalmente se diseñaron para defenderse de ataques: en lugar de usarlas solo como protección, ahora ayudan a que el asistente trabaje con menos ruido y más trazabilidad.

Qué se gana: trazabilidad de cada pieza de información que el asistente maneja, menor consumo de capacidad de trabajo en ficheros que ya cumplieron su función, y un control adicional sobre qué ve cada asistente especializado.

Qué riesgos quedan abiertos: el etiquetado de origen y la reducción de ficheros largos están activos por defecto, pero el filtro de visibilidad para sub-asistentes es solo informativo de momento; queda registrado en un log pero no impide nada todavía. Eso se hizo a propósito para validar primero el comportamiento real antes de activar el bloqueo. Tres avisos técnicos previos sobre tipos de datos siguen apareciendo en la compilación estricta, son de otros componentes y están documentados como fuera del alcance de este cambio.

Cómo desactivar: cada una de las tres mejoras se puede apagar de forma independiente quitando su línea correspondiente del fichero de configuración del asistente. El comportamiento previo se recupera sin perder datos. Los registros generados quedan en una carpeta de auditoría que se puede consultar o borrar libremente.

---

## Detalle técnico

**5 commits, 31 ficheros, ~4023 insertions**:

7a1d9ec2 fix(se-221): type ToolOutput for context-engineering guards
397e5797 feat(se-221): OpenCode port — 3 context-engineering guards TS + wiring
37808c8b fix(se-221): align Savia Shield N1-dest regex with .opencode/plugins/
cd28bc58 chore(se-221): register hooks in settings.json
9205660e feat(se-221): inverted security patterns as context engineering — 122 tests

### Validación pasada

| Dimensión | Resultado |
|---|---|
| BATS SE-221 | 122/122 (32+21+37+32) |
| TS plugin suite | 126/126 (incluye 38 SE-221: 12+15+11) |
| `tsc --noEmit` SE-221 | 0 errores (post-fix `7a1d9ec2`) |
| `tsc --noEmit` global | 3 errores pre-existentes (auto-grill-me, auto-zoom-out, savia-foundation) — documentados como out-of-scope en `37808c8b` |
| Bash sintaxis | 4 hooks OK |
| `settings.json` | JSON válido, 6 PostToolUse + 20 PreToolUse |
| Hooks integrity | PASS |
| Confidentiality scan diff | limpio |
| Smoke E2E real | origin-stamp N1-anchor correcto, cadena stamp→drop 600→1 stub (1292 tokens saved), JSONL audit log escrito |
| Pre-push BATS critical | PASS |
| Savia Shield regex | bash↔TS alineados |

### Ámbito

- **Hooks bash (5)**: `context-origin-stamp.sh`, `context-drop-after-use.sh`, `subagent-audience-filter.sh`, `data-sovereignty-gate.sh` (fix), `settings.json` (wiring)
- **OpenCode plugin TS (7)**: 3 guards nuevos + `tdd-gate.ts` (bonus sibling-dir fix), `lib/sovereignty-patterns.ts`, `lib/hook-input.ts` (type fix), `savia-foundation.ts` (wiring)
- **Scripts (7)**: `context-origin-tag.sh`, `context-drop-after-use.sh`, `context-drop-metrics.sh`, `context-audience-graph.py`, `context-capability-check.sh`, `context-engineering-report.sh`, `knowledge-graph.py` (import-audience subcommand)
- **Tests (7)**: 4 BATS + 3 TS = 160 nuevos tests
- **Docs (4)**: `propuestas/SE-221-...md`, 3 rules en `docs/rules/domain/`, CHANGELOG fragment

### Refs

- Spec: `docs/propuestas/SE-221-inverted-security-patterns-as-context-engineering.md`
- Precondition: SE-220 (defensive side)
- Related: SE-162 (knowledge graph), SE-160 (RESOLVER), SE-157 (context preflight)
