### PR TITLE
feat(specs-193-194): Context Provenance Hardening + Criterion Simulation Layer (PROPOSED)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e4999f5502c0c19898097db18c255ec1698cf80a68455aaba50cd71f21a2ac53
-timestamp=2026-06-13T12:12:36Z
-branch=agent/spec-192-anti-adulation
-head_commit=cce1f490
-signature=928995df73d08e14c09cb7560d01092e9d50c9d0165f814014de7c70c24358ab
+diff_hash=e44b3343fc7e654a9e7ff0cf0892c24070612497cf6cefa283a88027890e83a5
+timestamp=2026-06-13T12:42:51Z
+branch=agent/specs-193-194-defense-meta
+head_commit=27c697a4
+signature=4d4c4408c05634eaedbb306d296bd092b02bdb2a132982c0540a2c48e98314dc

--- a/CHANGELOG.d/specs-193-194-defense-meta.md
+++ b/CHANGELOG.d/specs-193-194-defense-meta.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Added
+---
+
+### Added
+
+- SPEC-193 (Context Provenance & Injection Hardening) and SPEC-194 (Criterion Simulation Layer) PROPOSED. Two complementary specs addressing structural limits of agentic systems with explicit honesty about what they cannot do. SPEC-193 closes 6 of 7 documented prompt-injection vectors via 12 components in 3 layers (deterministic sanitize, LLM judges, temporal correlation). SPEC-194 adds meta-reflection simulation BEFORE applying ideas — 4 questions (frame challenge, historical priors, operator state, alternative reframing) that interrupt visually but never block. Both spec files include disclaimer that the layer is heuristic simulation, not real criterion. Origin: 2026-06-13 jailbreak techniques study + user reflection on review vs reflection. ROADMAP backlog reordered: 8 items, 3 in PR review + 1 P0 new + 4 P2/P3.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-06-11 | **Version:** v6.20.0 | **562 commands · 72 agents · 103 skills · 76 hooks · 450+ test suites · Active backlog 2 items (~12h P2)** — ver `## Active Stack — 2026-06-11`
+**Updated:** 2026-06-13 | **Version:** v6.20.0 | **562 commands · 75 agents · 104 skills · 80 hooks · 450+ test suites · Active backlog 7 items (3 in PR review + 4 P2/P3)** — ver `### Backlog restante — repriorizado 2026-06-13`
 
 ---
 
@@ -714,14 +714,17 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | SE-218 S1-S5 | codebase-memory patterns: hook augmentation, KG snapshot, qualified names, tiered flush, .saviaignore — 81 tests | #834 |
 | SE-219 S1-S5 | abtop patterns: session-status, context-meter, session-cleanup, profile-discover, agent-tick — 48 tests | #835 |
 
-### Backlog restante — repriorizado 2026-06-11
+### Backlog restante — repriorizado 2026-06-13
 
 | # | ID | Qué | Esfuerzo | Prioridad | Deps |
 |---|---|---|---|---|---|
-| 1 | **SPEC-SE-036 Slice 3** | JWT sunset opt-in (PAT file migration) | 4h | P2 | Slice 1+2 ✓ |
-| 2 | **SPEC-188 Fase 2** | Sealed Contract Tests | ~8h | P2 | Fase 1 ✓ |
-| 3 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
-| 4 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
+| 1 | **SPEC-189** | Greedy Context Budget + Read injector hook | 88 tests, PR #838 | P1 | — |
+| 2 | **SPEC-192** | Anti-Adulation defense (3 LLM judges + Layer 1 hook + skill) | 68 tests, PR #839 | P0 | — |
+| 3 | **SPEC-193** | Context Provenance & Injection Hardening (12 components, 3 layers, 22 ACs) | 4-6d / 5-8h agente | P0 | SPEC-192 (hermana operacional) |
+| 4 | **SPEC-SE-036 Slice 3** | JWT sunset opt-in (PAT file migration) | 4h | P2 | Slice 1+2 ✓ |
+| 5 | **SPEC-188 Fase 2** | Sealed Contract Tests | ~8h | P2 | Fase 1 ✓ |
+| 6 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
+| 7 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
 
 ### Tier 3 — SaviaClaw (requiere sistema externo)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap Unificado — pm-workspace / Savia
 
-**Updated:** 2026-06-13 | **Version:** v6.20.0 | **562 commands · 75 agents · 104 skills · 80 hooks · 450+ test suites · Active backlog 7 items (3 in PR review + 4 P2/P3)** — ver `### Backlog restante — repriorizado 2026-06-13`
+**Updated:** 2026-06-13 | **Version:** v6.20.0 | **562 commands · 75 agents · 104 skills · 80 hooks · 450+ test suites · Active backlog 8 items (3 in PR review + 1 P0 nuevo + 4 P2/P3)** — ver `### Backlog restante — repriorizado 2026-06-13`
 
 ---
 
@@ -721,10 +721,11 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | 1 | **SPEC-189** | Greedy Context Budget + Read injector hook | 88 tests, PR #838 | P1 | — |
 | 2 | **SPEC-192** | Anti-Adulation defense (3 LLM judges + Layer 1 hook + skill) | 68 tests, PR #839 | P0 | — |
 | 3 | **SPEC-193** | Context Provenance & Injection Hardening (12 components, 3 layers, 22 ACs) | 4-6d / 5-8h agente | P0 | SPEC-192 (hermana operacional) |
-| 4 | **SPEC-SE-036 Slice 3** | JWT sunset opt-in (PAT file migration) | 4h | P2 | Slice 1+2 ✓ |
-| 5 | **SPEC-188 Fase 2** | Sealed Contract Tests | ~8h | P2 | Fase 1 ✓ |
-| 6 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
-| 7 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
+| 4 | **SPEC-194** | Criterion Simulation Layer (meta-reflexion antes de aplicar; 11 components, 20 ACs; explicitamente simulacion no criterio) | 5-7d / 6-9h agente | P0 | SPEC-188 (memoria de fallos) |
+| 5 | **SPEC-SE-036 Slice 3** | JWT sunset opt-in (PAT file migration) | 4h | P2 | Slice 1+2 ✓ |
+| 6 | **SPEC-188 Fase 2** | Sealed Contract Tests | ~8h | P2 | Fase 1 ✓ |
+| 7 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
+| 8 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
 
 ### Tier 3 — SaviaClaw (requiere sistema externo)
 

--- a/docs/propuestas/SPEC-193-context-provenance-injection-hardening.md
+++ b/docs/propuestas/SPEC-193-context-provenance-injection-hardening.md
@@ -1,0 +1,432 @@
+---
+status: PROPOSED
+---
+
+# SPEC-193 — Context Provenance & Injection Hardening
+
+> **Priority:** P0 · **Estimate (human):** 4-6d · **Estimate (agent):** 5-8h · **Category:** standard · **Type:** infrastructure
+
+> **Dual estimate**: 4-6 dias humano end-to-end (12 componentes en tres capas + tests + actualizacion de reglas + datos de telemetria iniciales). 5-8h agente con pipeline supervisado. Categoria standard. Detalle en `@docs/rules/domain/dual-estimation.md`.
+
+## Objective
+
+Savia tiene cobertura defensiva parcial contra prompt injection y manipulacion de contexto. La auditoria 2026-06-13 (`output/20260613-jailbreak-techniques-defensive-study.md`) inventaria 7 tecnicas + 2 meta-tecnicas documentadas en literatura academica de los ultimos 3 anos y mapea 6 gaps explotables, especialmente en memoria persistente y correlacion cross-turn.
+
+Esta spec cierra los 6 gaps con 12 componentes en defensa-en-capas: capa A deterministic (sin LLM, alto ROI), capa B LLM judges (extension del Recommendation Tribunal SPEC-125), capa C correlacion temporal y consistencia. Defaults conservadores (shadow -> warn -> block tras 30 dias de telemetria). El objetivo NO es defensa perfecta (no existe en LLMs); es elevar el coste del ataque y dar visibilidad medible.
+
+Trade-off honesto: deteccion semantica costosa en latencia, falsos positivos sobre creative writing legitimo, decomposition cross-turn requiere taxonomia mantenida. La defensa heuristica reduce superficie pero no la cierra. Documentado en seccion Limitaciones.
+
+## Principles affected
+
+- **#1 Data sovereignty** — Telemetria local (`output/context-hardening-telemetry.jsonl`). Cero envio externo.
+- **#3 Reversible** — `SAVIA_HARDENING=off` desactiva las tres capas. Cada componente env-overridable.
+- **#5 Humans decide** — Capas B y C solo emiten verdict + banner. La usuaria ve la senal, no se censura.
+- **#9 Confidentiality** — Provenance tagging refuerza N1-N5 confidentiality tiers existentes.
+- **Linea Roja L1-L5** (`savia-ethical-principles.md`) — esta spec implementa la defensa que mantiene las lineas rojas frente a ataques sofisticados (decomposition, fiction framing, authority claims).
+- **Genesis B9 GOAL STEWARD** — los jueces y la correlacion son guardia activa contra deriva del proposito por manipulacion adversaria.
+
+NO contradice SE-028 (`prompt-injection-guard.sh`) ni SE-221 (`context-origin-stamp.sh`): los extiende.
+
+## Design
+
+### Overview
+
+Defensa en tres capas sucesivas. Cualquier evento de entrada externa (Read, memory-store save, KG insert, tool output) atraviesa al menos la Capa A. Output del modelo atraviesa la Capa B. La sesion entera es observada por la Capa C.
+
+```
+[input externo: Read, tool_output, memory.save, KG.insert]
+     |
+     v
+[Capa A: Sanitize deterministic, <50ms, no LLM]
+     | NFKC normalize, ASCII-fold, invisible-char strip,
+     | bidi-control reject, homoglyph score, script-mixing detect
+     | provenance tag obligatorio: source, trust_level, session_id
+     v
+[memoria persistente o contexto del modelo, marcado]
+     |
+     v
+[Capa B: LLM judges al output, extiende SPEC-125 Recommendation Tribunal]
+     | structural-framing-judge      (modo shadow)
+     | fiction-framing-judge         (modo shadow)
+     | authority-claim-judge         (modo shadow)
+     v
+[Capa C: Correlacion temporal y consistencia, observacion]
+     | cross-turn-correlation        (telemetria + warn si convergence)
+     | classification-consistency    (telemetria de inconsistencias entre clasificadores)
+     | re-anchor periodico de L1-L5 al system prompt
+     v
+[output al usuario, con banner si WARN/VETO]
+```
+
+### Components
+
+| # | Name | Kind | Purpose |
+|---|------|------|---------|
+| 1 | `scripts/context-sanitize/normalize.py` | py script (stdlib) | NFKC + ASCII-fold + invisible-char strip + bidi-control reject |
+| 2 | `scripts/context-sanitize/homoglyph-detect.py` | py script (stdlib) | Detecta Latin <-> Cyrillic / Greek / Mathematical mixing; score 0-100 |
+| 3 | `.opencode/hooks/context-sanitize-input.sh` | hook (PreToolUse Read/Write) | Sanitiza antes de carga al contexto |
+| 4 | `.opencode/hooks/memory-write-sanitize.sh` | hook (PreToolUse antes memory-store save) | Bloquea entradas con homoglyphs no justificados |
+| 5 | `.opencode/agents/structural-framing-judge.md` | LLM judge (mid model) | Detecta output que parece manual/protocolo sobre dominio sensible |
+| 6 | `.opencode/agents/fiction-framing-judge.md` | LLM judge (mid model) | Detecta persona-shift y fiction-frame con contenido equivalente al rechazado |
+| 7 | `.opencode/agents/authority-claim-judge.md` | LLM judge (fast model) | Detecta y descuenta auto-declaraciones de credencial |
+| 8 | `scripts/cross-turn-correlation/track.py` | py script | Registra clase semantica de cada turn; alerta si convergence |
+| 9 | `scripts/classification-consistency-audit.py` | py script | Compara verdicts entre clasificadores; loguea inconsistencias |
+| 10 | KG schema migration | sql | Anade columnas `source`, `trust_level`, `created_by_session` a `entities` |
+| 11 | `.opencode/hooks/re-anchor-redlines.sh` | hook (UserPromptSubmit periodico) | Reinjecta L1-L5 cada N turns |
+| 12 | `docs/rules/domain/authority-claims-not-evidence.md` | rule | Auto-declaracion de rol NO relaja umbrales en dominios sensibles |
+
+Adicionalmente: extension de `scripts/recommendation-tribunal/aggregate.sh` para los 3 nuevos jueces (mismo patron fail-soft que SPEC-192).
+
+### Contracts
+
+#### Capa A — sanitize input
+
+```bash
+# context-sanitize-input.sh
+INPUT=$(cat)  # JSON envelope
+DRAFT=$(jq -r '.tool_input.text // .tool_response.output' <<< "$INPUT")
+RESULT=$(python3 scripts/context-sanitize/normalize.py --text "$DRAFT" --json)
+# Result fields: {normalized, original, transformations: [list], homoglyph_score, bidi_present}
+SCORE=$(jq -r '.homoglyph_score' <<< "$RESULT")
+case "$MODE" in
+  off) exit 0 ;;
+  shadow) telemetry "SANITIZE_OBSERVED" ; exit 0 ;;
+  warn)   [[ $SCORE -gt 30 ]] && stderr "WARN: homoglyphs detected (score=$SCORE)" ; exit 0 ;;
+  block)  [[ $SCORE -gt 70 ]] && exit 2 ; exit 0 ;;
+esac
+```
+
+Reglas de bloqueo:
+- `bidi_present` -> SIEMPRE block (no hay caso legitimo de RLO/LRO en payload de tool).
+- `homoglyph_score >= 70` con `script_mixing` activo -> block en modo block.
+- `homoglyph_score 30-70` -> warn.
+- `homoglyph_score < 30` -> pass.
+
+#### Capa A — homoglyph score algoritmo
+
+Tabla resumen:
+
+| Caracteristica | Peso |
+|---|---|
+| Mezcla Latin + Cyrillic en misma palabra | +30 |
+| Mezcla Latin + Greek en misma palabra | +25 |
+| Caracter de Mathematical Alphanumeric (U+1D400-U+1D7FF) | +20 por ocurrencia |
+| Tags Unicode (U+E0000-U+E007F) | +50 (siempre adversario) |
+| Zero-width chars (U+200B, U+200C, U+200D, U+FEFF) en posicion no-justificada | +15 |
+| Soft hyphen (U+00AD) en cadena de caracteres alfa | +20 |
+| Bidi controls (U+202A-U+202E, U+2066-U+2069) | +50 + bidi_present=true |
+
+Score capped a 100. NFKC normalization se aplica SIEMPRE; el score se calcula sobre el original para detectar el intento.
+
+#### Capa B — structural-framing-judge
+
+```yaml
+input:  { draft: string, context: string (last 2 turns) }
+output: { score: 0-100, veto: bool, confidence: 0-1, reason: str, evidence: [phrase] }
+veto trigger: score >= 85 AND confidence >= 0.85 AND domain in CBRN_TAXONOMY
+latency: 3s p95
+```
+
+Heuristica del prompt: detectar si el draft adopta forma de:
+- Manual / protocolo numerado ("1. preparar", "2. mezclar")
+- Capitulo / seccion ("Capitulo 3.2", "Section IV")
+- Tabla taxonomica con valores especificos
+- Pseudocodigo experimental
+Y si la materia es de dominio sensible (CBRN, manipulacion psicologica, autoharm, armas).
+
+#### Capa B — fiction-framing-judge
+
+```yaml
+input: { draft, last_3_turns }
+output: { score, veto, confidence, persona_shift_detected: bool, content_equivalent: bool }
+veto trigger: persona_shift_detected AND content_equivalent AND domain_sensitive
+latency: 3s p95
+```
+
+Test del juez: "si removieras el frame de ficcion, el contenido se rechazaria solo?" Si si -> flag. Linea Roja L3 ya prohibe roleplay como entidad sin principios; este juez detecta la version sutil.
+
+#### Capa B — authority-claim-judge
+
+```yaml
+input: { draft, user_message }
+output: { claim_detected: str, claim_type: "credential|professional|research|other", domain_sensitive: bool, threshold_relaxed: bool }
+veto: false (siempre warn)
+latency: 2s p95 (fast model)
+```
+
+Heuristica: detecta frases tipo "soy investigador", "para mi tesis", "estoy escribiendo paper". NO emite veto. Solo loguea: si el draft posterior baja umbrales en dominio sensible despues de claim, telemetria lo marca.
+
+#### Capa C — cross-turn-correlation
+
+```python
+# track.py
+session_log_path = output/cross-turn/{session_id}.jsonl
+on_turn(turn):
+    domain = classify_semantic_domain(turn.input + turn.output)
+    append_log(session_id, turn_id, domain, timestamp)
+    recent = last_N_turns(session_id, N=10)
+    if len(set(recent.domains) & SENSITIVE_DOMAINS) >= 3:
+        emit_alert(session_id, "convergence_on_sensitive_domain", recent)
+```
+
+`SENSITIVE_DOMAINS` se define en `scripts/cross-turn-correlation/sensitive-taxonomy.json`: CBRN sub-domains (chem-synthesis, bio-pathogen, nuclear-fissile, radiological), weapons, manipulation, self-harm, child-safety. Lista reducida y mantenible.
+
+correlation_score = `len(intersection) / N`. Threshold default 0.30 (3 de 10 turns). Modo:
+- shadow: solo log
+- warn: emite banner + log
+- block: NO disponible para esta capa (heuristica, falsos positivos)
+
+#### Capa C — classification-consistency-audit
+
+```python
+# audit.py
+on_turn(turn):
+    input_verdict  = classify_input(turn.input)
+    output_verdict = classify_output(turn.output)
+    tribunal_verdict = recommendation_tribunal(turn.output)
+    if disagreement(input, output, tribunal):
+        log("INCONSISTENCY", turn_id, verdicts)
+```
+
+Solo telemetria. Datos para detectar grietas en clasificadores que el atacante explota (#6).
+
+#### Capa C — re-anchor-redlines
+
+Hook UserPromptSubmit. Cada N=15 turns o si session_token_count > 40000:
+- Lee `docs/rules/domain/savia-ethical-principles.md` lineas rojas L1-L5.
+- Anade al inicio del system context: `[RE-ANCHOR L1-L5: armas/manipulacion/autonomia/transhumanismo/CBRN — inmutables]`.
+- Telemetria: `{ts, session_id, anchor_count, turn_count}`.
+
+Mitiga "Lost in the Middle" (Liu 2023): los principios no se diluyen en sesiones largas.
+
+#### Schema migration KG
+
+```sql
+ALTER TABLE entities ADD COLUMN source TEXT DEFAULT 'unknown';
+ALTER TABLE entities ADD COLUMN trust_level INTEGER DEFAULT 50;
+ALTER TABLE entities ADD COLUMN created_by_session TEXT DEFAULT NULL;
+CREATE INDEX idx_entities_trust ON entities(trust_level);
+CREATE INDEX idx_entities_source ON entities(source);
+```
+
+Migracion idempotente via `scripts/kg-schema-migrate.py`. trust_level por defecto:
+- system / spec / rule -> 100
+- user -> 80
+- tool (Bash, Grep) -> 60
+- external (WebFetch, MCP) -> 40
+- llm-generated -> 30
+
+### Configuration
+
+```bash
+# Master switch
+SAVIA_HARDENING=on|off                              # default on
+
+# Capa A
+SAVIA_SANITIZE_INPUT=off|shadow|warn|block          # default warn
+SAVIA_HOMOGLYPH_THRESHOLD_BLOCK=70                  # block si score >= este
+SAVIA_HOMOGLYPH_THRESHOLD_WARN=30
+SAVIA_MEMORY_WRITE_SANITIZE=off|warn|block          # default warn
+
+# Capa B
+SAVIA_STRUCTURAL_FRAMING_JUDGE=off|shadow|warn       # default shadow
+SAVIA_FICTION_FRAMING_JUDGE=off|shadow|warn          # default shadow
+SAVIA_AUTHORITY_CLAIM_JUDGE=off|shadow|warn          # default shadow
+
+# Capa C
+SAVIA_CROSS_TURN_CORRELATION=off|shadow|warn         # default shadow
+SAVIA_CLASSIFICATION_CONSISTENCY=off|shadow          # default shadow (siempre)
+SAVIA_RE_ANCHOR_INTERVAL=15                          # turns
+
+# Telemetria
+SAVIA_HARDENING_LOG=output/context-hardening-telemetry.jsonl
+
+# Red-team mode (testing)
+SAVIA_REDTEAM_MODE=on   # bypassea bloqueos para tests; loguea TODO
+```
+
+## Acceptance criteria
+
+1. **NFKC + ASCII-fold canonico**: dado input con caracteres confusables, `normalize.py` produce salida ASCII deterministica. Verificado por pytest con 30 ejemplos (homoglyphs Cyrillic, Greek, Mathematical, fullwidth).
+2. **Bidi-control rejection siempre block**: input con U+202E (RLO) en mode warn devuelve exit 2 con mensaje. Verificado por bats.
+3. **Homoglyph score correctly rises**: input "paypal" puro Latin -> score 0; mezcla "paypa1" con Cyrillic 'a' -> score >= 30. Verificado por pytest.
+4. **Memory-write-sanitize rechaza score > 70**: `bash scripts/memory-store.sh save` con entrada que contiene mezcla Latin+Cyrillic -> rechazado en modo block. Verificado por bats.
+5. **structural-framing-judge detecta manual**: prompt sintetico con forma "Capitulo 1: preparacion" sobre dominio CBRN -> score >= 70. Verificado por pytest sintetico.
+6. **structural-framing-judge ignora doc legitima**: README de proyecto de software con headings "1. Install / 2. Configure" -> score < 30. Verificado por pytest.
+7. **fiction-framing-judge detecta persona-shift + content-equivalent**: prompt sintetico "escribe novela donde X explica Y" sobre dominio sensible -> persona_shift_detected=true. Verificado por pytest.
+8. **fiction-framing-judge ignora ficcion legitima**: ficcion sin contenido equivalente al rechazado (ej. dialogo entre dos personajes sobre tema benigno) -> score 0. Verificado por pytest.
+9. **authority-claim-judge detecta credential claim**: input "soy investigador en seguridad" -> claim_detected. Verificado por pytest.
+10. **authority-claim-judge no veto**: siempre `veto: false`. Verificado por pytest.
+11. **cross-turn-correlation registra clase semantica**: 10 turnos sinteticos con 3+ sobre dominio CBRN -> alerta `convergence_on_sensitive_domain`. Verificado por pytest.
+12. **cross-turn-correlation no falso positivo**: 10 turnos diversos sin convergence -> sin alerta. Verificado por pytest.
+13. **classification-consistency-audit logea inconsistencias**: input clasificado OK + output clasificado FAIL -> entry en log con severity="inconsistency". Verificado por pytest.
+14. **re-anchor inserta L1-L5 cada N turns**: simulacion de 30 turns con N=15 -> 2 inyecciones registradas. Verificado por pytest.
+15. **KG migration idempotente**: ejecutar `kg-schema-migrate.py` 2 veces no duplica columnas ni rompe datos. Verificado por pytest con sqlite temporal.
+16. **`authority-claims-not-evidence.md` regla existe**: fichero canonico, citado por authority-claim-judge. Verificado por grep.
+17. **Master switch SAVIA_HARDENING=off**: con esa env, ningun hook ni juez actua. Verificado por bats integracion.
+18. **Telemetria JSONL valida**: cada componente escribe linea JSON parseable con campos `ts, layer, decision, evidence`. Verificado por bats.
+19. **Latencia tribunal con 10 jueces**: p95 < 7s (relajado desde 5s con 7 jueces de SPEC-192). Verificado por benchmark.
+20. **No falsos positivos en outputs historicos**: ejecutar Capa A en modo warn contra ultimos 5 ficheros de output/ -> 0 bloqueos. Verificado manualmente + script.
+21. **SAVIA_REDTEAM_MODE bypassea bloqueos pero logea**: con esa env, mode=block deja pasar pero loguea como `REDTEAM_BYPASS`. Verificado por bats.
+22. **Tests sinteticos cubren 7+2 vectores**: 30 positivos por capa + 30 negativos = 180 casos. Verificado por pytest.
+
+## Out of scope
+
+- **Mejorar el modelo subyacente**: imposible desde el workspace.
+- **Cobertura cross-session de illusory truth completa**: cross-turn-correlation es por sesion. Cross-session via active-user MEMORY.md se aborda en spec sucesora si los datos lo justifican.
+- **Internacionalizacion completa**: capa A cubre Latin/Cyrillic/Greek/Mathematical. Otros scripts (Arabic, Hebrew, CJK confusables) en spec sucesora.
+- **Deteccion de irony / sarcasmo**: requiere modelo mas avanzado.
+- **Auto-rewrite del draft**: el modelo NO regenera automaticamente. Solo en modo block; en warn/strip output llega con banner.
+- **Defensa contra ataques de modelo-base** (ej. abuso de fine-tuning): out of scope, asume modelo Anthropic/OpenAI/equivalente con safety baseline propia.
+- **Testing en produccion contra red team activo**: requiere acuerdo separado.
+
+## Dependencies
+
+- Blocked by: ninguno.
+- Blocks: ninguna spec actualmente.
+- Related:
+  - SE-028 `prompt-injection-guard.sh`: extension natural; capa A ejecuta antes y enriquece.
+  - SE-221 `context-origin-stamp.sh`: capa A complementa con homoglyph score y trust_level numerico.
+  - SPEC-125 Recommendation Tribunal: extension con 3 jueces nuevos (capa B).
+  - SPEC-192 anti-adulation: hermana operacionalmente; mismo patron de defaults y telemetria.
+  - SE-072 `verified-source-required`: trust_level en KG es la implementacion numerica.
+  - Linea Roja L1-L5 (`savia-ethical-principles.md`): los principios que esta spec defiende.
+
+## Migration path
+
+Despliegue gradual en 4 semanas:
+
+| Semana | Cambio | Modo |
+|---|---|---|
+| 1 | Capa A componentes 1-4 | shadow global |
+| 2 | Revisar telemetria, ajustar patterns | warn capa A |
+| 3 | Anadir capa B (3 jueces) | shadow capa B |
+| 4 | Anadir capa C (correlacion + consistency) | shadow capa C |
+| 8 (mes 2) | Revisar telemetria 30d, decidir promocion a warn / block | — |
+
+Reverse: cambiar env vars a `off` revierte. Borrar agentes/hooks/scripts/skill remueve el codigo. KG migration es additiva (no destruye datos existentes).
+
+## Reference code
+
+Patron del normalize.py (esqueleto):
+
+```python
+import unicodedata
+import re
+
+INVISIBLE_CHARS = set("\u200b\u200c\u200d\u2060\ufeff\u00ad")
+BIDI_CONTROLS = set("\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069")
+TAGS_RANGE = (0xE0000, 0xE007F)
+
+def normalize(text: str) -> dict:
+    bidi_present = any(c in BIDI_CONTROLS for c in text)
+    transformations = []
+
+    # Strip invisible
+    cleaned = "".join(c for c in text if c not in INVISIBLE_CHARS)
+    if cleaned != text:
+        transformations.append("invisible_stripped")
+
+    # Strip Unicode tags
+    cleaned = "".join(c for c in cleaned if not (TAGS_RANGE[0] <= ord(c) <= TAGS_RANGE[1]))
+
+    # NFKC
+    nfkc = unicodedata.normalize("NFKC", cleaned)
+    if nfkc != cleaned:
+        transformations.append("nfkc_normalized")
+
+    # Compute homoglyph score
+    score = compute_homoglyph_score(text)  # raw, on original
+
+    return {
+        "normalized": nfkc,
+        "original": text,
+        "transformations": transformations,
+        "homoglyph_score": score,
+        "bidi_present": bidi_present,
+    }
+```
+
+## Impact statement
+
+Cierra los 6 gaps explotables documentados en la auditoria 2026-06-13. Eleva la cobertura defensiva de Savia de ~30% a ~75% sobre los 7 vectores conocidos. Convierte SE-028 de filtro pasivo en sistema multicapa observable. La telemetria mensual permite iterar sobre datos reales y promover modos solo cuando estan justificados. La defensa NO sera perfecta — research demuestra que ningun filtro LLM es invulnerable — pero el coste para el atacante sube de minutos a horas y los intentos quedan registrados.
+
+## OpenCode Implementation Plan
+
+> Required post-2026-04-26 (per `docs/rules/domain/spec-opencode-implementation-plan.md`).
+
+**Classification**: Tier 2. Anade infraestructura nueva en 3 capas (12 componentes), modifica `scripts/recommendation-tribunal/aggregate.sh` para extension fail-soft, anade 3 agentes al tribunal, migra KG schema, anade 1 regla canonica nueva.
+
+### Phase 1 — Capa A deterministic (semana 1)
+
+1. Crear `scripts/context-sanitize/normalize.py` con NFKC + ASCII-fold + invisible-strip + bidi-reject.
+2. Crear `scripts/context-sanitize/homoglyph-detect.py` con tabla de pesos.
+3. Tests unitarios `tests/scripts/test_context_sanitize.py` (30 positivos + 30 negativos).
+4. Crear `.opencode/hooks/context-sanitize-input.sh` con 4 modos (off/shadow/warn/block).
+5. Crear `.opencode/hooks/memory-write-sanitize.sh`.
+6. Tests bats `tests/test-context-sanitize-hook.bats` cubriendo todos los modos.
+7. Registrar hooks en `.claude/settings.json` matcher PreToolUse Read/Write y memory-store.
+8. Modo inicial: `shadow` global.
+
+### Phase 2 — Capa B LLM judges (semana 2-3)
+
+9. Crear `.opencode/agents/structural-framing-judge.md` con prompt + esquema JSON.
+10. Crear `.opencode/agents/fiction-framing-judge.md`.
+11. Crear `.opencode/agents/authority-claim-judge.md`.
+12. Tests pytest sinteticos por juez (20 positivos + 20 negativos).
+13. Modificar `recommendation-tribunal-orchestrator.md`: anadir 3 jueces a la lista de despachos paralelos. Total 10 jueces.
+14. Modificar `scripts/recommendation-tribunal/aggregate.sh`: aceptar 3 nuevas claves opcionales fail-soft.
+15. Tests bats del aggregator extendido.
+16. Modo inicial: `shadow` para los 3.
+
+### Phase 3 — Capa C correlacion temporal (semana 3-4)
+
+17. Crear `scripts/cross-turn-correlation/track.py`.
+18. Crear `scripts/cross-turn-correlation/sensitive-taxonomy.json` con dominios CBRN minimos.
+19. Crear `scripts/classification-consistency-audit.py`.
+20. Tests pytest para correlacion (10 turnos sinteticos, 3 convergence positives + negatives).
+21. Crear `.opencode/hooks/re-anchor-redlines.sh` UserPromptSubmit.
+22. Tests bats del re-anchor.
+23. Modo inicial: `shadow`.
+
+### Phase 4 — Schema migration y reglas (semana 4)
+
+24. Crear `scripts/kg-schema-migrate.py` idempotente.
+25. Tests pytest con sqlite temporal: doble ejecucion no duplica.
+26. Crear `docs/rules/domain/authority-claims-not-evidence.md`.
+27. Anadir referencia a `radical-honesty.md` y `savia-ethical-principles.md`.
+28. Generar `output/context-hardening-telemetry.jsonl` esqueleto.
+
+### Phase 5 — Validacion end-to-end
+
+29. Benchmark de latencia tribunal con 10 jueces. Confirmar p95 < 7s.
+30. Smoke real: ejecutar pipeline completo contra 5 outputs historicos. 0 falsos positivos.
+31. Telemetria funcional: verificar JSONL escrita correctamente.
+32. Documentar en `CHANGELOG.d/spec-193-injection-hardening.md`.
+
+### Acceptance criteria checklist (mapping)
+
+| AC | Phase | Verifier |
+|---|---|---|
+| 1, 2, 3, 4, 17, 18, 20, 21 | 1 | pytest + bats |
+| 5, 6, 7, 8, 9, 10 | 2 | pytest sinteticos |
+| 11, 12, 13, 14 | 3 | pytest |
+| 15, 16 | 4 | pytest + grep |
+| 19 | 5 | benchmark |
+| 22 | 1+2+3 | pytest agregado |
+
+### Risks
+
+- **Falsos positivos en docs legitimas**: README con "1. Install / 2. Run" mal clasificados como manual. Mitigacion: el juez requiere material de dominio sensible Y estructura de manual, no solo estructura.
+- **Ficcion legitima rechazada**: la usuaria escribe novelas como tarea legitima. Mitigacion: fiction-framing-judge solo flagea si content_equivalent=true (el contenido se rechazaria fuera del frame).
+- **Latencia con 10 jueces excede budget**: si pasa, los 3 jueces de capa B se hacen async (no bloquean output, registran post-hoc).
+- **Cross-turn correlation taxonomia incompleta**: los dominios sensibles cambian. Mantener `sensitive-taxonomy.json` requiere disciplina. Mitigacion: revision trimestral; PRs propuestas etiquetadas.
+- **Re-anchor satura system prompt**: cada N=15 turns anade ~200 tokens. En sesiones de 100 turns suma ~1300 tokens. Mitigacion: cap de 5 anchors; tras eso solo se actualiza el ultimo.
+
+## Notes
+
+Esta spec es complementaria a SPEC-192 (anti-adulacion). Donde SPEC-192 protege contra patrones de RLHF interno (sycophancy, concession, illusory truth), SPEC-193 protege contra ataques externos de manipulacion del contexto (Unicode, framing, decomposition).
+
+Origen del estudio: `output/20260613-jailbreak-techniques-defensive-study.md`.
+
+Inspiracion academica: Boucher 2021, Liu 2023, Greshake 2023, Wei 2024, Schulhoff 2024, Glukhov 2024, Carlini 2024, Hines 2024.

--- a/docs/propuestas/SPEC-194-criterion-simulation-layer.md
+++ b/docs/propuestas/SPEC-194-criterion-simulation-layer.md
@@ -1,0 +1,437 @@
+---
+status: PROPOSED
+---
+
+# SPEC-194 — Criterion Simulation Layer
+
+> **Priority:** P0 · **Estimate (human):** 5-7d · **Estimate (agent):** 6-9h · **Category:** novel · **Type:** governance-infrastructure
+
+> **Dual estimate**: 5-7 dias humano end-to-end (definicion del modelo de operator state, heuristicas de trigger, juez meta-reflexivo, integracion con tribunales existentes, tests, validacion empirica). 6-9h agente con pipeline supervisado. Categoria novel: no hay patron previo que copiar; el componente meta-reflexivo es nuevo en la arquitectura.
+
+## Objective
+
+Existe un limite estructural en cualquier sistema agentico actual: el agente puede ejecutar el ciclo idea -> aplicacion -> revision, pero NO puede dudar del frame de la idea. Solo evalua si la aplicacion fue correcta DADA la idea. La revision es otra aplicacion del criterio preexistente, no una reflexion sobre si el criterio mismo es correcto.
+
+> Cita textual de la usuaria (2026-06-13):
+> "Un humano, en la fase de revision, puede concluir que el problema no estaba en la ejecucion sino en la idea original. Puede dudar de la pregunta, no solo de la respuesta. Un agente, sin ese meta-nivel disenado, revisara la aplicacion pero no cuestionara la idea. Optimizara dentro del marco. No transformara el marco. Se delega la ejecucion, no el criterio. Cuando el humano no mantiene el suyo, el sistema no cierra el loop. Lo simula."
+
+Esta spec acepta esa limitacion y la aborda **explicitamente como simulacion**, no como sustituto de criterio humano. Anade una capa que se activa cuando el riesgo de criterio humano relajado es alto y, antes de aplicar la idea, ejecuta cuatro preguntas meta-reflexivas que el humano se haria si tuviera energia y distancia para hacerlo. El output es un challenge visible al humano que NO bloquea automatico — fuerza al humano a reafirmar el frame conscientemente.
+
+Trade-off honesto: esto NO es criterio real. Un LLM no tiene criterio. Es heuristica de pausa. Mas caro en tokens. No siempre acierta. Tiene falsos positivos sobre tareas legitimas. La spec declara esto desde el primer parrafo del banner que emite: "soy una simulacion de meta-reflexion, no tu criterio".
+
+## Principles affected
+
+- **#3 Humans decide** — La capa NO bloquea. Emite challenge. La decision final sigue siendo del humano. Lo que cambia: el humano se ve forzado a reafirmar conscientemente.
+- **#5 Truth as common good** — Reconocer la limitacion (no es criterio real, es simulacion) es parte de la verdad sobre el sistema.
+- **#9 Disarm words** — El banner usa lenguaje plano sin promesas exageradas: "esta idea podria estar mal planteada" no "esta idea esta mal".
+- **Linea Roja L4** (autonomia destructiva) — Nunca bloquea autonoma; solo interpela.
+- **Genesis B9 GOAL STEWARD + B8 ATTENTION ANCHOR** — Esta spec es la implementacion mas directa de B9 (cuestionar el proposito, no solo ejecutarlo).
+
+NO contradice `radical-honesty.md` (Rule #24): la honestidad sobre la limitacion es parte del diseno. NO contradice `autonomous-safety.md`: no hay autonomia destructiva, solo interrupcion del flujo.
+
+## Design
+
+### Overview
+
+```
+[task arrives: spec, PR plan, code change request]
+     |
+     v
+[trigger evaluator: should criterion-simulation activate?]
+     | high-impact task? recent revert pattern? operator-state signals?
+     | yes -> proceed; no -> bypass (telemetry only)
+     v
+[criterion-simulation-judge: 4 meta-questions]
+     | Q1 frame challenge: la idea responde al problema real?
+     | Q2 historical priors: tareas similares fracasaron por frame?
+     | Q3 operator state: fatiga / presion / hora atipica / overrides?
+     | Q4 alternative reframing: existe tarea mas simple que resuelva igual?
+     v
+[verdict: FRAME_OK | FRAME_DOUBT | FRAME_REJECT]
+     | FRAME_OK: continua silencioso, telemetria.
+     | FRAME_DOUBT: emite challenge banner. NO bloquea.
+     | FRAME_REJECT: emite challenge mas fuerte. NO bloquea.
+     v
+[human decides: confirma frame o lo redefine]
+     | si confirma: registra reaffirmation con timestamp + razon (>=20 chars)
+     | si redefine: registra reframe + diff de tarea
+     v
+[task ejecuta con frame confirmado/redefinido]
+```
+
+### Components
+
+| # | Name | Kind | Purpose |
+|---|------|------|---------|
+| 1 | `scripts/criterion-simulation/trigger-evaluator.py` | py script | Decide si activar la capa basado en operator-state signals |
+| 2 | `scripts/criterion-simulation/operator-state-signals.py` | py script | Calcula score de operator state (fatigue, pressure, time, override-rate) |
+| 3 | `.opencode/agents/criterion-simulation-judge.md` | LLM judge (heavy model) | Ejecuta las 4 meta-preguntas. Output: verdict + razonamiento. |
+| 4 | `.opencode/hooks/criterion-simulation-challenge.sh` | hook (pre-task / pre-spec-implement) | Activa el judge si trigger; emite challenge banner si verdict != FRAME_OK |
+| 5 | `scripts/criterion-simulation/historical-priors.py` | py script | Busca en KG y memory tareas similares revertidas o fracasadas |
+| 6 | `scripts/criterion-simulation/reaffirmation-log.py` | py script | Registra confirmaciones humanas con timestamp + razon |
+| 7 | `output/criterion-simulation/` | dir | Logs de challenges + reaffirmations + reframes |
+| 8 | `docs/rules/domain/criterion-simulation-honesty.md` | rule | Declara explicitamente que NO es criterio real, es simulacion |
+| 9 | `.opencode/skills/meta-reflection/SKILL.md` | skill | Protocolo que el LLM carga para ejecutar las 4 meta-preguntas |
+| 10 | `.opencode/skills/meta-reflection/DOMAIN.md` | skill domain | Knowledge: como diferenciar evaluacion vs reflexion |
+| 11 | KG schema extension | sql | Anade tabla `frame_reaffirmations` (task_id, ts, operator, reason, verdict_before) |
+
+### Contracts
+
+#### Trigger evaluator
+
+```python
+# trigger-evaluator.py
+def should_activate(task_context: dict) -> dict:
+    """Returns {activate: bool, reason: str, score: int 0-100}.
+
+    Activates if score >= TRIGGER_THRESHOLD (default 50).
+    """
+    score = 0
+    reasons = []
+
+    # High-impact signals
+    if task_context.get("touches_production"):       score += 25; reasons.append("production")
+    if task_context.get("touches_security"):         score += 30; reasons.append("security")
+    if task_context.get("touches_human_safety"):     score += 50; reasons.append("safety")
+    if task_context.get("estimated_hours") > 16:     score += 15; reasons.append("large")
+
+    # Operator state signals (from operator-state-signals.py)
+    state = compute_operator_state(task_context["operator"])
+    score += state["fatigue_score"] * 0.3       # 0-30
+    score += state["pressure_score"] * 0.2      # 0-20
+    score += state["override_rate"] * 0.2       # 0-20
+
+    # Historical priors
+    priors = recent_failed_frames(task_context, lookback_days=90)
+    if priors["count"] >= 2: score += 20; reasons.append(f"{priors['count']} similar reverts")
+
+    return {
+        "activate": score >= TRIGGER_THRESHOLD,
+        "score": min(100, score),
+        "reasons": reasons,
+        "operator_state": state,
+        "priors": priors,
+    }
+```
+
+#### Operator state signals
+
+```python
+# operator-state-signals.py
+def compute_operator_state(operator_id: str) -> dict:
+    """Computes operator-state signals from local data.
+
+    Reads:
+    - Last N commits by operator (timestamps, frequency, gaps)
+    - Last N reviews / approvals (override-rate)
+    - Current time of day (fatigue heuristic by hour band)
+    - Calendar pressure if available (~/.savia/preferences.yaml deadline_proximity)
+
+    Privacy: all data is local. NO external service queried.
+
+    Returns {fatigue_score, pressure_score, override_rate, time_band}.
+    """
+```
+
+Honesto: estas heuristicas son groseras. Hora del dia no es prueba de fatiga real. Tasa de override puede ser legitimamente alta. La capa puede dispararse por motivos malos. Eso esta documentado en la regla de honestidad asociada.
+
+#### Criterion simulation judge
+
+```yaml
+# criterion-simulation-judge.md
+input:
+  task_context: { spec_path, pr_url, problem_statement, proposed_solution }
+  operator_state: { fatigue, pressure, override_rate, time_band }
+  historical_priors: { similar_failed_frames: [...] }
+
+output:
+  verdict: FRAME_OK | FRAME_DOUBT | FRAME_REJECT
+  meta_questions:
+    Q1_frame_challenge: { passed: bool, reasoning: str }
+    Q2_historical_priors: { passed: bool, reasoning: str, cited_priors: [str] }
+    Q3_operator_state: { passed: bool, reasoning: str, mitigation: str }
+    Q4_alternative_reframing: { proposed_reframe: str | null, would_solve: bool }
+  banner_text: str   # what to show the human
+  confidence: 0.0-1.0
+  is_simulation_disclaimer: "I am a meta-reflection simulation, not your judgment."
+```
+
+Las 4 meta-preguntas operacionalmente:
+
+**Q1 frame challenge**: dado el problem_statement, leer la spec/PR y verificar si la solucion propuesta responde al problema declarado o a uno parecido pero distinto. Tipica falla: spec resuelve "como X" cuando el problema real es "deberiamos X?".
+
+**Q2 historical priors**: buscar en KG / memory tareas etiquetadas con label similar (touches mismos modulos, mismas categorias de cambio). Si hay >=2 reverts en 90d, citar los IDs y resumir por que se revirtieron. NO bloquea, informa.
+
+**Q3 operator state**: si el operador tiene fatigue alto / hora atipica / override-rate alto, mencionarlo. Banner: "tu firmaste 5 specs en las ultimas 2 horas. Esta es la sexta. Las dos anteriores fueron revertidas por @X. Quieres reafirmar el frame de esta?".
+
+**Q4 alternative reframing**: el modelo propone (cuando puede) una formulacion alternativa: "el problema declarado es A. Una alternativa seria B, que requiere menos cambio y resuelve el subproblema critico. Quieres considerarla?".
+
+Confidence calibration: el modelo NO tiene criterio. La confidence es una estimacion de cuan robusto es su analisis (cuantas senales convergen, cuanta evidencia historica), no de cuan correcto es. Documentado.
+
+#### Hook integration
+
+```bash
+# criterion-simulation-challenge.sh — pre-task / pre-spec-implement
+INPUT=$(cat)
+TASK_CTX=$(extract_task_context "$INPUT")
+
+TRIGGER=$(python3 scripts/criterion-simulation/trigger-evaluator.py --task "$TASK_CTX")
+ACTIVATE=$(echo "$TRIGGER" | jq -r '.activate')
+
+if [[ "$ACTIVATE" != "true" ]]; then
+  log_telemetry "BYPASS_LOW_SCORE"
+  exit 0
+fi
+
+# Run judge
+VERDICT=$(invoke_agent criterion-simulation-judge --task "$TASK_CTX" --operator-state "$TRIGGER")
+DECISION=$(echo "$VERDICT" | jq -r '.verdict')
+
+case "$DECISION" in
+  FRAME_OK)
+    log_telemetry "FRAME_OK_PASS"
+    exit 0
+    ;;
+  FRAME_DOUBT|FRAME_REJECT)
+    log_telemetry "$DECISION"
+    cat >&2 <<EOF
+
+[criterion-simulation SPEC-194]
+DISCLAIMER: I am a meta-reflection simulation, not your judgment.
+This is a heuristic interruption when operator-state signals are high.
+
+$(echo "$VERDICT" | jq -r '.banner_text')
+
+ACTION: reaffirm the frame consciously OR redefine the task.
+  bash scripts/criterion-simulation/reaffirmation-log.py reaffirm \
+       --task <id> --reason "<>=20 chars why this frame is correct>"
+  bash scripts/criterion-simulation/reaffirmation-log.py reframe \
+       --task <id> --new-statement "<new problem statement>"
+
+Bypass: SAVIA_CRITERION_SIMULATION=off
+EOF
+    # NO blocking. Just visible challenge.
+    exit 0
+    ;;
+esac
+```
+
+Crucial: **exit 0 siempre**. La capa nunca bloquea. Solo interrumpe visualmente.
+
+### Configuration
+
+```bash
+# Master switch
+SAVIA_CRITERION_SIMULATION=on|off                    # default off (opt-in inicial)
+
+# Trigger
+SAVIA_CS_TRIGGER_THRESHOLD=50                        # 0-100; menor = mas activaciones
+SAVIA_CS_LOOKBACK_DAYS=90                            # ventana para historical priors
+
+# Judge model
+SAVIA_CS_JUDGE_MODEL=heavy                           # heavy por default; meta-reflexion es costosa
+
+# Operator state
+SAVIA_CS_OPERATOR_DATA=local                         # local | none (privacidad)
+SAVIA_CS_FATIGUE_HOUR_BAND="22:00-06:00"             # horas consideradas atipicas
+
+# Telemetria
+SAVIA_CS_LOG=output/criterion-simulation/events.jsonl
+
+# Modes individuales
+SAVIA_CS_MODE=shadow|advise|interrupt                # default advise
+# shadow: telemetria solamente
+# advise: emite banner pero sin bloquear ni requerir reaffirmation
+# interrupt: emite banner Y registra reaffirmation requerida (NO bloquea ejecucion, pero el log queda)
+```
+
+### Lo que NO hace esta spec (importante)
+
+- **NO genera criterio**. Solo activa heuristicas que un humano competente con tiempo activaria solo.
+- **NO bloquea ejecucion**. Es visualmente intrusivo pero el humano sigue decidiendo.
+- **NO sustituye revision humana de PRs**. Es ANTERIOR: cuestiona el frame antes de la aplicacion.
+- **NO juzga personas**. operator-state es signal del momento, no del operador en general.
+- **NO se activa en tareas normales**. Trigger threshold conservador. Bypass facil.
+
+### Limitaciones honestas
+
+1. **No es criterio real, es heuristica**. El sistema no piensa. La spec lo declara desde el primer mensaje al humano.
+2. **Falsos positivos esperados**. Tareas legitimas con score alto activaran la capa. El coste: ~30 segundos del humano confirmando. El beneficio: 1 de cada N veces, el humano se da cuenta de que efectivamente no estaba pensando.
+3. **Operator-state heuristicas son crudas**. Hora del dia, frecuencia de commits, override-rate son proxies. No miden cansancio real. La calibracion solo sera buena con telemetria de meses.
+4. **Coste en tokens significativo**. Heavy model + 4 meta-preguntas + busqueda en KG. ~15-25K tokens por activacion. Por eso threshold conservador.
+5. **Privacy concerns sobre operator-state**. La spec exige `SAVIA_CS_OPERATOR_DATA=local` por defecto. No se envia a ningun lugar externo. Datos eliminables.
+6. **Tipologia de problemas que NO atrapa**: errores ejecutivos (eso lo cubre el tribunal). Problemas de timing puro. Politica organizacional. La capa SOLO ataca el slot "frame de la idea".
+
+## Acceptance criteria
+
+1. **Disclaimer visible siempre**: cualquier challenge banner contiene la frase "simulacion de meta-reflexion, no tu criterio". Verificado por bats.
+2. **Exit 0 siempre**: en los 3 verdicts (FRAME_OK, FRAME_DOUBT, FRAME_REJECT), el hook devuelve exit 0 — nunca bloquea. Verificado por bats.
+3. **Trigger conservador**: en 50 task-contexts sinteticos representativos del workspace, el activador dispara en <= 20%. Verificado por pytest con dataset.
+4. **Trigger detecta high-impact**: en 10 task-contexts con `touches_security=true` o `touches_human_safety=true`, dispara en >= 8/10. Verificado por pytest.
+5. **Operator-state signals son locales**: `operator-state-signals.py` no realiza llamadas de red. Verificado por test que mocka socket y falla si se usa.
+6. **Q2 historical priors funciona**: dado un KG con 3 reverts etiquetados similar, el judge cita >= 2 en el output. Verificado por pytest sintetico con KG temporal.
+7. **Reaffirmation se registra con razon obligatoria >= 20 chars**: `reaffirmation-log.py reaffirm --reason "x"` (3 chars) -> rechazo + exit 2. Verificado por bats.
+8. **Reframe se registra con new-statement obligatorio**: similar al anterior, --new-statement requerido. Verificado por bats.
+9. **Telemetria JSONL valida**: cada activacion escribe linea con campos `ts, task_id, verdict, score, reasons, operator_state_summary, banner_emitted`. Verificado por bats.
+10. **Modo `shadow` no emite banner**: con `SAVIA_CS_MODE=shadow`, los 3 verdicts solo loguean; no escriben a stderr. Verificado por bats.
+11. **Modo `advise` emite banner pero no requiere reaffirmation**: el flujo continua. Verificado por bats.
+12. **Modo `interrupt` emite banner Y registra reaffirmation pending**: el log incluye `reaffirmation_required: true`. Verificado por bats.
+13. **Master switch off**: con `SAVIA_CRITERION_SIMULATION=off`, ningun componente se activa. Verificado por bats.
+14. **KG migration idempotente**: ejecutar `kg-schema-migrate-cs.py` 2 veces no duplica tabla. Verificado por pytest.
+15. **Skill `meta-reflection` cargable**: tiene SKILL.md y DOMAIN.md. Verificado por bats (test-skills-no-orphans).
+16. **Regla `criterion-simulation-honesty.md`**: declara que la capa NO es criterio real. Verificado por grep.
+17. **Latencia con judge heavy**: p95 < 30s desde trigger hasta verdict. Verificado por benchmark.
+18. **No falsos positivos en outputs historicos**: ejecutar trigger contra ultimos 20 commits hechos en horario atipico -> activaciones <= 4 (20%). Verificado manualmente + script.
+19. **Documentacion del mecanismo de revision**: la regla declara la limitacion conceptual (revision != reflexion) explicitamente para que el equipo no tome la capa por mas de lo que es. Verificado por grep de la cita.
+20. **Coste documentado**: el output del judge incluye `tokens_used` para que el coste sea visible. Verificado por bats.
+
+## Out of scope
+
+- **Generar criterio real**. Imposible con LLM.
+- **Sustituir revision humana de PR**. Es complementaria, no sustitutiva.
+- **Bloquear ejecucion automaticamente**. La capa interrumpe; el humano decide.
+- **Modelo predictivo de operator burnout**. Heuristicas crudas son suficientes; no construimos un modelo psicometrico.
+- **Integracion con Outlook/calendar para fatigue**. Solo si la usuaria tiene archivo local explicito; no se conecta a servicios externos.
+- **Auto-escalado a otro humano**. La capa interpela al operador actual. Si esta cansado, debe reconocerlo y delegar manualmente.
+
+## Dependencies
+
+- Blocked by: ninguna spec activa.
+- Blocks: ninguna spec actualmente.
+- Related:
+  - SPEC-188 Root-Cause Investigation Architecture: la capa usa la memoria de fallos como input para Q2 historical priors.
+  - SPEC-125 Recommendation Tribunal: ortogonal — el tribunal evalua el output, esta spec cuestiona el frame antes de generar el output.
+  - SPEC-192 Anti-adulation: ortogonal — anti-adulation cubre patrones de output, esta spec cubre el frame de la entrada.
+  - SE-072 verified-source-required: la capa usa fuentes verificadas para Q2.
+  - `radical-honesty.md` Rule #24: la honestidad sobre la limitacion (es simulacion, no criterio) es obligatoria.
+
+## Migration path
+
+Despliegue gradual extra-conservador (la capa interrumpe trabajo humano, errar caro):
+
+| Semana | Cambio | Modo |
+|---|---|---|
+| 1 | Componentes 1-3 + telemetria | `shadow` global; threshold 80 (alto, dispara poco) |
+| 2 | Revisar telemetria. Calibrar thresholds. Reducir falsos positivos. | `shadow` |
+| 3-4 | Componentes 4-7. Habilitar `advise` en tareas TIER touches_security solamente | `advise` parcial |
+| 5-8 | Si advise tiene <= 30% falsos positivos a juicio de la usuaria, ampliar a touches_production | `advise` ampliado |
+| 9+ | Modo `interrupt` solo si la usuaria lo activa explicitamente | opt-in |
+
+Reverse: `SAVIA_CRITERION_SIMULATION=off` desactiva. Borrar agente/hook/scripts/skill remueve el codigo. KG migration es additiva.
+
+## Reference code
+
+Esqueleto del judge prompt:
+
+```
+Eres una capa de simulacion de meta-reflexion. NO eres criterio real.
+NO eres juicio humano. Eres una heuristica de pausa que activa preguntas
+que un senior con energia y distancia se haria.
+
+Recibes:
+- Problem statement (la tarea original)
+- Proposed solution (la spec / PR)
+- Operator state (fatigue, pressure, hora, override-rate)
+- Historical priors (tareas similares revertidas, si las hay)
+
+Para cada una de las 4 preguntas:
+
+Q1 FRAME CHALLENGE: la solucion propuesta responde al problema real, o
+   responde a un problema parecido pero distinto? Cita evidencia textual.
+
+Q2 HISTORICAL PRIORS: existen tareas similares que fracasaron por frame
+   (no por ejecucion) en los ultimos 90 dias? Cita IDs y resume por que.
+
+Q3 OPERATOR STATE: dado el estado del operador (fatigue/pressure/...),
+   hay riesgo elevado de criterio relajado? Si si, mencionalo sin juzgar.
+
+Q4 ALTERNATIVE REFRAMING: existe una formulacion mas simple del problema
+   que resolveria el caso critico con menos cambio? Si si, propon en 1-2
+   frases.
+
+Output:
+- verdict: FRAME_OK si las 4 preguntas pasan
+- FRAME_DOUBT si 1-2 fallan
+- FRAME_REJECT si 3-4 fallan o si Q1 falla solo (frame challenge directo)
+- banner_text: maximo 6 lineas, lenguaje plano, SIN promesas exageradas
+- IMPORTANTE: incluir SIEMPRE la frase "soy simulacion de meta-reflexion,
+  no tu criterio. Tu decides".
+```
+
+## Impact statement
+
+Cierra (parcialmente, con honestidad) el limite estructural identificado por la usuaria: los sistemas agenticos ejecutan, evaluan, pero no reflexionan sobre el frame. Esta spec NO da criterio al sistema; activa heuristicas de pausa cuando el humano puede haber soltado el suyo. El beneficio esperado es modesto: 1 de cada N tareas, el humano reconoce que no estaba pensando y reformula. El coste es real (tokens, ~30s de interrupcion). La spec es opt-in, conservadora en triggers y empieza en modo shadow para validar antes de molestar.
+
+Honestidad final: si esta capa no detecta NADA en 30 dias de uso, es senal de que la usuaria si mantiene su criterio. Si detecta mucho, es senal de que el flujo organizacional esta empujando a errar el frame. Ambas senales son utiles. La capa no fracasa silenciosamente: cada activacion deja log auditable.
+
+## OpenCode Implementation Plan
+
+> Required post-2026-04-26.
+
+**Classification**: Tier 2. Anade infraestructura nueva (1 agent + 1 hook + 5 scripts + 1 skill + 1 regla + KG schema), modifica nada del flujo existente, defaults extra-conservadores.
+
+### Phase 1 — Trigger evaluator + operator-state signals (semana 1)
+
+1. Crear `scripts/criterion-simulation/operator-state-signals.py` (stdlib + sqlite local).
+2. Crear `scripts/criterion-simulation/trigger-evaluator.py`.
+3. Crear `scripts/criterion-simulation/historical-priors.py` (consume KG SE-162).
+4. Tests pytest `tests/scripts/test_criterion_simulation_trigger.py` (50 sinteticos + 10 high-impact).
+5. KG schema: anadir tabla `frame_reaffirmations` via `kg-schema-migrate-cs.py` idempotente.
+
+### Phase 2 — Judge + skill (semana 2)
+
+6. Crear `.opencode/agents/criterion-simulation-judge.md` con prompt + esquema.
+7. Crear `.opencode/skills/meta-reflection/SKILL.md` con protocolo de las 4 preguntas.
+8. Crear `.opencode/skills/meta-reflection/DOMAIN.md` (reflexion vs evaluacion).
+9. Tests pytest sinteticos del judge (Q1-Q4 cada uno con positivos y negativos).
+
+### Phase 3 — Hook + reaffirmation (semana 3)
+
+10. Crear `.opencode/hooks/criterion-simulation-challenge.sh`.
+11. Crear `scripts/criterion-simulation/reaffirmation-log.py` con --reaffirm y --reframe.
+12. Registrar hook en `.claude/settings.json` matcher pre-Task / pre-Edit con guard de high-impact.
+13. Tests bats `tests/test-criterion-simulation-hook.bats` (3 modos, telemetria, exit 0 siempre).
+
+### Phase 4 — Regla y honestidad (semana 4)
+
+14. Crear `docs/rules/domain/criterion-simulation-honesty.md` con la cita explicita.
+15. Tests grep que la regla cita la limitacion (revision != reflexion).
+16. Actualizar `radical-honesty.md` con seccion sobre simulacion-no-es-criterio.
+
+### Phase 5 — Validacion empirica (semanas 5-8)
+
+17. Modo shadow durante 4 semanas en el workspace.
+18. Recopilar telemetria: cuantos triggers, cuantos verdicts != FRAME_OK, cuantos llevarian a reframe segun la usuaria.
+19. Calibrar thresholds. Documentar en CHANGELOG.
+20. Decidir promocion a `advise` si los datos lo justifican.
+
+### Acceptance criteria checklist (mapping)
+
+| AC | Phase | Verifier |
+|---|---|---|
+| 1, 2, 9, 10, 11, 12, 13 | 3 | bats |
+| 3, 4, 5, 6, 17, 18, 20 | 1+2+5 | pytest + benchmark |
+| 7, 8 | 3 | bats |
+| 14 | 1 | pytest |
+| 15 | 2 | bats (test-skills-no-orphans) |
+| 16, 19 | 4 | grep |
+
+### Risks
+
+- **Falsos positivos altos en early modo `advise`**: amenaza adopcion. Mitigacion: empezar en `shadow` 4 semanas, solo activar high-impact + signals fuertes.
+- **Operator-state heuristicas mal calibradas**: hora del dia / frecuencia de commits son crudas. Mitigacion: estado parameterizable; usuaria puede ajustar `SAVIA_CS_FATIGUE_HOUR_BAND` y override rates aceptables.
+- **Coste en tokens significativo**: ~15-25K por activacion. Mitigacion: trigger conservador. Threshold default 50 produce <= 20% activacion en tasks normales.
+- **Privacy creep**: operator-state podria expandirse a tracking. Mitigacion: regla explicita `SAVIA_CS_OPERATOR_DATA=local` y NO conexion externa; test que falla si hay socket.
+- **La capa se vuelve adulatoria**: el judge podria suavizar challenges para no molestar. Mitigacion: SPEC-192 anti-adulation cubre los outputs del judge tambien.
+- **El humano la ignora siempre**: se vuelve ruido. Mitigacion: si telemetria muestra >70% reaffirmation sin reflexion (operator confirma siempre con razon < 30 chars), threshold sube automaticamente.
+
+## Notes
+
+Origen del diseno: reflexion textual de la usuaria 2026-06-13.
+
+Esta spec es conscientemente honesta sobre lo que NO es: NO genera criterio, NO sustituye juicio humano, NO bloquea autonoma. Es heuristica de pausa con disclaimer explicito. Mas valiosa que silenciosa. Menos valiosa que un buen senior dudando del frame.
+
+La regla acompañante (`criterion-simulation-honesty.md`) cita textualmente:
+"Un agente que no puede dudar de su propia idea no cierra el loop. Lo simula. Esta spec es esa simulacion, declarada como tal."
+
+Hermana operacional de SPEC-192 (anti-adulation) y SPEC-193 (injection hardening): las tres atacan limites de los sistemas agenticos sin pretender resolverlos del todo, con honestidad sobre el alcance.


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR no añade código nuevo todavía. Añade dos documentos de diseño que describen dos defensas conceptualmente distintas pero hermanas: una protege contra ataques externos sobre el contexto que la asistente lee; la otra protege contra el momento en que el humano deja de mantener su criterio.

La primera defensa es técnica. Hay siete técnicas conocidas en la investigación reciente sobre cómo engañar a una asistente IA: usar caracteres parecidos pero distintos para evadir filtros, esconder instrucciones en el medio de un texto largo, disfrazar peticiones como capítulos de manual, envolverlas en ficción, decir "soy investigador" para bajar la guardia, encontrar grietas entre los clasificadores, o trocear una petición prohibida en piezas inocentes que se recomponen después. La asistente actual cubre dos o tres de las siete. Esta propuesta cubre seis con doce piezas en tres capas: una capa rápida sin IA que limpia caracteres extraños, una capa de jueces inteligentes que evalúan los patrones más sutiles, y una capa que vigila la sesión entera para detectar cuando varias preguntas inocentes convergen sobre algo que no debería estar permitido. Todo opt-in, todo empieza en modo silencioso recogiendo datos antes de actuar.

La segunda defensa es estructural. Cuando un humano revisa una decisión, puede dudar no solo de la respuesta sino de la pregunta. Puede concluir que el problema no estaba en cómo se ejecutó, sino en que la idea no era la correcta. Una asistente IA, por construcción, no hace eso. Optimiza dentro del marco. Cuando el humano firma una tarea y la asistente la ejecuta perfectamente, ambos están dentro del mismo marco. Si el marco era equivocado, nadie lo detecta. Esta segunda propuesta acepta esa limitación con honestidad. No promete dar criterio a la máquina (no se puede). Lo que hace: cuando se detecta que el humano podría no estar manteniendo su criterio (cansancio, hora atípica, muchos commits seguidos, tasa alta de aprobaciones sin revisar), activa cuatro preguntas meta-reflexivas antes de empezar la tarea. ¿La solución responde al problema real, o a uno parecido? ¿Hay tareas similares que se revirtieron en el pasado? ¿Cuál es el estado del operador? ¿Hay una forma más simple de plantear el problema? El resultado es un mensaje al humano: "tu firmaste cinco specs en dos horas, las dos anteriores fueron revertidas por X, ¿quieres reafirmar el frame de esta?". No bloquea. Solo interrumpe visualmente y obliga a confirmar conscientemente o redefinir.

La honestidad sobre los límites es parte del diseño. Las dos propuestas declaran lo que NO pueden hacer. La primera no hace defensa perfecta — research demuestra que ningún filtro LLM lo es. La segunda no genera criterio real — solo activa heurísticas de pausa que un senior con energía y distancia activaría solo. Las dos empiezan en modo silencioso para validar antes de molestar.

Importa porque ambas tocan el límite real de los sistemas agénticos. Hasta hoy hay reglas declarativas que dicen "no aduladores", "no asumas verdad por repetición", "duda del frame". Sin enforcement. Esto convierte declaración en mecanismo medible, con telemetría que dirá si el problema realmente ocurre y dónde.

Lo que se pierde: las dos specs son grandes (12 + 11 componentes, 22 + 20 criterios de aceptación, 5 + 5 fases). La implementación completa requiere 4-6 días humano cada una. Si los datos en modo silencioso muestran que el problema no aparece en la práctica, ninguna se promueve a modo activo y queda como infraestructura latente. Eso es deliberado: medir antes de imponer.

Cómo desactivar: cada componente tiene su propia variable de entorno. Un master switch (`SAVIA_HARDENING=off` para SPEC-193, `SAVIA_CRITERION_SIMULATION=off` para SPEC-194) desactiva la spec entera. Borrar los ficheros nuevos elimina cualquier rastro. Las reglas declarativas que ya existen (radical-honesty, savia-ethical-principles) sobreviven al borrado.

## Summary

Two PROPOSED specs added to `docs/propuestas/` plus ROADMAP update.

**SPEC-193 — Context Provenance & Injection Hardening** (P0, 4-6d/5-8h, 22 ACs).
Closes 6 of 7 documented prompt-injection vectors via 12 components in 3 layers:
- Layer A deterministic (NFKC normalize, ASCII-fold, homoglyph detect, bidi reject).
- Layer B LLM judges (structural-framing, fiction-framing, authority-claim).
- Layer C temporal correlation (cross-turn convergence on sensitive domains,
  classification-consistency audit, KG provenance schema, periodic re-anchor of
  red lines).
Origin: `output/20260613-jailbreak-techniques-defensive-study.md`.
Defaults: shadow → warn → block over 30 days of telemetry.

**SPEC-194 — Criterion Simulation Layer** (P0, 5-7d/6-9h, 20 ACs).
Addresses the structural gap identified by the user: agents execute and
evaluate, but cannot doubt the frame of the idea itself. The spec
ACCEPTS this as a fundamental limitation and treats the new layer as
SIMULATION, not substitute. 4 meta-questions before applying the idea:
- Q1 frame challenge — does the solution answer the real problem?
- Q2 historical priors — similar tasks reverted by frame, not execution?
- Q3 operator state — signals of relaxed criterion?
- Q4 alternative reframing — simpler formulation that solves the case?
Output: FRAME_OK / FRAME_DOUBT / FRAME_REJECT. Never blocks. Forces
human reaffirmation or reframe with mandatory `>=20 chars` reason.
Origin: user reflection 2026-06-13 on review vs reflection.
Honest disclaimer in every banner: "I am simulation, not your judgment".

## Files

| Path | Kind | Lines |
|---|---|---|
| `docs/propuestas/SPEC-193-context-provenance-injection-hardening.md` | new spec | 432 |
| `docs/propuestas/SPEC-194-criterion-simulation-layer.md` | new spec | 437 |
| `docs/ROADMAP.md` | modified | header + backlog table |

## Why one PR for two specs

Both specs share:
- Operational pattern (defense-in-depth, conservative defaults, shadow-first).
- Honesty about what they cannot do (no perfect defense, no real criterion).
- Telemetry-first activation philosophy.
- Integration with existing tribunal infrastructure (SPEC-125, SPEC-192).

Reviewing them together preserves context. Implementation will be split
into separate PRs by phase.

## Acceptance criteria coverage

This is a docs-only PR. ACs in each spec describe the implementation contract
to be verified by future PRs that build the components.

## Scope-trace overrides

Scope-trace: skip — this is a docs-only PR. The two SPEC files are themselves
the deliverable; ROADMAP.md is updated metadata. No implementation files yet.