### PR TITLE
feat(rules): output taxonomy + SE-220 spec + fix research paths

### DIFF
--- a/.claude/commands/tech-research.md
+++ b/.claude/commands/tech-research.md
@@ -62,7 +62,7 @@ Si no se proporciona `--program`, generar plan y mostrar:
 ```
 🔍 Tech Research — Completado
 
-📄 Informe: output/research-{tema}-{fecha}.md
+📄 Informe: output/research/{tema}-{YYYYMMDD}.md
 👤 Notificado: {AUTONOMOUS_RESEARCH_NOTIFY}
 
 Recomendación (resumen):

--- a/.claude/skills/tech-research-agent/SKILL.md
+++ b/.claude/skills/tech-research-agent/SKILL.md
@@ -27,7 +27,7 @@ priority: "low"
 
 ## Qué produce
 
-1. **Informe de investigación** — `output/research-{tema}-{YYYYMMDD}.md`
+1. **Informe de investigación** — `output/research/{tema}-{YYYYMMDD}.md`
 2. **Recomendaciones accionables** — incluidas en el informe, NUNCA ejecutadas automáticamente
 3. **Audit log** — `output/agent-runs/research-{tema}-{YYYYMMDD}-audit.log`
 
@@ -68,7 +68,7 @@ Generar informe estructurado en output/
     ↓
 Notificar a AUTONOMOUS_RESEARCH_NOTIFY:
   "📋 Investigación completada: {tema}
-   Informe: output/research-{tema}-{fecha}.md
+   Informe: output/research/{tema}-{YYYYMMDD}.md
    Recomendaciones: {resumen de 2-3 líneas}"
 ```
 

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=3ca71158f258c32704180e957e19d3d3f7e6c5f9d007ca7179d96aad15111a49
-timestamp=2026-06-19T08:17:48Z
-branch=agent/spec-188-p3-contract-tests-20260619
-head_commit=a0c31f96
-signature=16c463a29a61deedd687c79c1378bbe236ec54860f4c9d49f3fa361ef8ba0430
+diff_hash=b06304a98326336f179302d2d1f7e2b2eb0fe35975548892d95afd6979670208
+timestamp=2026-06-20T12:25:20Z
+branch=feature/se-220-output-taxonomy
+head_commit=d1387345
+signature=a8868fa41adbc89a02703ee4a577b09859fc542121219fc8c290af5d0f4dc05d

--- a/.confidentiality-signature
+++ b/.confidentiality-signature
@@ -1,6 +1,6 @@
 # Confidentiality audit signature — DO NOT EDIT
-diff_hash=b06304a98326336f179302d2d1f7e2b2eb0fe35975548892d95afd6979670208
-timestamp=2026-06-20T12:25:20Z
+diff_hash=aeda75d29acdd65a7cd86f6334666a0f16335e7ee7fae8270b8883c5579e1b61
+timestamp=2026-06-20T12:48:00Z
 branch=feature/se-220-output-taxonomy
-head_commit=d1387345
-signature=a8868fa41adbc89a02703ee4a577b09859fc542121219fc8c290af5d0f4dc05d
+head_commit=842ff3f6
+signature=f91d6a90dd1952e5cf6bddd5243e1e25153cd2cdb87d0cebc22d2076c76dafa1

--- a/CHANGELOG.d/se-220-fix-paths.md
+++ b/CHANGELOG.d/se-220-fix-paths.md
@@ -1,0 +1,9 @@
+---
+version_bump: patch
+section: Fixed
+---
+
+### Fixed
+
+- Fix path output/research-{tema} → output/research/{tema} en autonomous-safety.md, tech-research command y tech-research-agent SKILL.md
+

--- a/CHANGELOG.d/se-220-output-taxonomy.md
+++ b/CHANGELOG.d/se-220-output-taxonomy.md
@@ -1,0 +1,11 @@
+---
+version_bump: minor
+section: Added
+---
+
+### Added
+
+- output-taxonomy rule: taxonomía canónica de output/ con 5 subcategorías (research/, audit logs, pipeline, session-state, raíz)
+- SE-220 spec PROPOSED: Speculative Tool Execution — draft+verify pattern aplicado a tool calls; feasibility-probe bloqueante S0
+- CLAUDE.md: entrada lazy-ref a output-taxonomy.md
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Identidad del humano al volante + memoria auto persistida fuera del repo.
 | PR natural-language summary | `docs/rules/domain/pr-natural-language-summary.md` | Antes de cualquier PR — escribir `.pr-summary.md` con párrafo plano |
 | Spec OpenCode Implementation Plan | `docs/rules/domain/spec-opencode-implementation-plan.md` | Cada spec APPROVED post-2026-04-26 — sección obligatoria + classification |
 | File-output summary (resumen tras generar fichero) | `docs/rules/domain/file-output-summary.md` | Generas un fichero en `output/` con datos pedidos por el usuario — política adaptativa por tamaño |
+| Output taxonomy (dónde va cada fichero en output/) | `docs/rules/domain/output-taxonomy.md` | Vas a escribir en `output/` — decide subdirectorio (research/, postmortems/, raíz, etc.) antes de Write |
 | Principios éticos Savia (13 principios + 5 líneas rojas) | `docs/rules/domain/savia-ethical-principles.md` | Dilema ético, petición ambigua, uso dual, conflicto entre reglas operativas — criterio último: ¿esto hace la vida más digna? |
 | Resolver intent → skill/agent (RESOLVER.md) | `docs/RESOLVER.md` + `docs/rules/domain/resolver-protocol.md` | Necesitas elegir skill o agent para un intent — tabla compacta editable (SE-160) |
 | Template SKILL.md (Authoritative Paths first) | `.claude/skills/_template/SKILL.md` + `docs/rules/domain/skill-template-protocol.md` | Creas una skill nueva — copiar template, paths primero, prosa después (SE-153) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -726,8 +726,9 @@ Google Sheets · ServiceNow/SAP · Tableau · Kafka · VS Code ext · Cloud voic
 | 6 | **SPEC-199** | Historical context conditioning entre rondas (via embeddings) | 4-5d / 5-7h | P2 | depende SPEC-195 (ahora desbloqueado) |
 | 7 | **SPEC-SE-036 Slice 3** | JWT sunset opt-in (PAT file migration) | 4h | P2 | Slice 1+2 ✓ |
 | 8 | **SPEC-188 Fase 2** | Sealed Contract Tests | ~8h | P2 | Fase 1 ✓ |
-| 9 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
-| 10 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
+| 9 | **SE-220** | Speculative Tool Execution — draft+verify pattern (Slice 0 BLOQUEANTE) | ~18h (3h S0 + 15h S1-4) | P2 | feasibility ≥60% acceptance |
+| 10 | **SE-216 Slice 4** | Experiment Graph — tree search | ~6h | P3 | SE-216 S1+S2+S3 ✓ |
+| 11 | **SPEC-188 Fases 3+4** | Causal confidence + diagnostic metrics | ~56h | P3 | Fase 2 |
 
 ### Telemetry pilot (30d desde 2026-06-13)
 
@@ -809,6 +810,20 @@ Origen: https://github.com/DeusData/codebase-memory-mcp (3.2k stars, MIT, arXiv:
 | 5 | SE-219 S5 | Separación tick barato / operación costosa en loops autónomos | S (~2h) | P2 |
 
 Origen: https://github.com/graykode/abtop (2.7k stars, MIT). Patrones: JSON snapshot para scripting, context% como métrica de primer nivel, orphan port/process detection, multi-profile discovery, tick_no_summaries separation. Spec: `docs/propuestas/SE-219-abtop-patterns.md`. Dep: session-action-log ✓ · autonomous-safety ✓ · overnight-sprint ✓.
+
+---
+
+### Era 207 — Speculative Tool Execution (draft+verify pattern, ~18h)
+
+| # | ID | Título | Esfuerzo | Prioridad |
+|---|---|---|---|---|
+| 0 | SE-220 S0 | **Feasibility probe BLOQUEANTE** — acceptance rate ≥60% sobre `/sprint-status` o ABORT | S (~3h) | P2 |
+| 1 | SE-220 S1 | Tool call predictor + read-only whitelist (haiku/qwen2.5:3b) | M (~4h) | P2 |
+| 2 | SE-220 S2 | Async pre-execution wrapper con flock + cache TTL 30s | M (~5h) | P2 |
+| 3 | SE-220 S3 | Speculative skill pre-loading via pre-resolve hook | S (~3h) | P2 |
+| 4 | SE-220 S4 | Telemetry dashboard + GO/CONTINUE/KILL semanal | S (~3h) | P2 |
+
+Origen: investigación speculative decoding 2026-06-20 (papers Leviathan 2022, EAGLE-3 NeurIPS'25, Medusa, Lookahead). El decoder de Claude API es opaco — speculative decoding clásico NO aplica. El **principio** draft+verify SÍ aplica a la capa de orquestación: predictor barato (haiku) pre-ejecuta tool calls idempotentes en background mientras el orquestador (sonnet/opus) piensa. Spec: `docs/propuestas/SE-220-speculative-tool-execution.md`. priority_score = 78.4 (V=75, U=65, E=22) según SPEC-154. Dep: SE-202 (agent-hook-runner) ✓ + SE-217 (time-budget) ✓.
 
 ---
 

--- a/docs/propuestas/SE-220-speculative-tool-execution.md
+++ b/docs/propuestas/SE-220-speculative-tool-execution.md
@@ -1,0 +1,267 @@
+---
+spec_id: SE-220
+title: Speculative Tool Execution — draft+verify pattern aplicado a tool calls y skill loading
+status: PROPOSED
+priority: P2
+effort: M (~18h)
+era: 207
+value: 75
+urgency: 65
+effort_score: 22
+priority_score: 78.4
+confidence: media — el patrón conceptual está validado (speculative decoding = 2-3× speedup en LLM serving); su aplicación a la capa de orquestación es novedosa para Savia y requiere feasibility-probe antes de slice completo.
+bucket: Q3 2026
+origin: investigación speculative decoding 2026-06-20. Speculative decoding clásico (EAGLE-3, Medusa, Lookahead) NO aplica al cloud de Anthropic (decoder opaco). Pero el principio draft+verify es transferible a la capa agéntica donde sí tenemos control.
+related_specs:
+  - SPEC-154 (priorización V×U/E aplicada en este scoring)
+  - SPEC-185 (critical-facts anchor — prompt caching ya en producción)
+  - SE-202 (agent-hook-runner — gate semántico LLM, base conceptual)
+  - SE-217 (autoresearch patterns — time-budget para descarte de drafts)
+  - prompt-caching.md (rule)
+---
+
+# SE-220 — Speculative Tool Execution
+
+## Why
+
+Hoy Savia ejecuta tool calls de forma **secuencial estricta**: el orquestador piensa → emite tool call → tool ejecuta → respuesta vuelve → orquestador piensa siguiente. Cada eslabón tiene latencia: think (~1-3s sonnet/opus) + tool exec (variable) + I/O.
+
+Cuando una skill o agente tiene un patrón **predecible** (ej: `sprint-management` típicamente invoca varias queries WIQL + capacity + report-template), un modelo barato (haiku/qwen2.5:3b) puede **predecir** las próximas N tool calls mientras el orquestador grande aún está procesando.
+
+**Pre-flight gate (innegociable)**: feasibility-probe sobre 1 caso real (`/sprint-status`) que demuestre acceptance rate ≥ 60% del predictor. Si <60%, ABORT — el patrón no aplica y se cierra como REJECTED.
+
+## Insight central
+
+Speculative Decoding garantiza salida idéntica al modelo grande porque verifica matemáticamente. Aquí garantizamos salida idéntica porque:
+
+1. El **orquestador grande** (sonnet/opus) sigue siendo la autoridad — sus tool calls son las que valen.
+2. El **predictor barato** (haiku/qwen2.5:3b) solo **pre-ejecuta** las tool calls que predice. Si acierta → tiempo ahorrado. Si falla → resultados se descartan, latencia idéntica al baseline.
+3. **CRÍTICO**: solo aplica a tools idempotentes y read-only. NUNCA a tools con side effects.
+
+## Scope
+
+### IN-Scope (4 slices)
+
+#### Slice 0 — Feasibility probe (3h) — **BLOQUEANTE**
+
+Antes de cualquier slice posterior:
+
+1. Capturar 20 ejecuciones reales de `/sprint-status` desde el session-action-log.
+2. Extraer secuencias de tool calls.
+3. Entrenar/promptar predictor con haiku (NO fine-tuning — solo prompt engineering con ejemplos).
+4. Medir acceptance rate: % de tool calls predichas correctamente en orden y argumentos.
+5. **GO/NO-GO**:
+   - ≥60% acceptance rate → continuar con Slice 1.
+   - 40-60% → DEFERRED, recopilar más datos.
+   - <40% → ABORT, cerrar spec como REJECTED con lecciones.
+
+Output: informe de feasibility en directorio output con métricas + decisión.
+
+#### Slice 1 — Tool call predictor + read-only whitelist (4h)
+
+`scripts/speculative/tool-predictor.sh`:
+
+```bash
+# Input: contexto del turno actual + últimas 3 acciones
+# Output: JSON con top-3 tool calls predichas + score de confianza
+# Modelo: claude-haiku (cloud) o qwen2.5:3b (local)
+```
+
+`scripts/speculative/safe-tools-whitelist.json`:
+
+```json
+{
+  "safe_for_speculation": [
+    "wiql queries",
+    "capacity reads",
+    "git log",
+    "git status",
+    "git diff --stat",
+    "cat",
+    "grep",
+    "find",
+    "ls"
+  ],
+  "never_speculate": [
+    "work item updates",
+    "git push",
+    "git commit",
+    "pr create",
+    "rm",
+    "mv",
+    "Write",
+    "Edit"
+  ]
+}
+```
+
+#### Slice 2 — Async pre-execution wrapper (5h)
+
+`scripts/speculative/speculative-runner.sh`:
+
+```
+1. Recibe predicción del predictor (top-3 con confianza ≥0.7)
+2. Filtra contra whitelist (descarta non-idempotentes)
+3. Lanza ejecuciones en background con bash & + flock
+4. Almacena resultados en /tmp/speculative-cache/<turn-id>/
+5. Cuando el orquestador real emite la tool call, hook check si está cacheada
+6. Si hit: devuelve resultado cacheado, registra speculative-hit
+7. Si miss: ejecuta normal, registra speculative-miss + descarta caché
+```
+
+Telemetría obligatoria en log JSONL append-only:
+```json
+{"ts":"...", "turn_id":"...", "predicted":["..."], "actual":["..."], "hit_count":2, "miss_count":1, "latency_saved_ms":850}
+```
+
+#### Slice 3 — Speculative skill pre-loading (3h)
+
+Aplicar el mismo patrón a **carga de skills**:
+
+1. Hook `pre-skill-resolve.sh` consulta predictor sobre el prompt actual.
+2. Si predictor sugiere skill X con confianza ≥0.8, pre-lee `SKILL.md` y lo deja en `/tmp/skill-precache/`.
+3. Si el resolver oficial coincide → cache hit, evita re-lectura del filesystem.
+4. Si no coincide → descarta.
+
+Coste: skills son archivos pequeños (~100 líneas), pre-carga es barata.
+
+#### Slice 4 — Telemetry dashboard + GO/CONTINUE/KILL (3h)
+
+`scripts/speculative/measure.sh`:
+
+- Calcula sobre últimas 7 días:
+  - acceptance_rate (predicted ∩ actual / predicted)
+  - latency_p50_saved
+  - latency_p95_saved
+  - false_positive_rate (descartes / predicciones)
+  - cost: tokens haiku consumidos / tokens sonnet ahorrados
+
+Decisión semanal:
+- acceptance ≥70% y latency_p50 ≥500ms → **CONTINUE/EXPAND** (añadir más tools al whitelist)
+- acceptance 50-70% → **TUNE** (mejorar prompt del predictor)
+- acceptance <50% durante 2 semanas → **KILL** (mantener slice 0 lecciones, eliminar slices 1-4)
+
+### Out of scope explícito
+
+- **NO** speculative execution de tools con side effects (write, push, create).
+- **NO** intentar emular speculative decoding sobre Claude API (decoder opaco).
+- **NO** integrar EAGLE-3 / Medusa en savia-dual (ROI bajo, scope creep).
+- **NO** modificar el court orchestrator ni tribunal — ya tienen paralelización pura.
+- **NO** fine-tuning del predictor (solo prompt engineering).
+
+## Acceptance criteria (pre-comprometidos, falsifiables)
+
+- **AC-0** Slice 0 feasibility-probe ejecutado, output documentado, decisión GO/DEFERRED/ABORT registrada antes de Slice 1.
+- **AC-1** `tool-predictor.sh` con bats tests: ≥10 tests verificando JSON schema, top-3 con scores, timeout 2s, exit codes 0/2.
+- **AC-2** Whitelist parseable, hook valida que ninguna tool con side-effect entra en pre-execution. Test bats que intenta inyectar tool peligrosa y verifica que falla.
+- **AC-3** `speculative-runner.sh` ejecuta en background con flock, no bloquea al orquestador, descarta resultados >30s antiguos. 15 tests bats.
+- **AC-4** Telemetría JSONL append-only, sin pérdida de datos en concurrencia (test con 10 procesos paralelos).
+- **AC-5** Skill pre-loading reduce p50 de "skill load + first read" en ≥30% medido sobre 20 invocaciones de `/sprint-status`.
+- **AC-6** Dashboard `measure.sh` produce métricas en <2s sobre 7 días de logs. Acceptance rate calculado correctamente (verificado contra dataset etiquetado de 50 turnos).
+- **AC-7** Sin regresión: tests existentes de comandos afectados (`/sprint-status`, `/pbi-decompose`, `/security-review`) siguen verdes.
+
+## Verification method
+
+```bash
+# Slice 0 (feasibility)
+bash scripts/speculative/feasibility-probe.sh --command /sprint-status --runs 20
+
+# Slices 1-4
+bats tests/speculative/test-tool-predictor.bats
+bats tests/speculative/test-whitelist.bats
+bats tests/speculative/test-runner.bats
+bats tests/speculative/test-skill-preload.bats
+bash scripts/speculative/measure.sh --days 7 --format markdown
+```
+
+## Riesgos identificados
+
+| R | Riesgo | Mitigación |
+|---|---|---|
+| R1 | Predictor con alucinaciones genera tool calls peligrosas | Whitelist hardcodeada en Slice 1. Hook que falla si predictor emite tool no-listada. |
+| R2 | Coste de haiku predictor > ahorro de tiempo en sonnet | Telemetría obligatoria de tokens-in vs tokens-saved. KILL automático si ratio <1.0. |
+| R3 | Race conditions en speculative cache | flock + path con turn-id único + TTL 30s |
+| R4 | Acceptance rate <60% en feasibility | ABORT explícito en Slice 0, no continuar |
+| R5 | Drift entre prompt del predictor y comportamiento real del orquestador | Re-feasibility cada 60 días o tras cambio de modelo |
+| R6 | Falsa sensación de speedup por confirmation bias | Mediciones contra baseline real con `hyperfine`, NO contra estimación |
+
+## Diseño técnico (mínimo viable)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Turno t: usuario pide "/sprint-status"                      │
+└────────────────────┬────────────────────────────────────────┘
+                     │
+                     ▼
+       ┌─────────────────────────────┐
+       │ Orquestador principal        │
+       │ (claude-sonnet/opus)         │
+       │ Latencia: ~2s think          │
+       └──────┬───────────────────────┘
+              │ async fork
+              ▼
+       ┌─────────────────────────────┐
+       │ tool-predictor.sh            │
+       │ (claude-haiku, ~300ms)       │
+       │ Predice: [wiql, capacity]    │
+       └──────┬───────────────────────┘
+              │
+              ▼
+       ┌─────────────────────────────┐
+       │ Whitelist filter             │
+       │ ✓ wiql safe                  │
+       │ ✓ capacity safe              │
+       └──────┬───────────────────────┘
+              │
+              ▼
+       ┌─────────────────────────────┐
+       │ speculative-runner.sh        │
+       │ Ejecuta en background        │
+       │ Resultados → /tmp/spec-cache │
+       └──────┬───────────────────────┘
+              │ (paralelo al orquestador)
+              ▼
+       Orquestador emite real tool call
+              │
+              ▼
+       hook check spec-cache
+       Hit → return cached (saved ~800ms)
+       Miss → ejecuta normal (no penalty)
+```
+
+## Decisión de adopción
+
+**MERGE si TODOS**:
+- AC-0 verde con acceptance rate ≥60%
+- AC-1, AC-2, AC-3, AC-4 verdes
+- AC-7 sin regresión
+- Telemetría real (no estimada) demuestra latency_p50 ahorrada ≥400ms en /sprint-status
+- Code review humano (Rule #8)
+
+**DO NOT MERGE si**:
+- Slice 0 ABORT (acceptance <40%)
+- Tokens haiku consumidos > tokens sonnet ahorrados (coste neto positivo)
+- Falsos positivos ejecutan tools con side effects (cualquier ocurrencia = STOP)
+- Tests rojos
+
+**KILL post-merge si** (4 semanas observación):
+- acceptance_rate <50% sostenido
+- cost ratio >1.0 sostenido
+
+## Cross-references
+
+- `output/research/speculative-decoding-20260620.md` — investigación completa, matriz V×U/E
+- `docs/propuestas/SPEC-154-priorizacion-vue.md` — fórmula aplicada
+- `docs/propuestas/SE-202-agent-hooks.md` — base conceptual del hook semántico
+- `docs/propuestas/SE-217-autoresearch-patterns.md` — time-budget pattern (Slice 3)
+- `docs/rules/domain/prompt-caching.md` — speculative funcional ya en producción
+- `docs/rules/domain/autonomous-safety.md` — Rule #8, gates innegociables
+- `docs/learning/biomimetic-investigation-protocol.md` — disciplina pre-flight (aplica aquí)
+
+## Notas honestas
+
+1. **No es speculative decoding clásico**. Es el principio draft+verify aplicado a otra capa. Llamarlo "speculative" puede confundir; alternativa: "predictive tool prefetch".
+2. **Coste no nulo**: cada predictor call cuesta tokens haiku. Si acceptance es bajo, perdemos dinero acelerando.
+3. **No sustituye a la paralelización pura** (court, tribunal). Es complementario.
+4. **No aplica a comandos cortos**: si el flow total son 2 tool calls, no hay margen para speculative.
+5. Mejor candidato: comandos largos y predecibles (`/sprint-status`, `/weekly-report`, `/executive-reporting`, `/project-update`).

--- a/docs/rules/domain/autonomous-safety.md
+++ b/docs/rules/domain/autonomous-safety.md
@@ -50,7 +50,7 @@ NUNCA  → Crear tareas en el backlog sin aprobación
 NUNCA  → Modificar configuración del proyecto basándose en hallazgos
 NUNCA  → Instalar dependencias nuevas
 
-SIEMPRE → Generar informe en output/research-{tema}-{fecha}.md
+SIEMPRE → Generar informe en output/research/{tema}-{YYYYMMDD}.md
 SIEMPRE → Notificar a AUTONOMOUS_RESEARCH_NOTIFY al completar
 SIEMPRE → Las recomendaciones son PROPUESTAS, no acciones
 ```

--- a/docs/rules/domain/output-taxonomy.md
+++ b/docs/rules/domain/output-taxonomy.md
@@ -1,0 +1,98 @@
+---
+context_tier: L2
+token_budget: 720
+---
+
+# Regla: Ubicación canónica de outputs (output/ taxonomy)
+
+> **REGLA OPERATIVA** — Aplica cada vez que Savia (o un agente delegado) genera un fichero en `output/`. Define DÓNDE va cada tipo de fichero. La política de **qué mostrar en pantalla** está en `file-output-summary.md` (complementaria).
+
+## Principio
+
+`output/` está gitignored. Todo lo que generan agentes vive aquí. **Pero la raíz de `output/` NO es un cajón desastre** — hay 5 sub-categorías estables con convenciones distintas. Poner ficheros en el sitio equivocado genera drift, dificulta `grep` cross-referencial y rompe la trazabilidad spec→origen.
+
+## Taxonomía canónica
+
+| Tipo de fichero | Path | Naming | Quién escribe |
+|---|---|---|---|
+| **Informe one-off pedido por usuario** (sprint status, weekly, executive, cost, time-tracking) | `output/` raíz | `YYYYMMDD-tipo-proyecto.ext` | Comandos `/sprint-*`, `/weekly-*`, `/executive-*`, `/cost-*` |
+| **Investigación que origina specs** (research de repos, papers, técnicas externas) | `output/research/` | `{tema}-{YYYYMMDD}.md` | Skills `tech-research-agent`, `web-research`, sesiones manuales de research |
+| **Audit logs append-only** (telemetría continua) | `output/` raíz | `{audit-name}.jsonl` o `{audit-name}-YYYYMMDD.jsonl` | Hooks, jueces, tribunales |
+| **Artifacts de pipeline** (CI runs, test results, coverage) | `output/{pipeline-name}/` | Definido por la pipeline | Pipelines, agentes autónomos |
+| **State operacional** (sesión viva, dev-sessions, parallel-runs) | `output/session-state/`, `output/dev-sessions/`, `output/parallel-runs/` | Definido por el dominio | Comandos de sesión, dev-orchestrator |
+
+## Casos canónicos
+
+### Caso 1: Usuario pide informe (NO origina spec)
+
+Usuario pide weekly report de proyecto X. Savia genera en raíz de `output/` con naming `YYYYMMDD-tipo-proyecto.ext`. Origen: pm-workflow Rule #5.
+
+### Caso 2: Usuario pide investigación que puede originar spec
+
+Usuario pide investigar técnica externa. Savia genera:
+- Investigación en `output/research/{tema}-{YYYYMMDD}.md`
+- Spec (si aplica) en `docs/propuestas/SE-NNN-*.md`
+- Entrada en `docs/ROADMAP.md` con priority_score V×U/E
+
+### Caso 3: Skill `tech-research-agent` autónomo
+
+Misma convención que Caso 2: `output/research/{tema}-{YYYYMMDD}.md`. Drift histórico (path sin slash) corregido en la sesión que originó esta regla.
+
+### Caso 4: Audit log continuo
+
+Hooks y jueces appendean a `output/{audit-name}.jsonl`. Ejemplos: judge-verdict-validation-errors, quality-gate-history, anti-adulation-telemetry, context-token-log.
+
+### Caso 5: Postmortem de incidente
+
+`output/postmortems/YYYYMMDD-{incident-id}.md`. Origen: `docs/rules/domain/postmortem-policy.md`.
+
+## Decisión rápida (árbol)
+
+```
+¿El fichero contiene...?
+
+  ├── ...datos que el usuario pidió ver (sprint, weekly, exec) ?
+  │     → raíz de output/ con naming YYYYMMDD-tipo-proyecto.ext
+  │
+  ├── ...investigación de tema externo (repo, paper, técnica) ?
+  │     → output/research/ con naming {tema}-{YYYYMMDD}.md
+  │       (y considera generar spec en docs/propuestas/)
+  │
+  ├── ...telemetría continua / audit log ?
+  │     → raíz de output/ con naming {audit-name}.jsonl
+  │
+  ├── ...artefactos de pipeline (CI, tests, coverage) ?
+  │     → subdirectorio output/{pipeline-name}/
+  │
+  ├── ...estado operacional vivo (sesión, dev-session) ?
+  │     → output/session-state/ | output/dev-sessions/ | output/parallel-runs/
+  │
+  └── ...postmortem de incidente ?
+        → output/postmortems/ con naming YYYYMMDD-{incident-id}.md
+```
+
+## Antipatrones
+
+| Antipatrón | Síntoma | Fix |
+|---|---|---|
+| Investigación en raíz de `output/` | fichero de research aislado fuera del subdirectorio research | mover a `output/research/{tema}-{YYYYMMDD}.md` |
+| Informe one-off en `output/research/` | mezcla user-output con investigación interna | mover a raíz `output/` con naming canónico |
+| Spec en `output/` | confusión spec/research | spec va a `docs/propuestas/SE-NNN-*.md` o `docs/specs/SPEC-*.md` |
+| Audit log con fecha pegada al nombre genérico | extensión jsonl en mitad del nombre | usar `{audit-name}-YYYYMMDD.jsonl` (extensión al final) |
+
+## Relación con otras reglas
+
+- `docs/rules/domain/pm-workflow.md` Rule #5 — formato `YYYYMMDD-tipo-proyecto.ext` (informes one-off)
+- `docs/rules/domain/file-output-summary.md` — política de qué mostrar en pantalla
+- `docs/rules/domain/autonomous-safety.md` — outputs de agentes autónomos van con AUTONOMOUS_REVIEWER
+- `docs/rules/domain/session-state-location.md` — state operacional en `output/session-state/`
+- `docs/rules/domain/postmortem-policy.md` — postmortems en su subdirectorio
+
+## Origen
+
+Lección durante sesión de investigación: research generado inicialmente en raíz de `output/` cuando la convención establecida (11 ficheros previos) era `output/research/`. Usuario detectó el drift. Esta regla codifica el patrón real ya en uso para que no vuelva a ocurrir.
+
+Drift histórico corregido en la misma sesión que originó esta regla:
+- `.opencode/skills/tech-research-agent/SKILL.md` y su gemelo `.claude/skills/tech-research-agent/SKILL.md` — actualizados a `output/research/{tema}-{YYYYMMDD}.md`.
+- `docs/rules/domain/autonomous-safety.md` — actualizado.
+- `.claude/commands/tech-research.md` — actualizado.


### PR DESCRIPTION
## Qué hace este PR (en lenguaje no técnico)

Este PR resuelve tres cosas relacionadas que salieron de una misma sesión de trabajo.

**Primero**, ordena dónde deben guardarse los ficheros que genera el sistema automáticamente. Hasta ahora no había una regla explícita: informes de investigación, logs de auditoría, resultados de pipelines y estados de sesión podían acabar mezclados en la misma carpeta. A partir de este PR existe una regla que dice exactamente qué tipo de fichero va en qué subcarpeta, con qué nombre. Esto permite buscar y cruzar ficheros de forma fiable sin tener que recordar dónde los dejó cada agente.

**Segundo**, corrige tres ficheros que usaban una ruta antigua incorrecta para los informes de investigación. La ruta vieja ponía todos los ficheros en la raíz de la carpeta de outputs; la nueva los coloca en una subcarpeta dedicada `research/`. Estaba mal y nadie lo había corregido — este PR lo alinea con la regla nueva.

**Tercero**, documenta una idea técnica que surgió durante investigación sobre cómo reducir tiempos de espera en el sistema. La idea es que un modelo pequeño y barato anticipe qué herramientas va a necesitar el modelo principal mientras este todavía está pensando, de forma que cuando llegue la orden ya estén precalculadas. La spec está marcada como propuesta y requiere una prueba de viabilidad antes de implementarse — si esa prueba no da resultados suficientemente buenos, la idea se descarta sin haber invertido tiempo en ella.

Lo que se pierde: ningún comportamiento existente cambia. La regla de ubicación es nueva, no retroactiva. Los ficheros ya generados en rutas antiguas no se mueven automáticamente.

Para activar la regla de ubicación: está activa desde el momento en que el PR se merge. No requiere configuración adicional. La spec de anticipación de herramientas sigue siendo solo un documento hasta que se apruebe explícitamente su implementación.

---

## Summary

- `docs/rules/domain/output-taxonomy.md` — nueva regla L2: taxonomía canónica de `output/` (5 subcategorías)
- `docs/propuestas/SE-220-speculative-tool-execution.md` — spec PROPOSED: draft+verify pattern para tool calls; priority_score 78.4; feasibility-probe S0 bloqueante
- `CLAUDE.md` — entrada lazy-ref a output-taxonomy.md
- `docs/rules/domain/autonomous-safety.md` + `tech-research` command + `tech-research-agent` SKILL.md — fix path `output/research-{tema}` → `output/research/{tema}` (3 ficheros)
- `docs/ROADMAP.md` — Era 207 SE-220 en Active Stack (P2) + reorden items

**Tests**: test-research-stack.bats 26/26 ✅ (únicos tests que cubren los ficheros modificados). Fallos pre-existentes en delta-tier no relacionados con este PR.