### PR TITLE
fix(test-spec-190): prevent code-twin fixture from aging out

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
 diff_hash=e09e320af0e6246ceff5c8b2aa32fe6536f367490c570b2d930af5eb46f61918
-timestamp=2026-06-13T10:35:23Z
-branch=agent/spec-189-greedy-context-budget
-head_commit=ab89c5a5
-signature=9f3abef4a4954c90e0e24d8b8252572c0656c0925bd34c91222819bd4b46b498
+timestamp=2026-06-13T12:02:12Z
+branch=agent/fix-code-twin-fixture-aging
+head_commit=67696a12
+signature=ce90a51905e2ec0ea1163342309e26fb12495940f1db9ca89b16e120d0918fb2

--- a/tests/fixtures/code-twin/application/auth-service.md
+++ b/tests/fixtures/code-twin/application/auth-service.md
@@ -12,7 +12,7 @@ provides:
   - logout
   - refreshToken
   - validateToken
-stale_after_days: 7
+stale_after_days: 3650  # SE-191 fix: avoid temporal aging of fixture
 ---
 
 # AuthService


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

El fichero de prueba que comprueba si el sistema detecta documentos desactualizados tenía una fecha fija que envejecía automáticamente. El día 7 después de subirlo, los propios tests empezaban a fallar — no porque algo estuviera mal, sino porque la fecha del fixture había caducado. Esto bloqueaba los flujos de varios PRs abiertos sin tener nada que ver con ellos.

El cambio es de una línea: amplía la ventana de frescura del fixture de 7 días a 3650 (10 años). El fixture deja de envejecer. La parte importante del test — comprobar que el sistema detecta correctamente documentos viejos — sigue funcionando porque otros tests crean sus propios fixtures stale con fechas explícitamente antiguas.

## Summary

Single-line fix to `tests/fixtures/code-twin/application/auth-service.md`:
`stale_after_days: 7` → `3650`.

This unblocks BATS Hook Tests on PR #838 and PR #839, which were both
failing on `test-spec-190-code-twin-load #18-#19` (sync-check exits 0
when all CTFs are fresh) due to fixture aging — last_sync: 2026-06-06,
threshold 7 days, hits the cutoff exactly on 2026-06-13.

Original PR that introduced the fixture: #821 (SPEC-190 Slice 8).

## Tests

- `bats tests/test-spec-190-code-twin-load.bats` → 36/36 pass.
- `bash scripts/code-twin-sync-check.sh tests/fixtures/code-twin` → exit 0.

The stale-detection logic remains verified by tests #20-#22 which
construct their own stale fixture with `last_sync: 2025-01-01`.

## Scope-trace overrides

Scope-trace: skip — single test fixture line; the change unblocks unrelated PRs (#838 #839) and has no AC of its own beyond the test suite continuing to pass.