### PR TITLE
feat(telemetry-pilot): activate SPEC-198/200 warn defaults (30d window)

### DIFF
--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=e6e00e84ada03f6711d51ea03b4a727b8d4f6042afeb86911f508a3d3d86fa3d
-timestamp=2026-06-13T19:38:30Z
-branch=agent/wire-specs-195-200
-head_commit=9076175d
-signature=8eb2314d0b4d1850f9dbfe0c1bbaa1f321256705bc828c34d169f0f7b1076ae8
+diff_hash=f805cb63fc312e00e65287533bd4f9935c7276c1eab14d8723f2fc9937947e07
+timestamp=2026-06-13T21:34:16Z
+branch=agent/activate-telemetria-warn
+head_commit=ef0143d2
+signature=2e1740609b592d5482dc2ef1d17d01b3ce52427d5a7d13772bdfc8ab61f42dc4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,22 @@ jobs:
         run: bash scripts/audit-test-quality.sh --summary
 
       - name: "Gate: Test Quality (SPEC-055 — all tests >= 80)"
+        env:
+          # SPEC-200 telemetry pilot (30d): compute adaptive threshold and
+          # emit advisory to stderr, but still gate on fixed_min=80.
+          # Promote to 'on' once output/quality-gate-history.jsonl shows
+          # the adaptive threshold tracks the score distribution well.
+          SAVIA_QUALITY_GATE_ADAPTIVE: warn
         run: bash scripts/ci-test-quality-gate.sh
+
+      - name: "Upload SPEC-200 telemetry (quality-gate-history.jsonl)"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spec-200-telemetry-${{ github.run_number }}
+          path: output/quality-gate-history.jsonl
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Run coverage report
         run: bash scripts/coverage-report.sh --ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased] — 2026-06-13 · Activate SPEC-198/200 telemetry pilot defaults
+
+Changed: tras mergear PR #844, los toggles SPEC-198/200 estaban presentes
+pero defaultaban a off. Esta entrada activa modo warn por default durante
+ventana de pilot 30 dias, segun decision pactada con el usuario.
+
+- savia-env.sh exporta SAVIA_QUALITY_GATE_ADAPTIVE=warn y
+  SAVIA_JUDGE_VERDICT_VALIDATE=warn por default cuando no hay override.
+- CI workflow ci.yml setea SAVIA_QUALITY_GATE_ADAPTIVE=warn en el step
+  Gate Test Quality y sube output/quality-gate-history.jsonl como
+  artifact (retencion 30 dias).
+- 11 tests nuevos en test-telemetria-pilot-defaults.bats que verifican
+  defaults, overrides explicitos, e2e generation de los dos JSONL.
+
+Backward compat: cualquier sesion que exporte explicitamente
+SAVIA_QUALITY_GATE_ADAPTIVE=off o SAVIA_JUDGE_VERDICT_VALIDATE=off
+mantiene comportamiento anterior. Promocion warn->on tras revision
+de telemetria de 30 dias.
+
+
 ## [Unreleased] — 2026-06-13 · Wire SPEC-195/196/197/198/200
 
 Added: wiring opt-in de cinco specs implementadas previamente a sus

--- a/scripts/savia-env.sh
+++ b/scripts/savia-env.sh
@@ -302,6 +302,11 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
   _savia_activate_venv "$SAVIA_WORKSPACE_DIR"
   export SAVIA_PROVIDER="${SAVIA_PROVIDER:-$(_resolve_provider)}"
   export SAVIA_PROJECT_SLUG="${SAVIA_PROJECT_SLUG:-$(_resolve_project_slug)}"
+  # ── Telemetry pilot defaults (SPEC-198/200, 30d window from 2026-06-13) ────
+  # Defaults to 'warn' so logs are produced without blocking. Override with
+  # env var or .env to disable. Promote to 'on' once telemetry data is reviewed.
+  export SAVIA_QUALITY_GATE_ADAPTIVE="${SAVIA_QUALITY_GATE_ADAPTIVE:-warn}"
+  export SAVIA_JUDGE_VERDICT_VALIDATE="${SAVIA_JUDGE_VERDICT_VALIDATE:-warn}"
 else
   # Direct invocation: print requested value
   case "${1:-}" in

--- a/tests/test-telemetria-pilot-defaults.bats
+++ b/tests/test-telemetria-pilot-defaults.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+# test-telemetria-pilot-defaults.bats — verify SPEC-198/200 telemetry pilot defaults
+# When savia-env.sh is sourced without explicit env vars, SPEC-198/200 should
+# default to 'warn' mode so telemetry logs are produced without blocking.
+# SCRIPT="scripts/savia-env.sh"
+# SCRIPT="scripts/ci-test-quality-gate.sh"
+# SCRIPT="scripts/recommendation-tribunal/aggregate.sh"
+# Safety: set -uo pipefail enforced in setup() below.
+
+setup() {
+  set -uo pipefail
+  ROOT="${BATS_TEST_DIRNAME}/.."
+  cd "$ROOT"
+  export TEST_TMP
+  TEST_TMP=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "$TEST_TMP" 2>/dev/null || true
+}
+
+# ── savia-env.sh exports defaults ───────────────────────────────────────────
+
+@test "savia-env.sh defaults SPEC-200 ADAPTIVE to warn when unset" {
+  run bash -c 'unset SAVIA_QUALITY_GATE_ADAPTIVE; source scripts/savia-env.sh; echo "$SAVIA_QUALITY_GATE_ADAPTIVE"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"warn"* ]]
+}
+
+@test "savia-env.sh defaults SPEC-198 VALIDATE to warn when unset" {
+  run bash -c 'unset SAVIA_JUDGE_VERDICT_VALIDATE; source scripts/savia-env.sh; echo "$SAVIA_JUDGE_VERDICT_VALIDATE"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"warn"* ]]
+}
+
+@test "savia-env.sh respects explicit ADAPTIVE override (off)" {
+  run bash -c 'export SAVIA_QUALITY_GATE_ADAPTIVE=off; source scripts/savia-env.sh; echo "$SAVIA_QUALITY_GATE_ADAPTIVE"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"off"* ]]
+  [[ "$output" != *"warn"* ]]
+}
+
+@test "savia-env.sh respects explicit VALIDATE override (on)" {
+  run bash -c 'export SAVIA_JUDGE_VERDICT_VALIDATE=on; source scripts/savia-env.sh; echo "$SAVIA_JUDGE_VERDICT_VALIDATE"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"on"* ]]
+}
+
+# ── End-to-end telemetry generation ─────────────────────────────────────────
+
+@test "SPEC-200 e2e: ci-test-quality-gate writes JSONL when ADAPTIVE=warn" {
+  rm -f output/quality-gate-history.jsonl
+  run bash -c '
+    unset SAVIA_QUALITY_GATE_ADAPTIVE
+    source scripts/savia-env.sh
+    bash scripts/ci-test-quality-gate.sh
+  '
+  [ "$status" -eq 0 ]
+  [ -f "output/quality-gate-history.jsonl" ]
+  # Last line has the warn-mode schema
+  last=$(tail -1 output/quality-gate-history.jsonl)
+  [[ "$last" == *"\"mode\":\"warn\""* ]]
+  [[ "$last" == *"\"strategy\":"* ]]
+}
+
+@test "SPEC-198 e2e: aggregator writes JSONL when VALIDATE=warn and bad json present" {
+  cat > "$TEST_TMP/memory.json" << 'EOF'
+{"judge":"memory","score":85,"veto":false,"confidence":0.9,"reason":"ok"}
+EOF
+  cat > "$TEST_TMP/rule.json" << 'EOF'
+{"judge":"rule","score":80,"veto":false,"confidence":0.85,"reason":"ok"}
+EOF
+  cat > "$TEST_TMP/halluc.json" << 'EOF'
+{"judge":"hallucination","score":90,"veto":false,"confidence":0.95,"reason":"ok"}
+EOF
+  cat > "$TEST_TMP/expert.json" << 'EOF'
+{"judge":"expertise","score":75,"veto":false,"confidence":0.8,"reason":"ok"}
+EOF
+  # Edge: out-of-range confidence and empty judge name
+  cat > "$TEST_TMP/sycophancy.json" << 'EOF'
+{"judge":"","score":0,"veto":false,"confidence":2.0,"reason":""}
+EOF
+
+  rm -f output/judge-verdict-validation-errors.jsonl
+  run bash -c "
+    unset SAVIA_JUDGE_VERDICT_VALIDATE
+    source scripts/savia-env.sh
+    bash scripts/recommendation-tribunal/aggregate.sh \
+      --judges $TEST_TMP/memory.json $TEST_TMP/rule.json \
+                $TEST_TMP/halluc.json $TEST_TMP/expert.json \
+                --sycophancy $TEST_TMP/sycophancy.json
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\"verdict\":\"PASS\""* ]]
+  [ -f "output/judge-verdict-validation-errors.jsonl" ]
+  grep -q "sycophancy.json" output/judge-verdict-validation-errors.jsonl
+}
+
+# ── CI workflow integration ────────────────────────────────────────────────
+
+@test "ci.yml exports SAVIA_QUALITY_GATE_ADAPTIVE=warn for the quality gate step" {
+  run grep -A8 'Gate: Test Quality' .github/workflows/ci.yml
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SAVIA_QUALITY_GATE_ADAPTIVE"* ]]
+  [[ "$output" == *"warn"* ]]
+}
+
+@test "ci.yml uploads SPEC-200 telemetry as artifact" {
+  run grep -B2 -A6 "spec-200-telemetry" .github/workflows/ci.yml
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"upload-artifact"* ]]
+  [[ "$output" == *"quality-gate-history.jsonl"* ]]
+}
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+@test "edge: empty SAVIA_QUALITY_GATE_ADAPTIVE falls back to warn default" {
+  # Empty string treated as unset by ${VAR:-default} expansion
+  run bash -c 'export SAVIA_QUALITY_GATE_ADAPTIVE=""; source scripts/savia-env.sh; echo "$SAVIA_QUALITY_GATE_ADAPTIVE"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"warn"* ]]
+}
+
+@test "edge: nonexistent .env file does not break savia-env defaults" {
+  # _savia_load_dotenv is a no-op when .env is absent; defaults still apply
+  run bash -c '
+    unset SAVIA_QUALITY_GATE_ADAPTIVE SAVIA_JUDGE_VERDICT_VALIDATE
+    source scripts/savia-env.sh
+    [[ "$SAVIA_QUALITY_GATE_ADAPTIVE" == "warn" ]] || exit 1
+    [[ "$SAVIA_JUDGE_VERDICT_VALIDATE" == "warn" ]] || exit 1
+    echo "ok"
+  '
+  [ "$status" -eq 0 ]
+}
+
+@test "edge: large telemetry history file does not block append" {
+  # Boundary test: existing log with many entries should still accept a new one
+  rm -f output/quality-gate-history.jsonl
+  mkdir -p output
+  for i in $(seq 1 500); do
+    echo "{\"ts\":\"2026-01-01\",\"mode\":\"warn\",\"threshold\":80,\"strategy\":\"high_mean_strict\",\"mean\":85.0,\"stddev\":2.0,\"total_tests\":100}"
+  done > output/quality-gate-history.jsonl
+  initial_lines=$(wc -l < output/quality-gate-history.jsonl)
+  [ "$initial_lines" -eq 500 ]
+
+  run bash -c '
+    source scripts/savia-env.sh
+    bash scripts/ci-test-quality-gate.sh > /dev/null 2>&1
+  '
+  [ "$status" -eq 0 ]
+  final_lines=$(wc -l < output/quality-gate-history.jsonl)
+  [ "$final_lines" -gt "$initial_lines" ]
+}


### PR DESCRIPTION
## Goal

Activar el pilot de telemetria 30 dias para SPEC-198 (judge verdict validation) y SPEC-200 (adaptive quality gate threshold), tal como se acordo en el seguimiento de PR #844.

Hasta ahora estos toggles estaban presentes en el repo pero defaulting a off — generaban cero datos. Esta PR los activa en modo warn (no bloquea, solo recopila telemetria) durante 30 dias para validar la calidad de los algoritmos antes de promocionar a on/block.

## Cambios

### CI workflow (.github/workflows/ci.yml)

- El step Gate Test Quality (SPEC-055) ahora exporta SAVIA_QUALITY_GATE_ADAPTIVE=warn. Computa el adaptive threshold y emite advisory a stderr; el gate sigue bloqueando con fixed_min=80 (sin cambio de comportamiento real).
- Nuevo step que sube output/quality-gate-history.jsonl como artifact spec-200-telemetry-<run-number> (retencion 30 dias). Cada run de CI deja un JSONL line con {mode, threshold, strategy, mean, stddev, total_tests} para analisis post-pilot.

### Workspace runtime (scripts/savia-env.sh)

- Cuando se hace source scripts/savia-env.sh sin env vars previos, exporta los defaults SAVIA_QUALITY_GATE_ADAPTIVE=warn y SAVIA_JUDGE_VERDICT_VALIDATE=warn.
- Defaults se aplican DESPUES del .env loader, asi que un .env puede sobrescribirlos.
- Cualquier export SAVIA_QUALITY_GATE_ADAPTIVE=off previo al source mantiene el opt-out (precedencia explicita sobre default).

### Tests (tests/test-telemetria-pilot-defaults.bats — 11/11 verdes)

- Defaults aplicados cuando unset
- Overrides explicitos respetados (off, on)
- E2E: ci-test-quality-gate.sh escribe JSONL en modo warn
- E2E: aggregate.sh escribe validation JSONL cuando hay judge JSON invalido
- Verificaciones grep contra ci.yml
- Edge cases: empty string, .env ausente, log grande preexistente

Auditor 85 sobre 100 (target minimo 80).

## Honestidad sobre el alcance

1. SPEC-198 no se invoca en CI porque aggregate.sh solo se llama runtime cuando el orchestrator agent se invoca. El default en savia-env.sh cubre las sesiones reales (que es donde el aggregator se usa).
2. El gate sigue bloqueando con threshold 80 — el modo warn es estrictamente advisory. Si quieres que el gate use el threshold adaptive, eso es escalar a on tras revisar la telemetria.
3. No se ha activado SPEC-195 ni SPEC-196 — siguen en sus defaults originales. Decision del usuario: solo telemetria 30 dias para 198/200 primero.

## Recordatorio diario

Persistido en memoria como decision/telemetria-wirings-revision-diaria. Revisar diariamente output/quality-gate-history.jsonl (SPEC-200), output/judge-verdict-validation-errors.jsonl (SPEC-198), artifacts spec-200-telemetry en GitHub Actions runs. Promocion warn a on se decidira tras 30 dias de datos.

## Branch

agent/activate-telemetria-warn (per autonomous-safety.md).

## Risk

Muy bajo. Cambios son aditivos. Modo warn no cambia veredictos del gate ni del tribunal. Backward compat verificado por test 3 (override off).
